### PR TITLE
Hierarchical query supports column expression in targetList

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3708,6 +3708,9 @@ transformHierarStmt(ParseState *pstate, SelectStmt *stmt)
 	 * duplicity
 	 */
 	ctequery_l->targetList = list_concat_unique(ctequery_l->targetList, newCols);
+
+	/* qualify the target list columns with appropriate relation */
+	newCols = qualifyTlistColumns(ps, newCols, rv->relname);
 	ctequery_r->targetList = list_concat_unique(ctequery_r->targetList, newCols);
 
 	/* qualify the target list columns with appropriate relation */
@@ -3899,7 +3902,9 @@ fixupWhenAndSortClauses(ParseState *pstate, SelectStmt *stmt,
 	{
 		SortBy	   *sortby = (SortBy *) lfirst(lc);
 
+		pstate->p_ctehflags |= EXPR_FLAG_ORDER;
 		resolvePseudoColumns(pstate, (Node *) sortby->node, NULL, relname, &cols);
+		pstate->p_ctehflags &= ~EXPR_FLAG_ORDER;
 	}
 
 	/*

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -3309,6 +3309,16 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 							return (Node *) n;
 						}
 					}
+					else if (pstate->p_ctehflags & EXPR_FLAG_ORDER)
+					{
+						/* add column used in order-by clause to cols list */
+						if (cols != NULL)
+						{
+							ResTarget  *rt = makeNode(ResTarget);
+							rt->val = copyObject((Node *) cref);
+							*cols = lappend(*cols, rt);
+						}
+					}
 					else
 					{
 						/* add column used in order-by clause to cols list */
@@ -3317,6 +3327,9 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 							ResTarget  *rt = makeNode(ResTarget);
 
 							rt->val = copyObject((Node *) cref);
+							if (relname)
+								cref->fields = lcons(makeString(relname),
+													 cref->fields);
 							*cols = lappend(*cols, rt);
 						}
 					}

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -3558,6 +3558,11 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 			{
 				ConnectRoot *n = (ConnectRoot *) expr;
 
+				if (!IsA(n->expr, ColumnRef))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("only simple column references are allowed in CONNECT_BY_ROOT")));
+
 				/* add column alias if not present */
 				if (res && res->name == NULL)
 					res->name = FigureColname(expr);

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -3496,10 +3496,17 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 			{
 				ColumnRef  *cref;
 				SysConnectPath *n = (SysConnectPath *) expr;
-				A_Expr	   *rexpr = makeSimpleA_Expr(AEXPR_OP, "||",
-													 (Node *) n->chr,
-													 (Node *) n->expr,
-													 -1);
+				A_Expr	   *rexpr;
+
+				if (!IsA(n->expr, ColumnRef))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("only simple column references are allowed in SYS_CONNECT_BY_PATH")));
+
+				rexpr = makeSimpleA_Expr(AEXPR_OP, "||",
+										 (Node *)n->chr,
+										 (Node *)n->expr,
+										 -1);
 
 				/* add column alias if not present */
 				if (res && res->name == NULL)

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -3597,7 +3597,14 @@ resolvePseudoColumns(ParseState *pstate, Node *expr, ResTarget *res,
 		case T_PriorClause:
 			{
 				PriorClause *n = (PriorClause *) expr;
-				ColumnRef  *cref = (ColumnRef *) n->expr;
+				ColumnRef   *cref;
+
+				if (!IsA(n->expr, ColumnRef))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("only simple column references are allowed in PRIOR")));
+
+				cref = (ColumnRef *) n->expr;
 
 				/* add conditional columns to the target list */
 				if (cols != NULL)

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -19,8 +19,9 @@
 #include "utils/relcache.h"
 
 /* flags for hierarical query */
-#define EXPR_FLAG_LEVEL		0x0001	/* LEVEL clause */
-#define EXPR_FLAG_WHERE		0x0002	/* WHERE clause */
+#define EXPR_FLAG_LEVEL		(1 << 1)	/* LEVEL clause */
+#define EXPR_FLAG_WHERE		(1 << 2)	/* WHERE clause */
+#define EXPR_FLAG_ORDER		(1 << 3)	/* ORDER clause */
 
 
 /* Forward references for some structs declared below */

--- a/src/test/regress/expected/select_hierar.out
+++ b/src/test/regress/expected/select_hierar.out
@@ -150,6 +150,9 @@ SELECT id, manager_id from t_tab CONNECT BY  id =  manager_id order by id;
   3 |          2
 (3 rows)
 
+-- test PRIOR exception
+SELECT id, manager_id from t_tab CONNECT BY PRIOR 50 =  manager_id;
+ERROR:  only simple column references are allowed in PRIOR
 -- tests with level in expression
 SELECT id, manager_id, level, level * 100 * manager_id  from t_tab CONNECT BY prior id =  manager_id order by id;
  id | manager_id | LEVEL | LEVEL 

