### PR TITLE
Support for REVERSE in Oracle PL/SQL

### DIFF
--- a/src/pl/plisql/src/expected/plisql_control.out
+++ b/src/pl/plisql/src/expected/plisql_control.out
@@ -54,6 +54,32 @@ NOTICE:  2147483620..2147483647 by 10: i = 2147483640
 NOTICE:  reverse -2147483620..-2147483647 by 10: i = -2147483620
 NOTICE:  reverse -2147483620..-2147483647 by 10: i = -2147483630
 NOTICE:  reverse -2147483620..-2147483647 by 10: i = -2147483640
+do $$
+begin
+  -- REVERSE
+  for i in reverse 0..10 by 3 loop
+    raise notice 'reverse 0..10 by 3: i = %', i;
+  end loop;
+  -- potential overflow
+  for i in 2147483620..2147483647 by 10 loop
+    raise notice '2147483620..2147483647 by 10: i = %', i;
+  end loop;
+  -- potential overflow, reverse direction
+  for i in reverse -2147483647..-2147483620 by 10 loop
+    raise notice 'reverse -2147483647..-2147483620 by 10: i = %', i;
+  end loop;
+end;
+$$ language plisql;
+NOTICE:  reverse 0..10 by 3: i = 10
+NOTICE:  reverse 0..10 by 3: i = 7
+NOTICE:  reverse 0..10 by 3: i = 4
+NOTICE:  reverse 0..10 by 3: i = 1
+NOTICE:  2147483620..2147483647 by 10: i = 2147483620
+NOTICE:  2147483620..2147483647 by 10: i = 2147483630
+NOTICE:  2147483620..2147483647 by 10: i = 2147483640
+NOTICE:  reverse -2147483647..-2147483620 by 10: i = -2147483620
+NOTICE:  reverse -2147483647..-2147483620 by 10: i = -2147483630
+NOTICE:  reverse -2147483647..-2147483620 by 10: i = -2147483640
 -- BY can't be zero or negative
 do $$
 begin
@@ -261,6 +287,15 @@ NOTICE:  Scenario 2: 170
 NOTICE:  Scenario 2: 180
 NOTICE:  Scenario 2: 190
 NOTICE:  Scenario 2: 200
+do $$
+begin
+  for i in reverse 1..3 by -1 loop
+    raise notice 'reverse 1..3 by -1: i = %', i;
+  end loop;
+end;
+$$ language plisql;
+ERROR:  BY value of FOR loop must be greater than zero
+CONTEXT:  PL/iSQL function inline_code_block line 3 at FOR with integer loop variable
 -- CONTINUE statement
 create table conttesttbl(idx serial, v integer);
 insert into conttesttbl(v) values(10);

--- a/src/pl/plisql/src/expected/plisql_control.out
+++ b/src/pl/plisql/src/expected/plisql_control.out
@@ -114,7 +114,7 @@ begin
 		raise notice '%', i;
 	end loop;
 
-  for i in 1..3 , reverse 55..51 loop
+  for i in 1..3 , reverse 51..55 loop
 		raise info '%', i;
 	end loop;
 
@@ -123,10 +123,6 @@ begin
 	end loop;
 
 	for i in 1..3 loop
-		raise notice '%', i;
-	end loop;
-
-	for i in reverse 3..1 loop
 		raise notice '%', i;
 	end loop;
 
@@ -150,12 +146,12 @@ INFO:  54
 INFO:  53
 INFO:  52
 INFO:  51
-NOTICE:  1
-NOTICE:  2
-NOTICE:  3
 NOTICE:  3
 NOTICE:  2
 NOTICE:  1
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
 NOTICE:  1..10 by 3: i = 1
 NOTICE:  1..10 by 3: i = 4
 NOTICE:  1..10 by 3: i = 7
@@ -164,7 +160,7 @@ do $$
 declare
    i int := 10;
 begin
-   for i in reverse i+10..i+1 loop
+   for i in reverse i+1..i+10 loop
       raise info '%', i;
    end loop;
 end; $$ language plisql;
@@ -182,7 +178,7 @@ do $$
 declare
    j int := 10;
 begin
-   for i in 1..3, reverse j+10..j+1 loop
+   for i in 1..3, reverse j+1..j+10 loop
       raise info '%', i;
    end loop;
 end; $$ language plisql;
@@ -203,7 +199,7 @@ do $$
 declare
    j int := 10;
 begin
-   for i in reverse j+10..j+1 loop
+   for i in reverse j+1..j+10 loop
       raise info '%', i;
    end loop;
 end; $$ language plisql;

--- a/src/pl/plisql/src/pl_gram.y
+++ b/src/pl/plisql/src/pl_gram.y
@@ -1820,6 +1820,16 @@ for_control		: for_variable K_IN
 										in_item->reverse = firstflag ? reverse : reverseflag;
 										in_item->lower = expr1;
 										in_item->upper = expr2;
