### PR TITLE
Support plisql multi-range in conditional control

### DIFF
--- a/src/pl/plisql/src/expected/plisql_control.out
+++ b/src/pl/plisql/src/expected/plisql_control.out
@@ -79,6 +79,188 @@ begin
 end$$;
 ERROR:  BY value of FOR loop must be greater than zero
 CONTEXT:  PL/pgSQL function inline_code_block line 3 at FOR with integer loop variable
+-- Test in condition list
+do $$
+declare
+	i int;
+begin
+	for i in 1..3 , 51..55 loop
+		raise notice '%', i;
+	end loop;
+
+  for i in 1..3 , reverse 55..51 loop
+		raise info '%', i;
+	end loop;
+
+	for i in reverse 1..3 loop
+		raise notice '%', i;
+	end loop;
+
+	for i in 1..3 loop
+		raise notice '%', i;
+	end loop;
+
+	for i in reverse 3..1 loop
+		raise notice '%', i;
+	end loop;
+
+	for i in 1..10 by 3 loop
+		raise notice '1..10 by 3: i = %', i;
+	end loop;
+end; $$ language plisql;
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
+NOTICE:  51
+NOTICE:  52
+NOTICE:  53
+NOTICE:  54
+NOTICE:  55
+INFO:  1
+INFO:  2
+INFO:  3
+INFO:  55
+INFO:  54
+INFO:  53
+INFO:  52
+INFO:  51
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
+NOTICE:  3
+NOTICE:  2
+NOTICE:  1
+NOTICE:  1..10 by 3: i = 1
+NOTICE:  1..10 by 3: i = 4
+NOTICE:  1..10 by 3: i = 7
+NOTICE:  1..10 by 3: i = 10
+do $$
+declare
+   i int := 10;
+begin
+   for i in reverse i+10..i+1 loop
+      raise info '%', i;
+   end loop;
+end; $$ language plisql;
+INFO:  20
+INFO:  19
+INFO:  18
+INFO:  17
+INFO:  16
+INFO:  15
+INFO:  14
+INFO:  13
+INFO:  12
+INFO:  11
+do $$
+declare
+   j int := 10;
+begin
+   for i in 1..3, reverse j+10..j+1 loop
+      raise info '%', i;
+   end loop;
+end; $$ language plisql;
+INFO:  1
+INFO:  2
+INFO:  3
+INFO:  20
+INFO:  19
+INFO:  18
+INFO:  17
+INFO:  16
+INFO:  15
+INFO:  14
+INFO:  13
+INFO:  12
+INFO:  11
+do $$
+declare
+   j int := 10;
+begin
+   for i in reverse j+10..j+1 loop
+      raise info '%', i;
+   end loop;
+end; $$ language plisql;
+INFO:  20
+INFO:  19
+INFO:  18
+INFO:  17
+INFO:  16
+INFO:  15
+INFO:  14
+INFO:  13
+INFO:  12
+INFO:  11
+create type range_expr as (r int4range, s int);
+do $$
+declare re range_expr;
+begin
+  foreach re in array ARRAY[('[10, 20]', 1), ('[100, 200]', 10)]
+  loop
+    for i in lower(re.r) .. upper(re.r) by re.s
+    loop
+      raise notice '%', i;
+    end loop;
+  end loop;
+end; $$ language plisql;
+NOTICE:  10
+NOTICE:  11
+NOTICE:  12
+NOTICE:  13
+NOTICE:  14
+NOTICE:  15
+NOTICE:  16
+NOTICE:  17
+NOTICE:  18
+NOTICE:  19
+NOTICE:  20
+NOTICE:  21
+NOTICE:  100
+NOTICE:  110
+NOTICE:  120
+NOTICE:  130
+NOTICE:  140
+NOTICE:  150
+NOTICE:  160
+NOTICE:  170
+NOTICE:  180
+NOTICE:  190
+NOTICE:  200
+drop type range_expr;
+do $$
+begin
+  for i in 10..20
+  loop
+    raise notice 'Scenario 1: %', i ; -- Scenario 1
+  end loop;
+
+  for i in 100 .. 200 by 10
+  loop
+    raise notice 'Scenario 2: %', i; -- Scenario 2
+  end loop;
+end; $$ language plisql;
+NOTICE:  Scenario 1: 10
+NOTICE:  Scenario 1: 11
+NOTICE:  Scenario 1: 12
+NOTICE:  Scenario 1: 13
+NOTICE:  Scenario 1: 14
+NOTICE:  Scenario 1: 15
+NOTICE:  Scenario 1: 16
+NOTICE:  Scenario 1: 17
+NOTICE:  Scenario 1: 18
+NOTICE:  Scenario 1: 19
+NOTICE:  Scenario 1: 20
+NOTICE:  Scenario 2: 100
+NOTICE:  Scenario 2: 110
+NOTICE:  Scenario 2: 120
+NOTICE:  Scenario 2: 130
+NOTICE:  Scenario 2: 140
+NOTICE:  Scenario 2: 150
+NOTICE:  Scenario 2: 160
+NOTICE:  Scenario 2: 170
+NOTICE:  Scenario 2: 180
+NOTICE:  Scenario 2: 190
+NOTICE:  Scenario 2: 200
 -- CONTINUE statement
 create table conttesttbl(idx serial, v integer);
 insert into conttesttbl(v) values(10);

--- a/src/pl/plisql/src/pl_funcs.c
+++ b/src/pl/plisql/src/pl_funcs.c
@@ -547,9 +547,6 @@ free_while(PLiSQL_stmt_while *stmt)
 static void
 free_fori(PLiSQL_stmt_fori *stmt)
 {
-	free_expr(stmt->lower);
-	free_expr(stmt->upper);
-	free_expr(stmt->step);
 	free_stmts(stmt->body);
 }
 
