### PR TITLE
Match END identifier with the function/procedure name. Furthermore,

### DIFF
--- a/src/pl/plisql/src/expected/plisql_control.out
+++ b/src/pl/plisql/src/expected/plisql_control.out
@@ -319,7 +319,6 @@ select exit_block1();
 
 -- verbose end block and end loop
 create function end_label1() returns void as $$
-<<blbl>>
 begin
   <<flbl1>>
   for i in 1 .. 10 loop
@@ -331,7 +330,7 @@ begin
     raise notice 'j = %', j;
     exit flbl2;
   end loop;
-end blbl;
+end end_label1;
 $$ language plisql;
 select end_label1();
 NOTICE:  i = 1
@@ -354,7 +353,6 @@ LINE 5:   end loop flbl1;
                    ^
 -- should fail: end label does not match start label
 create function end_label3() returns void as $$
-<<outer_label>>
 begin
   <<inner_label>>
   for _i in 1 .. 10 loop
@@ -363,11 +361,10 @@ begin
 end;
 $$ language plisql;
 ERROR:  end label "outer_label" differs from block's label "inner_label"
-LINE 7:   end loop outer_label;
+LINE 6:   end loop outer_label;
                    ^
 -- should fail: end label on a block without a start label
 create function end_label4() returns void as $$
-<<outer_label>>
 begin
   for _i in 1 .. 10 loop
     exit;
@@ -375,7 +372,7 @@ begin
 end;
 $$ language plisql;
 ERROR:  end label "outer_label" specified for unlabeled block
-LINE 6:   end loop outer_label;
+LINE 5:   end loop outer_label;
                    ^
 -- unlabeled exit matches no blocks
 do $$
@@ -504,7 +501,7 @@ select return_from_while();
 
 -- using list of scalars in fori and fore stmts
 create function for_vect() returns void as $proc$
-<<lbl>>declare a integer; b varchar; c varchar; r record;
+a integer; b varchar; c varchar; r record;
 begin
   -- fori
   for i in 1 .. 3 loop
@@ -523,7 +520,7 @@ begin
     raise notice '% % %', a, b, c;
   end loop;
   -- using qualified names in fors, fore is enabled, disabled only for fori
-  for lbl.a, lbl.b, lbl.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop
+  for for_vect.a, for_vect.b, for_vect.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop
     raise notice '% % %', a, b, c;
   end loop;
 end;
@@ -681,3 +678,129 @@ select case_test(13);
  other
 (1 row)
 
+-- test end label match with function/procedure name
+create function end_label5() return int as
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label5;
+/
+select end_label5();
+NOTICE:  i = 1
+NOTICE:  j = 1
+ end_label5 
+------------
+          0
+(1 row)
+
+-- test vars in different blocks
+create or replace function end_label5() return int as
+   a varchar := 'villiage';
+BEGIN
+   DECLARE
+      a varchar := 'city';
+   BEGIN
+      IF a = end_label5.a THEN
+         raise notice 'inner and outer vars matched';
+      ELSE
+         raise notice 'inner and outer vars not matched';
+      END IF;
+   END;
+   return 0;
+END;
+/
+select end_label5();
+NOTICE:  inner and outer vars not matched
+ end_label5 
+------------
+          0
+(1 row)
+
+drop function end_label5;
+-- should fail: end label must match with function/procedure name
+create function end_label5() return int as
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label;
+/
+ERROR:  END identifier 'end_label' must match 'end_label5'
+LINE 2: begin
+        ^
+QUERY:  
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label
+select end_label5();
+ERROR:  function end_label5() does not exist
+LINE 1: select end_label5();
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- should fail: syntax error. first block cannot have label
+create function end_label5() return int as
+<<firstlabel>>
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label;
+/
+ERROR:  syntax error at or near "<<"
+LINE 2: <<firstlabel>>
+        ^
+QUERY:  
+<<firstlabel>>
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label
+select end_label5();
+ERROR:  function end_label5() does not exist
+LINE 1: select end_label5();
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