+										if(in_item->reverse)
+										{
+											in_item->lower	  = expr2;
+											in_item->upper	  = expr1;
+										}
+										else
+										{
+											in_item->lower	  = expr1;
+											in_item->upper	  = expr2;
+										}
 										in_item->step = expr_by;
 										firstflag = false;
 
@@ -1868,18 +1878,6 @@ for_control		: for_variable K_IN
 
 								new->stmtid	  = ++plisql_curr_compile->nstatements;
 								new->var	  = fvar;
-								new->reverse  = reverse;
-								if(reverse)
-								{
-									new->lower	  = expr2;
-									new->upper	  = expr1;
-								}
-								else
-								{
-									new->lower	  = expr1;
-									new->upper	  = expr2;
-								}
-								new->step	  = expr_by;
 
 								$$ = (PLiSQL_stmt *) new;
 							}

--- a/src/pl/plisql/src/pl_gram.y
+++ b/src/pl/plisql/src/pl_gram.y
@@ -1868,6 +1868,18 @@ for_control		: for_variable K_IN
 
 								new->stmtid	  = ++plisql_curr_compile->nstatements;
 								new->var	  = fvar;
+								new->reverse  = reverse;
+								if(reverse)
+								{
+									new->lower	  = expr2;
+									new->upper	  = expr1;
+								}
+								else
+								{
+									new->lower	  = expr1;
+									new->upper	  = expr2;
+								}
+								new->step	  = expr_by;
 
 								$$ = (PLiSQL_stmt *) new;
 							}

--- a/src/pl/plisql/src/sql/plisql_control.sql
+++ b/src/pl/plisql/src/sql/plisql_control.sql
@@ -85,7 +85,7 @@ begin
 		raise notice '%', i;
 	end loop;
 
-  for i in 1..3 , reverse 55..51 loop
+  for i in 1..3 , reverse 51..55 loop
 		raise info '%', i;
 	end loop;
 
@@ -94,10 +94,6 @@ begin
 	end loop;
 
 	for i in 1..3 loop
-		raise notice '%', i;
-	end loop;
-
-	for i in reverse 3..1 loop
 		raise notice '%', i;
 	end loop;
 
@@ -110,7 +106,7 @@ do $$
 declare
    i int := 10;
 begin
-   for i in reverse i+10..i+1 loop
+   for i in reverse i+1..i+10 loop
       raise info '%', i;
    end loop;
 end; $$ language plisql;
@@ -119,7 +115,7 @@ do $$
 declare
    j int := 10;
 begin
-   for i in 1..3, reverse j+10..j+1 loop
+   for i in 1..3, reverse j+1..j+10 loop
       raise info '%', i;
    end loop;
 end; $$ language plisql;
@@ -128,7 +124,7 @@ do $$
 declare
    j int := 10;
 begin
-   for i in reverse j+10..j+1 loop
+   for i in reverse j+1..j+10 loop
       raise info '%', i;
    end loop;
 end; $$ language plisql;

--- a/src/pl/plisql/src/sql/plisql_control.sql
+++ b/src/pl/plisql/src/sql/plisql_control.sql
@@ -36,6 +36,23 @@ begin
   end loop;
 end$$;
 
+do $$
+begin
+  -- REVERSE
+  for i in reverse 0..10 by 3 loop
+    raise notice 'reverse 0..10 by 3: i = %', i;
+  end loop;
+  -- potential overflow
+  for i in 2147483620..2147483647 by 10 loop
+    raise notice '2147483620..2147483647 by 10: i = %', i;
+  end loop;
+  -- potential overflow, reverse direction
+  for i in reverse -2147483647..-2147483620 by 10 loop
+    raise notice 'reverse -2147483647..-2147483620 by 10: i = %', i;
+  end loop;
+end;
+$$ language plisql;
+
 -- BY can't be zero or negative
 do $$
 begin
@@ -144,6 +161,13 @@ begin
     raise notice 'Scenario 2: %', i; -- Scenario 2
   end loop;
 end; $$ language plisql;
+do $$
+begin
+  for i in reverse 1..3 by -1 loop
+    raise notice 'reverse 1..3 by -1: i = %', i;
+  end loop;
+end;
+$$ language plisql;
 
 -- CONTINUE statement
 


### PR DESCRIPTION
## REVERSE in Oracle PL/SQL:

![image](https://user-images.githubusercontent.com/49380232/217817640-3a71aba8-84af-412d-815c-7385e8c7ca93.png)

---


## REVERSE in PL/pgSQL:

```
ivorysql=# do $$
ivorysql$# BEGIN
ivorysql$#    FOR i IN REVERSE 3..1 LOOP
ivorysql$#       raise info '%',i;
ivorysql$#    END LOOP;
ivorysql$#    
ivorysql$#    FOR i IN 1..3 LOOP
ivorysql$#       raise info '%',i;
ivorysql$#    END LOOP;
ivorysql$# END;
ivorysql$# $$ language plpgsql;
INFO:  3
INFO:  2
INFO:  1
INFO:  1
INFO:  2
INFO:  3
DO
ivorysql=#
```
