### PR TITLE
Let the log collector collect the DDL statements of the packages.

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -3681,6 +3681,10 @@ GetCommandLogLevel(Node *parsetree)
 			lev = LOGSTMT_DDL;
 			break;
 
+		case T_CreatePackageStmt:
+			lev = LOGSTMT_DDL;
+			break;
+
 			/* already-planned queries */
 		case T_PlannedStmt:
 			{


### PR DESCRIPTION
when logging_collector = on and log_statement = ddl,There will throw out WARING when create package.And the package statements can't be writen to log file.