### PR TITLE
IvorySQL:'merge into' include custom function error

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_merge.out
+++ b/contrib/ivorysql_ora/expected/ora_merge.out
@@ -511,3 +511,55 @@ WHEN MATCHED THEN
 ERROR:  specified row no longer exists
 drop table target;
 drop table source;
+CREATE TABLE wq_target_TIMU048170046 (tid integer not null, balance integer DEFAULT -1);
+CREATE TABLE wq_source_TIMU048170046 (balance integer, sid integer);
+INSERT INTO wq_source_TIMU048170046 (sid, balance) VALUES (1, 100);
+select * from wq_target_TIMU048170046;
+ tid | balance 
+-----+---------
+(0 rows)
+
+select * from wq_source_TIMU048170046;
+ balance | sid 
+---------+-----
+     100 |   1
+(1 row)
+
+create or replace function merge_when_and_write_TIMU048170046(bflag int)
+RETURN int
+IS
+BEGIN
+    IF bflag <10 then
+        RETURN 1;
+    ELSE
+        RETURN 0;
+    END IF;
+    ROLLBACK;
+END;
+/
+MERGE INTO wq_target_TIMU048170046 t
+USING wq_source_TIMU048170046 s ON (t.tid = s.sid)
+WHEN MATCHED THEN
+UPDATE SET balance = t.balance + s.balance
+  WHERE merge_when_and_write_TIMU048170046(8)=1;
+MERGE INTO wq_source_TIMU048170046 t
+USING wq_source_TIMU048170046 s ON (t.ctid = s.ctid)
+WHEN MATCHED THEN
+ UPDATE SET ctid = s.ctid;
+ERROR:  cannot assign to system column "ctid"
+LINE 4:  UPDATE SET ctid = s.ctid;
+                    ^
+INSERT INTO wq_target_TIMU048170046 (tid, balance) VALUES (1, 100);
+MERGE INTO wq_target_TIMU048170046 t
+USING wq_target_TIMU048170046 s ON (t.ctid = s.ctid)
+WHEN MATCHED THEN
+ UPDATE SET balance = t.balance + s.balance;
+select * from wq_target_TIMU048170046;
+ tid | balance 
+-----+---------
+   1 |     200
+(1 row)
+
+DROP function merge_when_and_write_TIMU048170046;
+DROP table wq_target_TIMU048170046;
+DROP table wq_source_TIMU048170046;

--- a/contrib/ivorysql_ora/sql/ora_merge.sql
+++ b/contrib/ivorysql_ora/sql/ora_merge.sql
@@ -431,3 +431,48 @@ WHEN MATCHED THEN
 
 drop table target;
 drop table source;
+
+CREATE TABLE wq_target_TIMU048170046 (tid integer not null, balance integer DEFAULT -1);
+CREATE TABLE wq_source_TIMU048170046 (balance integer, sid integer);
+
+INSERT INTO wq_source_TIMU048170046 (sid, balance) VALUES (1, 100);
+
+select * from wq_target_TIMU048170046;
+select * from wq_source_TIMU048170046;
+
+create or replace function merge_when_and_write_TIMU048170046(bflag int)
+RETURN int
+IS
+BEGIN
+    IF bflag <10 then
+        RETURN 1;
+    ELSE
+        RETURN 0;
+    END IF;
+    ROLLBACK;
+END;
+/
+
+MERGE INTO wq_target_TIMU048170046 t
+USING wq_source_TIMU048170046 s ON (t.tid = s.sid)
+WHEN MATCHED THEN
+UPDATE SET balance = t.balance + s.balance
+  WHERE merge_when_and_write_TIMU048170046(8)=1;
+
+MERGE INTO wq_source_TIMU048170046 t
+USING wq_source_TIMU048170046 s ON (t.ctid = s.ctid)
+WHEN MATCHED THEN
+ UPDATE SET ctid = s.ctid;
+
+
+INSERT INTO wq_target_TIMU048170046 (tid, balance) VALUES (1, 100);
+
+MERGE INTO wq_target_TIMU048170046 t
+USING wq_target_TIMU048170046 s ON (t.ctid = s.ctid)
+WHEN MATCHED THEN
+ UPDATE SET balance = t.balance + s.balance;
+
+select * from wq_target_TIMU048170046;
+DROP function merge_when_and_write_TIMU048170046;
+DROP table wq_target_TIMU048170046;
+DROP table wq_source_TIMU048170046;

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -253,6 +253,8 @@ struct ParseState
 	CoerceParamHook p_coerce_param_hook;
 	ParseSubprocFuncHook p_subprocfunc_hook;
 	void	   *p_ref_hook_state;	/* common passthrough link for above */
+	uint16	    merge_on_attr_size;
+	uint8 	   *merge_on_attrno;
 };
 
 /*


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a new function `merge_when_and_write_TIMU048170046` to handle conditional updates in the `wq_target_TIMU048170046` table.
- Bug Fix: Updated error message to include column name when columns referenced in the ON clause are updated, improving debuggability.
- Refactor: Replaced `pull_var_clause` with a `foreach` loop for better iteration over `action->targetList`.
- New Feature: Added inline function `set_merge_on_attrno` to track columns used in join conditions, enhancing query optimization.
- Refactor: Extended `ParseState` struct with two new fields `merge_on_attr_size` and `merge_on_attrno` to support tracking of columns used in join conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->