### PR TITLE
IvorySQL:When the year in the time format is RRRR, the data processing of the year exceeding 4 digits is inconsistent with oracle

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -1834,3 +1834,102 @@ select * from ds_tb;
 (2 rows)
 
 drop table ds_tb;
+alter session set NLS_TIMESTAMP_FORMAT='RRRR-MM-DD HH24.MI.SS.FF';
+create table timestp_tb(timestp_clo timestamp);
+INSERT INTO timestp_tb VALUES('22022-08-19 11.11.11');   --err
+ERROR:  Number value does not match the length of the format item.
+LINE 1: INSERT INTO timestp_tb VALUES('22022-08-19 11.11.11');
+                                      ^
+INSERT INTO timestp_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('20220819 11.11.11');   --succ
+select * from timestp_tb;
+        timestp_clo         
+----------------------------
+ 2022-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+ 2002-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+(6 rows)
+
+drop table timestp_tb;
+alter session set NLS_TIMESTAMP_TZ_FORMAT='RRRR-MM-DD HH24.MI.SS.FF TZH:TZM';
+create table timestpwtz_tb(timestp_clo timestamp with time zone);
+INSERT INTO timestpwtz_tb VALUES('22022-08-19 11.11.11');   --err
+ERROR:  Number value does not match the length of the format item.
+LINE 1: INSERT INTO timestpwtz_tb VALUES('22022-08-19 11.11.11');
+                                         ^
+INSERT INTO timestpwtz_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('20220819 11.11.11');   --succ
+select * from timestpwtz_tb;
+            timestp_clo            
+-----------------------------------
+ 2022-08-19 11.11.11.000000 +08:00
+ 2022-08-19 11.11.11.000000 +08:00
+ 2022-08-19 11.11.11.000000 +08:00
+ 2002-08-19 11.11.11.000000 +08:00
+ 2022-08-19 11.11.11.000000 +08:00
+ 2022-08-19 11.11.11.000000 +08:00
+(6 rows)
+
+drop table timestpwtz_tb;
+alter session set NLS_TIMESTAMP_FORMAT='RRRR-MM-DD HH24.MI.SS.FF';
+create table timestpwltz_tb(timestp_clo timestamp with local time zone);
+INSERT INTO timestpwltz_tb VALUES('22022-08-19 11.11.11');  --err
+ERROR:  Number value does not match the length of the format item.
+LINE 1: INSERT INTO timestpwltz_tb VALUES('22022-08-19 11.11.11');
+                                          ^
+INSERT INTO timestpwltz_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('20220819 11.11.11');   --succ
+select * from timestpwltz_tb;
+        timestp_clo         
+----------------------------
+ 2022-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+ 2002-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+ 2022-08-19 11.11.11.000000
+(6 rows)
+
+drop table timestpwltz_tb;
+alter session set NLS_DATE_FORMAT='RRRR-MM-DD HH24.MI.SS';
+create table ds_tb(timestp_clo date);
+INSERT INTO ds_tb VALUES('22022-08-19 11.11.11');   --err
+ERROR:  Number value does not match the length of the format item.
+LINE 1: INSERT INTO ds_tb VALUES('22022-08-19 11.11.11');
+                                 ^
+INSERT INTO ds_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('20220819 11.11.11');   --succ
+select * from ds_tb;
+     timestp_clo     
+---------------------
+ 2022-08-19 11.11.11
+ 2022-08-19 11.11.11
+ 2022-08-19 11.11.11
+ 2002-08-19 11.11.11
+ 2022-08-19 11.11.11
+ 2022-08-19 11.11.11
+(6 rows)
+
+drop table ds_tb;
+reset NLS_TIMESTAMP_FORMAT;
+reset NLS_TIMESTAMP_TZ_FORMAT;
+reset NLS_DATE_FORMAT;

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -672,3 +672,54 @@ select * from ds_tb;
 alter session set NLS_DATE_FORMAT='YYYY-MM-DD HH24.MI.SS';
 select * from ds_tb;
 drop table ds_tb;
+alter session set NLS_TIMESTAMP_FORMAT='RRRR-MM-DD HH24.MI.SS.FF';
+create table timestp_tb(timestp_clo timestamp);
+INSERT INTO timestp_tb VALUES('22022-08-19 11.11.11');   --err
+INSERT INTO timestp_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO timestp_tb VALUES('20220819 11.11.11');   --succ
+select * from timestp_tb;
+drop table timestp_tb;
+
+alter session set NLS_TIMESTAMP_TZ_FORMAT='RRRR-MM-DD HH24.MI.SS.FF TZH:TZM';
+create table timestpwtz_tb(timestp_clo timestamp with time zone);
+INSERT INTO timestpwtz_tb VALUES('22022-08-19 11.11.11');   --err
+INSERT INTO timestpwtz_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO timestpwtz_tb VALUES('20220819 11.11.11');   --succ
+select * from timestpwtz_tb;
+drop table timestpwtz_tb;
+
+alter session set NLS_TIMESTAMP_FORMAT='RRRR-MM-DD HH24.MI.SS.FF';
+create table timestpwltz_tb(timestp_clo timestamp with local time zone);
+INSERT INTO timestpwltz_tb VALUES('22022-08-19 11.11.11');  --err
+INSERT INTO timestpwltz_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO timestpwltz_tb VALUES('20220819 11.11.11');   --succ
+select * from timestpwltz_tb;
+drop table timestpwltz_tb;
+
+alter session set NLS_DATE_FORMAT='RRRR-MM-DD HH24.MI.SS';
+create table ds_tb(timestp_clo date);
+INSERT INTO ds_tb VALUES('22022-08-19 11.11.11');   --err
+INSERT INTO ds_tb VALUES('2022-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('022-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('22-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('2-08-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('202208-19 11.11.11');   --succ
+INSERT INTO ds_tb VALUES('20220819 11.11.11');   --succ
+select * from ds_tb;
+drop table ds_tb;
+
+reset NLS_TIMESTAMP_FORMAT;
+reset NLS_TIMESTAMP_TZ_FORMAT;
+reset NLS_DATE_FORMAT;

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -4262,6 +4262,25 @@ DCH_from_char(FormatNode *node, const char *in, TmFromChar *out,
 				SKIP_THth(s, n->suffix);
 				break;
 			case DCH_RRRR:
+				if (ORA_PARSER == compatible_db)
+				{
+					if (*s == '+')
+						s++;
+					if (*s == '-')
+						ereport(ERROR,
+							(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+							 errmsg("The year value must be between -4713 and +9999, and it is not 0")));
+					numlen = ivy_getnumlength(s);
+					if (numlen < 6)
+					{
+						if (numlen == 5)
+							ereport(ERROR,
+									(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+								  errmsg("Number value does not match the length of the format item.")));
+
+						n->sep = true;
+					}
+				}
 				len = from_char_parse_int(&out->year, &s, n, escontext);
 				if (len < 0)
 					return;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced Oracle compatibility by introducing additional validation for the year value in date and timestamp formats. This includes checks to ensure the year value is not 0 and that its length is appropriate.
- New Feature: Added SQL statements for creating tables, inserting data, and querying the tables with different date and timestamp formats. This allows users to interact with `timestp_tb`, `timestpwtz_tb`, `timestpwltz_tb`, and `ds_tb` tables more effectively.
- Bug Fix: Improved error handling for invalid date and timestamp formats, providing clearer error messages to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->