--- a/src/pl/plisql/src/pl_comp.c
+++ b/src/pl/plisql/src/pl_comp.c
@@ -877,6 +877,7 @@ do_compile(FunctionCallInfo fcinfo,
 	/*
 	 * Now parse the function's text
 	 */
+	plisql_IdentifierLookup = IDENTIFIER_LOOKUP_DECLARE;
 	parse_rc = plisql_yyparse();
 	if (parse_rc != 0)
 		elog(ERROR, "plisql parser returned %d", parse_rc);

--- a/src/pl/plisql/src/sql/plisql_control.sql
+++ b/src/pl/plisql/src/sql/plisql_control.sql
@@ -228,7 +228,6 @@ select exit_block1();
 
 -- verbose end block and end loop
 create function end_label1() returns void as $$
-<<blbl>>
 begin
   <<flbl1>>
   for i in 1 .. 10 loop
@@ -240,7 +239,7 @@ begin
     raise notice 'j = %', j;
     exit flbl2;
   end loop;
-end blbl;
+end end_label1;
 $$ language plisql;
 
 select end_label1();
@@ -256,7 +255,6 @@ $$ language plisql;
 
 -- should fail: end label does not match start label
 create function end_label3() returns void as $$
-<<outer_label>>
 begin
   <<inner_label>>
   for _i in 1 .. 10 loop
@@ -267,7 +265,6 @@ $$ language plisql;
 
 -- should fail: end label on a block without a start label
 create function end_label4() returns void as $$
-<<outer_label>>
 begin
   for _i in 1 .. 10 loop
     exit;
@@ -397,7 +394,7 @@ select return_from_while();
 
 -- using list of scalars in fori and fore stmts
 create function for_vect() returns void as $proc$
-<<lbl>>declare a integer; b varchar; c varchar; r record;
+a integer; b varchar; c varchar; r record;
 begin
   -- fori
   for i in 1 .. 3 loop
@@ -416,7 +413,7 @@ begin
     raise notice '% % %', a, b, c;
   end loop;
   -- using qualified names in fors, fore is enabled, disabled only for fori
-  for lbl.a, lbl.b, lbl.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop
+  for for_vect.a, for_vect.b, for_vect.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop
     raise notice '% % %', a, b, c;
   end loop;
 end;
@@ -486,3 +483,81 @@ select case_test(1);
 select case_test(2);
 select case_test(12);
 select case_test(13);
+
+-- test end label match with function/procedure name
+create function end_label5() return int as
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label5;
+/
+
+select end_label5();
+
+-- test vars in different blocks
+create or replace function end_label5() return int as
+   a varchar := 'villiage';
+BEGIN
+   DECLARE
+      a varchar := 'city';
+   BEGIN
+      IF a = end_label5.a THEN
+         raise notice 'inner and outer vars matched';
+      ELSE
+         raise notice 'inner and outer vars not matched';
+      END IF;
+   END;
+   return 0;
+END;
+/
+
+select end_label5();
+drop function end_label5;
+
+-- should fail: end label must match with function/procedure name
+create function end_label5() return int as
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label;
+/
+
+select end_label5();
+
+-- should fail: syntax error. first block cannot have label
+create function end_label5() return int as
+<<firstlabel>>
+begin
+  <<flbl1>>
+  for i in 1 .. 10 loop
+    raise notice 'i = %', i;
+    exit flbl1;
+  end loop flbl1;
+  <<flbl2>>
+  for j in 1 .. 10 loop
+    raise notice 'j = %', j;
+    exit flbl2;
+  end loop;
+  return 0;
+end end_label;
+/
+
+select end_label5();

--- a/src/test/regress/expected/plisql.out
+++ b/src/test/regress/expected/plisql.out
@@ -544,7 +544,6 @@ end;
 create or replace function use_refcursor(rc refcursor) return int 
 as
 declare
-    rc refcursor;
     x record;
 begin
     rc := return_unnamed_refcursor();
@@ -1044,7 +1043,33 @@ set plisql.extra_errors to 'all';
 set plisql.extra_errors to 'none';
 -- test warnings when shadowing a variable
 set plisql.extra_warnings to 'shadowed_variables';
--- simple shadowing of input and output parameters
+-- simple shadowing of vars between blocks
+create or replace function shadowtest()
+	returns table (x int) as $$
+declare --block 1
+  in1 int;
+  out1 int;
+begin
+  declare --block 2
+    in1 int;
+    out1 int;
+  begin
+  end;
+end
+$$ language plisql;
+WARNING:  variable "in1" shadows a previously defined variable
+LINE 8:     in1 int;
+            ^
+WARNING:  variable "out1" shadows a previously defined variable
+LINE 9:     out1 int;
+            ^
+select shadowtest();
+ shadowtest 
+------------
+(0 rows)
+
+drop function shadowtest();
+-- duplicate var declaration with function parameter
 create or replace function shadowtest(in1 int)
 	returns table (out1 int) as $$
 declare
@@ -1053,18 +1078,9 @@ out1 int;
 begin
 end
 $$ language plisql;
-WARNING:  variable "in1" shadows a previously defined variable
+ERROR:  duplicate declaration at or near "in1"
 LINE 4: in1 int;
         ^
-WARNING:  variable "out1" shadows a previously defined variable
-LINE 5: out1 int;
-        ^
-select shadowtest(1);
- shadowtest 
-------------
-(0 rows)
-
-drop function shadowtest(int);
 -- shadowing in a second DECLARE block
 create or replace function shadowtest()
 	returns void as $$
@@ -1091,13 +1107,9 @@ begin
 	begin
 	end;
 end$$ language plisql;
-WARNING:  variable "in1" shadows a previously defined variable
+ERROR:  duplicate declaration at or near "in1"
 LINE 4: in1 int;
         ^
-WARNING:  variable "in1" shadows a previously defined variable
-LINE 7:  in1 int;
-         ^
-drop function shadowtest(int);
 -- shadowing in cursor definitions
 create or replace function shadowtest()
 	returns void as $$
@@ -1115,26 +1127,17 @@ set plisql.extra_errors to 'shadowed_variables';
 create or replace function shadowtest(f1 int)
 	returns boolean as $$
 declare f1 int; begin return 1; end $$ language plisql;
-ERROR:  variable "f1" shadows a previously defined variable
+ERROR:  duplicate declaration at or near "f1"
 LINE 3: declare f1 int; begin return 1; end $$ language plisql;
                 ^
-select shadowtest(1);
-ERROR:  function shadowtest(integer) does not exist
-LINE 1: select shadowtest(1);
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 reset plisql.extra_errors;
 reset plisql.extra_warnings;
 create or replace function shadowtest(f1 int)
 	returns boolean as $$
 declare f1 int; begin return 1; end $$ language plisql;
-select shadowtest(1);
- shadowtest 
-------------
- t
-(1 row)
-
-drop function shadowtest(int);
+ERROR:  duplicate declaration at or near "f1"
+LINE 3: declare f1 int; begin return 1; end $$ language plisql;
+                ^
 -- runtime extra checks
 set plisql.extra_warnings to 'too_many_rows';
 declare x int;
@@ -1387,9 +1390,8 @@ drop function sc_test();
 drop table tcur_tb;
 -- test qualified variable names
 create or replace function pl_qual_names (param1 int) return void as
-<<outerblock>>
 declare
-  param1 int := 1;
+  param2 int := 1;
 begin
   <<innerblock>>
   declare
@@ -1397,7 +1399,7 @@ begin
   begin
     raise notice 'param1 = %', param1;
     raise notice 'pl_qual_names.param1 = %', pl_qual_names.param1;
-    raise notice 'outerblock.param1 = %', outerblock.param1;
+    raise notice 'pl_qual_names.param2 = %', pl_qual_names.param2;
     raise notice 'innerblock.param1 = %', innerblock.param1;
   end;
 end;
@@ -1405,7 +1407,7 @@ end;
 select pl_qual_names(42);
 NOTICE:  param1 = 2
 NOTICE:  pl_qual_names.param1 = 42
-NOTICE:  outerblock.param1 = 1
+NOTICE:  pl_qual_names.param2 = 1
 NOTICE:  innerblock.param1 = 2
  pl_qual_names 
 ---------------


### PR DESCRIPTION
function argument's list and variable declarations immediately after
cannot have duplicates.

Similarly, a function/procedure cannot specifiy a label right after
it's signature.