### PR TITLE
IvorySQL:calculates strings using bytes instead of characters

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2686,6 +2686,183 @@ SELECT to_number(12.34) from dual;
 -----------
  12.34
 (1 row)
+
+/*
+ * instrb
+ */
+select instrb(1, 1) from dual;
+ instrb 
+--------
+      1
+(1 row)
+
+select instrb('a', 1) from dual;
+ instrb 
+--------
+      0
+(1 row)
+
+SELECT instrb(20121209, cast(12 as int), cast(1 as text), 2, 4) "instrb" FROM DUAL; --err
+ERROR:  function instrb(integer, integer, text, integer, integer) does not exist
+LINE 1: SELECT instrb(20121209, cast(12 as int), cast(1 as text), 2,...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT instrb(20121209, cast(12 as int), cast(1 as varchar2), '2') "instrb" FROM DUAL;
+ instrb 
+--------
+      5
+(1 row)
+
+SELECT instrb(20121209, cast(12 as int), cast(1 as text), 2, '4', 5) "instrb" FROM DUAL; --err
+ERROR:  function instrb(integer, integer, text, integer, unknown, integer) does not exist
+LINE 1: SELECT instrb(20121209, cast(12 as int), cast(1 as text), 2,...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT instrb(20121209) "instrb" FROM DUAL;
+ERROR:  function instrb(integer) does not exist
+LINE 1: SELECT instrb(20121209) "instrb" FROM DUAL;
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT instrb(20121209,12, 1, 2) "instrb" FROM DUAL;
+ instrb 
+--------
+      5
+(1 row)
+
+SELECT instrb(20121209,12, 1) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(20121209,12) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(cast(2012 as int2), cast(12 as int2), cast(1 as int2), cast(2 as int2)) "instrb" FROM DUAL;
+ instrb 
+--------
+      0
+(1 row)
+
+SELECT instrb(cast(2012 as int2), cast(12 as int2), cast(1 as int2)) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(cast(2012 as int2), cast(12 as int2)) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(cast(20121209 as int), cast(12 as int), cast(1.9 as int), cast(2.99 as int)) "instrb" FROM DUAL;
+ instrb 
+--------
+      0
+(1 row)
+
+SELECT instrb(cast(20121209 as int), cast(12 as int), cast(1.9 as int)) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(cast(20121209 as int), cast(12 as int)) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(cast(20121212 as int8), cast(1212 as int8), cast(1.9 as int8), cast(1.99 as int8)) "instrb" FROM DUAL;
+ instrb 
+--------
+      5
+(1 row)
+
+SELECT instrb(cast(20121212 as int8), cast(1212 as int8), cast(1.9 as int8)) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(cast(20121212 as int8), cast(1212 as int8)) "instrb" FROM DUAL;
+ instrb 
+--------
+      3
+(1 row)
+
+SELECT instrb(cast(201212.09 as int),cast(12.9 as int), cast(1.9 as numeric), 2.99::numeric) "instrb" FROM DUAL;
+ instrb 
+--------
+      0
+(1 row)
+
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric), cast(1.9 as int), cast(1.99 as int)) "instrb" FROM DUAL;
+ instrb 
+--------
+      0
+(1 row)
+
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric), cast(1.9 as numeric), cast(1.99 as numeric)) "instrb" FROM DUAL;
+ instrb 
+--------
+      5
+(1 row)
+
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric), cast(1.9 as numeric)) "instrb" FROM DUAL;
+ instrb 
+--------
+      5
+(1 row)
+
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric)) "instrb" FROM DUAL;
+ instrb 
+--------
+      5
+(1 row)
+
+SELECT instrb(null,null,null,null) FROM DUAL;
+ instrb 
+--------
+       
+(1 row)
+
+SELECT instrb(null,null,null) FROM DUAL;
+ instrb 
+--------
+       
+(1 row)
+
+SELECT instrb(null,null) FROM DUAL;
+ instrb 
+--------
+       
+(1 row)
+
+select instrb(1, 1) from dual;
+ instrb 
+--------
+      1
+(1 row)
+
+select instrb('a', 1) from dual;
+ instrb 
+--------
+      0
+(1 row)
+
+reset nls_timestamp_format;
+reset nls_date_format;
+select instrb(cast('2022-09-27' as date), 2) from dual;
+ instrb 
+--------
+      1
+(1 row)
+
 /*
  * decode
  */

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1028,6 +1028,44 @@ select to_number('1.1,2,6,7,8', '9999,99,99,9,999') from dual; --error
 select to_number('1.1,2,6,77,8', '9999,99,99,9,999') from dual; --error
 select to_number(123) from dual;
 SELECT to_number(12.34) from dual;
