### PR TITLE
Regression fix

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -49,12 +49,15 @@ jobs:
     - name: regression
       run: make check-world
 
+    - name: collect files
+      if: failure()
+      run: |
+          find . \( -name "*.diffs" -or -name "regression.out" -or -path \*/tmp_check/log \) -print0 |
+                xargs -0 tar -czf regression.tar.gz
+
     - name: upload regression files
       if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: results
-        path: |
-            src/test/regress/regression.diffs
-            src/test/regress/regression.out
-
+        path: ${{ github.workspace }}/regression.tar.gz

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -14,8 +14,14 @@ test: test_setup
 # run tablespace by itself, and early, because it forces a checkpoint;
 # we'd prefer not to have checkpoints later in the tests because that
 # interferes with crash-recovery testing.
-test: packages plisql select_hierar
 test: tablespace
+
+# ----------
+# IvorySQL tests
+# ----------
+test: packages
+test: plisql
+test: select_hierar
 
 # ----------
 # The first group of parallel tests


### PR DESCRIPTION
Test running in the same parallel group and used the same object naming which conflicted when a test dropped or created the object while the other was using the same. 

Also when test fails in some other contrib module, the regression files were not uploaded. This pr fixes that as well.