### PR TITLE
Fix a regression test failed for orafce

### DIFF
--- a/contrib/orafce/Makefile
+++ b/contrib/orafce/Makefile
@@ -12,7 +12,7 @@ all:
 REGRESS = orafce orafce2 dbms_output dbms_utility files varchar2 nvarchar2 aggregates nlssort dbms_random regexp_func ora_to_char convertfunc ora_to_number comparefunc null_relate_func datefuncs
 
 #REGRESS_OPTS = --load-language=plpgsql --schedule=parallel_schedule --encoding=utf8
-REGRESS_OPTS = --schedule=parallel_schedule --no-locale --encoding=utf8
+REGRESS_OPTS = --schedule=$(srcdir)/parallel_schedule --no-locale --encoding=utf8
 
 #override CFLAGS += -Wextra -Wimplicit-fallthrough=0
 


### PR DESCRIPTION
When running check-world, the orafce regression test cannot run, since
the parallel_schedule has wrong path location.