+
+/*
+ * instrb
+ */
+select instrb(1, 1) from dual;
+select instrb('a', 1) from dual;
+SELECT instrb(20121209, cast(12 as int), cast(1 as text), 2, 4) "instrb" FROM DUAL; --err
+SELECT instrb(20121209, cast(12 as int), cast(1 as varchar2), '2') "instrb" FROM DUAL;
+SELECT instrb(20121209, cast(12 as int), cast(1 as text), 2, '4', 5) "instrb" FROM DUAL; --err
+SELECT instrb(20121209) "instrb" FROM DUAL;
+SELECT instrb(20121209,12, 1, 2) "instrb" FROM DUAL;
+SELECT instrb(20121209,12, 1) "instrb" FROM DUAL;
+SELECT instrb(20121209,12) "instrb" FROM DUAL;
+SELECT instrb(cast(2012 as int2), cast(12 as int2), cast(1 as int2), cast(2 as int2)) "instrb" FROM DUAL;
+SELECT instrb(cast(2012 as int2), cast(12 as int2), cast(1 as int2)) "instrb" FROM DUAL;
+SELECT instrb(cast(2012 as int2), cast(12 as int2)) "instrb" FROM DUAL;
+SELECT instrb(cast(20121209 as int), cast(12 as int), cast(1.9 as int), cast(2.99 as int)) "instrb" FROM DUAL;
+SELECT instrb(cast(20121209 as int), cast(12 as int), cast(1.9 as int)) "instrb" FROM DUAL;
+SELECT instrb(cast(20121209 as int), cast(12 as int)) "instrb" FROM DUAL;
+SELECT instrb(cast(20121212 as int8), cast(1212 as int8), cast(1.9 as int8), cast(1.99 as int8)) "instrb" FROM DUAL;
+SELECT instrb(cast(20121212 as int8), cast(1212 as int8), cast(1.9 as int8)) "instrb" FROM DUAL;
+SELECT instrb(cast(20121212 as int8), cast(1212 as int8)) "instrb" FROM DUAL;
+SELECT instrb(cast(201212.09 as int),cast(12.9 as int), cast(1.9 as numeric), 2.99::numeric) "instrb" FROM DUAL;
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric), cast(1.9 as int), cast(1.99 as int)) "instrb" FROM DUAL;
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric), cast(1.9 as numeric), cast(1.99 as numeric)) "instrb" FROM DUAL;
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric), cast(1.9 as numeric)) "instrb" FROM DUAL;
+SELECT instrb(cast(201212.12 as numeric),cast(12.12 as numeric)) "instrb" FROM DUAL;
+SELECT instrb(null,null,null,null) FROM DUAL;
+SELECT instrb(null,null,null) FROM DUAL;
+SELECT instrb(null,null) FROM DUAL;
+select instrb(1, 1) from dual;
+select instrb('a', 1) from dual;
+
+reset nls_timestamp_format;
+reset nls_date_format;
+
+select instrb(cast('2022-09-27' as date), 2) from dual;
+
 /*
  * decode
  */

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -330,7 +330,7 @@ AS 'MODULE_PATHNAME','ora_replace'
 LANGUAGE C
 IMMUTABLE;
 
-CREATE FUNCTION sys.instrb(varchar, text, number default 1, number default 1)
+CREATE FUNCTION sys.instrb(varchar2, varchar2, number default 1, number default 1)
 RETURNS int
 AS 'MODULE_PATHNAME','ora_instrb'
 LANGUAGE C

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -997,8 +997,8 @@ ora_instrb(PG_FUNCTION_ARGS)
 {
 	text	*str = NULL;
 	text	*search_str = NULL;
-	int32	position = DatumGetInt32(DirectFunctionCall1(numeric_int4, PG_GETARG_DATUM(2)));
-	int32	occurrence = DatumGetInt32(DirectFunctionCall1(numeric_int4, PG_GETARG_DATUM(3)));
+	int32	position = DatumGetInt32(DirectFunctionCall1(numeric_int4, DirectFunctionCall2(numeric_trunc, PG_GETARG_DATUM(2),Int32GetDatum(0))));
+	int32	occurrence = DatumGetInt32(DirectFunctionCall1(numeric_int4, DirectFunctionCall2(numeric_trunc, PG_GETARG_DATUM(3),Int32GetDatum(0))));
 
 	if (position == 0)
 		PG_RETURN_INT32(0);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated the `sys.instrb` function signature in `builtin_functions--1.0.sql` to use `varchar2` data type for the first two parameters, improving compatibility.
- Refactor: Modified the `ora_instrb` function in `character_datatype_functions.c` to truncate decimal parts of input values before conversion to integers, ensuring accurate position and occurrence calculations.
- Chore: Added new SQL queries in `ora_character_datatype_functions.sql` and `ora_character_datatype_functions.out` for testing purposes, including error scenarios and explicit value conversions using `cast`.
- Chore: Reset `nls_timestamp_format` and `nls_date_format` settings in test queries to ensure consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->