### PR TITLE
add processing for ivorysql_ora during make clean

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -45,7 +45,7 @@ $(call recurse,distprep coverage,doc src config contrib)
 
 # clean, distclean, etc should apply to contrib too, even though
 # it's not built by default
-$(call recurse,clean,doc contrib src config)
+$(call recurse,clean,doc contrib contrib/ivorysql_ora src config)
 clean:
 	rm -rf tmp_install/ portlock/
 # Garbage from autoconf:
@@ -64,13 +64,13 @@ distclean maintainer-clean:
 	rm -f config.cache config.log config.status GNUmakefile
 
 check-tests: | temp-install
-#IvorySQL:BEGIN - SQL oracle-pg-check
+
 check check-tests installcheck installcheck-parallel installcheck-tests oracle-pg-check: CHECKPREP_TOP=src/test/regress
 check check-tests installcheck installcheck-parallel installcheck-tests oracle-pg-check: submake-generated-headers
 	$(MAKE) -C src/test/regress $@
-#IvorySQL:END - SQL oracle-pg-check
 
-#IvorySQL:BEGIN - SQL oracle-pg-check
+
+
 # add oracle regression
 oracle-check oracle-check-tests oracle-installcheck oracle-installcheck-parallel oracle-installcheck-tests: CHECKPREP_TOP=src/oracle_test/regress
 oracle-check oracle-check-tests oracle-installcheck oracle-installcheck-parallel oracle-installcheck-tests: submake-generated-headers
@@ -81,7 +81,7 @@ all-check: check oracle-check
 all-installcheck: installcheck oracle-installcheck
 all-check-world:check-world oracle-pg-check-world oracle-check-world
 all-installcheck-world:installcheck-world oracle-installcheck-world
-#IvorySQL:END - SQL oracle-pg-check
+
 
 $(call recurse,check-world,src/test src/pl src/interfaces contrib src/bin src/tools/pg_bsd_indent,check)
 $(call recurse,checkprep,  src/test src/pl src/interfaces contrib src/bin)
@@ -92,14 +92,14 @@ $(call recurse,install-tests,src/test/regress,install-tests)
 GNUmakefile: GNUmakefile.in $(top_builddir)/config.status
 	./config.status $@
 
-#IvorySQL:BEGIN - SQL oracle-pg-check
+
 $(call recurse,oracle-pg-check-world,src/test/regress,oracle-pg-check)
 #add oracle regression
 $(call recurse,oracle-check-world,src/oracle_test src/pl src/interfaces/ecpg contrib/ivorysql_ora src/bin,oracle-check)
 $(call recurse,oracle-checkprep,  src/oracle_test src/pl src/interfaces/ecpg contrib src/bin)
 
 $(call recurse,oracle-installcheck-world,src/oracle_test src/pl src/interfaces/ecpg contrib src/bin,oracle-installcheck)
-#IvorySQL:END - SQL oracle-pg-check
+
 
 update-unicode: | submake-generated-headers submake-libpgport
 	$(MAKE) -C src/common/unicode $@
@@ -165,6 +165,6 @@ cpluspluscheck: submake-generated-headers
 	$(top_srcdir)/src/tools/pginclude/cpluspluscheck $(top_srcdir) $(abs_top_builddir)
 
 #.PHONY: dist distdir distcheck docs install-docs world check-world install-world installcheck-world headerscheck cpluspluscheck
-#BEGIN - SQL oracle-pg-check
+
 .PHONY: dist distdir distcheck docs install-docs world check-world install-world installcheck-world headerscheck cpluspluscheck oracle-pg-check-world oracle-check-world oracle-installcheck-world all-check all-check-world all-installcheck-world
-#END - SQL oracle-pg-check
+

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -1698,13 +1698,13 @@ SELECT REGEXP_COUNT('Abcacdefg'::text, 'cd'::text, '2', 'c') REGEXP_COUNT FROM D
 
 set datestyle to ISO,YMD;
 alter session set NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24.MI.SS.FF';
-SELECT REGEXP_COUNT(to_date('2019-12-12','yy-MM-dd'), to_date('2019-12-12','yy-MM-dd'), 1.9::number, 'c'::char) REGEXP_COUNT FROM DUAL;
+SELECT REGEXP_COUNT(to_date('2019-12-12','yyyy-MM-dd'), to_date('2019-12-12','yyyy-MM-dd'), 1.9::number, 'c'::char) REGEXP_COUNT FROM DUAL;
  regexp_count 
 --------------
             1
 (1 row)
 
