### PR TITLE
Implement mechanism to control creation of extensions and other objec…

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -8,7 +8,7 @@ subdir =
 top_builddir = .
 include $(top_builddir)/src/Makefile.global
 
-$(call recurse,all install,src config)
+$(call recurse,all install,src config contrib)
 
 docs:
 	$(MAKE) -C doc all

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -92,6 +92,9 @@ SUBDIRS += orafce
 # Missing:
 #		start-scripts	\ (does not have a makefile)
 
+# install the ivy_module.config
+install:
+	+@cp $(srcdir)/ivy_module.config $(DESTDIR)$(datadir)/
 
 $(recurse)
 $(recurse_always)

--- a/contrib/ivy_module.config
+++ b/contrib/ivy_module.config
@@ -12,5 +12,5 @@
 # All other lines that do not start with '@' are considered as SQL scripts
 # and initdb will look for those in 'share/postgresql/contrib/' directory
 
-@Orafce
+#@orafce
 

--- a/contrib/ivy_module.config
+++ b/contrib/ivy_module.config
@@ -1,0 +1,16 @@
+# Extensions and scripts that are needed to be installed at initdb
+#
+# Each module listed in this file will be installed by initdb
+# in the same order as listed in this file.
+#
+# Each line can contain only single entry, while the empty
+# lines and lines starting with # gets ignored.
+#
+# lines begining with @ are considered as extension names and initdb
+# will use CREATE EXTENSION for those.
+#
+# All other lines that do not start with '@' are considered as SQL scripts
+# and initdb will look for those in 'share/postgresql/contrib/' directory
+
+@Orafce
+


### PR DESCRIPTION
…ts at initdb

The commit includes the contrib directory to default buid target IvorySQL src.
Along with that it  adds a new file ivy_module.config to contrib directory,
that can be used to list extensions and SQL scripts required to be
executed by initdb.

ivy_module.config gets installed at '$INSTALL_DIR/share/postgresql/' and is read
by initdb to install all extensions and scripts listed in that file.