--- a/src/test/regress/expected/select_hierar.out
+++ b/src/test/regress/expected/select_hierar.out
@@ -202,6 +202,12 @@ FROM example
 START WITH manager_id is not null
 CONNECT BY PRIOR employee_id = manager_id;
 ERROR:  only simple column references are allowed in SYS_CONNECT_BY_PATH
+-- test CONNECT_BY_ROOT exception
+SELECT employee_id, CONNECT_BY_ROOT 'employee_id' as "Manager"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+ERROR:  only simple column references are allowed in CONNECT_BY_ROOT
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example

--- a/src/test/regress/expected/select_hierar.out
+++ b/src/test/regress/expected/select_hierar.out
@@ -236,6 +236,19 @@ ORDER BY employee_id, manager_id;
            5 |          4 | Kyle     |       5 | /Kyle
 (4 rows)
 
+-- test Column expression
+SELECT employee_id, employee_id + 1
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+ employee_id | ?column? 
+-------------+----------
+           2 |        3
+           3 |        4
+           5 |        6
+           3 |        4
+(4 rows)
+
 -- test CONNECT_BY_ROOT and SYS_CONNECT_BY_PATH when there associated
 -- columns are not explicitly specified in the target list.
 SELECT CONNECT_BY_ROOT manager_id, SYS_CONNECT_BY_PATH(id, '\') PATH

--- a/src/test/regress/expected/select_hierar.out
+++ b/src/test/regress/expected/select_hierar.out
@@ -196,6 +196,12 @@ order by employee_id, manager_id;
            5 |          4 | Kyle     |       5 | /Kyle
 (4 rows)
 
+-- test SYS_CONNECT_BY_PATH parameter exception
+SELECT employee_id, SYS_CONNECT_BY_PATH('employee', '/') "Path"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+ERROR:  only simple column references are allowed in SYS_CONNECT_BY_PATH
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example

--- a/src/test/regress/sql/select_hierar.sql
+++ b/src/test/regress/sql/select_hierar.sql
@@ -79,6 +79,9 @@ WITH RECURSIVE test (id, manager_id) AS (
 
 SELECT id, manager_id from t_tab CONNECT BY  id =  manager_id order by id;
 
+-- test PRIOR exception
+SELECT id, manager_id from t_tab CONNECT BY PRIOR 50 =  manager_id;
+
 -- tests with level in expression
 SELECT id, manager_id, level, level * 100 * manager_id  from t_tab CONNECT BY prior id =  manager_id order by id;
 SELECT level, level * 100 * manager_id, id, manager_id from t_tab CONNECT BY id =  prior manager_id order by id;

--- a/src/test/regress/sql/select_hierar.sql
+++ b/src/test/regress/sql/select_hierar.sql
@@ -106,6 +106,12 @@ FROM example
 START WITH manager_id is not null
 CONNECT BY PRIOR employee_id = manager_id;
 
+-- test CONNECT_BY_ROOT exception
+SELECT employee_id, CONNECT_BY_ROOT 'employee_id' as "Manager"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example

--- a/src/test/regress/sql/select_hierar.sql
+++ b/src/test/regress/sql/select_hierar.sql
@@ -100,6 +100,12 @@ START WITH manager_id is not null
 CONNECT BY PRIOR employee_id = manager_id
 order by employee_id, manager_id;
 
+-- test SYS_CONNECT_BY_PATH parameter exception
+SELECT employee_id, SYS_CONNECT_BY_PATH('employee', '/') "Path"
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+
 -- test order-by clause when order-by columns are not in target list
 SELECT employee, CONNECT_BY_ROOT employee_id as "Manager", SYS_CONNECT_BY_PATH(employee, '/') "Path"
 FROM example

--- a/src/test/regress/sql/select_hierar.sql
+++ b/src/test/regress/sql/select_hierar.sql
@@ -126,6 +126,12 @@ START WITH manager_id is not null
 CONNECT BY PRIOR employee_id = manager_id
 ORDER BY employee_id, manager_id;
 
+-- test Column expression
+SELECT employee_id, employee_id + 1
+FROM example
+START WITH manager_id is not null
+CONNECT BY PRIOR employee_id = manager_id;
+
 -- test CONNECT_BY_ROOT and SYS_CONNECT_BY_PATH when there associated
 -- columns are not explicitly specified in the target list.
 SELECT CONNECT_BY_ROOT manager_id, SYS_CONNECT_BY_PATH(id, '\') PATH


### PR DESCRIPTION
Currently，Hierarchical query do not support column expression in targetList.

```sql
SELECT employee_id + 1
FROM example
START WITH manager_id is not null
CONNECT BY PRIOR employee_id = manager_id;
ERROR:  column reference "employee_id" is ambiguous
LINE 1: SELECT employee_id + 1
               ^

```