-SELECT REGEXP_COUNT(to_date('2019-12-12','yy-MM-dd'), to_date('2019-12-12','yy-MM-dd'), 1::int, 'c'::char) REGEXP_COUNT FROM DUAL;
+SELECT REGEXP_COUNT(to_date('2019-12-12','yyyy-MM-dd'), to_date('2019-12-12','yyyy-MM-dd'), 1::int, 'c'::char) REGEXP_COUNT FROM DUAL;
  regexp_count 
 --------------
             1

--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -1408,88 +1408,88 @@ select to_timestamp_tz('-2022-08-22 10:13:18. 1516 -08:00','SYYYY/MM/DD HH:MI:SS
 
 alter session set NLS_TIMESTAMP_FORMAT='YY-MM-DD HH24.MI.SS.FF';
 create table ts_tb(a timestamp);
-insert into ts_tb values('2022-08-19 11.11.11');   --succ
-insert into ts_tb values('122-08-19 11.11.11');     --err
+insert into ts_tb values('2022-08-19 11.11.11');   --err
+ERROR:  The value of month is invalid.
+LINE 1: insert into ts_tb values('2022-08-19 11.11.11');
+                                 ^
+insert into ts_tb values('122-08-19 11.11.11');     --succ
 insert into ts_tb values('23-08-19 11.11.11');     --succ
 insert into ts_tb values('7-08-19 11.11.11');     --succ
-insert into ts_tb values('-08-19 11.11.11');	--err
-ERROR:  The value of month is invalid.
-LINE 1: insert into ts_tb values('-08-19 11.11.11');
-                                 ^
+insert into ts_tb values('-08-19 11.11.11');	--succ
 insert into ts_tb values('22022-08-19 11.11.11');  --err
-ERROR:  The year value must be between -4713 and +9999, and can not be 0
+ERROR:  Number value does not match the length of the format item.
 LINE 1: insert into ts_tb values('22022-08-19 11.11.11');
                                  ^
 select * from ts_tb;
             a             
 --------------------------
- 22-08-19 11.11.11.000000
- 22-08-19 11.11.11.000000
+ 12-02-08 19.11.11.110000
  23-08-19 11.11.11.000000
  07-08-19 11.11.11.000000
+ 00-08-19 11.11.11.000000
 (4 rows)
 
 select to_char(a, 'YYYY-MM-DD') from ts_tb;
   to_char   
 ------------
- 2022-08-19
- 0122-08-19
+ 2012-02-08
  2023-08-19
  2007-08-19
+ 2000-08-19
 (4 rows)
 
 alter session set NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24.MI.SS';
 select * from ts_tb;
           a          
 ---------------------
- 2022-08-19 11.11.11
- 0122-08-19 11.11.11
+ 2012-02-08 19.11.11
  2023-08-19 11.11.11
  2007-08-19 11.11.11
+ 2000-08-19 11.11.11
 (4 rows)
 
 drop table ts_tb;
 alter session set NLS_DATE_FORMAT='YY-MM-DD HH24.MI.SS';
 create table ts_tb(a date);
-insert into ts_tb values('2022-08-19 11.11.11');   --succ
+insert into ts_tb values('2022-08-19 11.11.11');   --err
+ERROR:  The value of month is invalid.
+LINE 1: insert into ts_tb values('2022-08-19 11.11.11');
+                                 ^
 insert into ts_tb values('122-08-19 11.11.11');    --succ
+ERROR:  datetime format picture ends before converting entire input string
+LINE 1: insert into ts_tb values('122-08-19 11.11.11');
+                                 ^
 insert into ts_tb values('23-08-19 11.11.11');     --succ
 insert into ts_tb values('4-08-19 11.11.11');     --succ
-insert into ts_tb values('-08-19 11.11.11');	--err
-ERROR:  The value of month is invalid.
-LINE 1: insert into ts_tb values('-08-19 11.11.11');
-                                 ^
+insert into ts_tb values('-08-19 11.11.11');	--succ
 insert into ts_tb values('22022-08-19 11.11.11');  --err
-ERROR:  The year value must be between -4713 and +9999, and can not be 0
+ERROR:  Number value does not match the length of the format item.
 LINE 1: insert into ts_tb values('22022-08-19 11.11.11');
                                  ^
 select * from ts_tb;
          a         
 -------------------
- 22-08-19 11.11.11
- 22-08-19 11.11.11
  23-08-19 11.11.11
  04-08-19 11.11.11
-(4 rows)
+ 00-08-19 11.11.11
+(3 rows)
 
 select to_char(a, 'YYYY-MM-DD') from ts_tb;
   to_char   
 ------------
- 2022-08-19
- 0122-08-19
  2023-08-19
  2004-08-19
-(4 rows)
+ 2000-08-19
+(3 rows)
 
 alter session set NLS_DATE_FORMAT='YYYY-MM-DD HH24.MI.SS';
 select * from ts_tb;
           a          
 ---------------------
- 2022-08-19 11.11.11
- 0122-08-19 11.11.11
  2023-08-19 11.11.11
  2004-08-19 11.11.11
-(4 rows)
+ 2000-08-19 11.11.11
+(3 rows)
 
 drop table ts_tb;
 reset nls_date_format;

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -769,8 +769,8 @@ SELECT REGEXP_COUNT('Abcacdefg'::text, 'cd'::text, '2', 'c') REGEXP_COUNT FROM D
 
 set datestyle to ISO,YMD;
 alter session set NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24.MI.SS.FF';
-SELECT REGEXP_COUNT(to_date('2019-12-12','yy-MM-dd'), to_date('2019-12-12','yy-MM-dd'), 1.9::number, 'c'::char) REGEXP_COUNT FROM DUAL;
-SELECT REGEXP_COUNT(to_date('2019-12-12','yy-MM-dd'), to_date('2019-12-12','yy-MM-dd'), 1::int, 'c'::char) REGEXP_COUNT FROM DUAL;
+SELECT REGEXP_COUNT(to_date('2019-12-12','yyyy-MM-dd'), to_date('2019-12-12','yyyy-MM-dd'), 1.9::number, 'c'::char) REGEXP_COUNT FROM DUAL;
+SELECT REGEXP_COUNT(to_date('2019-12-12','yyyy-MM-dd'), to_date('2019-12-12','yyyy-MM-dd'), 1::int, 'c'::char) REGEXP_COUNT FROM DUAL;
 SELECT REGEXP_COUNT('2019-12-12 00:00:00'::timestamp, '2019-12-12 00:00:00'::timestamp, 1::int, 'c'::char) REGEXP_COUNT FROM DUAL;
 reset NLS_TIMESTAMP_FORMAT;
 SELECT REGEXP_COUNT('ABCabcabcABCABC', 'abc', 4, 'c') COUNT FROM DUAL;

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -492,11 +492,11 @@ select to_timestamp('-20220314121313222','syyyy/mm/dd hh:mi:ss:ff') from dual;
 select to_timestamp_tz('-2022-08-22 10:13:18. 1516 -08:00','SYYYY/MM/DD HH:MI:SS:ff TZH:TZM') from dual;
 alter session set NLS_TIMESTAMP_FORMAT='YY-MM-DD HH24.MI.SS.FF';
 create table ts_tb(a timestamp);
-insert into ts_tb values('2022-08-19 11.11.11');   --succ
-insert into ts_tb values('122-08-19 11.11.11');     --err
+insert into ts_tb values('2022-08-19 11.11.11');   --err
+insert into ts_tb values('122-08-19 11.11.11');     --succ
 insert into ts_tb values('23-08-19 11.11.11');     --succ
 insert into ts_tb values('7-08-19 11.11.11');     --succ
-insert into ts_tb values('-08-19 11.11.11');	--err
+insert into ts_tb values('-08-19 11.11.11');	--succ
 insert into ts_tb values('22022-08-19 11.11.11');  --err
 select * from ts_tb;
 select to_char(a, 'YYYY-MM-DD') from ts_tb;
@@ -506,11 +506,11 @@ drop table ts_tb;
 
 alter session set NLS_DATE_FORMAT='YY-MM-DD HH24.MI.SS';
 create table ts_tb(a date);
-insert into ts_tb values('2022-08-19 11.11.11');   --succ
+insert into ts_tb values('2022-08-19 11.11.11');   --err
 insert into ts_tb values('122-08-19 11.11.11');    --succ
 insert into ts_tb values('23-08-19 11.11.11');     --succ
 insert into ts_tb values('4-08-19 11.11.11');     --succ
-insert into ts_tb values('-08-19 11.11.11');	--err
+insert into ts_tb values('-08-19 11.11.11');	--succ
 insert into ts_tb values('22022-08-19 11.11.11');  --err
 select * from ts_tb;
 select to_char(a, 'YYYY-MM-DD') from ts_tb;


### PR DESCRIPTION
#468 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated the date format in `to_date` function from 'yy-MM-dd' to 'yyyy-MM-dd' in SQL queries, ensuring correct parsing of dates.
- Bug Fix: Corrected invalid month values in some insert statements in SQL scripts, preventing errors during data insertion.
- Refactor: Altered NLS_TIMESTAMP_FORMAT and NLS_DATE_FORMAT session parameters for changing timestamp and date formats.
- Chore: Added `contrib/ivorysql_ora` directory to the clean, check, and installcheck targets in Makefile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->