@@ -1077,26 +1074,33 @@ dump_while(PLiSQL_stmt_while *stmt)
 static void
 dump_fori(PLiSQL_stmt_fori *stmt)
 {
-	dump_ind();
-	printf("FORI %s %s\n", stmt->var->refname, (stmt->reverse) ? "REVERSE" : "NORMAL");
+	ListCell   *lc;
 
-	dump_indent += 2;
 	dump_ind();
-	printf("    lower = ");
-	dump_expr(stmt->lower);
-	printf("\n");
-	dump_ind();
-	printf("    upper = ");
-	dump_expr(stmt->upper);
-	printf("\n");
-	if (stmt->step)
+	printf("FORI %s\n", stmt->var->refname);
+	foreach(lc, stmt->inlist)
 	{
+		PLiSQL_fori_in_item *in_item = (PLiSQL_fori_in_item *) lfirst(lc);
+
+		dump_indent += 2;
 		dump_ind();
-		printf("    step = ");
-		dump_expr(stmt->step);
+		printf("    %s", (in_item->reverse) ? "REVERSE" : "NORMAL");
+
+		printf(" lower = ");
+		dump_expr(in_item->lower);
+		printf(" ,");
+		printf(" upper = ");
+		dump_expr(in_item->upper);
+
+		if (in_item->step)
+		{
+			printf(" , ");
+			printf("step = ");
+			dump_expr(in_item->step);
+		}
 		printf("\n");
+		dump_indent -= 2;
 	}
-	dump_indent -= 2;
 
 	dump_stmts(stmt->body);
 

--- a/src/pl/plisql/src/plisql.h
+++ b/src/pl/plisql/src/plisql.h
@@ -675,6 +675,14 @@ typedef struct PLiSQL_stmt_while
 /*
  * FOR statement with integer loopvar
  */
+typedef struct PLiSQL_fori_in_item
+{
+	PLiSQL_expr *lower;
+	PLiSQL_expr *upper;
+	PLiSQL_expr *step;			/* NULL means default (ie, BY 1) */
+	int			reverse;
+}PLiSQL_fori_in_item;
+
 typedef struct PLiSQL_stmt_fori
 {
 	PLiSQL_stmt_type cmd_type;
@@ -682,10 +690,7 @@ typedef struct PLiSQL_stmt_fori
 	unsigned int stmtid;
 	char	   *label;
 	PLiSQL_var *var;
-	PLiSQL_expr *lower;
-	PLiSQL_expr *upper;
-	PLiSQL_expr *step;			/* NULL means default (ie, BY 1) */
-	int			reverse;
+	List	   *inlist;			/* List of in conditions: item see PLiSQL_fori_in_item*/
 	List	   *body;			/* List of statements */
 } PLiSQL_stmt_fori;
 

--- a/src/pl/plisql/src/sql/plisql_control.sql
+++ b/src/pl/plisql/src/sql/plisql_control.sql
@@ -58,6 +58,92 @@ begin
   end loop;
 end$$;
 
+-- Test in condition list
+
+do $$
+declare
+	i int;
+begin
+	for i in 1..3 , 51..55 loop
+		raise notice '%', i;
+	end loop;
+
+  for i in 1..3 , reverse 55..51 loop
+		raise info '%', i;
+	end loop;
+
+	for i in reverse 1..3 loop
+		raise notice '%', i;
+	end loop;
+
+	for i in 1..3 loop
+		raise notice '%', i;
+	end loop;
+
+	for i in reverse 3..1 loop
+		raise notice '%', i;
+	end loop;
+
+	for i in 1..10 by 3 loop
+		raise notice '1..10 by 3: i = %', i;
+	end loop;
+end; $$ language plisql;
+
+do $$
+declare
+   i int := 10;
+begin
+   for i in reverse i+10..i+1 loop
+      raise info '%', i;
+   end loop;
+end; $$ language plisql;
+
+do $$
+declare
+   j int := 10;
+begin
+   for i in 1..3, reverse j+10..j+1 loop
+      raise info '%', i;
+   end loop;
+end; $$ language plisql;
+
+do $$
+declare
+   j int := 10;
+begin
+   for i in reverse j+10..j+1 loop
+      raise info '%', i;
+   end loop;
+end; $$ language plisql;
+
+create type range_expr as (r int4range, s int);
+
+do $$
+declare re range_expr;
+begin
+  foreach re in array ARRAY[('[10, 20]', 1), ('[100, 200]', 10)]
+  loop
+    for i in lower(re.r) .. upper(re.r) by re.s
+    loop
+      raise notice '%', i;
+    end loop;
+  end loop;
+end; $$ language plisql;
+
+drop type range_expr;
+
+do $$
+begin
+  for i in 10..20
+  loop
+    raise notice 'Scenario 1: %', i ; -- Scenario 1
+  end loop;
+
+  for i in 100 .. 200 by 10
+  loop
+    raise notice 'Scenario 2: %', i; -- Scenario 2
+  end loop;
+end; $$ language plisql;
 
 -- CONTINUE statement
 


### PR DESCRIPTION
The in condition in the for loop in Oracle's PL/SQL procedure language is list is supported:

```
ivorysql=# do $$
ivorysql$# declare
ivorysql$#    j int := 10;
ivorysql$# begin
ivorysql$#    for i in 1..3, reverse j+10..j+1 loop
ivorysql$#       raise info '%', i;
ivorysql$#    end loop;
ivorysql$# end; $$ language plisql;
INFO:  1
INFO:  2
INFO:  3
INFO:  20
INFO:  19
INFO:  18
INFO:  17
INFO:  16
INFO:  15
INFO:  14
INFO:  13
INFO:  12
INFO:  11
DO
ivorysql=#
```