### PR TITLE
bugfix: When CONNECT_BY_ROOT parameter exception, the server terminated abnormally

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -3558,6 +3558,11 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 			{
 				ConnectRoot *n = (ConnectRoot *) expr;
 
+				if (!IsA(n->expr, ColumnRef))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("only simple column references are allowed in CONNECT_BY_ROOT")));
+
 				/* add column alias if not present */
 				if (res && res->name == NULL)
 					res->name = FigureColname(expr);

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -3496,10 +3496,17 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 			{
 				ColumnRef  *cref;
 				SysConnectPath *n = (SysConnectPath *) expr;
-				A_Expr	   *rexpr = makeSimpleA_Expr(AEXPR_OP, "||",
-													 (Node *) n->chr,
-													 (Node *) n->expr,
-													 -1);
+				A_Expr	   *rexpr;
+
+				if (!IsA(n->expr, ColumnRef))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("only simple column references are allowed in SYS_CONNECT_BY_PATH")));
+
+				rexpr = makeSimpleA_Expr(AEXPR_OP, "||",
+										 (Node *)n->chr,
+										 (Node *)n->expr,
+										 -1);
 
 				/* add column alias if not present */
 				if (res && res->name == NULL)

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -3597,7 +3597,14 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 		case T_PriorClause:
 			{
 				PriorClause *n = (PriorClause *) expr;
-				ColumnRef  *cref = (ColumnRef *) n->expr;
+				ColumnRef   *cref;
+
+				if (!IsA(n->expr, ColumnRef))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("only simple column references are allowed in PRIOR")));
+
+				cref = (ColumnRef *) n->expr;
 
 				/* add conditional columns to the target list */
 				if (cols != NULL)

--- a/src/test/regress/expected/select_hierar.out
+++ b/src/test/regress/expected/select_hierar.out
@@ -150,6 +150,9 @@ SELECT id, manager_id from t_tab CONNECT BY  id =  manager_id order by id;
   3 |          2
 (3 rows)
 
+-- test PRIOR exception
+SELECT id, manager_id from t_tab CONNECT BY PRIOR 50 =  manager_id;
+ERROR:  only simple column references are allowed in PRIOR
 -- tests with level in expression
 SELECT id, manager_id, level, level * 100 * manager_id  from t_tab CONNECT BY prior id =  manager_id order by id;
  id | manager_id | LEVEL | LEVEL 

--- a/src/test/regress/expected/select_hierar.out
+++ b/src/test/regress/expected/select_hierar.out
@@ -202,6 +202,12 @@ FROM example
 START WITH manager_id is not null
 CONNECT BY PRIOR employee_id = manager_id;
 ERROR:  only simple column references are allowed in SYS_CONNECT_BY_PATH
+-- test CONNECT_BY_ROOT exception
+SELECT employee_id, CONNECT_BY_ROOT 'employee_id' as "Manager"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+ERROR:  only simple column references are allowed in CONNECT_BY_ROOT
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example

--- a/src/test/regress/expected/select_hierar.out
+++ b/src/test/regress/expected/select_hierar.out
@@ -196,6 +196,12 @@ order by employee_id, manager_id;
            5 |          4 | Kyle     |       5 | /Kyle
 (4 rows)
 
+-- test SYS_CONNECT_BY_PATH parameter exception
+SELECT employee_id, SYS_CONNECT_BY_PATH('employee', '/') "Path"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+ERROR:  only simple column references are allowed in SYS_CONNECT_BY_PATH
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example

--- a/src/test/regress/sql/select_hierar.sql
+++ b/src/test/regress/sql/select_hierar.sql
@@ -79,6 +79,9 @@ WITH RECURSIVE test (id, manager_id) AS (
 
 SELECT id, manager_id from t_tab CONNECT BY  id =  manager_id order by id;
 
+-- test PRIOR exception
+SELECT id, manager_id from t_tab CONNECT BY PRIOR 50 =  manager_id;
+
 -- tests with level in expression
 SELECT id, manager_id, level, level * 100 * manager_id  from t_tab CONNECT BY prior id =  manager_id order by id;
 SELECT level, level * 100 * manager_id, id, manager_id from t_tab CONNECT BY id =  prior manager_id order by id;

--- a/src/test/regress/sql/select_hierar.sql
+++ b/src/test/regress/sql/select_hierar.sql
@@ -106,6 +106,12 @@ FROM example
 START WITH manager_id is not null
 CONNECT BY PRIOR employee_id = manager_id;
 
+-- test CONNECT_BY_ROOT exception
+SELECT employee_id, CONNECT_BY_ROOT 'employee_id' as "Manager"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example

--- a/src/test/regress/sql/select_hierar.sql
+++ b/src/test/regress/sql/select_hierar.sql
@@ -100,6 +100,12 @@ START WITH manager_id is not null
 CONNECT BY PRIOR employee_id = manager_id
 order by employee_id, manager_id;
 
+-- test SYS_CONNECT_BY_PATH parameter exception
+SELECT employee_id, SYS_CONNECT_BY_PATH('employee', '/') "Path"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example


### PR DESCRIPTION
```sql
create table example(manager_id int, employee_id int, employee VARCHAR);

SELECT employee_id, CONNECT_BY_ROOT 'employee_id' as "Manager"
FROM example
START WITH manager_id is not null
CONNECT BY PRIOR employee_id = manager_id;

server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
```