### PR TITLE
IvorySQL:When the year in the time format is RR, the data processing for the year exceeding 2 digits is inconsistent with oracle

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -1754,3 +1754,83 @@ drop table timestp_tb;
 reset nls_date_format;
 reset nls_timestamp_format;
 reset nls_timestamp_tz_format;
+alter session set NLS_TIMESTAMP_FORMAT='RR-MM-DD HH24.MI.SS.FF';
+create table timestp_tb(timestp_clo timestamp);
+INSERT INTO timestp_tb VALUES('2022-08-19 11.11.11');   --succ  22-08-19 11.11.11.000000
+insert into timestp_tb values('122-08-19 11.11.11');  --succ  22-08-19 11.11.11
+select * from timestp_tb;
+       timestp_clo        
+--------------------------
+ 22-08-19 11.11.11.000000
+ 22-08-19 11.11.11.000000
+(2 rows)
+
+alter session set NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24.MI.SS.FF';
+select * from timestp_tb;
+        timestp_clo         
+----------------------------
+ 2022-08-19 11.11.11.000000
+ 0122-08-19 11.11.11.000000
+(2 rows)
+
+drop table timestp_tb;
+alter session set NLS_TIMESTAMP_TZ_FORMAT='RR-MM-DD HH24.MI.SS.FF TZH:TZM';
+create table timestpwtz_tb(timestp_clo timestamp with time zone);
+INSERT INTO timestpwtz_tb VALUES('2022-08-19 11.11.11'); 
+insert into timestpwtz_tb values('122-08-19 11.11.11');
+select * from timestpwtz_tb;
+           timestp_clo           
+---------------------------------
+ 22-08-19 11.11.11.000000 +08:00
+ 22-08-19 11.11.11.000000 +07:36
+(2 rows)
+
+alter session set NLS_TIMESTAMP_TZ_FORMAT='YYYY-MM-DD HH24.MI.SS.FF TZH:TZM';
+select * from timestpwtz_tb;
+            timestp_clo            
+-----------------------------------
+ 2022-08-19 11.11.11.000000 +08:00
+ 0122-08-19 11.11.11.000000 +07:36
+(2 rows)
+
+drop table timestpwtz_tb;
+alter session set NLS_TIMESTAMP_FORMAT='RR-MM-DD HH24.MI.SS.FF';
+create table timestpwltz_tb(timestp_clo timestamp with local time zone);
+INSERT INTO timestpwltz_tb VALUES('2022-08-19 11.11.11'); 
+insert into timestpwltz_tb values('122-08-19 11.11.11');
+select * from timestpwltz_tb;
+       timestp_clo        
+--------------------------
+ 22-08-19 11.11.11.000000
+ 22-08-19 11.11.11.000000
+(2 rows)
+
+alter session set NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24.MI.SS.FF';
+select * from timestpwltz_tb;
+        timestp_clo         
+----------------------------
+ 2022-08-19 11.11.11.000000
+ 0122-08-19 11.11.11.000000
+(2 rows)
+
+drop table timestpwltz_tb;
+alter session set NLS_DATE_FORMAT='RR-MM-DD HH24.MI.SS';
+create table ds_tb(date_clo date);
+INSERT INTO ds_tb VALUES('2022-08-19 11.11.11');   --succ  22-08-19 11.11.11
+insert into ds_tb values('122-08-19 11.11.11');  --succ  22-08-19 11.11.11
+select * from ds_tb;
+     date_clo      
+-------------------
+ 22-08-19 11.11.11
+ 22-08-19 11.11.11
+(2 rows)
+
+alter session set NLS_DATE_FORMAT='YYYY-MM-DD HH24.MI.SS';
+select * from ds_tb;
+      date_clo       
+---------------------
+ 2022-08-19 11.11.11
+ 0122-08-19 11.11.11
+(2 rows)
+
+drop table ds_tb;

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -637,3 +637,38 @@ drop table timestp_tb;
 reset nls_date_format;
 reset nls_timestamp_format;
 reset nls_timestamp_tz_format;
+alter session set NLS_TIMESTAMP_FORMAT='RR-MM-DD HH24.MI.SS.FF';
+create table timestp_tb(timestp_clo timestamp);
+INSERT INTO timestp_tb VALUES('2022-08-19 11.11.11');   --succ  22-08-19 11.11.11.000000
+insert into timestp_tb values('122-08-19 11.11.11');  --succ  22-08-19 11.11.11
+select * from timestp_tb;
+alter session set NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24.MI.SS.FF';
+select * from timestp_tb;
+drop table timestp_tb;
+
+alter session set NLS_TIMESTAMP_TZ_FORMAT='RR-MM-DD HH24.MI.SS.FF TZH:TZM';
+create table timestpwtz_tb(timestp_clo timestamp with time zone);
+INSERT INTO timestpwtz_tb VALUES('2022-08-19 11.11.11'); 
+insert into timestpwtz_tb values('122-08-19 11.11.11');
+select * from timestpwtz_tb;
+alter session set NLS_TIMESTAMP_TZ_FORMAT='YYYY-MM-DD HH24.MI.SS.FF TZH:TZM';
+select * from timestpwtz_tb;
+drop table timestpwtz_tb;
+
+alter session set NLS_TIMESTAMP_FORMAT='RR-MM-DD HH24.MI.SS.FF';
+create table timestpwltz_tb(timestp_clo timestamp with local time zone);
+INSERT INTO timestpwltz_tb VALUES('2022-08-19 11.11.11'); 
+insert into timestpwltz_tb values('122-08-19 11.11.11');
+select * from timestpwltz_tb;
+alter session set NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24.MI.SS.FF';
+select * from timestpwltz_tb;
+drop table timestpwltz_tb;
+
+alter session set NLS_DATE_FORMAT='RR-MM-DD HH24.MI.SS';
+create table ds_tb(date_clo date);
+INSERT INTO ds_tb VALUES('2022-08-19 11.11.11');   --succ  22-08-19 11.11.11
+insert into ds_tb values('122-08-19 11.11.11');  --succ  22-08-19 11.11.11
+select * from ds_tb;
+alter session set NLS_DATE_FORMAT='YYYY-MM-DD HH24.MI.SS';
+select * from ds_tb;
+drop table ds_tb;

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -4228,6 +4228,10 @@ DCH_from_char(FormatNode *node, const char *in, TmFromChar *out,
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
 							 errmsg("negative YEAR must use SYYYY format")));
+				if (ORA_PARSER == compatible_db)
+				{
+					n->sep = true;
+				}
 				len = from_char_parse_int(&out->year, &s, n,escontext);
 				if (len < 0)
 					return;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for Oracle-compatible date and timestamp formats in SQL queries. This includes the creation of new tables (`timestp_tb`, `timestpwtz_tb`, `timestpwltz_tb`, `ds_tb`) and modifications to session settings for date and timestamp formats.
- Bug Fix: Updated the logic in `formatting.c` to correctly separate the year component in the output when using the `ORA_PARSER`. This ensures accurate representation of date and time values in Oracle-compatible format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->