### PR TITLE
Fix server terminated abnormally When the targetList of hierarchical query contains subquery

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3660,6 +3660,17 @@ transformHierarStmt(ParseState *pstate, SelectStmt *stmt)
 	ctequery->larg = (SelectStmt *) ctequery_l;
 	ctequery->rarg = (SelectStmt *) ctequery_r;
 
+	/*
+	 * check if is a simple RangeVar, support only one simple table
+	 */
+	if (list_length(stmt->fromClause) != 1 || 
+		!IsA(linitial(stmt->fromClause), RangeVar))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("only a single simple relation is allowed in hierarchical statement")));
+	}
+
 	/* Buildup a CTE name and fill up other info */
 	rv = (RangeVar *) linitial(stmt->fromClause);
 	cte->ctename = psprintf("cte_%s", rv->relname);


### PR DESCRIPTION
fixed #181
```sql
--  create table and build data
create table area(id int, name text, pid int);
insert into area values(1, 'china', 0);
insert into area values(101, 'zhejiang', 1);
insert into area values(102, 'jiangsu', 1);
insert into area values(103, 'heilongjiang', 1);
insert into area values(10101, 'hangzhou', 101);
insert into area values(10102, 'ningbo', 101);
insert into area values(10103, 'shaoxing', 101);
insert into area values(10104, 'wenzhou', 101);
insert into area values(1010101, 'binjiang', 10101);
insert into area values(1010102, 'shangcheng', 10101);
insert into area values(1010103, 'xihu', 10101);
insert into area values(1010101, 'gongshu', 10101);

select * from (select * from area) start with name = 'hangzhou' connect by  pid = prior id;
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
```