### PR TITLE
add compatible test case

### DIFF
--- a/contrib/file_fdw/expected/ivy_file_fdw.out
+++ b/contrib/file_fdw/expected/ivy_file_fdw.out
@@ -13,11 +13,11 @@ CREATE ROLE regress_no_priv_user LOGIN;                 -- has priv but no user 
 -- Install file_fdw
 CREATE EXTENSION file_fdw;
 -- create function to filter unstable results of EXPLAIN
-CREATE FUNCTION explain_filter(text) RETURNS setof text
+CREATE FUNCTION explain_filter(varchar2(1024)) RETURNS setof varchar2(1024)
 LANGUAGE plpgsql AS
 $$
 declare
-    ln text;
+    ln varchar2(1024);
 begin
     for ln in execute $1
     loop
@@ -95,28 +95,28 @@ CREATE FOREIGN TABLE tbl () SERVER file_server;  -- ERROR
 ERROR:  either filename or program is required for file_fdw foreign tables
 \set filename :abs_srcdir '/data/agg.data'
 CREATE FOREIGN TABLE agg_text (
-	a	int CHECK (a >= 0),
-	b	number
+	a	number(38,0) CHECK (a >= 0),
+	b	binary_float
 ) SERVER file_server
 OPTIONS (format 'text', filename :'filename', delimiter ' ', null '\N');
 GRANT SELECT ON agg_text TO regress_file_fdw_user;
 \set filename :abs_srcdir '/data/agg.csv'
 CREATE FOREIGN TABLE agg_csv (
-	a int2,
-	b float4
+	a	number(38,0),
+	b	binary_float
 ) SERVER file_server
 OPTIONS (format 'csv', filename :'filename', header 'true', delimiter ';', quote '@', escape '"', null ' ');
 ALTER FOREIGN TABLE agg_csv ADD CHECK (a >= 0);
 \set filename :abs_srcdir '/data/agg.bad'
 CREATE FOREIGN TABLE agg_bad (
-	a	int2,
-	b	float4
+	a	number(38,0),
+	b	binary_float
 ) SERVER file_server
 OPTIONS (format 'csv', filename :'filename', header 'true', delimiter ';', quote '@', escape '"', null ' ');
 ALTER FOREIGN TABLE agg_bad ADD CHECK (a >= 0);
 -- test header matching
 \set filename :abs_srcdir '/data/list1.csv'
-CREATE FOREIGN TABLE header_match ("1" int, foo text) SERVER file_server
+CREATE FOREIGN TABLE header_match ("1" number(38,0), foo varchar2(1024)) SERVER file_server
 OPTIONS (format 'csv', filename :'filename', delimiter ',', header 'match');
 SELECT * FROM header_match;
  1 | foo 
@@ -124,7 +124,7 @@ SELECT * FROM header_match;
  1 | bar
 (1 row)
 
-CREATE FOREIGN TABLE header_doesnt_match (a int, foo text) SERVER file_server
+CREATE FOREIGN TABLE header_doesnt_match (a number(38,0), foo varchar2(1024)) SERVER file_server
 OPTIONS (format 'csv', filename :'filename', delimiter ',', header 'match');
 SELECT * FROM header_doesnt_match; -- ERROR
 ERROR:  column name mismatch in header line field 1: got "1", expected "a"
@@ -132,10 +132,10 @@ CONTEXT:  COPY header_doesnt_match, line 1: "1,foo"
 -- per-column options tests
 \set filename :abs_srcdir '/data/text.csv'
 CREATE FOREIGN TABLE text_csv (
-    word1 text OPTIONS (force_not_null 'true'),
-    word2 text OPTIONS (force_not_null 'off'),
-    word3 text OPTIONS (force_null 'true'),
-    word4 text OPTIONS (force_null 'off')
+    word1 varchar2(1024) OPTIONS (force_not_null 'true'),
+    word2 varchar2(1024) OPTIONS (force_not_null 'off'),
+    word3 varchar2(1024) OPTIONS (force_null 'true'),
+    word4 varchar2(1024) OPTIONS (force_null 'off')
 ) SERVER file_server
 OPTIONS (format 'text', filename :'filename', null 'NULL');
 SELECT * FROM text_csv; -- ERROR
@@ -183,29 +183,29 @@ ERROR:  invalid option "force_null"
 SELECT * FROM agg_text WHERE b > 10.0 ORDER BY a;
   a  |   b    
 -----+--------
-  42 | 324.78
+ 42  | 324.78
  100 | 99.097
 (2 rows)
 
 SELECT * FROM agg_csv ORDER BY a;
   a  |    b    
 -----+---------
-   0 | 0.09561
-  42 |  324.78
- 100 |  99.097
+ 0   | 0.09561
+ 42  | 324.78
+ 100 | 99.097
 (3 rows)
 
 SELECT * FROM agg_csv c JOIN agg_text t ON (t.a = c.a) ORDER BY c.a;
   a  |    b    |  a  |    b    
 -----+---------+-----+---------
-   0 | 0.09561 |   0 | 0.09561
-  42 |  324.78 |  42 | 324.78
- 100 |  99.097 | 100 | 99.097
+ 0   | 0.09561 | 0   | 0.09561
+ 42  | 324.78  | 42  | 324.78
+ 100 | 99.097  | 100 | 99.097
 (3 rows)
 
 -- error context report tests
 SELECT * FROM agg_bad;               -- ERROR
-ERROR:  invalid input syntax for type real: "aaa"
+ERROR:  invalid input syntax for type binary_float: "aaa"
 CONTEXT:  COPY agg_bad, line 3, column b: "aaa"
 -- misc query tests
 \t on
@@ -233,9 +233,9 @@ DEALLOCATE st;
 SELECT tableoid::regclass, b FROM agg_csv;
  tableoid |    b    
 ----------+---------
- agg_csv  |  99.097
+ agg_csv  | 99.097
  agg_csv  | 0.09561
- agg_csv  |  324.78
+ agg_csv  | 324.78
 (3 rows)
 
 -- updates aren't supported
@@ -251,9 +251,9 @@ ERROR:  cannot truncate foreign table "agg_csv"
 SELECT * FROM agg_csv FOR UPDATE;
   a  |    b    
 -----+---------
- 100 |  99.097
-   0 | 0.09561
-  42 |  324.78
+ 100 | 99.097
+ 0   | 0.09561
+ 42  | 324.78
 (3 rows)
 
 -- copy from isn't supported either
@@ -264,7 +264,7 @@ ERROR:  cannot insert into foreign table "agg_csv"
 SELECT explain_filter('EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv WHERE a < 0');
  Foreign Scan on public.agg_csv
    Output: a, b
-   Filter: (agg_csv.a < 0)
+   Filter: (agg_csv.a < '0'::number)
    Foreign File: .../agg.csv
 
 \t off
@@ -288,22 +288,22 @@ SELECT * FROM agg_csv WHERE a < 0;
 
 RESET constraint_exclusion;
 -- table inheritance tests
-CREATE TABLE agg (a int2, b float4);
+CREATE TABLE agg (a number(38,0), b binary_float);
 ALTER FOREIGN TABLE agg_csv INHERIT agg;
 SELECT tableoid::regclass, * FROM agg;
  tableoid |  a  |    b    
 ----------+-----+---------
- agg_csv  | 100 |  99.097
- agg_csv  |   0 | 0.09561
- agg_csv  |  42 |  324.78
+ agg_csv  | 100 | 99.097
+ agg_csv  | 0   | 0.09561
+ agg_csv  | 42  | 324.78
 (3 rows)
 
 SELECT tableoid::regclass, * FROM agg_csv;
  tableoid |  a  |    b    
 ----------+-----+---------
- agg_csv  | 100 |  99.097
- agg_csv  |   0 | 0.09561
- agg_csv  |  42 |  324.78
+ agg_csv  | 100 | 99.097
+ agg_csv  | 0   | 0.09561
+ agg_csv  | 42  | 324.78
 (3 rows)
 
 SELECT tableoid::regclass, * FROM ONLY agg;
@@ -320,16 +320,16 @@ ERROR:  cannot delete from foreign table "agg_csv"
 SELECT tableoid::regclass, * FROM agg FOR UPDATE;
  tableoid |  a  |    b    
 ----------+-----+---------
- agg_csv  | 100 |  99.097
- agg_csv  |   0 | 0.09561
- agg_csv  |  42 |  324.78
+ agg_csv  | 100 | 99.097
+ agg_csv  | 0   | 0.09561
+ agg_csv  | 42  | 324.78
 (3 rows)
 
 ALTER FOREIGN TABLE agg_csv NO INHERIT agg;
 DROP TABLE agg;
 -- declarative partitioning tests
 SET ROLE regress_file_fdw_superuser;
-CREATE TABLE pt (a int, b text) partition by list (a);
+CREATE TABLE pt (a number(38,0), b varchar2(1024)) partition by list (a);
 \set filename :abs_srcdir '/data/list1.csv'
 CREATE FOREIGN TABLE p1 partition of pt for values in (1) SERVER file_server
 OPTIONS (format 'csv', filename :'filename', delimiter ',');
@@ -415,7 +415,7 @@ SELECT tableoid::regclass, * FROM p2;
 DROP TABLE pt;
 -- generated column tests
 \set filename :abs_srcdir '/data/list1.csv'
-CREATE FOREIGN TABLE gft1 (a int, b text, c text GENERATED ALWAYS AS ('foo') STORED) SERVER file_server
+CREATE FOREIGN TABLE gft1 (a number(38,0), b varchar2(1024), c varchar2(1024) GENERATED ALWAYS AS ('foo') STORED) SERVER file_server
 OPTIONS (format 'csv', filename :'filename', delimiter ',');
 SELECT a, c FROM gft1;
  a |   c    
@@ -428,17 +428,17 @@ DROP FOREIGN TABLE gft1;
 -- copy default tests
 \set filename :abs_srcdir '/data/copy_default.csv'
 CREATE FOREIGN TABLE copy_default (
-	id integer,
-	text_value text not null default 'test',
+	id number(38,0),
+	text_value varchar2(1024) not null default 'test',
 	ts_value timestamp without time zone not null default '2022-07-05'
 ) SERVER file_server
 OPTIONS (format 'csv', filename :'filename', default '\D');
 SELECT id, text_value, ts_value FROM copy_default;
  id | text_value |          ts_value          
 ----+------------+----------------------------
-  1 | value      | 2022-07-04 00:00:00.000000
-  2 | test       | 2022-07-03 00:00:00.000000
-  3 | test       | 2022-07-05 00:00:00.000000
+ 1  | value      | 2022-07-04 00:00:00.000000
+ 2  | test       | 2022-07-03 00:00:00.000000
+ 3  | test       | 2022-07-05 00:00:00.000000
 (3 rows)
 
 DROP FOREIGN TABLE copy_default;
@@ -447,9 +447,9 @@ SET ROLE regress_file_fdw_superuser;
 SELECT * FROM agg_text ORDER BY a;
   a  |    b    
 -----+---------
-   0 | 0.09561
-  42 | 324.78
-  56 | 7.8
+ 0   | 0.09561
+ 42  | 324.78
+ 56  | 7.8
  100 | 99.097
 (4 rows)
 
@@ -457,9 +457,9 @@ SET ROLE regress_file_fdw_user;
 SELECT * FROM agg_text ORDER BY a;
   a  |    b    
 -----+---------
-   0 | 0.09561
-  42 | 324.78
-  56 | 7.8
+ 0   | 0.09561
+ 42  | 324.78
+ 56  | 7.8
  100 | 99.097
 (4 rows)
 
@@ -471,7 +471,7 @@ SET ROLE regress_file_fdw_user;
 SELECT explain_filter('EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_text WHERE a > 0');
  Foreign Scan on public.agg_text
    Output: a, b
-   Filter: (agg_text.a > 0)
+   Filter: (agg_text.a > '0'::number)
    Foreign File: .../agg.data
 
 \t off
@@ -480,9 +480,9 @@ DROP USER MAPPING FOR regress_file_fdw_user SERVER file_server;
 SELECT * FROM agg_text ORDER BY a;
   a  |    b    
 -----+---------
-   0 | 0.09561
-  42 | 324.78
-  56 | 7.8
+ 0   | 0.09561
+ 42  | 324.78
+ 56  | 7.8
  100 | 99.097
 (4 rows)
 

--- a/contrib/ltree/expected/ivy_ltree.out
+++ b/contrib/ltree/expected/ivy_ltree.out
@@ -8133,4 +8133,32 @@ FROM (VALUES ('.2.3', 'ltree'),
  !tree & aWdf@* | ltxtquery | t  |                |                                    |                          | 
 (8 rows)
 
+CREATE FUNCTION sys.ltree2varchar2(ltree)
+RETURNS text AS $$
+SELECT ltree2text($1::ltree);
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+/
+CREATE FUNCTION sys.varchar22ltree(varchar2)
+RETURNS ltree AS $$
+SELECT text2ltree($1::text);
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+/
+SELECT ltree2varchar2('1.2.3.34.sdf');
+ ltree2varchar2 
+----------------
+ 1.2.3.34.sdf
+(1 row)
+
+SELECT varchar22ltree('1.2.3.34.sdf');
+ varchar22ltree 
+----------------
+ 1.2.3.34.sdf
+(1 row)
+
+SELECT 'Top.Child1.Child2'::ltree || 'Child3'::varchar2;
+         ?column?         
+--------------------------
+ Top.Child1.Child2.Child3
+(1 row)
+
 RESET ivorysql.enable_emptystring_to_null;

--- a/contrib/ltree/sql/ivy_ltree.sql
+++ b/contrib/ltree/sql/ivy_ltree.sql
@@ -411,4 +411,20 @@ FROM (VALUES ('.2.3', 'ltree'),
       AS a(str,typ),
      LATERAL pg_input_error_info(a.str, a.typ) as errinfo;
 
+CREATE FUNCTION sys.ltree2varchar2(ltree)
+RETURNS text AS $$
+SELECT ltree2text($1::ltree);
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+/
+
+CREATE FUNCTION sys.varchar22ltree(varchar2)
+RETURNS ltree AS $$
+SELECT text2ltree($1::text);
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+/
+
+SELECT ltree2varchar2('1.2.3.34.sdf');
+SELECT varchar22ltree('1.2.3.34.sdf');
+SELECT 'Top.Child1.Child2'::ltree || 'Child3'::varchar2;
+
 RESET ivorysql.enable_emptystring_to_null;

--- a/contrib/pageinspect/Makefile
+++ b/contrib/pageinspect/Makefile
@@ -23,7 +23,7 @@ DATA =  pageinspect--1.11--1.12.sql pageinspect--1.10--1.11.sql \
 PGFILEDESC = "pageinspect - functions to inspect contents of database pages"
 
 REGRESS = page btree brin gin gist hash checksum oldextversions
-ORA_REGRESS = page btree brin gin gist hash checksum oldextversions
+ORA_REGRESS = ivy_page btree ivy_brin ivy_gin ivy_gist ivy_hash checksum ivy_oldextversions
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/pageinspect/expected/ivy_brin.out
+++ b/contrib/pageinspect/expected/ivy_brin.out
@@ -1,0 +1,92 @@
+CREATE TABLE test1 (a number(38,0), b varchar2(1024));
+INSERT INTO test1 VALUES (1, 'one');
+CREATE INDEX test1_a_idx ON test1 USING brin (a);
+SELECT brin_page_type(get_raw_page('test1_a_idx', 0));
+ brin_page_type 
+----------------
+ meta
+(1 row)
+
+SELECT brin_page_type(get_raw_page('test1_a_idx', 1));
+ brin_page_type 
+----------------
+ revmap
+(1 row)
+
+SELECT brin_page_type(get_raw_page('test1_a_idx', 2));
+ brin_page_type 
+----------------
+ regular
+(1 row)
+
+SELECT * FROM brin_metapage_info(get_raw_page('test1_a_idx', 0));
+   magic    | version | pagesperrange | lastrevmappage 
+------------+---------+---------------+----------------
+ 0xA8109CFA |       1 |           128 |              1
+(1 row)
+
+SELECT * FROM brin_metapage_info(get_raw_page('test1_a_idx', 1));
+ERROR:  page is not a BRIN page of type "metapage"
+DETAIL:  Expected special type 0000f091, got 0000f092.
+SELECT * FROM brin_revmap_data(get_raw_page('test1_a_idx', 0)) LIMIT 5;
+ERROR:  page is not a BRIN page of type "revmap"
+DETAIL:  Expected special type 0000f092, got 0000f091.
+SELECT * FROM brin_revmap_data(get_raw_page('test1_a_idx', 1)) LIMIT 5;
+ pages 
+-------
+ (2,1)
+ (0,0)
+ (0,0)
+ (0,0)
+ (0,0)
+(5 rows)
+
+SELECT * FROM brin_page_items(get_raw_page('test1_a_idx', 2), 'test1_a_idx')
+    ORDER BY blknum, attnum LIMIT 5;
+ itemoffset | blknum | attnum | allnulls | hasnulls | placeholder | empty |  value   
+------------+--------+--------+----------+----------+-------------+-------+----------
+          1 |      0 |      1 | f        | f        | f           | f     | {1 .. 1}
+(1 row)
+
+-- Mask DETAIL messages as these are not portable across architectures.
+\set VERBOSITY terse
+-- Failures for non-BRIN index.
+CREATE INDEX test1_a_btree ON test1 (a);
+SELECT brin_page_items(get_raw_page('test1_a_btree', 0), 'test1_a_btree');
+ERROR:  "test1_a_btree" is not a BRIN index
+SELECT brin_page_items(get_raw_page('test1_a_btree', 0), 'test1_a_idx');
+ERROR:  input page is not a valid BRIN page
+-- Invalid special area size
+SELECT brin_page_type(get_raw_page('test1', 0));
+ERROR:  input page is not a valid BRIN page
+SELECT * FROM brin_metapage_info(get_raw_page('test1', 0));
+ERROR:  input page is not a valid BRIN page
+SELECT * FROM brin_revmap_data(get_raw_page('test1', 0));
+ERROR:  input page is not a valid BRIN page
+\set VERBOSITY default
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT brin_page_type(decode(repeat('00', :block_size), 'hex'));
+ brin_page_type 
+----------------
+ 
+(1 row)
+
+SELECT brin_page_items(decode(repeat('00', :block_size), 'hex'), 'test1_a_idx');
+ brin_page_items 
+-----------------
+(0 rows)
+
+SELECT brin_metapage_info(decode(repeat('00', :block_size), 'hex'));
+ brin_metapage_info 
+--------------------
+ 
+(1 row)
+
+SELECT brin_revmap_data(decode(repeat('00', :block_size), 'hex'));
+ brin_revmap_data 
+------------------
+ 
+(1 row)
+
+DROP TABLE test1;

--- a/contrib/pageinspect/expected/ivy_gin.out
+++ b/contrib/pageinspect/expected/ivy_gin.out
@@ -1,0 +1,71 @@
+CREATE TABLE test1 (x number(38,0), y int[]);
+INSERT INTO test1 VALUES (1, ARRAY[11, 111]);
+CREATE INDEX test1_y_idx ON test1 USING gin (y) WITH (fastupdate = off);
+\x
+SELECT * FROM gin_metapage_info(get_raw_page('test1_y_idx', 0));
+-[ RECORD 1 ]----+-----------
+pending_head     | 4294967295
+pending_tail     | 4294967295
+tail_free_size   | 0
+n_pending_pages  | 0
+n_pending_tuples | 0
+n_total_pages    | 2
+n_entry_pages    | 1
+n_data_pages     | 0
+n_entries        | 2
+version          | 2
+
+SELECT * FROM gin_metapage_info(get_raw_page('test1_y_idx', 1));
+ERROR:  input page is not a GIN metapage
+DETAIL:  Flags 0002, expected 0008
+SELECT * FROM gin_page_opaque_info(get_raw_page('test1_y_idx', 1));
+-[ RECORD 1 ]---------
+rightlink | 4294967295
+maxoff    | 0
+flags     | {leaf}
+
+SELECT * FROM gin_leafpage_items(get_raw_page('test1_y_idx', 1));
+ERROR:  input page is not a compressed GIN data leaf page
+DETAIL:  Flags 0002, expected 0083
+INSERT INTO test1 SELECT x, ARRAY[1,10] FROM generate_series(2,10000) x;
+SELECT COUNT(*) > 0
+FROM gin_leafpage_items(get_raw_page('test1_y_idx',
+                        (pg_relation_size('test1_y_idx') /
+                         current_setting('block_size')::bigint)::int - 1));
+-[ RECORD 1 ]
+?column? | t
+
+-- Failure with various modes.
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes and architectures.
+\set VERBOSITY terse
+-- invalid page size
+SELECT gin_leafpage_items('aaa'::bytea);
+ERROR:  invalid page size
+SELECT gin_metapage_info('bbb'::bytea);
+ERROR:  invalid page size
+SELECT gin_page_opaque_info('ccc'::bytea);
+ERROR:  invalid page size
+-- invalid special area size
+SELECT * FROM gin_metapage_info(get_raw_page('test1', 0));
+ERROR:  input page is not a valid GIN metapage
+SELECT * FROM gin_page_opaque_info(get_raw_page('test1', 0));
+ERROR:  input page is not a valid GIN data leaf page
+SELECT * FROM gin_leafpage_items(get_raw_page('test1', 0));
+ERROR:  input page is not a valid GIN data leaf page
+\set VERBOSITY default
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT gin_leafpage_items(decode(repeat('00', :block_size), 'hex'));
+-[ RECORD 1 ]------+-
+gin_leafpage_items | 
+
+SELECT gin_metapage_info(decode(repeat('00', :block_size), 'hex'));
+-[ RECORD 1 ]-----+-
+gin_metapage_info | 
+
+SELECT gin_page_opaque_info(decode(repeat('00', :block_size), 'hex'));
+-[ RECORD 1 ]--------+-
+gin_page_opaque_info | 
+
+DROP TABLE test1;

--- a/contrib/pageinspect/expected/ivy_gist.out
+++ b/contrib/pageinspect/expected/ivy_gist.out
@@ -1,0 +1,133 @@
+-- The gist_page_opaque_info() function prints the page's LSN. Normally,
+-- that's constant 1 (GistBuildLSN) on every page of a freshly built GiST
+-- index. But with wal_level=minimal, the whole relation is dumped to WAL at
+-- the end of the transaction if it's smaller than wal_skip_threshold, which
+-- updates the LSNs. Wrap the tests on gist_page_opaque_info() in the
+-- same transaction with the CREATE INDEX so that we see the LSNs before
+-- they are possibly overwritten at end of transaction.
+BEGIN;
+-- Create a test table and GiST index.
+CREATE TABLE test_gist AS SELECT point(i,i) p, i::varchar(64) t FROM
+    generate_series(1,1000) i;
+CREATE INDEX test_gist_idx ON test_gist USING gist (p);
+-- Page 0 is the root, the rest are leaf pages
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist_idx', 0));
+ lsn | nsn | rightlink  | flags 
+-----+-----+------------+-------
+ 0/1 | 0/0 | 4294967295 | {}
+(1 row)
+
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist_idx', 1));
+ lsn | nsn | rightlink  | flags  
+-----+-----+------------+--------
+ 0/1 | 0/0 | 4294967295 | {leaf}
+(1 row)
+
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist_idx', 2));
+ lsn | nsn | rightlink | flags  
+-----+-----+-----------+--------
+ 0/1 | 0/0 |         1 | {leaf}
+(1 row)
+
+COMMIT;
+SELECT * FROM gist_page_items(get_raw_page('test_gist_idx', 0), 'test_gist_idx');
+ itemoffset |   ctid    | itemlen | dead |             keys              
+------------+-----------+---------+------+-------------------------------
+          1 | (1,65535) |      40 | f    | (p)=("(185,185),(1,1)")
+          2 | (2,65535) |      40 | f    | (p)=("(370,370),(186,186)")
+          3 | (3,65535) |      40 | f    | (p)=("(555,555),(371,371)")
+          4 | (4,65535) |      40 | f    | (p)=("(740,740),(556,556)")
+          5 | (5,65535) |      40 | f    | (p)=("(870,870),(741,741)")
+          6 | (6,65535) |      40 | f    | (p)=("(1000,1000),(871,871)")
+(6 rows)
+
+SELECT * FROM gist_page_items(get_raw_page('test_gist_idx', 1), 'test_gist_idx') LIMIT 5;
+ itemoffset | ctid  | itemlen | dead |        keys         
+------------+-------+---------+------+---------------------
+          1 | (0,1) |      40 | f    | (p)=("(1,1),(1,1)")
+          2 | (0,2) |      40 | f    | (p)=("(2,2),(2,2)")
+          3 | (0,3) |      40 | f    | (p)=("(3,3),(3,3)")
+          4 | (0,4) |      40 | f    | (p)=("(4,4),(4,4)")
+          5 | (0,5) |      40 | f    | (p)=("(5,5),(5,5)")
+(5 rows)
+
+-- gist_page_items_bytea prints the raw key data as a bytea. The output of that is
+-- platform-dependent (endianness), so omit the actual key data from the output.
+SELECT itemoffset, ctid, itemlen FROM gist_page_items_bytea(get_raw_page('test_gist_idx', 0));
+ itemoffset |   ctid    | itemlen 
+------------+-----------+---------
+          1 | (1,65535) |      40
+          2 | (2,65535) |      40
+          3 | (3,65535) |      40
+          4 | (4,65535) |      40
+          5 | (5,65535) |      40
+          6 | (6,65535) |      40
+(6 rows)
+
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes and architectures.
+\set VERBOSITY terse
+-- Failures with non-GiST index.
+CREATE INDEX test_gist_btree on test_gist(t);
+SELECT gist_page_items(get_raw_page('test_gist_btree', 0), 'test_gist_btree');
+ERROR:  "test_gist_btree" is not a GiST index
+SELECT gist_page_items(get_raw_page('test_gist_btree', 0), 'test_gist_idx');
+ERROR:  input page is not a valid GiST page
+-- Failure with various modes.
+-- invalid page size
+SELECT gist_page_items_bytea('aaa'::bytea);
+ERROR:  invalid page size
+SELECT gist_page_items('aaa'::bytea, 'test_gist_idx'::regclass);
+ERROR:  invalid page size
+SELECT gist_page_opaque_info('aaa'::bytea);
+ERROR:  invalid page size
+-- invalid special area size
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist', 0));
+ERROR:  input page is not a valid GiST page
+SELECT gist_page_items_bytea(get_raw_page('test_gist', 0));
+ERROR:  input page is not a valid GiST page
+SELECT gist_page_items_bytea(get_raw_page('test_gist_btree', 0));
+ERROR:  input page is not a valid GiST page
+\set VERBOSITY default
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT gist_page_items_bytea(decode(repeat('00', :block_size), 'hex'));
+ gist_page_items_bytea 
+-----------------------
+(0 rows)
+
+SELECT gist_page_items(decode(repeat('00', :block_size), 'hex'), 'test_gist_idx'::regclass);
+ gist_page_items 
+-----------------
+(0 rows)
+
+SELECT gist_page_opaque_info(decode(repeat('00', :block_size), 'hex'));
+ gist_page_opaque_info 
+-----------------------
+ 
+(1 row)
+
+-- Test gist_page_items with included columns.
+-- Non-leaf pages contain only the key attributes, and leaf pages contain
+-- the included attributes.
+ALTER TABLE test_gist ADD COLUMN i int DEFAULT NULL;
+CREATE INDEX test_gist_idx_inc ON test_gist
+  USING gist (p) INCLUDE (t, i);
+-- Mask the value of the key attribute to avoid alignment issues.
+SELECT regexp_replace(keys, '\(p\)=\("(.*?)"\)', '(p)=("<val>")') AS keys_nonleaf_1
+  FROM gist_page_items(get_raw_page('test_gist_idx_inc', 0), 'test_gist_idx_inc')
+  WHERE itemoffset = 1;
+ keys_nonleaf_1 
+----------------
+ (p)=("<val>")
+(1 row)
+
+SELECT keys AS keys_leaf_1
+  FROM gist_page_items(get_raw_page('test_gist_idx_inc', 1), 'test_gist_idx_inc')
+  WHERE itemoffset = 1;
+                     keys_leaf_1                      
+------------------------------------------------------
+ (p) INCLUDE (t, i)=("(1,1),(1,1)") INCLUDE (1, null)
+(1 row)
+
+DROP TABLE test_gist;

--- a/contrib/pageinspect/expected/ivy_hash.out
+++ b/contrib/pageinspect/expected/ivy_hash.out
@@ -1,0 +1,133 @@
+CREATE TABLE test_hash (a number(38,0), b varchar2(1024));
+INSERT INTO test_hash VALUES (1, 'one');
+CREATE INDEX test_hash_a_idx ON test_hash USING hash (a);
+\x
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 0));
+-[ RECORD 1 ]--+---------
+hash_page_type | metapage
+
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 1));
+-[ RECORD 1 ]--+-------
+hash_page_type | bucket
+
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 2));
+-[ RECORD 1 ]--+-------
+hash_page_type | bucket
+
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 3));
+-[ RECORD 1 ]--+-------
+hash_page_type | bitmap
+
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 4));
+ERROR:  block number 4 is out of range for relation "test_hash_a_idx"
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', -1);
+ERROR:  invalid block number
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 0);
+ERROR:  invalid overflow block number 0
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 1);
+ERROR:  invalid overflow block number 1
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 2);
+ERROR:  invalid overflow block number 2
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 3);
+ERROR:  invalid overflow block number 3
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 4);
+ERROR:  block number 4 is out of range for relation "test_hash_a_idx"
+SELECT magic, version, ntuples, bsize, bmsize, bmshift, maxbucket, highmask,
+lowmask, ovflpoint, firstfree, nmaps, procid, spares, mapp FROM
+hash_metapage_info(get_raw_page('test_hash_a_idx', 1));
+ERROR:  page is not a hash meta page
+SELECT magic, version, ntuples, bsize, bmsize, bmshift, maxbucket, highmask,
+lowmask, ovflpoint, firstfree, nmaps, procid, spares, mapp FROM
+hash_metapage_info(get_raw_page('test_hash_a_idx', 2));
+ERROR:  page is not a hash meta page
+SELECT magic, version, ntuples, bsize, bmsize, bmshift, maxbucket, highmask,
+lowmask, ovflpoint, firstfree, nmaps, procid, spares, mapp FROM
+hash_metapage_info(get_raw_page('test_hash_a_idx', 3));
+ERROR:  page is not a hash meta page
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 0));
+ERROR:  page is not a hash bucket or overflow page
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 1));
+-[ RECORD 1 ]---+-----------
+live_items      | 1
+dead_items      | 0
+page_size       | 8192
+hasho_prevblkno | 1
+hasho_nextblkno | 4294967295
+hasho_bucket    | 0
+hasho_flag      | 2
+hasho_page_id   | 65408
+
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 2));
+-[ RECORD 1 ]---+-----------
+live_items      | 0
+dead_items      | 0
+page_size       | 8192
+hasho_prevblkno | 1
+hasho_nextblkno | 4294967295
+hasho_bucket    | 1
+hasho_flag      | 2
+hasho_page_id   | 65408
+
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 3));
+ERROR:  page is not a hash bucket or overflow page
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 0));
+ERROR:  page is not a hash bucket or overflow page
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 1));
+-[ RECORD 1 ]----------
+itemoffset | 1
+ctid       | (0,1)
+data       | 1324868424
+
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 2));
+(0 rows)
+
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 3));
+ERROR:  page is not a hash bucket or overflow page
+-- Failure with non-hash index
+CREATE INDEX test_hash_a_btree ON test_hash USING btree (a);
+SELECT hash_bitmap_info('test_hash_a_btree', 0);
+ERROR:  "test_hash_a_btree" is not a hash index
+-- Failure with various modes.
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes and architectures.
+\set VERBOSITY terse
+-- invalid page size
+SELECT hash_metapage_info('aaa'::bytea);
+ERROR:  invalid page size
+SELECT hash_page_items('bbb'::bytea);
+ERROR:  invalid page size
+SELECT hash_page_stats('ccc'::bytea);
+ERROR:  invalid page size
+SELECT hash_page_type('ddd'::bytea);
+ERROR:  invalid page size
+-- invalid special area size
+SELECT hash_metapage_info(get_raw_page('test_hash', 0));
+ERROR:  input page is not a valid hash page
+SELECT hash_page_items(get_raw_page('test_hash', 0));
+ERROR:  input page is not a valid hash page
+SELECT hash_page_stats(get_raw_page('test_hash', 0));
+ERROR:  input page is not a valid hash page
+SELECT hash_page_type(get_raw_page('test_hash', 0));
+ERROR:  input page is not a valid hash page
+\set VERBOSITY default
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT hash_metapage_info(decode(repeat('00', :block_size), 'hex'));
+ERROR:  page is not a hash meta page
+SELECT hash_page_items(decode(repeat('00', :block_size), 'hex'));
+ERROR:  page is not a hash bucket or overflow page
+SELECT hash_page_stats(decode(repeat('00', :block_size), 'hex'));
+ERROR:  page is not a hash bucket or overflow page
+SELECT hash_page_type(decode(repeat('00', :block_size), 'hex'));
+-[ RECORD 1 ]--+-------
+hash_page_type | unused
+
+DROP TABLE test_hash;

--- a/contrib/pageinspect/expected/ivy_oldextversions.out
+++ b/contrib/pageinspect/expected/ivy_oldextversions.out
@@ -1,0 +1,56 @@
+-- test old extension version entry points
+DROP EXTENSION pageinspect;
+CREATE EXTENSION pageinspect VERSION '1.8';
+CREATE TABLE test1 (a int8, b varchar2(32));
+INSERT INTO test1 VALUES (72057594037927937, 'text');
+CREATE INDEX test1_a_idx ON test1 USING btree (a);
+-- from page.sql
+SELECT octet_length(get_raw_page('test1', 0)) AS main_0;
+ main_0 
+--------
+   8192
+(1 row)
+
+SELECT octet_length(get_raw_page('test1', 'main', 0)) AS main_0;
+ main_0 
+--------
+   8192
+(1 row)
+
+SELECT page_checksum(get_raw_page('test1', 0), 0) IS NOT NULL AS silly_checksum_test;
+ silly_checksum_test 
+---------------------
+ t
+(1 row)
+
+-- from btree.sql
+SELECT * FROM bt_page_stats('test1_a_idx', 1);
+ blkno | type | live_items | dead_items | avg_item_size | page_size | free_size | btpo_prev | btpo_next | btpo | btpo_flags 
+-------+------+------------+------------+---------------+-----------+-----------+-----------+-----------+------+------------
+     1 | l    |          1 |          0 |            16 |      8192 |      8128 |         0 |         0 |    0 |          3
+(1 row)
+
+SELECT * FROM bt_page_items('test1_a_idx', 1);
+ itemoffset | ctid  | itemlen | nulls | vars |          data           | dead | htid  | tids 
+------------+-------+---------+-------+------+-------------------------+------+-------+------
+          1 | (0,1) |      16 | f     | f    | 01 00 00 00 00 00 00 01 | f    | (0,1) | 
+(1 row)
+
+-- page_header() uses int instead of smallint for lower, upper, special and
+-- pagesize in pageinspect >= 1.10.
+ALTER EXTENSION pageinspect UPDATE TO '1.9';
+\df page_header
+                                                                                                                  List of functions
+ Schema |    Name     | Result data type |                                                                                         Argument data types                                                                                         | Type 
+--------+-------------+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------
+ public | page_header | record           | page bytea, OUT lsn pg_lsn, OUT checksum smallint, OUT flags smallint, OUT lower smallint, OUT upper smallint, OUT special smallint, OUT pagesize smallint, OUT version smallint, OUT prune_xid xid | func
+(1 row)
+
+SELECT pagesize, version FROM page_header(get_raw_page('test1', 0));
+ pagesize | version 
+----------+---------
+     8192 |       4
+(1 row)
+
+DROP TABLE test1;
+DROP EXTENSION pageinspect;

--- a/contrib/pageinspect/expected/ivy_page.out
+++ b/contrib/pageinspect/expected/ivy_page.out
@@ -1,0 +1,240 @@
+CREATE EXTENSION pageinspect;
+CREATE TEMP TABLE test1 (a number(38,0), b number(38,0));
+INSERT INTO test1 VALUES (16777217, 131584);
+VACUUM (DISABLE_PAGE_SKIPPING) test1;  -- set up FSM
+-- The page contents can vary, so just test that it can be read
+-- successfully, but don't keep the output.
+SELECT octet_length(get_raw_page('test1', 'main', 0)) AS main_0;
+ main_0 
+--------
+   8192
+(1 row)
+
+SELECT octet_length(get_raw_page('test1', 'main', 1)) AS main_1;
+ERROR:  block number 1 is out of range for relation "test1"
+SELECT octet_length(get_raw_page('test1', 'fsm', 0)) AS fsm_0;
+ fsm_0 
+-------
+  8192
+(1 row)
+
+SELECT octet_length(get_raw_page('test1', 'fsm', 1)) AS fsm_1;
+ fsm_1 
+-------
+  8192
+(1 row)
+
+SELECT octet_length(get_raw_page('test1', 'vm', 0)) AS vm_0;
+ vm_0 
+------
+ 8192
+(1 row)
+
+SELECT octet_length(get_raw_page('test1', 'vm', 1)) AS vm_1;
+ERROR:  block number 1 is out of range for relation "test1"
+SELECT octet_length(get_raw_page('test1', 'main', -1));
+ERROR:  invalid block number
+SELECT octet_length(get_raw_page('xxx', 'main', 0));
+ERROR:  relation "xxx" does not exist
+SELECT octet_length(get_raw_page('test1', 'xxx', 0));
+ERROR:  invalid fork name
+HINT:  Valid fork names are "main", "fsm", "vm", and "init".
+SELECT get_raw_page('test1', 0) = get_raw_page('test1', 'main', 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT pagesize, version FROM page_header(get_raw_page('test1', 0));
+ pagesize | version 
+----------+---------
+     8192 |       4
+(1 row)
+
+SELECT page_checksum(get_raw_page('test1', 0), 0) IS NOT NULL AS silly_checksum_test;
+ silly_checksum_test 
+---------------------
+ t
+(1 row)
+
+SELECT page_checksum(get_raw_page('test1', 0), -1);
+ERROR:  invalid block number
+SELECT tuple_data_split('test1'::regclass, t_data, t_infomask, t_infomask2, t_bits)
+    FROM heap_page_items(get_raw_page('test1', 0));
+             tuple_data_split              
+-------------------------------------------
+ {"\\x0f01808d06311c","\\x0f01800d003006"}
+(1 row)
+
+SELECT * FROM fsm_page_contents(get_raw_page('test1', 'fsm', 0));
+ fsm_page_contents 
+-------------------
+ 0: 253           +
+ 1: 253           +
+ 3: 253           +
+ 7: 253           +
+ 15: 253          +
+ 31: 253          +
+ 63: 253          +
+ 127: 253         +
+ 255: 253         +
+ 511: 253         +
+ 1023: 253        +
+ 2047: 253        +
+ 4095: 253        +
+ fp_next_slot: 0  +
+ 
+(1 row)
+
+-- If we freeze the only tuple on test1, the infomask should
+-- always be the same in all test runs.
+VACUUM (FREEZE, DISABLE_PAGE_SKIPPING) test1;
+SELECT t_infomask, t_infomask2, raw_flags, combined_flags
+FROM heap_page_items(get_raw_page('test1', 0)),
+     LATERAL heap_tuple_infomask_flags(t_infomask, t_infomask2);
+ t_infomask | t_infomask2 |                                 raw_flags                                  |   combined_flags   
+------------+-------------+----------------------------------------------------------------------------+--------------------
+       2818 |           2 | {HEAP_HASVARWIDTH,HEAP_XMIN_COMMITTED,HEAP_XMIN_INVALID,HEAP_XMAX_INVALID} | {HEAP_XMIN_FROZEN}
+(1 row)
+
+-- tests for decoding of combined flags
+-- HEAP_XMAX_SHR_LOCK = (HEAP_XMAX_EXCL_LOCK | HEAP_XMAX_KEYSHR_LOCK)
+SELECT * FROM heap_tuple_infomask_flags(x'0050'::int, 0);
+                  raw_flags                  |    combined_flags    
+---------------------------------------------+----------------------
+ {HEAP_XMAX_KEYSHR_LOCK,HEAP_XMAX_EXCL_LOCK} | {HEAP_XMAX_SHR_LOCK}
+(1 row)
+
+-- HEAP_XMIN_FROZEN = (HEAP_XMIN_COMMITTED | HEAP_XMIN_INVALID)
+SELECT * FROM heap_tuple_infomask_flags(x'0300'::int, 0);
+                raw_flags                |   combined_flags   
+-----------------------------------------+--------------------
+ {HEAP_XMIN_COMMITTED,HEAP_XMIN_INVALID} | {HEAP_XMIN_FROZEN}
+(1 row)
+
+-- HEAP_MOVED = (HEAP_MOVED_IN | HEAP_MOVED_OFF)
+SELECT * FROM heap_tuple_infomask_flags(x'C000'::int, 0);
+           raw_flags            | combined_flags 
+--------------------------------+----------------
+ {HEAP_MOVED_OFF,HEAP_MOVED_IN} | {HEAP_MOVED}
+(1 row)
+
+SELECT * FROM heap_tuple_infomask_flags(x'C000'::int, 0);
+           raw_flags            | combined_flags 
+--------------------------------+----------------
+ {HEAP_MOVED_OFF,HEAP_MOVED_IN} | {HEAP_MOVED}
+(1 row)
+
+-- test all flags of t_infomask and t_infomask2
+SELECT unnest(raw_flags)
+  FROM heap_tuple_infomask_flags(x'FFFF'::int, x'FFFF'::int) ORDER BY 1;
+        unnest         
+-----------------------
+ HEAP_COMBOCID
+ HEAP_HASEXTERNAL
+ HEAP_HASNULL
+ HEAP_HASOID_OLD
+ HEAP_HASVARWIDTH
+ HEAP_HOT_UPDATED
+ HEAP_KEYS_UPDATED
+ HEAP_MOVED_IN
+ HEAP_MOVED_OFF
+ HEAP_ONLY_TUPLE
+ HEAP_UPDATED
+ HEAP_XMAX_COMMITTED
+ HEAP_XMAX_EXCL_LOCK
+ HEAP_XMAX_INVALID
+ HEAP_XMAX_IS_MULTI
+ HEAP_XMAX_KEYSHR_LOCK
+ HEAP_XMAX_LOCK_ONLY
+ HEAP_XMIN_COMMITTED
+ HEAP_XMIN_INVALID
+(19 rows)
+
+SELECT unnest(combined_flags)
+  FROM heap_tuple_infomask_flags(x'FFFF'::int, x'FFFF'::int) ORDER BY 1;
+       unnest       
+--------------------
+ HEAP_MOVED
+ HEAP_XMAX_SHR_LOCK
+ HEAP_XMIN_FROZEN
+(3 rows)
+
+-- no flags at all
+SELECT * FROM heap_tuple_infomask_flags(0, 0);
+ raw_flags | combined_flags 
+-----------+----------------
+ {}        | {}
+(1 row)
+
+-- no combined flags
+SELECT * FROM heap_tuple_infomask_flags(x'0010'::int, 0);
+        raw_flags        | combined_flags 
+-------------------------+----------------
+ {HEAP_XMAX_KEYSHR_LOCK} | {}
+(1 row)
+
+DROP TABLE test1;
+-- check that using any of these functions with a partitioned table or index
+-- would fail
+create table test_partitioned (a int) partition by range (a);
+create index test_partitioned_index on test_partitioned (a);
+select get_raw_page('test_partitioned', 0); -- error about partitioned table
+ERROR:  cannot get raw page from relation "test_partitioned"
+DETAIL:  This operation is not supported for partitioned tables.
+select get_raw_page('test_partitioned_index', 0); -- error about partitioned index
+ERROR:  cannot get raw page from relation "test_partitioned_index"
+DETAIL:  This operation is not supported for partitioned indexes.
+-- a regular table which is a member of a partition set should work though
+create table test_part1 partition of test_partitioned for values from ( 1 ) to (100);
+select get_raw_page('test_part1', 0); -- get farther and error about empty table
+ERROR:  block number 0 is out of range for relation "test_part1"
+drop table test_partitioned;
+-- check null bitmap alignment for table whose number of attributes is multiple of 8
+create table test8 (f1 int, f2 int, f3 int, f4 int, f5 int, f6 int, f7 int, f8 int);
+insert into test8(f1, f8) values (x'7f00007f'::int, 0);
+select t_bits, t_data from heap_page_items(get_raw_page('test8', 0));
+  t_bits  |       t_data       
+----------+--------------------
+ 10000001 | \x7f00007f00000000
+(1 row)
+
+select tuple_data_split('test8'::regclass, t_data, t_infomask, t_infomask2, t_bits)
+    from heap_page_items(get_raw_page('test8', 0));
+                      tuple_data_split                       
+-------------------------------------------------------------
+ {"\\x7f00007f",NULL,NULL,NULL,NULL,NULL,NULL,"\\x00000000"}
+(1 row)
+
+drop table test8;
+-- Failure with incorrect page size
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes.
+\set VERBOSITY terse
+SELECT fsm_page_contents('aaa'::bytea);
+ERROR:  invalid page size
+SELECT page_checksum('bbb'::bytea, 0);
+ERROR:  invalid page size
+SELECT page_header('ccc'::bytea);
+ERROR:  invalid page size
+\set VERBOSITY default
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT fsm_page_contents(decode(repeat('00', :block_size), 'hex'));
+ fsm_page_contents 
+-------------------
+ 
+(1 row)
+
+SELECT page_header(decode(repeat('00', :block_size), 'hex'));
+      page_header      
+-----------------------
+ (0/0,0,0,0,0,0,0,0,0)
+(1 row)
+
+SELECT page_checksum(decode(repeat('00', :block_size), 'hex'), 1);
+ page_checksum 
+---------------
+              
+(1 row)
+

--- a/contrib/pageinspect/sql/ivy_brin.sql
+++ b/contrib/pageinspect/sql/ivy_brin.sql
@@ -1,0 +1,39 @@
+CREATE TABLE test1 (a number(38,0), b varchar2(1024));
+INSERT INTO test1 VALUES (1, 'one');
+CREATE INDEX test1_a_idx ON test1 USING brin (a);
+
+SELECT brin_page_type(get_raw_page('test1_a_idx', 0));
+SELECT brin_page_type(get_raw_page('test1_a_idx', 1));
+SELECT brin_page_type(get_raw_page('test1_a_idx', 2));
+
+SELECT * FROM brin_metapage_info(get_raw_page('test1_a_idx', 0));
+SELECT * FROM brin_metapage_info(get_raw_page('test1_a_idx', 1));
+
+SELECT * FROM brin_revmap_data(get_raw_page('test1_a_idx', 0)) LIMIT 5;
+SELECT * FROM brin_revmap_data(get_raw_page('test1_a_idx', 1)) LIMIT 5;
+
+SELECT * FROM brin_page_items(get_raw_page('test1_a_idx', 2), 'test1_a_idx')
+    ORDER BY blknum, attnum LIMIT 5;
+
+-- Mask DETAIL messages as these are not portable across architectures.
+\set VERBOSITY terse
+
+-- Failures for non-BRIN index.
+CREATE INDEX test1_a_btree ON test1 (a);
+SELECT brin_page_items(get_raw_page('test1_a_btree', 0), 'test1_a_btree');
+SELECT brin_page_items(get_raw_page('test1_a_btree', 0), 'test1_a_idx');
+
+-- Invalid special area size
+SELECT brin_page_type(get_raw_page('test1', 0));
+SELECT * FROM brin_metapage_info(get_raw_page('test1', 0));
+SELECT * FROM brin_revmap_data(get_raw_page('test1', 0));
+\set VERBOSITY default
+
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT brin_page_type(decode(repeat('00', :block_size), 'hex'));
+SELECT brin_page_items(decode(repeat('00', :block_size), 'hex'), 'test1_a_idx');
+SELECT brin_metapage_info(decode(repeat('00', :block_size), 'hex'));
+SELECT brin_revmap_data(decode(repeat('00', :block_size), 'hex'));
+
+DROP TABLE test1;

--- a/contrib/pageinspect/sql/ivy_gin.sql
+++ b/contrib/pageinspect/sql/ivy_gin.sql
@@ -1,0 +1,41 @@
+CREATE TABLE test1 (x number(38,0), y int[]);
+INSERT INTO test1 VALUES (1, ARRAY[11, 111]);
+CREATE INDEX test1_y_idx ON test1 USING gin (y) WITH (fastupdate = off);
+
+\x
+
+SELECT * FROM gin_metapage_info(get_raw_page('test1_y_idx', 0));
+SELECT * FROM gin_metapage_info(get_raw_page('test1_y_idx', 1));
+
+SELECT * FROM gin_page_opaque_info(get_raw_page('test1_y_idx', 1));
+
+SELECT * FROM gin_leafpage_items(get_raw_page('test1_y_idx', 1));
+
+INSERT INTO test1 SELECT x, ARRAY[1,10] FROM generate_series(2,10000) x;
+
+SELECT COUNT(*) > 0
+FROM gin_leafpage_items(get_raw_page('test1_y_idx',
+                        (pg_relation_size('test1_y_idx') /
+                         current_setting('block_size')::bigint)::int - 1));
+
+-- Failure with various modes.
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes and architectures.
+\set VERBOSITY terse
+-- invalid page size
+SELECT gin_leafpage_items('aaa'::bytea);
+SELECT gin_metapage_info('bbb'::bytea);
+SELECT gin_page_opaque_info('ccc'::bytea);
+-- invalid special area size
+SELECT * FROM gin_metapage_info(get_raw_page('test1', 0));
+SELECT * FROM gin_page_opaque_info(get_raw_page('test1', 0));
+SELECT * FROM gin_leafpage_items(get_raw_page('test1', 0));
+\set VERBOSITY default
+
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT gin_leafpage_items(decode(repeat('00', :block_size), 'hex'));
+SELECT gin_metapage_info(decode(repeat('00', :block_size), 'hex'));
+SELECT gin_page_opaque_info(decode(repeat('00', :block_size), 'hex'));
+
+DROP TABLE test1;

--- a/contrib/pageinspect/sql/ivy_gist.sql
+++ b/contrib/pageinspect/sql/ivy_gist.sql
@@ -1,0 +1,69 @@
+-- The gist_page_opaque_info() function prints the page's LSN. Normally,
+-- that's constant 1 (GistBuildLSN) on every page of a freshly built GiST
+-- index. But with wal_level=minimal, the whole relation is dumped to WAL at
+-- the end of the transaction if it's smaller than wal_skip_threshold, which
+-- updates the LSNs. Wrap the tests on gist_page_opaque_info() in the
+-- same transaction with the CREATE INDEX so that we see the LSNs before
+-- they are possibly overwritten at end of transaction.
+BEGIN;
+
+-- Create a test table and GiST index.
+CREATE TABLE test_gist AS SELECT point(i,i) p, i::varchar(64) t FROM
+    generate_series(1,1000) i;
+CREATE INDEX test_gist_idx ON test_gist USING gist (p);
+
+-- Page 0 is the root, the rest are leaf pages
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist_idx', 0));
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist_idx', 1));
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist_idx', 2));
+
+COMMIT;
+
+SELECT * FROM gist_page_items(get_raw_page('test_gist_idx', 0), 'test_gist_idx');
+SELECT * FROM gist_page_items(get_raw_page('test_gist_idx', 1), 'test_gist_idx') LIMIT 5;
+
+-- gist_page_items_bytea prints the raw key data as a bytea. The output of that is
+-- platform-dependent (endianness), so omit the actual key data from the output.
+SELECT itemoffset, ctid, itemlen FROM gist_page_items_bytea(get_raw_page('test_gist_idx', 0));
+
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes and architectures.
+\set VERBOSITY terse
+
+-- Failures with non-GiST index.
+CREATE INDEX test_gist_btree on test_gist(t);
+SELECT gist_page_items(get_raw_page('test_gist_btree', 0), 'test_gist_btree');
+SELECT gist_page_items(get_raw_page('test_gist_btree', 0), 'test_gist_idx');
+
+-- Failure with various modes.
+-- invalid page size
+SELECT gist_page_items_bytea('aaa'::bytea);
+SELECT gist_page_items('aaa'::bytea, 'test_gist_idx'::regclass);
+SELECT gist_page_opaque_info('aaa'::bytea);
+-- invalid special area size
+SELECT * FROM gist_page_opaque_info(get_raw_page('test_gist', 0));
+SELECT gist_page_items_bytea(get_raw_page('test_gist', 0));
+SELECT gist_page_items_bytea(get_raw_page('test_gist_btree', 0));
+\set VERBOSITY default
+
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT gist_page_items_bytea(decode(repeat('00', :block_size), 'hex'));
+SELECT gist_page_items(decode(repeat('00', :block_size), 'hex'), 'test_gist_idx'::regclass);
+SELECT gist_page_opaque_info(decode(repeat('00', :block_size), 'hex'));
+
+-- Test gist_page_items with included columns.
+-- Non-leaf pages contain only the key attributes, and leaf pages contain
+-- the included attributes.
+ALTER TABLE test_gist ADD COLUMN i int DEFAULT NULL;
+CREATE INDEX test_gist_idx_inc ON test_gist
+  USING gist (p) INCLUDE (t, i);
+-- Mask the value of the key attribute to avoid alignment issues.
+SELECT regexp_replace(keys, '\(p\)=\("(.*?)"\)', '(p)=("<val>")') AS keys_nonleaf_1
+  FROM gist_page_items(get_raw_page('test_gist_idx_inc', 0), 'test_gist_idx_inc')
+  WHERE itemoffset = 1;
+SELECT keys AS keys_leaf_1
+  FROM gist_page_items(get_raw_page('test_gist_idx_inc', 1), 'test_gist_idx_inc')
+  WHERE itemoffset = 1;
+
+DROP TABLE test_gist;

--- a/contrib/pageinspect/sql/ivy_hash.sql
+++ b/contrib/pageinspect/sql/ivy_hash.sql
@@ -1,0 +1,82 @@
+CREATE TABLE test_hash (a number(38,0), b varchar2(1024));
+INSERT INTO test_hash VALUES (1, 'one');
+CREATE INDEX test_hash_a_idx ON test_hash USING hash (a);
+
+\x
+
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 0));
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 1));
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 2));
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 3));
+SELECT hash_page_type(get_raw_page('test_hash_a_idx', 4));
+
+
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', -1);
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 0);
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 1);
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 2);
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 3);
+SELECT * FROM hash_bitmap_info('test_hash_a_idx', 4);
+
+
+SELECT magic, version, ntuples, bsize, bmsize, bmshift, maxbucket, highmask,
+lowmask, ovflpoint, firstfree, nmaps, procid, spares, mapp FROM
+hash_metapage_info(get_raw_page('test_hash_a_idx', 1));
+
+SELECT magic, version, ntuples, bsize, bmsize, bmshift, maxbucket, highmask,
+lowmask, ovflpoint, firstfree, nmaps, procid, spares, mapp FROM
+hash_metapage_info(get_raw_page('test_hash_a_idx', 2));
+
+SELECT magic, version, ntuples, bsize, bmsize, bmshift, maxbucket, highmask,
+lowmask, ovflpoint, firstfree, nmaps, procid, spares, mapp FROM
+hash_metapage_info(get_raw_page('test_hash_a_idx', 3));
+
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 0));
+
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 1));
+
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 2));
+
+SELECT live_items, dead_items, page_size, hasho_prevblkno, hasho_nextblkno,
+hasho_bucket, hasho_flag, hasho_page_id FROM
+hash_page_stats(get_raw_page('test_hash_a_idx', 3));
+
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 0));
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 1));
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 2));
+SELECT * FROM hash_page_items(get_raw_page('test_hash_a_idx', 3));
+
+-- Failure with non-hash index
+CREATE INDEX test_hash_a_btree ON test_hash USING btree (a);
+SELECT hash_bitmap_info('test_hash_a_btree', 0);
+
+-- Failure with various modes.
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes and architectures.
+\set VERBOSITY terse
+-- invalid page size
+SELECT hash_metapage_info('aaa'::bytea);
+SELECT hash_page_items('bbb'::bytea);
+SELECT hash_page_stats('ccc'::bytea);
+SELECT hash_page_type('ddd'::bytea);
+-- invalid special area size
+SELECT hash_metapage_info(get_raw_page('test_hash', 0));
+SELECT hash_page_items(get_raw_page('test_hash', 0));
+SELECT hash_page_stats(get_raw_page('test_hash', 0));
+SELECT hash_page_type(get_raw_page('test_hash', 0));
+\set VERBOSITY default
+
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT hash_metapage_info(decode(repeat('00', :block_size), 'hex'));
+SELECT hash_page_items(decode(repeat('00', :block_size), 'hex'));
+SELECT hash_page_stats(decode(repeat('00', :block_size), 'hex'));
+SELECT hash_page_type(decode(repeat('00', :block_size), 'hex'));
+
+DROP TABLE test_hash;

--- a/contrib/pageinspect/sql/ivy_oldextversions.sql
+++ b/contrib/pageinspect/sql/ivy_oldextversions.sql
@@ -1,0 +1,26 @@
+-- test old extension version entry points
+
+DROP EXTENSION pageinspect;
+CREATE EXTENSION pageinspect VERSION '1.8';
+
+CREATE TABLE test1 (a int8, b varchar2(32));
+INSERT INTO test1 VALUES (72057594037927937, 'text');
+CREATE INDEX test1_a_idx ON test1 USING btree (a);
+
+-- from page.sql
+SELECT octet_length(get_raw_page('test1', 0)) AS main_0;
+SELECT octet_length(get_raw_page('test1', 'main', 0)) AS main_0;
+SELECT page_checksum(get_raw_page('test1', 0), 0) IS NOT NULL AS silly_checksum_test;
+
+-- from btree.sql
+SELECT * FROM bt_page_stats('test1_a_idx', 1);
+SELECT * FROM bt_page_items('test1_a_idx', 1);
+
+-- page_header() uses int instead of smallint for lower, upper, special and
+-- pagesize in pageinspect >= 1.10.
+ALTER EXTENSION pageinspect UPDATE TO '1.9';
+\df page_header
+SELECT pagesize, version FROM page_header(get_raw_page('test1', 0));
+
+DROP TABLE test1;
+DROP EXTENSION pageinspect;

--- a/contrib/pageinspect/sql/ivy_page.sql
+++ b/contrib/pageinspect/sql/ivy_page.sql
@@ -1,0 +1,99 @@
+CREATE EXTENSION pageinspect;
+
+CREATE TEMP TABLE test1 (a number(38,0), b number(38,0));
+INSERT INTO test1 VALUES (16777217, 131584);
+
+VACUUM (DISABLE_PAGE_SKIPPING) test1;  -- set up FSM
+
+-- The page contents can vary, so just test that it can be read
+-- successfully, but don't keep the output.
+
+SELECT octet_length(get_raw_page('test1', 'main', 0)) AS main_0;
+SELECT octet_length(get_raw_page('test1', 'main', 1)) AS main_1;
+
+SELECT octet_length(get_raw_page('test1', 'fsm', 0)) AS fsm_0;
+SELECT octet_length(get_raw_page('test1', 'fsm', 1)) AS fsm_1;
+
+SELECT octet_length(get_raw_page('test1', 'vm', 0)) AS vm_0;
+SELECT octet_length(get_raw_page('test1', 'vm', 1)) AS vm_1;
+
+SELECT octet_length(get_raw_page('test1', 'main', -1));
+SELECT octet_length(get_raw_page('xxx', 'main', 0));
+SELECT octet_length(get_raw_page('test1', 'xxx', 0));
+
+SELECT get_raw_page('test1', 0) = get_raw_page('test1', 'main', 0);
+
+SELECT pagesize, version FROM page_header(get_raw_page('test1', 0));
+
+SELECT page_checksum(get_raw_page('test1', 0), 0) IS NOT NULL AS silly_checksum_test;
+SELECT page_checksum(get_raw_page('test1', 0), -1);
+
+SELECT tuple_data_split('test1'::regclass, t_data, t_infomask, t_infomask2, t_bits)
+    FROM heap_page_items(get_raw_page('test1', 0));
+
+SELECT * FROM fsm_page_contents(get_raw_page('test1', 'fsm', 0));
+
+-- If we freeze the only tuple on test1, the infomask should
+-- always be the same in all test runs.
+VACUUM (FREEZE, DISABLE_PAGE_SKIPPING) test1;
+
+SELECT t_infomask, t_infomask2, raw_flags, combined_flags
+FROM heap_page_items(get_raw_page('test1', 0)),
+     LATERAL heap_tuple_infomask_flags(t_infomask, t_infomask2);
+
+-- tests for decoding of combined flags
+-- HEAP_XMAX_SHR_LOCK = (HEAP_XMAX_EXCL_LOCK | HEAP_XMAX_KEYSHR_LOCK)
+SELECT * FROM heap_tuple_infomask_flags(x'0050'::int, 0);
+-- HEAP_XMIN_FROZEN = (HEAP_XMIN_COMMITTED | HEAP_XMIN_INVALID)
+SELECT * FROM heap_tuple_infomask_flags(x'0300'::int, 0);
+-- HEAP_MOVED = (HEAP_MOVED_IN | HEAP_MOVED_OFF)
+SELECT * FROM heap_tuple_infomask_flags(x'C000'::int, 0);
+SELECT * FROM heap_tuple_infomask_flags(x'C000'::int, 0);
+
+-- test all flags of t_infomask and t_infomask2
+SELECT unnest(raw_flags)
+  FROM heap_tuple_infomask_flags(x'FFFF'::int, x'FFFF'::int) ORDER BY 1;
+SELECT unnest(combined_flags)
+  FROM heap_tuple_infomask_flags(x'FFFF'::int, x'FFFF'::int) ORDER BY 1;
+
+-- no flags at all
+SELECT * FROM heap_tuple_infomask_flags(0, 0);
+-- no combined flags
+SELECT * FROM heap_tuple_infomask_flags(x'0010'::int, 0);
+
+DROP TABLE test1;
+
+-- check that using any of these functions with a partitioned table or index
+-- would fail
+create table test_partitioned (a int) partition by range (a);
+create index test_partitioned_index on test_partitioned (a);
+select get_raw_page('test_partitioned', 0); -- error about partitioned table
+select get_raw_page('test_partitioned_index', 0); -- error about partitioned index
+
+-- a regular table which is a member of a partition set should work though
+create table test_part1 partition of test_partitioned for values from ( 1 ) to (100);
+select get_raw_page('test_part1', 0); -- get farther and error about empty table
+drop table test_partitioned;
+
+-- check null bitmap alignment for table whose number of attributes is multiple of 8
+create table test8 (f1 int, f2 int, f3 int, f4 int, f5 int, f6 int, f7 int, f8 int);
+insert into test8(f1, f8) values (x'7f00007f'::int, 0);
+select t_bits, t_data from heap_page_items(get_raw_page('test8', 0));
+select tuple_data_split('test8'::regclass, t_data, t_infomask, t_infomask2, t_bits)
+    from heap_page_items(get_raw_page('test8', 0));
+drop table test8;
+
+-- Failure with incorrect page size
+-- Suppress the DETAIL message, to allow the tests to work across various
+-- page sizes.
+\set VERBOSITY terse
+SELECT fsm_page_contents('aaa'::bytea);
+SELECT page_checksum('bbb'::bytea, 0);
+SELECT page_header('ccc'::bytea);
+\set VERBOSITY default
+
+-- Tests with all-zero pages.
+SHOW block_size \gset
+SELECT fsm_page_contents(decode(repeat('00', :block_size), 'hex'));
+SELECT page_header(decode(repeat('00', :block_size), 'hex'));
+SELECT page_checksum(decode(repeat('00', :block_size), 'hex'), 1);

--- a/contrib/pg_trgm/expected/ivy_pg_trgm.out
+++ b/contrib/pg_trgm/expected/ivy_pg_trgm.out
@@ -73,7 +73,7 @@ select similarity('---', '####---');
           0
 (1 row)
 
-CREATE TABLE test_trgm(t text COLLATE "C");
+CREATE TABLE test_trgm(t varchar2(1024) COLLATE "C");
 \copy test_trgm from 'data/trgm.data'
 select t,similarity(t,'qwertyu0988') as sml from test_trgm where t % 'qwertyu0988' order by sml desc, t;
       t      |   sml    
@@ -2344,11 +2344,11 @@ select t,similarity(t,'gwertyu1988') as sml from test_trgm where t % 'gwertyu198
 
 explain (costs off)
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
-                    QUERY PLAN                     
----------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Index Scan using trgm_idx on test_trgm
-         Order By: (t <-> 'q0987wertyu0988'::text)
+         Order By: ((t)::text <-> 'q0987wertyu0988'::text)
 (3 rows)
 
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
@@ -3501,11 +3501,11 @@ select t,similarity(t,'gwertyu1988') as sml from test_trgm where t % 'gwertyu198
 
 explain (costs off)
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
-                    QUERY PLAN                     
----------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Index Scan using trgm_idx on test_trgm
-         Order By: (t <-> 'q0987wertyu0988'::text)
+         Order By: ((t)::text <-> 'q0987wertyu0988'::text)
 (3 rows)
 
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
@@ -4659,13 +4659,13 @@ select count(*) from test_trgm where t ~ '[qwerty]{2}-?[qwerty]{2}';
 -- check handling of indexquals that generate no searchable conditions
 explain (costs off)
 select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Bitmap Heap Scan on test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+         Recheck Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qwerty%'::text COLLATE "C"))
          ->  Bitmap Index Scan on trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+               Index Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qwerty%'::text COLLATE "C"))
 (5 rows)
 
 select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
@@ -4676,13 +4676,13 @@ select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
 
 explain (costs off)
 select count(*) from test_trgm where t like '%99%' and t like '%qw%';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Bitmap Heap Scan on test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+         Recheck Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qw%'::text COLLATE "C"))
          ->  Bitmap Index Scan on trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+               Index Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qw%'::text COLLATE "C"))
 (5 rows)
 
 select count(*) from test_trgm where t like '%99%' and t like '%qw%';
@@ -4692,18 +4692,18 @@ select count(*) from test_trgm where t like '%99%' and t like '%qw%';
 (1 row)
 
 -- ensure that pending-list items are handled correctly, too
-create temp table t_test_trgm(t text COLLATE "C");
+create temp table t_test_trgm(t varchar2(1024) COLLATE "C");
 create index t_trgm_idx on t_test_trgm using gin (t gin_trgm_ops);
 insert into t_test_trgm values ('qwerty99'), ('qwerty01');
 explain (costs off)
 select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Bitmap Heap Scan on t_test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+         Recheck Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qwerty%'::text COLLATE "C"))
          ->  Bitmap Index Scan on t_trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+               Index Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qwerty%'::text COLLATE "C"))
 (5 rows)
 
 select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
@@ -4714,13 +4714,13 @@ select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
 
 explain (costs off)
 select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Bitmap Heap Scan on t_test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+         Recheck Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qw%'::text COLLATE "C"))
          ->  Bitmap Index Scan on t_trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+               Index Cond: (((t)::text ~~ '%99%'::text COLLATE "C") AND ((t)::text ~~ '%qw%'::text COLLATE "C"))
 (5 rows)
 
 select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
@@ -4757,7 +4757,7 @@ select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
 (1 row)
 
 reset enable_bitmapscan;
-create table test2(t text COLLATE "C");
+create table test2(t varchar2(1024) COLLATE "C");
 insert into test2 values ('abcdef');
 insert into test2 values ('quark');
 insert into test2 values ('  z foo bar');
@@ -4772,22 +4772,22 @@ create index test2_idx_gin on test2 using gin (t gin_trgm_ops);
 set enable_seqscan=off;
 explain (costs off)
   select * from test2 where t like '%BCD%';
-                QUERY PLAN                
-------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Bitmap Heap Scan on test2
-   Recheck Cond: (t ~~ '%BCD%'::text)
+   Recheck Cond: ((t)::text ~~ '%BCD%'::text COLLATE "C")
    ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~~ '%BCD%'::text)
+         Index Cond: ((t)::text ~~ '%BCD%'::text COLLATE "C")
 (4 rows)
 
 explain (costs off)
   select * from test2 where t ilike '%BCD%';
-                QUERY PLAN                 
--------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Bitmap Heap Scan on test2
-   Recheck Cond: (t ~~* '%BCD%'::text)
+   Recheck Cond: ((t)::text ~~* '%BCD%'::text)
    ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~~* '%BCD%'::text)
+         Index Cond: ((t)::text ~~* '%BCD%'::text)
 (4 rows)
 
 select * from test2 where t like '%BCD%';
@@ -4833,22 +4833,22 @@ select * from test2 where t like '  z foo%';
 
 explain (costs off)
   select * from test2 where t ~ '[abc]{3}';
-                 QUERY PLAN                 
---------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Bitmap Heap Scan on test2
-   Recheck Cond: (t ~ '[abc]{3}'::text)
+   Recheck Cond: ((t)::text ~ '[abc]{3}'::text)
    ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~ '[abc]{3}'::text)
+         Index Cond: ((t)::text ~ '[abc]{3}'::text)
 (4 rows)
 
 explain (costs off)
   select * from test2 where t ~* 'DEF';
-                QUERY PLAN                
-------------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  Bitmap Heap Scan on test2
-   Recheck Cond: (t ~* 'DEF'::text)
+   Recheck Cond: ((t)::text ~* 'DEF'::text)
    ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~* 'DEF'::text)
+         Index Cond: ((t)::text ~* 'DEF'::text)
 (4 rows)
 
 select * from test2 where t ~ '[abc]{3}';
@@ -4981,13 +4981,11 @@ select * from test2 where t ~ '/\d+/-\d';
 -- test = operator
 explain (costs off)
   select * from test2 where t = 'abcdef';
-                QUERY PLAN                
-------------------------------------------
- Bitmap Heap Scan on test2
-   Recheck Cond: (t = 'abcdef'::text)
-   ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t = 'abcdef'::text)
-(4 rows)
+             QUERY PLAN             
+------------------------------------
+ Seq Scan on test2
+   Filter: (t = 'abcdef'::varchar2)
+(2 rows)
 
 select * from test2 where t = 'abcdef';
    t    
@@ -4997,13 +4995,11 @@ select * from test2 where t = 'abcdef';
 
 explain (costs off)
   select * from test2 where t = '%line%';
-                QUERY PLAN                
-------------------------------------------
- Bitmap Heap Scan on test2
-   Recheck Cond: (t = '%line%'::text)
-   ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t = '%line%'::text)
-(4 rows)
+             QUERY PLAN             
+------------------------------------
+ Seq Scan on test2
+   Filter: (t = '%line%'::varchar2)
+(2 rows)
 
 select * from test2 where t = '%line%';
  t 
@@ -5070,18 +5066,18 @@ create index test2_idx_gist on test2 using gist (t gist_trgm_ops);
 set enable_seqscan=off;
 explain (costs off)
   select * from test2 where t like '%BCD%';
-                QUERY PLAN                
-------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~~ '%BCD%'::text)
+   Index Cond: ((t)::text ~~ '%BCD%'::text COLLATE "C")
 (2 rows)
 
 explain (costs off)
   select * from test2 where t ilike '%BCD%';
-                QUERY PLAN                
-------------------------------------------
+                 QUERY PLAN                  
+---------------------------------------------
  Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~~* '%BCD%'::text)
+   Index Cond: ((t)::text ~~* '%BCD%'::text)
 (2 rows)
 
 select * from test2 where t like '%BCD%';
@@ -5127,10 +5123,10 @@ select * from test2 where t like '  z foo%';
 
 explain (costs off)
   select * from test2 where t ~ '[abc]{3}';
-                QUERY PLAN                
-------------------------------------------
+                  QUERY PLAN                  
+----------------------------------------------
  Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~ '[abc]{3}'::text)
+   Index Cond: ((t)::text ~ '[abc]{3}'::text)
 (2 rows)
 
 explain (costs off)
@@ -5138,7 +5134,7 @@ explain (costs off)
                 QUERY PLAN                
 ------------------------------------------
  Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~* 'DEF'::text)
+   Index Cond: ((t)::text ~* 'DEF'::text)
 (2 rows)
 
 select * from test2 where t ~ '[abc]{3}';
@@ -5271,10 +5267,10 @@ select * from test2 where t ~ '/\d+/-\d';
 -- test = operator
 explain (costs off)
   select * from test2 where t = 'abcdef';
-                QUERY PLAN                
-------------------------------------------
- Index Scan using test2_idx_gist on test2
-   Index Cond: (t = 'abcdef'::text)
+             QUERY PLAN             
+------------------------------------
+ Seq Scan on test2
+   Filter: (t = 'abcdef'::varchar2)
 (2 rows)
 
 select * from test2 where t = 'abcdef';
@@ -5285,10 +5281,10 @@ select * from test2 where t = 'abcdef';
 
 explain (costs off)
   select * from test2 where t = '%line%';
-                QUERY PLAN                
-------------------------------------------
- Index Scan using test2_idx_gist on test2
-   Index Cond: (t = '%line%'::text)
+             QUERY PLAN             
+------------------------------------
+ Seq Scan on test2
+   Filter: (t = '%line%'::varchar2)
 (2 rows)
 
 select * from test2 where t = '%line%';
@@ -5352,7 +5348,7 @@ select * from test2 where t = 'li_e 6';
 (1 row)
 
 -- Check similarity threshold (bug #14202)
-CREATE TEMP TABLE restaurants (city text);
+CREATE TEMP TABLE restaurants (city varchar2(1024 char));
 INSERT INTO restaurants SELECT 'Warsaw' FROM generate_series(1, 10000);
 INSERT INTO restaurants SELECT 'Szczecin' FROM generate_series(1, 10000);
 CREATE INDEX ON restaurants USING gist(city gist_trgm_ops);
@@ -5367,14 +5363,14 @@ SELECT similarity('Szczecin', 'Warsaw');
 EXPLAIN (COSTS OFF)
 SELECT DISTINCT city, similarity(city, 'Warsaw'), show_limit()
   FROM restaurants WHERE city % 'Warsaw';
-                      QUERY PLAN                       
--------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  HashAggregate
-   Group Key: city, similarity(city, 'Warsaw'::text)
+   Group Key: city, similarity((city)::text, 'Warsaw'::text)
    ->  Bitmap Heap Scan on restaurants
-         Recheck Cond: (city % 'Warsaw'::text)
+         Recheck Cond: ((city)::text % 'Warsaw'::text)
          ->  Bitmap Index Scan on restaurants_city_idx
-               Index Cond: (city % 'Warsaw'::text)
+               Index Cond: ((city)::text % 'Warsaw'::text)
 (6 rows)
 
 SELECT set_limit(0.3);

--- a/contrib/pg_trgm/sql/ivy_pg_trgm.sql
+++ b/contrib/pg_trgm/sql/ivy_pg_trgm.sql
@@ -26,7 +26,7 @@ select similarity('wow',' WOW ');
 
 select similarity('---', '####---');
 
-CREATE TABLE test_trgm(t text COLLATE "C");
+CREATE TABLE test_trgm(t varchar2(1024) COLLATE "C");
 
 \copy test_trgm from 'data/trgm.data'
 
@@ -78,7 +78,7 @@ explain (costs off)
 select count(*) from test_trgm where t like '%99%' and t like '%qw%';
 select count(*) from test_trgm where t like '%99%' and t like '%qw%';
 -- ensure that pending-list items are handled correctly, too
-create temp table t_test_trgm(t text COLLATE "C");
+create temp table t_test_trgm(t varchar2(1024) COLLATE "C");
 create index t_trgm_idx on t_test_trgm using gin (t gin_trgm_ops);
 insert into t_test_trgm values ('qwerty99'), ('qwerty01');
 explain (costs off)
@@ -97,7 +97,7 @@ select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
 select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
 reset enable_bitmapscan;
 
-create table test2(t text COLLATE "C");
+create table test2(t varchar2(1024) COLLATE "C");
 insert into test2 values ('abcdef');
 insert into test2 values ('quark');
 insert into test2 values ('  z foo bar');
@@ -219,7 +219,7 @@ select * from test2 where t = 'li_e 6';
 
 -- Check similarity threshold (bug #14202)
 
-CREATE TEMP TABLE restaurants (city text);
+CREATE TEMP TABLE restaurants (city varchar2(1024 char));
 INSERT INTO restaurants SELECT 'Warsaw' FROM generate_series(1, 10000);
 INSERT INTO restaurants SELECT 'Szczecin' FROM generate_series(1, 10000);
 CREATE INDEX ON restaurants USING gist(city gist_trgm_ops);

--- a/contrib/pg_visibility/Makefile
+++ b/contrib/pg_visibility/Makefile
@@ -11,7 +11,7 @@ DATA = pg_visibility--1.1.sql pg_visibility--1.1--1.2.sql \
 PGFILEDESC = "pg_visibility - page visibility information"
 
 REGRESS = pg_visibility
-ORA_REGRESS = pg_visibility
+ORA_REGRESS = ivy_pg_visibility
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/pg_visibility/expected/ivy_pg_visibility.out
+++ b/contrib/pg_visibility/expected/ivy_pg_visibility.out
@@ -1,0 +1,279 @@
+CREATE EXTENSION pg_visibility;
+--
+-- recently-dropped table
+--
+\set VERBOSITY sqlstate
+BEGIN;
+CREATE TABLE droppedtest (c number(38,0));
+SELECT 'droppedtest'::regclass::oid AS oid \gset
+SAVEPOINT q; DROP TABLE droppedtest; RELEASE q;
+SAVEPOINT q; SELECT * FROM pg_visibility_map(:oid); ROLLBACK TO q;
+ERROR:  XX000
+-- ERROR:  could not open relation with OID 16xxx
+SAVEPOINT q; SELECT 1; ROLLBACK TO q;
+ ?column? 
+----------
+        1
+(1 row)
+
+SAVEPOINT q; SELECT 1; ROLLBACK TO q;
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT pg_relation_size(:oid), pg_relation_filepath(:oid),
+  has_table_privilege(:oid, 'SELECT');
+ pg_relation_size | pg_relation_filepath | has_table_privilege 
+------------------+----------------------+---------------------
+                  |                      | 
+(1 row)
+
+SELECT * FROM pg_visibility_map(:oid);
+ERROR:  XX000
+-- ERROR:  could not open relation with OID 16xxx
+ROLLBACK;
+\set VERBOSITY default
+--
+-- check that using the module's functions with unsupported relations will fail
+--
+-- partitioned tables (the parent ones) don't have visibility maps
+create table test_partitioned (a number(38,0)) partition by list (a);
+-- these should all fail
+select pg_visibility('test_partitioned', 0);
+ERROR:  relation "test_partitioned" is of wrong relation kind
+DETAIL:  This operation is not supported for partitioned tables.
+select pg_visibility_map('test_partitioned');
+ERROR:  relation "test_partitioned" is of wrong relation kind
+DETAIL:  This operation is not supported for partitioned tables.
+select pg_visibility_map_summary('test_partitioned');
+ERROR:  relation "test_partitioned" is of wrong relation kind
+DETAIL:  This operation is not supported for partitioned tables.
+select pg_check_frozen('test_partitioned');
+ERROR:  relation "test_partitioned" is of wrong relation kind
+DETAIL:  This operation is not supported for partitioned tables.
+select pg_truncate_visibility_map('test_partitioned');
+ERROR:  relation "test_partitioned" is of wrong relation kind
+DETAIL:  This operation is not supported for partitioned tables.
+create table test_partition partition of test_partitioned for values in (1);
+create index test_index on test_partition (a);
+-- indexes do not, so these all fail
+select pg_visibility('test_index', 0);
+ERROR:  relation "test_index" is of wrong relation kind
+DETAIL:  This operation is not supported for indexes.
+select pg_visibility_map('test_index');
+ERROR:  relation "test_index" is of wrong relation kind
+DETAIL:  This operation is not supported for indexes.
+select pg_visibility_map_summary('test_index');
+ERROR:  relation "test_index" is of wrong relation kind
+DETAIL:  This operation is not supported for indexes.
+select pg_check_frozen('test_index');
+ERROR:  relation "test_index" is of wrong relation kind
+DETAIL:  This operation is not supported for indexes.
+select pg_truncate_visibility_map('test_index');
+ERROR:  relation "test_index" is of wrong relation kind
+DETAIL:  This operation is not supported for indexes.
+create view test_view as select 1;
+-- views do not have VMs, so these all fail
+select pg_visibility('test_view', 0);
+ERROR:  relation "test_view" is of wrong relation kind
+DETAIL:  This operation is not supported for views.
+select pg_visibility_map('test_view');
+ERROR:  relation "test_view" is of wrong relation kind
+DETAIL:  This operation is not supported for views.
+select pg_visibility_map_summary('test_view');
+ERROR:  relation "test_view" is of wrong relation kind
+DETAIL:  This operation is not supported for views.
+select pg_check_frozen('test_view');
+ERROR:  relation "test_view" is of wrong relation kind
+DETAIL:  This operation is not supported for views.
+select pg_truncate_visibility_map('test_view');
+ERROR:  relation "test_view" is of wrong relation kind
+DETAIL:  This operation is not supported for views.
+create sequence test_sequence;
+-- sequences do not have VMs, so these all fail
+select pg_visibility('test_sequence', 0);
+ERROR:  relation "test_sequence" is of wrong relation kind
+DETAIL:  This operation is not supported for sequences.
+select pg_visibility_map('test_sequence');
+ERROR:  relation "test_sequence" is of wrong relation kind
+DETAIL:  This operation is not supported for sequences.
+select pg_visibility_map_summary('test_sequence');
+ERROR:  relation "test_sequence" is of wrong relation kind
+DETAIL:  This operation is not supported for sequences.
+select pg_check_frozen('test_sequence');
+ERROR:  relation "test_sequence" is of wrong relation kind
+DETAIL:  This operation is not supported for sequences.
+select pg_truncate_visibility_map('test_sequence');
+ERROR:  relation "test_sequence" is of wrong relation kind
+DETAIL:  This operation is not supported for sequences.
+create foreign data wrapper dummy;
+create server dummy_server foreign data wrapper dummy;
+create foreign table test_foreign_table () server dummy_server;
+-- foreign tables do not have VMs, so these all fail
+select pg_visibility('test_foreign_table', 0);
+ERROR:  relation "test_foreign_table" is of wrong relation kind
+DETAIL:  This operation is not supported for foreign tables.
+select pg_visibility_map('test_foreign_table');
+ERROR:  relation "test_foreign_table" is of wrong relation kind
+DETAIL:  This operation is not supported for foreign tables.
+select pg_visibility_map_summary('test_foreign_table');
+ERROR:  relation "test_foreign_table" is of wrong relation kind
+DETAIL:  This operation is not supported for foreign tables.
+select pg_check_frozen('test_foreign_table');
+ERROR:  relation "test_foreign_table" is of wrong relation kind
+DETAIL:  This operation is not supported for foreign tables.
+select pg_truncate_visibility_map('test_foreign_table');
+ERROR:  relation "test_foreign_table" is of wrong relation kind
+DETAIL:  This operation is not supported for foreign tables.
+-- check some of the allowed relkinds
+create table regular_table (a number(38,0), b varchar2(4000));
+alter table regular_table alter column b set storage external;
+insert into regular_table values (1, repeat('one', 1000)), (2, repeat('two', 1000));
+vacuum (disable_page_skipping) regular_table;
+select count(*) > 0 from pg_visibility('regular_table');
+ ?column? 
+----------
+ t
+(1 row)
+
+select count(*) > 0 from pg_visibility((select reltoastrelid from pg_class where relname = 'regular_table'));
+ ?column? 
+----------
+ t
+(1 row)
+
+truncate regular_table;
+select count(*) > 0 from pg_visibility('regular_table');
+ ?column? 
+----------
+ f
+(1 row)
+
+select count(*) > 0 from pg_visibility((select reltoastrelid from pg_class where relname = 'regular_table'));
+ ?column? 
+----------
+ f
+(1 row)
+
+create materialized view matview_visibility_test as select * from regular_table;
+vacuum (disable_page_skipping) matview_visibility_test;
+select count(*) > 0 from pg_visibility('matview_visibility_test');
+ ?column? 
+----------
+ f
+(1 row)
+
+insert into regular_table values (1), (2);
+refresh materialized view matview_visibility_test;
+select count(*) > 0 from pg_visibility('matview_visibility_test');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- regular tables which are part of a partition *do* have visibility maps
+insert into test_partition values (1);
+vacuum (disable_page_skipping) test_partition;
+select count(*) > 0 from pg_visibility('test_partition', 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+select count(*) > 0 from pg_visibility_map('test_partition');
+ ?column? 
+----------
+ t
+(1 row)
+
+select count(*) > 0 from pg_visibility_map_summary('test_partition');
+ ?column? 
+----------
+ t
+(1 row)
+
+select * from pg_check_frozen('test_partition'); -- hopefully none
+ t_ctid 
+--------
+(0 rows)
+
+select pg_truncate_visibility_map('test_partition');
+ pg_truncate_visibility_map 
+----------------------------
+ 
+(1 row)
+
+-- test copy freeze
+create table copyfreeze (a number(38,0), b char(1500));
+-- load all rows via COPY FREEZE and ensure that all pages are set all-visible
+-- and all-frozen.
+begin;
+truncate copyfreeze;
+copy copyfreeze from stdin freeze;
+commit;
+select * from pg_visibility_map('copyfreeze');
+ blkno | all_visible | all_frozen 
+-------+-------------+------------
+     0 | t           | t
+     1 | t           | t
+     2 | t           | t
+(3 rows)
+
+select * from pg_check_frozen('copyfreeze');
+ t_ctid 
+--------
+(0 rows)
+
+-- load half the rows via regular COPY and rest via COPY FREEZE. The pages
+-- which are touched by regular COPY must not be set all-visible/all-frozen. On
+-- the other hand, pages allocated by COPY FREEZE should be marked
+-- all-frozen/all-visible.
+begin;
+truncate copyfreeze;
+copy copyfreeze from stdin;
+copy copyfreeze from stdin freeze;
+commit;
+select * from pg_visibility_map('copyfreeze');
+ blkno | all_visible | all_frozen 
+-------+-------------+------------
+     0 | f           | f
+     1 | f           | f
+     2 | t           | t
+(3 rows)
+
+select * from pg_check_frozen('copyfreeze');
+ t_ctid 
+--------
+(0 rows)
+
+-- Try a mix of regular COPY and COPY FREEZE.
+begin;
+truncate copyfreeze;
+copy copyfreeze from stdin freeze;
+copy copyfreeze from stdin;
+copy copyfreeze from stdin freeze;
+commit;
+select * from pg_visibility_map('copyfreeze');
+ blkno | all_visible | all_frozen 
+-------+-------------+------------
+     0 | t           | t
+     1 | f           | f
+     2 | t           | t
+(3 rows)
+
+select * from pg_check_frozen('copyfreeze');
+ t_ctid 
+--------
+(0 rows)
+
+-- cleanup
+drop table test_partitioned;
+drop view test_view;
+drop sequence test_sequence;
+drop foreign table test_foreign_table;
+drop server dummy_server;
+drop foreign data wrapper dummy;
+drop materialized view matview_visibility_test;
+drop table regular_table;
+drop table copyfreeze;

--- a/contrib/pg_visibility/sql/ivy_pg_visibility.sql
+++ b/contrib/pg_visibility/sql/ivy_pg_visibility.sql
@@ -1,0 +1,182 @@
+CREATE EXTENSION pg_visibility;
+
+--
+-- recently-dropped table
+--
+\set VERBOSITY sqlstate
+BEGIN;
+CREATE TABLE droppedtest (c number(38,0));
+SELECT 'droppedtest'::regclass::oid AS oid \gset
+SAVEPOINT q; DROP TABLE droppedtest; RELEASE q;
+SAVEPOINT q; SELECT * FROM pg_visibility_map(:oid); ROLLBACK TO q;
+-- ERROR:  could not open relation with OID 16xxx
+SAVEPOINT q; SELECT 1; ROLLBACK TO q;
+SAVEPOINT q; SELECT 1; ROLLBACK TO q;
+SELECT pg_relation_size(:oid), pg_relation_filepath(:oid),
+  has_table_privilege(:oid, 'SELECT');
+SELECT * FROM pg_visibility_map(:oid);
+-- ERROR:  could not open relation with OID 16xxx
+ROLLBACK;
+\set VERBOSITY default
+
+--
+-- check that using the module's functions with unsupported relations will fail
+--
+
+-- partitioned tables (the parent ones) don't have visibility maps
+create table test_partitioned (a number(38,0)) partition by list (a);
+-- these should all fail
+select pg_visibility('test_partitioned', 0);
+select pg_visibility_map('test_partitioned');
+select pg_visibility_map_summary('test_partitioned');
+select pg_check_frozen('test_partitioned');
+select pg_truncate_visibility_map('test_partitioned');
+
+create table test_partition partition of test_partitioned for values in (1);
+create index test_index on test_partition (a);
+-- indexes do not, so these all fail
+select pg_visibility('test_index', 0);
+select pg_visibility_map('test_index');
+select pg_visibility_map_summary('test_index');
+select pg_check_frozen('test_index');
+select pg_truncate_visibility_map('test_index');
+
+create view test_view as select 1;
+-- views do not have VMs, so these all fail
+select pg_visibility('test_view', 0);
+select pg_visibility_map('test_view');
+select pg_visibility_map_summary('test_view');
+select pg_check_frozen('test_view');
+select pg_truncate_visibility_map('test_view');
+
+create sequence test_sequence;
+-- sequences do not have VMs, so these all fail
+select pg_visibility('test_sequence', 0);
+select pg_visibility_map('test_sequence');
+select pg_visibility_map_summary('test_sequence');
+select pg_check_frozen('test_sequence');
+select pg_truncate_visibility_map('test_sequence');
+
+create foreign data wrapper dummy;
+create server dummy_server foreign data wrapper dummy;
+create foreign table test_foreign_table () server dummy_server;
+-- foreign tables do not have VMs, so these all fail
+select pg_visibility('test_foreign_table', 0);
+select pg_visibility_map('test_foreign_table');
+select pg_visibility_map_summary('test_foreign_table');
+select pg_check_frozen('test_foreign_table');
+select pg_truncate_visibility_map('test_foreign_table');
+
+-- check some of the allowed relkinds
+create table regular_table (a number(38,0), b varchar2(4000));
+alter table regular_table alter column b set storage external;
+insert into regular_table values (1, repeat('one', 1000)), (2, repeat('two', 1000));
+vacuum (disable_page_skipping) regular_table;
+select count(*) > 0 from pg_visibility('regular_table');
+select count(*) > 0 from pg_visibility((select reltoastrelid from pg_class where relname = 'regular_table'));
+truncate regular_table;
+select count(*) > 0 from pg_visibility('regular_table');
+select count(*) > 0 from pg_visibility((select reltoastrelid from pg_class where relname = 'regular_table'));
+
+create materialized view matview_visibility_test as select * from regular_table;
+vacuum (disable_page_skipping) matview_visibility_test;
+select count(*) > 0 from pg_visibility('matview_visibility_test');
+insert into regular_table values (1), (2);
+refresh materialized view matview_visibility_test;
+select count(*) > 0 from pg_visibility('matview_visibility_test');
+
+-- regular tables which are part of a partition *do* have visibility maps
+insert into test_partition values (1);
+vacuum (disable_page_skipping) test_partition;
+select count(*) > 0 from pg_visibility('test_partition', 0);
+select count(*) > 0 from pg_visibility_map('test_partition');
+select count(*) > 0 from pg_visibility_map_summary('test_partition');
+select * from pg_check_frozen('test_partition'); -- hopefully none
+select pg_truncate_visibility_map('test_partition');
+
+-- test copy freeze
+create table copyfreeze (a number(38,0), b char(1500));
+
+-- load all rows via COPY FREEZE and ensure that all pages are set all-visible
+-- and all-frozen.
+begin;
+truncate copyfreeze;
+copy copyfreeze from stdin freeze;
+1	'1'
+2	'2'
+3	'3'
+4	'4'
+5	'5'
+6	'6'
+7	'7'
+8	'8'
+9	'9'
+10	'10'
+11	'11'
+12	'12'
+\.
+commit;
+select * from pg_visibility_map('copyfreeze');
+select * from pg_check_frozen('copyfreeze');
+
+-- load half the rows via regular COPY and rest via COPY FREEZE. The pages
+-- which are touched by regular COPY must not be set all-visible/all-frozen. On
+-- the other hand, pages allocated by COPY FREEZE should be marked
+-- all-frozen/all-visible.
+begin;
+truncate copyfreeze;
+copy copyfreeze from stdin;
+1	'1'
+2	'2'
+3	'3'
+4	'4'
+5	'5'
+6	'6'
+\.
+copy copyfreeze from stdin freeze;
+7	'7'
+8	'8'
+9	'9'
+10	'10'
+11	'11'
+12	'12'
+\.
+commit;
+select * from pg_visibility_map('copyfreeze');
+select * from pg_check_frozen('copyfreeze');
+
+-- Try a mix of regular COPY and COPY FREEZE.
+begin;
+truncate copyfreeze;
+copy copyfreeze from stdin freeze;
+1	'1'
+2	'2'
+3	'3'
+4	'4'
+5	'5'
+\.
+copy copyfreeze from stdin;
+6	'6'
+\.
+copy copyfreeze from stdin freeze;
+7	'7'
+8	'8'
+9	'9'
+10	'10'
+11	'11'
+12	'12'
+\.
+commit;
+select * from pg_visibility_map('copyfreeze');
+select * from pg_check_frozen('copyfreeze');
+
+-- cleanup
+drop table test_partitioned;
+drop view test_view;
+drop sequence test_sequence;
+drop foreign table test_foreign_table;
+drop server dummy_server;
+drop foreign data wrapper dummy;
+drop materialized view matview_visibility_test;
+drop table regular_table;
+drop table copyfreeze;

--- a/contrib/postgres_fdw/expected/ivy_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/ivy_postgres_fdw.out
@@ -2,20 +2,22 @@
 -- create FDW objects
 -- ===================================================================
 CREATE EXTENSION postgres_fdw;
+SET ivorysql.identifier_case_switch = normal;
+\set EXECUTE_RUN_PREPARE on
 CREATE SERVER testserver1 FOREIGN DATA WRAPPER postgres_fdw;
 DO $d$
     BEGIN
         EXECUTE $$CREATE SERVER loopback FOREIGN DATA WRAPPER postgres_fdw
             OPTIONS (dbname '$$||current_database()||$$',
-                     port '$$||current_setting('port')||$$'
+                     port '$$||current_setting('ivorysql.port')||$$'
             )$$;
         EXECUTE $$CREATE SERVER loopback2 FOREIGN DATA WRAPPER postgres_fdw
             OPTIONS (dbname '$$||current_database()||$$',
-                     port '$$||current_setting('port')||$$'
+                     port '$$||current_setting('ivorysql.port')||$$'
             )$$;
         EXECUTE $$CREATE SERVER loopback3 FOREIGN DATA WRAPPER postgres_fdw
             OPTIONS (dbname '$$||current_database()||$$',
-                     port '$$||current_setting('port')||$$'
+                     port '$$||current_setting('ivorysql.port')||$$'
             )$$;
     END;
 $d$;
@@ -30,31 +32,31 @@ CREATE USER MAPPING FOR public SERVER loopback3;
 CREATE TYPE user_enum AS ENUM ('foo', 'bar', 'buz');
 CREATE SCHEMA "S 1";
 CREATE TABLE "S 1"."T 1" (
-	"C 1" int NOT NULL,
-	c2 int NOT NULL,
-	c3 text,
-	c4 pg_catalog.timestamptz,
-	c5 pg_catalog.timestamp,
+	"C 1" number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024),
+	c4 timestamptz,
+	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10),
 	c8 user_enum,
 	CONSTRAINT t1_pkey PRIMARY KEY ("C 1")
 );
 CREATE TABLE "S 1"."T 2" (
-	c1 int NOT NULL,
-	c2 text,
+	c1 number(38,0) NOT NULL,
+	c2 varchar2(1024),
 	CONSTRAINT t2_pkey PRIMARY KEY (c1)
 );
 CREATE TABLE "S 1"."T 3" (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text,
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024),
 	CONSTRAINT t3_pkey PRIMARY KEY (c1)
 );
 CREATE TABLE "S 1"."T 4" (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text,
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024),
 	CONSTRAINT t4_pkey PRIMARY KEY (c1)
 );
 -- Disable autovacuum for these tables to avoid unexpected effects of that
@@ -66,8 +68,8 @@ INSERT INTO "S 1"."T 1"
 	SELECT id,
 	       id % 10,
 	       to_char(id, 'FM00000'),
-	       '1970-01-01'::pg_catalog.timestamptz + ((id % 100) || ' days')::pg_catalog.interval,
-	       '1970-01-01'::pg_catalog.timestamp + ((id % 100) || ' days')::pg_catalog.interval,
+	       '1970-01-01'::timestamptz + ((id % 100) || ' days')::pg_catalog.interval,
+	       '1970-01-01'::timestamp + ((id % 100) || ' days')::pg_catalog.interval,
 	       id % 10,
 	       id % 10,
 	       'foo'::user_enum
@@ -96,49 +98,115 @@ ANALYZE "S 1"."T 4";
 -- create foreign tables
 -- ===================================================================
 CREATE FOREIGN TABLE ft1 (
-	c0 int,
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text,
-	c4 pg_catalog.timestamptz,
-	c5 pg_catalog.timestamp,
+	c0 number(38,0),
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024),
+	c4 timestamptz,
+	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
 	c8 user_enum
 ) SERVER loopback;
 ALTER FOREIGN TABLE ft1 DROP COLUMN c0;
 CREATE FOREIGN TABLE ft2 (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	cx int,
-	c3 text,
-	c4 pg_catalog.timestamptz,
-	c5 pg_catalog.timestamp,
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	cx number(38,0),
+	c3 varchar2(1024),
+	c4 timestamptz,
+	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft2',
 	c8 user_enum
 ) SERVER loopback;
 ALTER FOREIGN TABLE ft2 DROP COLUMN cx;
 CREATE FOREIGN TABLE ft4 (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024)
 ) SERVER loopback OPTIONS (schema_name 'S 1', table_name 'T 3');
 CREATE FOREIGN TABLE ft5 (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024)
 ) SERVER loopback OPTIONS (schema_name 'S 1', table_name 'T 4');
 CREATE FOREIGN TABLE ft6 (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024)
 ) SERVER loopback2 OPTIONS (schema_name 'S 1', table_name 'T 4');
 CREATE FOREIGN TABLE ft7 (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024)
 ) SERVER loopback3 OPTIONS (schema_name 'S 1', table_name 'T 4');
+-- ===================================================================
+-- tests inteval
+-- ===================================================================
+CREATE TABLE "S 1".test_interval (
+    candidate_id NUMBER,
+    first_name VARCHAR2(50 byte) NOT NULL,
+    last_name VARCHAR2(50 byte) NOT NULL,
+    title VARCHAR2(255 char) NOT NULL,
+    year_of_exper INTERVAL YEAR TO MONTH,
+    second_of_exper INTERVAL day TO SECOND
+);
+INSERT INTO "S 1".test_interval (
+    candidate_id,
+    first_name,
+    last_name,
+    title,
+    year_of_exper,
+    second_of_exper
+    )
+VALUES (
+    1,
+    'test1',
+    'test2',
+    'test Manager',
+    INTERVAL '10-2' YEAR TO MONTH,
+    INTERVAL '11 10:09:08.555' DAY TO SECOND
+    );
+select * from "S 1".test_interval;
+ candidate_id | first_name | last_name |    title     | year_of_exper |   second_of_exper   
+--------------+------------+-----------+--------------+---------------+---------------------
+ 1            | test1      | test2     | test Manager | +10-02        | +11 10:09:08.555000
+(1 row)
+
+CREATE FOREIGN TABLE test_interval_foreige (
+    candidate_id NUMBER,
+    first_name VARCHAR2(50 byte) NOT NULL,
+    last_name VARCHAR2(50 byte) NOT NULL,
+    title VARCHAR2(255 char) NOT NULL,
+    year_of_exper INTERVAL YEAR TO MONTH,
+    second_of_exper INTERVAL day TO SECOND
+)SERVER loopback3 OPTIONS (schema_name 'S 1', table_name 'test_interval');
+INSERT INTO test_interval_foreige (
+    candidate_id,
+    first_name,
+    last_name,
+    title,
+    year_of_exper,
+    second_of_exper
+    )
+VALUES (
+    1,
+    'test3',
+    'test4',
+    'test3 Manager',
+    INTERVAL '10-2' YEAR TO MONTH,
+    INTERVAL '11 10:09:08.555' DAY TO SECOND
+    );
+select * from test_interval_foreige;
+ candidate_id | first_name | last_name |     title     | year_of_exper |   second_of_exper   
+--------------+------------+-----------+---------------+---------------+---------------------
+ 1            | test1      | test2     | test Manager  | +10-02        | +11 10:09:08.555000
+ 1            | test3      | test4     | test3 Manager | +10-02        | +11 10:09:08.555000
+(2 rows)
+
+DROP FOREIGN TABLE test_interval_foreige;
+DROP TABLE "S 1".test_interval;
 -- ===================================================================
 -- tests for validator
 -- ===================================================================
@@ -216,9 +284,9 @@ ALTER FOREIGN TABLE ft2 ALTER COLUMN c1 OPTIONS (column_name 'C 1');
 -- Remote's errors might be non-English, so hide them to ensure stable results
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
-  c3   |              c4              
--------+------------------------------
- 00001 | Fri Jan 02 00:00:00 1970 PST
+  c3   |                c4                 
+-------+-----------------------------------
+ 00001 | 1970-01-02 00:00:00.000000 -08:00
 (1 row)
 
 ALTER SERVER loopback OPTIONS (SET dbname 'no such database');
@@ -231,9 +299,9 @@ DO $d$
     END;
 $d$;
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again
-  c3   |              c4              
--------+------------------------------
- 00001 | Fri Jan 02 00:00:00 1970 PST
+  c3   |                c4                 
+-------+-----------------------------------
+ 00001 | 1970-01-02 00:00:00.000000 -08:00
 (1 row)
 
 -- Test that alteration of user mapping options causes reconnection
@@ -244,9 +312,9 @@ ERROR:  could not connect to server "loopback"
 ALTER USER MAPPING FOR CURRENT_USER SERVER loopback
   OPTIONS (DROP user);
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again
-  c3   |              c4              
--------+------------------------------
- 00001 | Fri Jan 02 00:00:00 1970 PST
+  c3   |                c4                 
+-------+-----------------------------------
+ 00001 | 1970-01-02 00:00:00.000000 -08:00
 (1 row)
 
 \set VERBOSITY default
@@ -266,24 +334,27 @@ DETAIL:  This operation is not supported for foreign tables.
 -- ===================================================================
 -- single table without alias
 EXPLAIN (COSTS OFF) SELECT * FROM ft1 ORDER BY c3, c1 OFFSET 100 LIMIT 10;
-     QUERY PLAN      
----------------------
- Foreign Scan on ft1
-(1 row)
+           QUERY PLAN            
+---------------------------------
+ Limit
+   ->  Sort
+         Sort Key: c3, c1
+         ->  Foreign Scan on ft1
+(4 rows)
 
 SELECT * FROM ft1 ORDER BY c3, c1 OFFSET 100 LIMIT 10;
- c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
------+----+-------+------------------------------+--------------------------+----+------------+-----
- 101 |  1 | 00101 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
- 102 |  2 | 00102 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
- 103 |  3 | 00103 | Sun Jan 04 00:00:00 1970 PST | Sun Jan 04 00:00:00 1970 | 3  | 3          | foo
- 104 |  4 | 00104 | Mon Jan 05 00:00:00 1970 PST | Mon Jan 05 00:00:00 1970 | 4  | 4          | foo
- 105 |  5 | 00105 | Tue Jan 06 00:00:00 1970 PST | Tue Jan 06 00:00:00 1970 | 5  | 5          | foo
- 106 |  6 | 00106 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 107 |  7 | 00107 | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
- 108 |  8 | 00108 | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
- 109 |  9 | 00109 | Sat Jan 10 00:00:00 1970 PST | Sat Jan 10 00:00:00 1970 | 9  | 9          | foo
- 110 |  0 | 00110 | Sun Jan 11 00:00:00 1970 PST | Sun Jan 11 00:00:00 1970 | 0  | 0          | foo
+ c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 101 | 1  | 00101 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+ 102 | 2  | 00102 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
+ 103 | 3  | 00103 | 1970-01-04 00:00:00.000000 -08:00 | 1970-01-04 00:00:00.000000 | 3  | 3          | foo
+ 104 | 4  | 00104 | 1970-01-05 00:00:00.000000 -08:00 | 1970-01-05 00:00:00.000000 | 4  | 4          | foo
+ 105 | 5  | 00105 | 1970-01-06 00:00:00.000000 -08:00 | 1970-01-06 00:00:00.000000 | 5  | 5          | foo
+ 106 | 6  | 00106 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 107 | 7  | 00107 | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 108 | 8  | 00108 | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 109 | 9  | 00109 | 1970-01-10 00:00:00.000000 -08:00 | 1970-01-10 00:00:00.000000 | 9  | 9          | foo
+ 110 | 0  | 00110 | 1970-01-11 00:00:00.000000 -08:00 | 1970-01-11 00:00:00.000000 | 0  | 0          | foo
 (10 rows)
 
 -- single table with alias - also test that tableoid sort is not pushed to remote side
@@ -301,42 +372,47 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 ORDER BY t1.c3, t1.c1, t1.tabl
 (8 rows)
 
 SELECT * FROM ft1 t1 ORDER BY t1.c3, t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
- c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
------+----+-------+------------------------------+--------------------------+----+------------+-----
- 101 |  1 | 00101 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
- 102 |  2 | 00102 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
- 103 |  3 | 00103 | Sun Jan 04 00:00:00 1970 PST | Sun Jan 04 00:00:00 1970 | 3  | 3          | foo
- 104 |  4 | 00104 | Mon Jan 05 00:00:00 1970 PST | Mon Jan 05 00:00:00 1970 | 4  | 4          | foo
- 105 |  5 | 00105 | Tue Jan 06 00:00:00 1970 PST | Tue Jan 06 00:00:00 1970 | 5  | 5          | foo
- 106 |  6 | 00106 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 107 |  7 | 00107 | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
- 108 |  8 | 00108 | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
- 109 |  9 | 00109 | Sat Jan 10 00:00:00 1970 PST | Sat Jan 10 00:00:00 1970 | 9  | 9          | foo
- 110 |  0 | 00110 | Sun Jan 11 00:00:00 1970 PST | Sun Jan 11 00:00:00 1970 | 0  | 0          | foo
+ c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 101 | 1  | 00101 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+ 102 | 2  | 00102 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
+ 103 | 3  | 00103 | 1970-01-04 00:00:00.000000 -08:00 | 1970-01-04 00:00:00.000000 | 3  | 3          | foo
+ 104 | 4  | 00104 | 1970-01-05 00:00:00.000000 -08:00 | 1970-01-05 00:00:00.000000 | 4  | 4          | foo
+ 105 | 5  | 00105 | 1970-01-06 00:00:00.000000 -08:00 | 1970-01-06 00:00:00.000000 | 5  | 5          | foo
+ 106 | 6  | 00106 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 107 | 7  | 00107 | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 108 | 8  | 00108 | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 109 | 9  | 00109 | 1970-01-10 00:00:00.000000 -08:00 | 1970-01-10 00:00:00.000000 | 9  | 9          | foo
+ 110 | 0  | 00110 | 1970-01-11 00:00:00.000000 -08:00 | 1970-01-11 00:00:00.000000 | 0  | 0          | foo
 (10 rows)
 
 -- whole-row reference
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Limit
    Output: t1.*, c3, c1
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" ORDER BY c3 ASC NULLS LAST, "C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint
-(3 rows)
+   ->  Sort
+         Output: t1.*, c3, c1
+         Sort Key: t1.c3, t1.c1
+         ->  Foreign Scan on public.ft1 t1
+               Output: t1.*, c3, c1
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(8 rows)
 
 SELECT t1 FROM ft1 t1 ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-                                             t1                                             
---------------------------------------------------------------------------------------------
- (101,1,00101,"Fri Jan 02 00:00:00 1970 PST","Fri Jan 02 00:00:00 1970",1,"1         ",foo)
- (102,2,00102,"Sat Jan 03 00:00:00 1970 PST","Sat Jan 03 00:00:00 1970",2,"2         ",foo)
- (103,3,00103,"Sun Jan 04 00:00:00 1970 PST","Sun Jan 04 00:00:00 1970",3,"3         ",foo)
- (104,4,00104,"Mon Jan 05 00:00:00 1970 PST","Mon Jan 05 00:00:00 1970",4,"4         ",foo)
- (105,5,00105,"Tue Jan 06 00:00:00 1970 PST","Tue Jan 06 00:00:00 1970",5,"5         ",foo)
- (106,6,00106,"Wed Jan 07 00:00:00 1970 PST","Wed Jan 07 00:00:00 1970",6,"6         ",foo)
- (107,7,00107,"Thu Jan 08 00:00:00 1970 PST","Thu Jan 08 00:00:00 1970",7,"7         ",foo)
- (108,8,00108,"Fri Jan 09 00:00:00 1970 PST","Fri Jan 09 00:00:00 1970",8,"8         ",foo)
- (109,9,00109,"Sat Jan 10 00:00:00 1970 PST","Sat Jan 10 00:00:00 1970",9,"9         ",foo)
- (110,0,00110,"Sun Jan 11 00:00:00 1970 PST","Sun Jan 11 00:00:00 1970",0,"0         ",foo)
+                                                t1                                                 
+---------------------------------------------------------------------------------------------------
+ (101,1,00101,"1970-01-02 00:00:00.000000 -08:00","1970-01-02 00:00:00.000000",1,"1         ",foo)
+ (102,2,00102,"1970-01-03 00:00:00.000000 -08:00","1970-01-03 00:00:00.000000",2,"2         ",foo)
+ (103,3,00103,"1970-01-04 00:00:00.000000 -08:00","1970-01-04 00:00:00.000000",3,"3         ",foo)
+ (104,4,00104,"1970-01-05 00:00:00.000000 -08:00","1970-01-05 00:00:00.000000",4,"4         ",foo)
+ (105,5,00105,"1970-01-06 00:00:00.000000 -08:00","1970-01-06 00:00:00.000000",5,"5         ",foo)
+ (106,6,00106,"1970-01-07 00:00:00.000000 -08:00","1970-01-07 00:00:00.000000",6,"6         ",foo)
+ (107,7,00107,"1970-01-08 00:00:00.000000 -08:00","1970-01-08 00:00:00.000000",7,"7         ",foo)
+ (108,8,00108,"1970-01-09 00:00:00.000000 -08:00","1970-01-09 00:00:00.000000",8,"8         ",foo)
+ (109,9,00109,"1970-01-10 00:00:00.000000 -08:00","1970-01-10 00:00:00.000000",9,"9         ",foo)
+ (110,0,00110,"1970-01-11 00:00:00.000000 -08:00","1970-01-11 00:00:00.000000",0,"0         ",foo)
 (10 rows)
 
 -- empty result
@@ -347,47 +423,49 @@ SELECT * FROM ft1 WHERE false;
 
 -- with WHERE clause
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: ((t1.c7 >= '1'::oracharbyte) AND (t1.c6 = '1'::varchar2))
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 101))
+   Filter: ((t1.c7 >= '1'::oracharbyte) AND (t1.c1 = '101'::number) AND (t1.c6 = '1'::varchar2))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
- c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
------+----+-------+------------------------------+--------------------------+----+------------+-----
- 101 |  1 | 00101 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 101 | 1  | 00101 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 -- with FOR UPDATE/SHARE
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = 101 FOR UPDATE;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8, t1.*
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 101)) FOR UPDATE
-(3 rows)
+   Filter: (t1.c1 = '101'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR UPDATE
+(4 rows)
 
 SELECT * FROM ft1 t1 WHERE c1 = 101 FOR UPDATE;
- c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
------+----+-------+------------------------------+--------------------------+----+------------+-----
- 101 |  1 | 00101 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 101 | 1  | 00101 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = 102 FOR SHARE;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8, t1.*
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 102)) FOR SHARE
-(3 rows)
+   Filter: (t1.c1 = '102'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR SHARE
+(4 rows)
 
 SELECT * FROM ft1 t1 WHERE c1 = 102 FOR SHARE;
- c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
------+----+-------+------------------------------+--------------------------+----+------------+-----
- 102 |  2 | 00102 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
+ c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 102 | 2  | 00102 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
 (1 row)
 
 -- aggregate
@@ -399,41 +477,41 @@ SELECT COUNT(*) FROM ft1 t1;
 
 -- subquery
 SELECT * FROM ft1 t1 WHERE t1.c3 IN (SELECT c3 FROM ft2 t2 WHERE c1 <= 10) ORDER BY c1;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
-  2 |  2 | 00002 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
-  3 |  3 | 00003 | Sun Jan 04 00:00:00 1970 PST | Sun Jan 04 00:00:00 1970 | 3  | 3          | foo
-  4 |  4 | 00004 | Mon Jan 05 00:00:00 1970 PST | Mon Jan 05 00:00:00 1970 | 4  | 4          | foo
-  5 |  5 | 00005 | Tue Jan 06 00:00:00 1970 PST | Tue Jan 06 00:00:00 1970 | 5  | 5          | foo
-  6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
-  7 |  7 | 00007 | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  8 |  8 | 00008 | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  9 |  9 | 00009 | Sat Jan 10 00:00:00 1970 PST | Sat Jan 10 00:00:00 1970 | 9  | 9          | foo
- 10 |  0 | 00010 | Sun Jan 11 00:00:00 1970 PST | Sun Jan 11 00:00:00 1970 | 0  | 0          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+ 2  | 2  | 00002 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
+ 3  | 3  | 00003 | 1970-01-04 00:00:00.000000 -08:00 | 1970-01-04 00:00:00.000000 | 3  | 3          | foo
+ 4  | 4  | 00004 | 1970-01-05 00:00:00.000000 -08:00 | 1970-01-05 00:00:00.000000 | 4  | 4          | foo
+ 5  | 5  | 00005 | 1970-01-06 00:00:00.000000 -08:00 | 1970-01-06 00:00:00.000000 | 5  | 5          | foo
+ 6  | 6  | 00006 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 7  | 7  | 00007 | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 8  | 8  | 00008 | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 9  | 9  | 00009 | 1970-01-10 00:00:00.000000 -08:00 | 1970-01-10 00:00:00.000000 | 9  | 9          | foo
+ 10 | 0  | 00010 | 1970-01-11 00:00:00.000000 -08:00 | 1970-01-11 00:00:00.000000 | 0  | 0          | foo
 (10 rows)
 
 -- subquery+MAX
 SELECT * FROM ft1 t1 WHERE t1.c3 = (SELECT MAX(c3) FROM ft2 t2) ORDER BY c1;
-  c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-------+----+-------+------------------------------+--------------------------+----+------------+-----
- 1000 |  0 | 01000 | Thu Jan 01 00:00:00 1970 PST | Thu Jan 01 00:00:00 1970 | 0  | 0          | foo
+  c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+------+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1000 | 0  | 01000 | 1970-01-01 00:00:00.000000 -08:00 | 1970-01-01 00:00:00.000000 | 0  | 0          | foo
 (1 row)
 
 -- used in CTE
 WITH t1 AS (SELECT * FROM ft1 WHERE c1 <= 10) SELECT t2.c1, t2.c2, t2.c3, t2.c4 FROM t1, ft2 t2 WHERE t1.c1 = t2.c1 ORDER BY t1.c1;
- c1 | c2 |  c3   |              c4              
-----+----+-------+------------------------------
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST
-  2 |  2 | 00002 | Sat Jan 03 00:00:00 1970 PST
-  3 |  3 | 00003 | Sun Jan 04 00:00:00 1970 PST
-  4 |  4 | 00004 | Mon Jan 05 00:00:00 1970 PST
-  5 |  5 | 00005 | Tue Jan 06 00:00:00 1970 PST
-  6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST
-  7 |  7 | 00007 | Thu Jan 08 00:00:00 1970 PST
-  8 |  8 | 00008 | Fri Jan 09 00:00:00 1970 PST
-  9 |  9 | 00009 | Sat Jan 10 00:00:00 1970 PST
- 10 |  0 | 00010 | Sun Jan 11 00:00:00 1970 PST
+ c1 | c2 |  c3   |                c4                 
+----+----+-------+-----------------------------------
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00
+ 2  | 2  | 00002 | 1970-01-03 00:00:00.000000 -08:00
+ 3  | 3  | 00003 | 1970-01-04 00:00:00.000000 -08:00
+ 4  | 4  | 00004 | 1970-01-05 00:00:00.000000 -08:00
+ 5  | 5  | 00005 | 1970-01-06 00:00:00.000000 -08:00
+ 6  | 6  | 00006 | 1970-01-07 00:00:00.000000 -08:00
+ 7  | 7  | 00007 | 1970-01-08 00:00:00.000000 -08:00
+ 8  | 8  | 00008 | 1970-01-09 00:00:00.000000 -08:00
+ 9  | 9  | 00009 | 1970-01-10 00:00:00.000000 -08:00
+ 10 | 0  | 00010 | 1970-01-11 00:00:00.000000 -08:00
 (10 rows)
 
 -- fixed values
@@ -449,20 +527,22 @@ SET enable_nestloop TO false;
 -- inner join; expressions in the clauses appear in the equivalence class list
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT t1.c1, t2."C 1" FROM ft2 t1 JOIN "S 1"."T 1" t2 ON (t1.c1 = t2."C 1") OFFSET 100 LIMIT 10;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Limit
    Output: t1.c1, t2."C 1"
    ->  Merge Join
          Output: t1.c1, t2."C 1"
-         Inner Unique: true
-         Merge Cond: (t1.c1 = t2."C 1")
-         ->  Foreign Scan on public.ft2 t1
-               Output: t1.c1
-               Remote SQL: SELECT "C 1" FROM "S 1"."T 1" ORDER BY "C 1" ASC NULLS LAST
+         Merge Cond: (t2."C 1" = t1.c1)
          ->  Index Only Scan using t1_pkey on "S 1"."T 1" t2
                Output: t2."C 1"
-(11 rows)
+         ->  Sort
+               Output: t1.c1
+               Sort Key: t1.c1
+               ->  Foreign Scan on public.ft2 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(13 rows)
 
 SELECT t1.c1, t2."C 1" FROM ft2 t1 JOIN "S 1"."T 1" t2 ON (t1.c1 = t2."C 1") OFFSET 100 LIMIT 10;
  c1  | C 1 
@@ -483,20 +563,22 @@ SELECT t1.c1, t2."C 1" FROM ft2 t1 JOIN "S 1"."T 1" t2 ON (t1.c1 = t2."C 1") OFF
 -- list but no output change as compared to the previous query
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT t1.c1, t2."C 1" FROM ft2 t1 LEFT JOIN "S 1"."T 1" t2 ON (t1.c1 = t2."C 1") OFFSET 100 LIMIT 10;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Limit
    Output: t1.c1, t2."C 1"
-   ->  Merge Left Join
+   ->  Merge Right Join
          Output: t1.c1, t2."C 1"
-         Inner Unique: true
-         Merge Cond: (t1.c1 = t2."C 1")
-         ->  Foreign Scan on public.ft2 t1
-               Output: t1.c1
-               Remote SQL: SELECT "C 1" FROM "S 1"."T 1" ORDER BY "C 1" ASC NULLS LAST
+         Merge Cond: (t2."C 1" = t1.c1)
          ->  Index Only Scan using t1_pkey on "S 1"."T 1" t2
                Output: t2."C 1"
-(11 rows)
+         ->  Sort
+               Output: t1.c1
+               Sort Key: t1.c1
+               ->  Foreign Scan on public.ft2 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(13 rows)
 
 SELECT t1.c1, t2."C 1" FROM ft2 t1 LEFT JOIN "S 1"."T 1" t2 ON (t1.c1 = t2."C 1") OFFSET 100 LIMIT 10;
  c1  | C 1 
@@ -517,21 +599,32 @@ SELECT t1.c1, t2."C 1" FROM ft2 t1 LEFT JOIN "S 1"."T 1" t2 ON (t1.c1 = t2."C 1"
 -- foreign join so that the local table can be joined using merge join strategy.
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT t1."C 1" FROM "S 1"."T 1" t1 left join ft1 t2 join ft2 t3 on (t2.c1 = t3.c1) on (t3.c1 = t1."C 1") OFFSET 100 LIMIT 10;
-                                                                       QUERY PLAN                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Limit
    Output: t1."C 1"
    ->  Merge Right Join
          Output: t1."C 1"
          Inner Unique: true
          Merge Cond: (t3.c1 = t1."C 1")
-         ->  Foreign Scan
+         ->  Merge Join
                Output: t3.c1
-               Relations: (public.ft1 t2) INNER JOIN (public.ft2 t3)
-               Remote SQL: SELECT r3."C 1" FROM ("S 1"."T 1" r2 INNER JOIN "S 1"."T 1" r3 ON (((r3."C 1" = r2."C 1")))) ORDER BY r2."C 1" ASC NULLS LAST
+               Merge Cond: (t2.c1 = t3.c1)
+               ->  Sort
+                     Output: t2.c1
+                     Sort Key: t2.c1
+                     ->  Foreign Scan on public.ft1 t2
+                           Output: t2.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Sort
+                     Output: t3.c1
+                     Sort Key: t3.c1
+                     ->  Foreign Scan on public.ft2 t3
+                           Output: t3.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
          ->  Index Only Scan using t1_pkey on "S 1"."T 1" t1
                Output: t1."C 1"
-(12 rows)
+(23 rows)
 
 SELECT t1."C 1" FROM "S 1"."T 1" t1 left join ft1 t2 join ft2 t3 on (t2.c1 = t3.c1) on (t3.c1 = t1."C 1") OFFSET 100 LIMIT 10;
  C 1 
@@ -553,21 +646,32 @@ SELECT t1."C 1" FROM "S 1"."T 1" t1 left join ft1 t2 join ft2 t3 on (t2.c1 = t3.
 -- included in join restrictions.
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT t1."C 1", t2.c1, t3.c1 FROM "S 1"."T 1" t1 left join ft1 t2 full join ft2 t3 on (t2.c1 = t3.c1) on (t3.c1 = t1."C 1") OFFSET 100 LIMIT 10;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Limit
    Output: t1."C 1", t2.c1, t3.c1
    ->  Merge Right Join
          Output: t1."C 1", t2.c1, t3.c1
          Inner Unique: true
          Merge Cond: (t3.c1 = t1."C 1")
-         ->  Foreign Scan
+         ->  Merge Left Join
                Output: t3.c1, t2.c1
-               Relations: (public.ft2 t3) LEFT JOIN (public.ft1 t2)
-               Remote SQL: SELECT r3."C 1", r2."C 1" FROM ("S 1"."T 1" r3 LEFT JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r3."C 1")))) ORDER BY r3."C 1" ASC NULLS LAST
+               Merge Cond: (t3.c1 = t2.c1)
+               ->  Sort
+                     Output: t3.c1
+                     Sort Key: t3.c1
+                     ->  Foreign Scan on public.ft2 t3
+                           Output: t3.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Sort
+                     Output: t2.c1
+                     Sort Key: t2.c1
+                     ->  Foreign Scan on public.ft1 t2
+                           Output: t2.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
          ->  Index Only Scan using t1_pkey on "S 1"."T 1" t1
                Output: t1."C 1"
-(12 rows)
+(23 rows)
 
 SELECT t1."C 1", t2.c1, t3.c1 FROM "S 1"."T 1" t1 left join ft1 t2 full join ft2 t3 on (t2.c1 = t3.c1) on (t3.c1 = t1."C 1") OFFSET 100 LIMIT 10;
  C 1 | c1  | c1  
@@ -587,21 +691,34 @@ SELECT t1."C 1", t2.c1, t3.c1 FROM "S 1"."T 1" t1 left join ft1 t2 full join ft2
 -- Test similar to above with all full outer joins
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT t1."C 1", t2.c1, t3.c1 FROM "S 1"."T 1" t1 full join ft1 t2 full join ft2 t3 on (t2.c1 = t3.c1) on (t3.c1 = t1."C 1") OFFSET 100 LIMIT 10;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Limit
    Output: t1."C 1", t2.c1, t3.c1
    ->  Merge Full Join
          Output: t1."C 1", t2.c1, t3.c1
-         Inner Unique: true
-         Merge Cond: (t3.c1 = t1."C 1")
-         ->  Foreign Scan
-               Output: t2.c1, t3.c1
-               Relations: (public.ft1 t2) FULL JOIN (public.ft2 t3)
-               Remote SQL: SELECT r2."C 1", r3."C 1" FROM ("S 1"."T 1" r2 FULL JOIN "S 1"."T 1" r3 ON (((r2."C 1" = r3."C 1")))) ORDER BY r3."C 1" ASC NULLS LAST
+         Merge Cond: (t1."C 1" = t3.c1)
          ->  Index Only Scan using t1_pkey on "S 1"."T 1" t1
                Output: t1."C 1"
-(12 rows)
+         ->  Sort
+               Output: t2.c1, t3.c1
+               Sort Key: t3.c1
+               ->  Merge Full Join
+                     Output: t2.c1, t3.c1
+                     Merge Cond: (t2.c1 = t3.c1)
+                     ->  Sort
+                           Output: t2.c1
+                           Sort Key: t2.c1
+                           ->  Foreign Scan on public.ft1 t2
+                                 Output: t2.c1
+                                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                     ->  Sort
+                           Output: t3.c1
+                           Sort Key: t3.c1
+                           ->  Foreign Scan on public.ft2 t3
+                                 Output: t3.c1
+                                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(25 rows)
 
 SELECT t1."C 1", t2.c1, t3.c1 FROM "S 1"."T 1" t1 full join ft1 t2 full join ft2 t3 on (t2.c1 = t3.c1) on (t3.c1 = t1."C 1") OFFSET 100 LIMIT 10;
  C 1 | c1  | c1  
@@ -623,39 +740,44 @@ RESET enable_nestloop;
 -- Test executing assertion in estimate_path_cost_size() that makes sure that
 -- retrieved_rows for foreign rel re-used to cost pre-sorted foreign paths is
 -- a sensible value even when the rel has tuples=0
-CREATE TABLE loct_empty (c1 int NOT NULL, c2 text);
-CREATE FOREIGN TABLE ft_empty (c1 int NOT NULL, c2 text)
+CREATE TABLE loct_empty (c1 number(38,0) NOT NULL, c2 varchar2(1024));
+CREATE FOREIGN TABLE ft_empty (c1 number(38,0) NOT NULL, c2 varchar2(1024))
   SERVER loopback OPTIONS (table_name 'loct_empty');
 INSERT INTO loct_empty
   SELECT id, 'AAA' || to_char(id, 'FM000') FROM generate_series(1, 100) id;
 DELETE FROM loct_empty;
 ANALYZE ft_empty;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft_empty ORDER BY c1;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Foreign Scan on public.ft_empty
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Sort
    Output: c1, c2
-   Remote SQL: SELECT c1, c2 FROM public.loct_empty ORDER BY c1 ASC NULLS LAST
-(3 rows)
+   Sort Key: ft_empty.c1
+   ->  Foreign Scan on public.ft_empty
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM public.loct_empty
+(6 rows)
 
 -- ===================================================================
 -- WHERE with remotely-executable conditions
 -- ===================================================================
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Var, OpExpr(b), Const
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
-(3 rows)
+   Filter: (t1.c1 = '1'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 0; -- BoolExpr
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 100)) AND ((c2 = 0))
-(3 rows)
+   Filter: ((t1.c1 = '100'::number) AND (t1.c2 = '0'::number))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- NullTest
                                            QUERY PLAN                                            
@@ -674,20 +796,22 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- Nu
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -- FuncExpr
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE ((round(abs("C 1")::numeric, 0) = 1::numeric))
-(3 rows)
+   Filter: (round((abs((t1.c1)::double precision))::numeric, 0) = '1'::numeric)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- OpExpr(l)
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = (- "C 1")))
-(3 rows)
+   Filter: (t1.c1 = (- t1.c1))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL); -- DistinctExpr
                                                                  QUERY PLAN                                                                 
@@ -698,20 +822,22 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DIST
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]); -- ScalarArrayOpExpr
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = ANY (ARRAY[c2, 1, ("C 1" + 0)])))
-(3 rows)
+   Filter: (t1.c1 = ANY (ARRAY[t1.c2, '1'::number, (t1.c1 + '0'::number)]))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- SubscriptingRef
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = ((ARRAY["C 1", c2, 3])[1])))
-(3 rows)
+   Filter: (t1.c1 = (ARRAY[t1.c1, t1.c2, '3'::number])[1])
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
                                QUERY PLAN                                
@@ -736,163 +862,169 @@ EXPLAIN (VERBOSE, COSTS OFF)
   SELECT * FROM "S 1"."T 1" a, ft2 b WHERE a."C 1" = 47 AND b.c1 = a.c2;
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
- Nested Loop
+ Hash Join
    Output: a."C 1", a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8, b.c1, b.c2, b.c3, b.c4, b.c5, b.c6, b.c7, b.c8
-   ->  Index Scan using t1_pkey on "S 1"."T 1" a
-         Output: a."C 1", a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8
-         Index Cond: (a."C 1" = 47)
+   Inner Unique: true
+   Hash Cond: (b.c1 = a.c2)
    ->  Foreign Scan on public.ft2 b
          Output: b.c1, b.c2, b.c3, b.c4, b.c5, b.c6, b.c7, b.c8
-         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = $1::integer))
-(8 rows)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+   ->  Hash
+         Output: a."C 1", a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8
+         ->  Index Scan using t1_pkey on "S 1"."T 1" a
+               Output: a."C 1", a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8
+               Index Cond: (a."C 1" = '47'::number)
+(12 rows)
 
 SELECT * FROM ft2 a, ft2 b WHERE a.c1 = 47 AND b.c1 = a.c2;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  | c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----+----+----+-------+------------------------------+--------------------------+----+------------+-----
- 47 |  7 | 00047 | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo |  7 |  7 | 00007 | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  | c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 47 | 7  | 00047 | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo | 7  | 7  | 00007 | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
 (1 row)
 
 -- check both safe and unsafe join conditions
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT * FROM ft2 a, ft2 b
   WHERE a.c2 = 6 AND b.c1 = a.c1 AND a.c8 = 'foo' AND b.c7 = upper(a.c7);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Nested Loop
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Hash Join
    Output: a.c1, a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8, b.c1, b.c2, b.c3, b.c4, b.c5, b.c6, b.c7, b.c8
-   ->  Foreign Scan on public.ft2 a
-         Output: a.c1, a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8
-         Filter: (a.c8 = 'foo'::user_enum)
-         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE ((c2 = 6))
+   Hash Cond: ((b.c1 = a.c1) AND ((b.c7)::text = upper((a.c7)::text)))
    ->  Foreign Scan on public.ft2 b
          Output: b.c1, b.c2, b.c3, b.c4, b.c5, b.c6, b.c7, b.c8
-         Filter: ((b.c7)::text = upper((a.c7)::text))
-         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (($1::integer = "C 1"))
-(10 rows)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+   ->  Hash
+         Output: a.c1, a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8
+         ->  Foreign Scan on public.ft2 a
+               Output: a.c1, a.c2, a.c3, a.c4, a.c5, a.c6, a.c7, a.c8
+               Filter: ((a.c2 = '6'::number) AND (a.c8 = 'foo'::user_enum))
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(12 rows)
 
 SELECT * FROM ft2 a, ft2 b
 WHERE a.c2 = 6 AND b.c1 = a.c1 AND a.c8 = 'foo' AND b.c7 = upper(a.c7);
- c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  | c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
------+----+-------+------------------------------+--------------------------+----+------------+-----+-----+----+-------+------------------------------+--------------------------+----+------------+-----
-   6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo |   6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
-  16 |  6 | 00016 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo |  16 |  6 | 00016 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
-  26 |  6 | 00026 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo |  26 |  6 | 00026 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
-  36 |  6 | 00036 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo |  36 |  6 | 00036 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
-  46 |  6 | 00046 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo |  46 |  6 | 00046 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
-  56 |  6 | 00056 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo |  56 |  6 | 00056 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
-  66 |  6 | 00066 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo |  66 |  6 | 00066 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
-  76 |  6 | 00076 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo |  76 |  6 | 00076 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
-  86 |  6 | 00086 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo |  86 |  6 | 00086 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
-  96 |  6 | 00096 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo |  96 |  6 | 00096 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 106 |  6 | 00106 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 106 |  6 | 00106 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 116 |  6 | 00116 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 116 |  6 | 00116 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 126 |  6 | 00126 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 126 |  6 | 00126 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 136 |  6 | 00136 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 136 |  6 | 00136 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 146 |  6 | 00146 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 146 |  6 | 00146 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 156 |  6 | 00156 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 156 |  6 | 00156 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 166 |  6 | 00166 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 166 |  6 | 00166 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 176 |  6 | 00176 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 176 |  6 | 00176 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 186 |  6 | 00186 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 186 |  6 | 00186 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 196 |  6 | 00196 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 196 |  6 | 00196 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 206 |  6 | 00206 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 206 |  6 | 00206 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 216 |  6 | 00216 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 216 |  6 | 00216 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 226 |  6 | 00226 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 226 |  6 | 00226 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 236 |  6 | 00236 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 236 |  6 | 00236 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 246 |  6 | 00246 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 246 |  6 | 00246 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 256 |  6 | 00256 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 256 |  6 | 00256 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 266 |  6 | 00266 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 266 |  6 | 00266 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 276 |  6 | 00276 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 276 |  6 | 00276 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 286 |  6 | 00286 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 286 |  6 | 00286 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 296 |  6 | 00296 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 296 |  6 | 00296 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 306 |  6 | 00306 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 306 |  6 | 00306 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 316 |  6 | 00316 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 316 |  6 | 00316 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 326 |  6 | 00326 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 326 |  6 | 00326 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 336 |  6 | 00336 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 336 |  6 | 00336 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 346 |  6 | 00346 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 346 |  6 | 00346 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 356 |  6 | 00356 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 356 |  6 | 00356 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 366 |  6 | 00366 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 366 |  6 | 00366 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 376 |  6 | 00376 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 376 |  6 | 00376 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 386 |  6 | 00386 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 386 |  6 | 00386 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 396 |  6 | 00396 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 396 |  6 | 00396 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 406 |  6 | 00406 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 406 |  6 | 00406 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 416 |  6 | 00416 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 416 |  6 | 00416 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 426 |  6 | 00426 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 426 |  6 | 00426 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 436 |  6 | 00436 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 436 |  6 | 00436 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 446 |  6 | 00446 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 446 |  6 | 00446 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 456 |  6 | 00456 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 456 |  6 | 00456 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 466 |  6 | 00466 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 466 |  6 | 00466 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 476 |  6 | 00476 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 476 |  6 | 00476 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 486 |  6 | 00486 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 486 |  6 | 00486 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 496 |  6 | 00496 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 496 |  6 | 00496 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 506 |  6 | 00506 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 506 |  6 | 00506 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 516 |  6 | 00516 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 516 |  6 | 00516 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 526 |  6 | 00526 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 526 |  6 | 00526 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 536 |  6 | 00536 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 536 |  6 | 00536 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 546 |  6 | 00546 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 546 |  6 | 00546 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 556 |  6 | 00556 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 556 |  6 | 00556 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 566 |  6 | 00566 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 566 |  6 | 00566 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 576 |  6 | 00576 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 576 |  6 | 00576 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 586 |  6 | 00586 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 586 |  6 | 00586 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 596 |  6 | 00596 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 596 |  6 | 00596 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 606 |  6 | 00606 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 606 |  6 | 00606 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 616 |  6 | 00616 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 616 |  6 | 00616 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 626 |  6 | 00626 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 626 |  6 | 00626 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 636 |  6 | 00636 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 636 |  6 | 00636 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 646 |  6 | 00646 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 646 |  6 | 00646 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 656 |  6 | 00656 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 656 |  6 | 00656 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 666 |  6 | 00666 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 666 |  6 | 00666 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 676 |  6 | 00676 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 676 |  6 | 00676 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 686 |  6 | 00686 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 686 |  6 | 00686 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 696 |  6 | 00696 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 696 |  6 | 00696 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 706 |  6 | 00706 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 706 |  6 | 00706 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 716 |  6 | 00716 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 716 |  6 | 00716 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 726 |  6 | 00726 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 726 |  6 | 00726 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 736 |  6 | 00736 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 736 |  6 | 00736 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 746 |  6 | 00746 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 746 |  6 | 00746 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 756 |  6 | 00756 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 756 |  6 | 00756 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 766 |  6 | 00766 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 766 |  6 | 00766 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 776 |  6 | 00776 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 776 |  6 | 00776 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 786 |  6 | 00786 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 786 |  6 | 00786 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 796 |  6 | 00796 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 796 |  6 | 00796 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 806 |  6 | 00806 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 806 |  6 | 00806 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 816 |  6 | 00816 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 816 |  6 | 00816 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 826 |  6 | 00826 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 826 |  6 | 00826 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 836 |  6 | 00836 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 836 |  6 | 00836 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 846 |  6 | 00846 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 846 |  6 | 00846 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 856 |  6 | 00856 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 856 |  6 | 00856 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 866 |  6 | 00866 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 866 |  6 | 00866 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 876 |  6 | 00876 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 876 |  6 | 00876 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 886 |  6 | 00886 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 886 |  6 | 00886 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 896 |  6 | 00896 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 896 |  6 | 00896 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
- 906 |  6 | 00906 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo | 906 |  6 | 00906 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
- 916 |  6 | 00916 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 916 |  6 | 00916 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
- 926 |  6 | 00926 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 926 |  6 | 00926 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo
- 936 |  6 | 00936 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 936 |  6 | 00936 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo
- 946 |  6 | 00946 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 946 |  6 | 00946 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo
- 956 |  6 | 00956 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 956 |  6 | 00956 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo
- 966 |  6 | 00966 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 966 |  6 | 00966 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo
- 976 |  6 | 00976 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 976 |  6 | 00976 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo
- 986 |  6 | 00986 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 986 |  6 | 00986 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo
- 996 |  6 | 00996 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 996 |  6 | 00996 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo
+ c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  | c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 6   | 6  | 00006 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 6   | 6  | 00006 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 16  | 6  | 00016 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 16  | 6  | 00016 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 26  | 6  | 00026 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 26  | 6  | 00026 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 36  | 6  | 00036 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 36  | 6  | 00036 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 46  | 6  | 00046 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 46  | 6  | 00046 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 56  | 6  | 00056 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 56  | 6  | 00056 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 66  | 6  | 00066 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 66  | 6  | 00066 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 76  | 6  | 00076 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 76  | 6  | 00076 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 86  | 6  | 00086 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 86  | 6  | 00086 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 96  | 6  | 00096 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 96  | 6  | 00096 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 106 | 6  | 00106 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 106 | 6  | 00106 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 116 | 6  | 00116 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 116 | 6  | 00116 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 126 | 6  | 00126 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 126 | 6  | 00126 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 136 | 6  | 00136 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 136 | 6  | 00136 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 146 | 6  | 00146 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 146 | 6  | 00146 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 156 | 6  | 00156 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 156 | 6  | 00156 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 166 | 6  | 00166 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 166 | 6  | 00166 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 176 | 6  | 00176 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 176 | 6  | 00176 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 186 | 6  | 00186 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 186 | 6  | 00186 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 196 | 6  | 00196 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 196 | 6  | 00196 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 206 | 6  | 00206 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 206 | 6  | 00206 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 216 | 6  | 00216 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 216 | 6  | 00216 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 226 | 6  | 00226 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 226 | 6  | 00226 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 236 | 6  | 00236 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 236 | 6  | 00236 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 246 | 6  | 00246 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 246 | 6  | 00246 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 256 | 6  | 00256 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 256 | 6  | 00256 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 266 | 6  | 00266 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 266 | 6  | 00266 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 276 | 6  | 00276 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 276 | 6  | 00276 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 286 | 6  | 00286 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 286 | 6  | 00286 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 296 | 6  | 00296 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 296 | 6  | 00296 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 306 | 6  | 00306 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 306 | 6  | 00306 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 316 | 6  | 00316 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 316 | 6  | 00316 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 326 | 6  | 00326 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 326 | 6  | 00326 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 336 | 6  | 00336 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 336 | 6  | 00336 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 346 | 6  | 00346 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 346 | 6  | 00346 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 356 | 6  | 00356 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 356 | 6  | 00356 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 366 | 6  | 00366 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 366 | 6  | 00366 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 376 | 6  | 00376 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 376 | 6  | 00376 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 386 | 6  | 00386 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 386 | 6  | 00386 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 396 | 6  | 00396 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 396 | 6  | 00396 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 406 | 6  | 00406 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 406 | 6  | 00406 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 416 | 6  | 00416 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 416 | 6  | 00416 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 426 | 6  | 00426 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 426 | 6  | 00426 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 436 | 6  | 00436 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 436 | 6  | 00436 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 446 | 6  | 00446 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 446 | 6  | 00446 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 456 | 6  | 00456 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 456 | 6  | 00456 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 466 | 6  | 00466 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 466 | 6  | 00466 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 476 | 6  | 00476 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 476 | 6  | 00476 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 486 | 6  | 00486 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 486 | 6  | 00486 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 496 | 6  | 00496 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 496 | 6  | 00496 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 506 | 6  | 00506 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 506 | 6  | 00506 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 516 | 6  | 00516 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 516 | 6  | 00516 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 526 | 6  | 00526 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 526 | 6  | 00526 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 536 | 6  | 00536 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 536 | 6  | 00536 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 546 | 6  | 00546 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 546 | 6  | 00546 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 556 | 6  | 00556 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 556 | 6  | 00556 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 566 | 6  | 00566 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 566 | 6  | 00566 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 576 | 6  | 00576 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 576 | 6  | 00576 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 586 | 6  | 00586 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 586 | 6  | 00586 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 596 | 6  | 00596 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 596 | 6  | 00596 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 606 | 6  | 00606 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 606 | 6  | 00606 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 616 | 6  | 00616 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 616 | 6  | 00616 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 626 | 6  | 00626 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 626 | 6  | 00626 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 636 | 6  | 00636 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 636 | 6  | 00636 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 646 | 6  | 00646 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 646 | 6  | 00646 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 656 | 6  | 00656 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 656 | 6  | 00656 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 666 | 6  | 00666 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 666 | 6  | 00666 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 676 | 6  | 00676 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 676 | 6  | 00676 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 686 | 6  | 00686 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 686 | 6  | 00686 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 696 | 6  | 00696 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 696 | 6  | 00696 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 706 | 6  | 00706 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 706 | 6  | 00706 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 716 | 6  | 00716 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 716 | 6  | 00716 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 726 | 6  | 00726 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 726 | 6  | 00726 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 736 | 6  | 00736 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 736 | 6  | 00736 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 746 | 6  | 00746 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 746 | 6  | 00746 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 756 | 6  | 00756 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 756 | 6  | 00756 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 766 | 6  | 00766 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 766 | 6  | 00766 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 776 | 6  | 00776 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 776 | 6  | 00776 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 786 | 6  | 00786 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 786 | 6  | 00786 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 796 | 6  | 00796 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 796 | 6  | 00796 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 806 | 6  | 00806 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 806 | 6  | 00806 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 816 | 6  | 00816 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 816 | 6  | 00816 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 826 | 6  | 00826 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 826 | 6  | 00826 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 836 | 6  | 00836 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 836 | 6  | 00836 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 846 | 6  | 00846 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 846 | 6  | 00846 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 856 | 6  | 00856 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 856 | 6  | 00856 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 866 | 6  | 00866 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 866 | 6  | 00866 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 876 | 6  | 00876 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 876 | 6  | 00876 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 886 | 6  | 00886 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 886 | 6  | 00886 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 896 | 6  | 00896 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 896 | 6  | 00896 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
+ 906 | 6  | 00906 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 906 | 6  | 00906 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 916 | 6  | 00916 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 916 | 6  | 00916 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
+ 926 | 6  | 00926 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 926 | 6  | 00926 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo
+ 936 | 6  | 00936 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 936 | 6  | 00936 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo
+ 946 | 6  | 00946 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 946 | 6  | 00946 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo
+ 956 | 6  | 00956 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 956 | 6  | 00956 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo
+ 966 | 6  | 00966 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 966 | 6  | 00966 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo
+ 976 | 6  | 00976 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 976 | 6  | 00976 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo
+ 986 | 6  | 00986 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 986 | 6  | 00986 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo
+ 996 | 6  | 00996 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 996 | 6  | 00996 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo
 (100 rows)
 
 -- bug before 9.3.5 due to sloppy handling of remote-estimate parameters
 SELECT * FROM ft1 WHERE c1 = ANY (ARRAY(SELECT c1 FROM ft2 WHERE c1 < 5));
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
-  2 |  2 | 00002 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
-  3 |  3 | 00003 | Sun Jan 04 00:00:00 1970 PST | Sun Jan 04 00:00:00 1970 | 3  | 3          | foo
-  4 |  4 | 00004 | Mon Jan 05 00:00:00 1970 PST | Mon Jan 05 00:00:00 1970 | 4  | 4          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+ 2  | 2  | 00002 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
+ 3  | 3  | 00003 | 1970-01-04 00:00:00.000000 -08:00 | 1970-01-04 00:00:00.000000 | 3  | 3          | foo
+ 4  | 4  | 00004 | 1970-01-05 00:00:00.000000 -08:00 | 1970-01-05 00:00:00.000000 | 4  | 4          | foo
 (4 rows)
 
 SELECT * FROM ft2 WHERE c1 = ANY (ARRAY(SELECT c1 FROM ft1 WHERE c1 < 5));
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
-  2 |  2 | 00002 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
-  3 |  3 | 00003 | Sun Jan 04 00:00:00 1970 PST | Sun Jan 04 00:00:00 1970 | 3  | 3          | foo
-  4 |  4 | 00004 | Mon Jan 05 00:00:00 1970 PST | Mon Jan 05 00:00:00 1970 | 4  | 4          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+ 2  | 2  | 00002 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
+ 3  | 3  | 00003 | 1970-01-04 00:00:00.000000 -08:00 | 1970-01-04 00:00:00.000000 | 3  | 3          | foo
+ 4  | 4  | 00004 | 1970-01-05 00:00:00.000000 -08:00 | 1970-01-05 00:00:00.000000 | 4  | 4          | foo
 (4 rows)
 
 -- we should not push order by clause with volatile expressions or unsafe
@@ -914,7 +1046,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Sort
-   Output: c1, c2, c3, c4, c5, c6, c7, c8, ((c3)::text)
+   Output: c1, c2, c3, c4, c5, c6, c7, c8, ((c3)::varchar2(1024))
    Sort Key: ft2.c1, ft2.c3 COLLATE "C"
    ->  Foreign Scan on public.ft2
          Output: c1, c2, c3, c4, c5, c6, c7, c8, c3
@@ -922,28 +1054,30 @@ EXPLAIN (VERBOSE, COSTS OFF)
 (6 rows)
 
 -- user-defined operator/function
-CREATE FUNCTION postgres_fdw_abs(int) RETURNS int AS $$
+CREATE FUNCTION postgres_fdw_abs(number(38,0)) RETURNS int AS $$
 BEGIN
 RETURN abs($1);
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 /
 CREATE OPERATOR === (
-    LEFTARG = int,
-    RIGHTARG = int,
-    PROCEDURE = int4eq,
+    LEFTARG = number(38,0),
+    RIGHTARG = number(38,0),
+    PROCEDURE = sys.number_eq,
     COMMUTATOR = ===
 );
 -- built-in operators and functions can be shipped for remote execution
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Foreign Scan
-   Output: (count(c3))
-   Relations: Aggregate on (public.ft1 t1)
-   Remote SQL: SELECT count(c3) FROM "S 1"."T 1" WHERE (("C 1" = abs(c2)))
-(4 rows)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Aggregate
+   Output: count(c3)
+   ->  Foreign Scan on public.ft1 t1
+         Output: c3
+         Filter: ((t1.c1)::binary_double = (abs((t1.c2)::double precision))::binary_double)
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+(6 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
  count 
@@ -953,13 +1087,15 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
 
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Foreign Scan
-   Output: (count(c3))
-   Relations: Aggregate on (public.ft1 t1)
-   Remote SQL: SELECT count(c3) FROM "S 1"."T 1" WHERE (("C 1" = c2))
-(4 rows)
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: count(c3)
+   ->  Foreign Scan on public.ft1 t1
+         Output: c3
+         Filter: (t1.c1 = t1.c2)
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+(6 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
  count 
@@ -970,13 +1106,13 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
 -- by default, user-defined ones cannot
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
-                        QUERY PLAN                         
------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  Aggregate
    Output: count(c3)
    ->  Foreign Scan on public.ft1 t1
          Output: c3
-         Filter: (t1.c1 = postgres_fdw_abs(t1.c2))
+         Filter: (t1.c1 = (postgres_fdw_abs(t1.c2))::number)
          Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
 (6 rows)
 
@@ -1007,36 +1143,41 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
 -- ORDER BY can be shipped, though
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT * FROM ft1 t1 WHERE t1.c1 === t1.c2 order by t1.c2 limit 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Limit
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   ->  Foreign Scan on public.ft1 t1
+   ->  Sort
          Output: c1, c2, c3, c4, c5, c6, c7, c8
-         Filter: (t1.c1 === t1.c2)
-         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" ORDER BY c2 ASC NULLS LAST
-(6 rows)
+         Sort Key: t1.c2
+         ->  Foreign Scan on public.ft1 t1
+               Output: c1, c2, c3, c4, c5, c6, c7, c8
+               Filter: (t1.c1 === t1.c2)
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(9 rows)
 
 SELECT * FROM ft1 t1 WHERE t1.c1 === t1.c2 order by t1.c2 limit 1;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 -- but let's put them in an extension ...
-ALTER EXTENSION postgres_fdw ADD FUNCTION postgres_fdw_abs(int);
-ALTER EXTENSION postgres_fdw ADD OPERATOR === (int, int);
+ALTER EXTENSION postgres_fdw ADD FUNCTION postgres_fdw_abs(number(38,0));
+ALTER EXTENSION postgres_fdw ADD OPERATOR === (number(38,0), number(38,0));
 ALTER SERVER loopback OPTIONS (ADD extensions 'postgres_fdw');
 -- ... now they can be shipped
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (count(c3))
-   Relations: Aggregate on (public.ft1 t1)
-   Remote SQL: SELECT count(c3) FROM "S 1"."T 1" WHERE (("C 1" = public.postgres_fdw_abs(c2)))
-(4 rows)
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Aggregate
+   Output: count(c3)
+   ->  Foreign Scan on public.ft1 t1
+         Output: c3
+         Filter: (t1.c1 = (postgres_fdw_abs(t1.c2))::number)
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+(6 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
  count 
@@ -1063,52 +1204,65 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
 -- and both ORDER BY and LIMIT can be shipped
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT * FROM ft1 t1 WHERE t1.c1 === t1.c2 order by t1.c2 limit 1;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2)) ORDER BY c2 ASC NULLS LAST LIMIT 1::bigint
-(3 rows)
+   ->  Sort
+         Output: c1, c2, c3, c4, c5, c6, c7, c8
+         Sort Key: t1.c2
+         ->  Foreign Scan on public.ft1 t1
+               Output: c1, c2, c3, c4, c5, c6, c7, c8
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
+(8 rows)
 
 SELECT * FROM ft1 t1 WHERE t1.c1 === t1.c2 order by t1.c2 limit 1;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 -- Test CASE pushdown
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1,c2,c3 FROM ft2 WHERE CASE WHEN c1 > 990 THEN c1 END < 1000 ORDER BY c1;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft2
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Sort
    Output: c1, c2, c3
-   Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1" WHERE (((CASE WHEN ("C 1" > 990) THEN "C 1" ELSE NULL::integer END) < 1000)) ORDER BY "C 1" ASC NULLS LAST
-(3 rows)
+   Sort Key: ft2.c1
+   ->  Foreign Scan on public.ft2
+         Output: c1, c2, c3
+         Filter: (CASE WHEN (ft2.c1 > '990'::number) THEN ft2.c1 ELSE NULL::number END < '1000'::number)
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+(7 rows)
 
 SELECT c1,c2,c3 FROM ft2 WHERE CASE WHEN c1 > 990 THEN c1 END < 1000 ORDER BY c1;
  c1  | c2 |  c3   
 -----+----+-------
- 991 |  1 | 00991
- 992 |  2 | 00992
- 993 |  3 | 00993
- 994 |  4 | 00994
- 995 |  5 | 00995
- 996 |  6 | 00996
- 997 |  7 | 00997
- 998 |  8 | 00998
- 999 |  9 | 00999
+ 991 | 1  | 00991
+ 992 | 2  | 00992
+ 993 | 3  | 00993
+ 994 | 4  | 00994
+ 995 | 5  | 00995
+ 996 | 6  | 00996
+ 997 | 7  | 00997
+ 998 | 8  | 00998
+ 999 | 9  | 00999
 (9 rows)
 
 -- Nested CASE
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1,c2,c3 FROM ft2 WHERE CASE CASE WHEN c2 > 0 THEN c2 END WHEN 100 THEN 601 WHEN c2 THEN c2 ELSE 0 END > 600 ORDER BY c1;
-                                                                                                QUERY PLAN                                                                                                 
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft2
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
    Output: c1, c2, c3
-   Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1" WHERE (((CASE (CASE WHEN (c2 > 0) THEN c2 ELSE NULL::integer END) WHEN 100 THEN 601 WHEN c2 THEN c2 ELSE 0 END) > 600)) ORDER BY "C 1" ASC NULLS LAST
-(3 rows)
+   Sort Key: ft2.c1
+   ->  Foreign Scan on public.ft2
+         Output: c1, c2, c3
+         Filter: (CASE CASE WHEN (ft2.c2 > '0'::number) THEN ft2.c2 ELSE NULL::number END WHEN '100'::number THEN '601'::number WHEN ft2.c2 THEN ft2.c2 ELSE '0'::number END > '600'::number)
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+(7 rows)
 
 SELECT c1,c2,c3 FROM ft2 WHERE CASE CASE WHEN c2 > 0 THEN c2 END WHEN 100 THEN 601 WHEN c2 THEN c2 ELSE 0 END > 600 ORDER BY c1;
  c1 | c2 | c3 
@@ -1118,52 +1272,54 @@ SELECT c1,c2,c3 FROM ft2 WHERE CASE CASE WHEN c2 > 0 THEN c2 END WHEN 100 THEN 6
 -- CASE arg WHEN
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1 WHERE c1 > (CASE mod(c1, 4) WHEN 0 THEN 1 WHEN 2 THEN 50 ELSE 100 END);
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" > (CASE mod("C 1", 4) WHEN 0 THEN 1 WHEN 2 THEN 50 ELSE 100 END)))
-(3 rows)
+   Filter: (ft1.c1 > (CASE mod((ft1.c1)::numeric, '4'::numeric) WHEN '0'::numeric THEN 1 WHEN '2'::numeric THEN 50 ELSE 100 END)::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 -- CASE cannot be pushed down because of unshippable arg clause
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1 WHERE c1 > (CASE random()::integer WHEN 0 THEN 1 WHEN 2 THEN 50 ELSE 100 END);
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: (ft1.c1 > CASE (random())::integer WHEN 0 THEN 1 WHEN 2 THEN 50 ELSE 100 END)
+   Filter: (ft1.c1 > (CASE (random())::integer WHEN 0 THEN 1 WHEN 2 THEN 50 ELSE 100 END)::number)
    Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 -- these are shippable
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1 WHERE CASE c6 WHEN 'foo' THEN true ELSE c3 < 'bar' END;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: CASE ft1.c6 WHEN 'foo'::varchar2 THEN true ELSE (ft1.c3 < 'bar'::text) END
+   Filter: CASE ft1.c6 WHEN 'foo'::varchar2 THEN true ELSE (ft1.c3 < 'bar'::varchar2) END
    Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1 WHERE CASE c3 WHEN c6 THEN true ELSE c3 < 'bar' END;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.ft1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE ((CASE c3 WHEN c6 THEN true ELSE (c3 < 'bar') END))
-(3 rows)
+   Filter: CASE ft1.c3 WHEN ft1.c6 THEN true ELSE (ft1.c3 < 'bar'::varchar2) END
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 -- but this is not because of collation
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1 WHERE CASE c3 COLLATE "C" WHEN c6 THEN true ELSE c3 < 'bar' END;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: CASE (ft1.c3)::text WHEN ft1.c6 THEN true ELSE (ft1.c3 < 'bar'::text) END
+   Filter: CASE (ft1.c3)::varchar2(1024) WHEN ft1.c6 THEN true ELSE (ft1.c3 < 'bar'::varchar2) END
    Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
@@ -1174,12 +1330,12 @@ CREATE TEXT SEARCH CONFIGURATION public.custom_search
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, to_tsvector('custom_search'::regconfig, c3) FROM ft1
 WHERE c1 = 642 AND length(to_tsvector('custom_search'::regconfig, c3)) > 0;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1
-   Output: c1, to_tsvector('custom_search'::regconfig, c3)
-   Filter: (length(to_tsvector('custom_search'::regconfig, ft1.c3)) > 0)
-   Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1" WHERE (("C 1" = 642))
+   Output: c1, to_tsvector('custom_search'::regconfig, (c3)::text)
+   Filter: ((ft1.c1 = '642'::number) AND (length(to_tsvector('custom_search'::regconfig, (ft1.c3)::text)) > 0))
+   Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
 (4 rows)
 
 SELECT c1, to_tsvector('custom_search'::regconfig, c3) FROM ft1
@@ -1196,12 +1352,13 @@ ALTER EXTENSION postgres_fdw ADD TEXT SEARCH CONFIGURATION public.custom_search;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, to_tsvector('custom_search'::regconfig, c3) FROM ft1
 WHERE c1 = 642 AND length(to_tsvector('custom_search'::regconfig, c3)) > 0;
-                                                                  QUERY PLAN                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1
-   Output: c1, to_tsvector('custom_search'::regconfig, c3)
-   Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1" WHERE (("C 1" = 642)) AND ((length(to_tsvector('public.custom_search'::regconfig, c3)) > 0))
-(3 rows)
+   Output: c1, to_tsvector('custom_search'::regconfig, (c3)::text)
+   Filter: (ft1.c1 = '642'::number)
+   Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1" WHERE ((length(to_tsvector('public.custom_search'::regconfig, c3)) > 0))
+(4 rows)
 
 SELECT c1, to_tsvector('custom_search'::regconfig, c3) FROM ft1
 WHERE c1 = 642 AND length(to_tsvector('custom_search'::regconfig, c3)) > 0;
@@ -1220,13 +1377,25 @@ ANALYZE ft5;
 -- join two tables
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-                                                                                                       QUERY PLAN                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1, t1.c3
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1."C 1", r2."C 1", r1.c3 FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")))) ORDER BY r1.c3 ASC NULLS LAST, r1."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.c1, t2.c1, t1.c3
+         Sort Key: t1.c3, t1.c1
+         ->  Hash Join
+               Output: t1.c1, t2.c1, t1.c3
+               Hash Cond: (t2.c1 = t1.c1)
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t1.c1, t1.c3
+                     ->  Foreign Scan on public.ft1 t1
+                           Output: t1.c1, t1.c3
+                           Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+(16 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
  c1  | c1  
@@ -1246,79 +1415,128 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t
 -- join three tables
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) JOIN ft4 t3 ON (t3.c1 = t1.c1) ORDER BY t1.c3, t1.c1 OFFSET 10 LIMIT 10;
-                                                                                                                                   QUERY PLAN                                                                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3, t1.c3
-   Relations: ((public.ft1 t1) INNER JOIN (public.ft2 t2)) INNER JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3, r1.c3 FROM (("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")))) INNER JOIN "S 1"."T 3" r4 ON (((r1."C 1" = r4.c1)))) ORDER BY r1.c3 ASC NULLS LAST, r1."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.c1, t2.c2, t3.c3, t1.c3
+         Sort Key: t1.c3, t1.c1
+         ->  Hash Join
+               Output: t1.c1, t2.c2, t3.c3, t1.c3
+               Hash Cond: (t2.c1 = t1.c1)
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c2, t2.c1
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t1.c1, t1.c3, t3.c3, t3.c1
+                     ->  Hash Join
+                           Output: t1.c1, t1.c3, t3.c3, t3.c1
+                           Hash Cond: (t1.c1 = t3.c1)
+                           ->  Foreign Scan on public.ft1 t1
+                                 Output: t1.c1, t1.c3
+                                 Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+                           ->  Hash
+                                 Output: t3.c3, t3.c1
+                                 ->  Foreign Scan on public.ft4 t3
+                                       Output: t3.c3, t3.c1
+                                       Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(24 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) JOIN ft4 t3 ON (t3.c1 = t1.c1) ORDER BY t1.c3, t1.c1 OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 22 |  2 | AAA022
- 24 |  4 | AAA024
- 26 |  6 | AAA026
- 28 |  8 | AAA028
- 30 |  0 | AAA030
- 32 |  2 | AAA032
- 34 |  4 | AAA034
- 36 |  6 | AAA036
- 38 |  8 | AAA038
- 40 |  0 | AAA040
+ 22 | 2  | AAA022
+ 24 | 4  | AAA024
+ 26 | 6  | AAA026
+ 28 | 8  | AAA028
+ 30 | 0  | AAA030
+ 32 | 2  | AAA032
+ 34 | 4  | AAA034
+ 36 | 6  | AAA036
+ 38 | 8  | AAA038
+ 40 | 0  | AAA040
 (10 rows)
 
 -- left outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft4 t1 LEFT JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1
-   Relations: (public.ft4 t1) LEFT JOIN (public.ft5 t2)
-   Remote SQL: SELECT r1.c1, r2.c1 FROM ("S 1"."T 3" r1 LEFT JOIN "S 1"."T 4" r2 ON (((r1.c1 = r2.c1)))) ORDER BY r1.c1 ASC NULLS LAST, r2.c1 ASC NULLS LAST LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.c1, t2.c1
+         Sort Key: t1.c1, t2.c1
+         ->  Hash Left Join
+               Output: t1.c1, t2.c1
+               Hash Cond: (t1.c1 = t2.c1)
+               ->  Foreign Scan on public.ft4 t1
+                     Output: t1.c1, t1.c2, t1.c3
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: t2.c1
+                     ->  Foreign Scan on public.ft5 t2
+                           Output: t2.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(16 rows)
 
 SELECT t1.c1, t2.c1 FROM ft4 t1 LEFT JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
  c1 | c1 
 ----+----
- 22 |   
+ 22 | 
  24 | 24
- 26 |   
- 28 |   
+ 26 | 
+ 28 | 
  30 | 30
- 32 |   
- 34 |   
+ 32 | 
+ 34 | 
  36 | 36
- 38 |   
- 40 |   
+ 38 | 
+ 40 | 
 (10 rows)
 
 -- left outer join three tables
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) LEFT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft2 t1) LEFT JOIN (public.ft2 t2)) LEFT JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 1" r1 LEFT JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1")))) LEFT JOIN "S 1"."T 3" r4 ON (((r2."C 1" = r4.c1)))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Right Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t2.c1 = t1.c1)
+         ->  Hash Left Join
+               Output: t2.c2, t2.c1, t3.c3
+               Hash Cond: (t2.c1 = t3.c1)
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c2, t2.c1
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t3.c3, t3.c1
+                     ->  Foreign Scan on public.ft4 t3
+                           Output: t3.c3, t3.c1
+                           Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+         ->  Hash
+               Output: t1.c1
+               ->  Foreign Scan on public.ft2 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) LEFT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 11 |  1 | 
- 12 |  2 | AAA012
- 13 |  3 | 
- 14 |  4 | AAA014
- 15 |  5 | 
- 16 |  6 | AAA016
- 17 |  7 | 
- 18 |  8 | AAA018
- 19 |  9 | 
- 20 |  0 | AAA020
+ 11 | 1  | 
+ 12 | 2  | AAA012
+ 13 | 3  | 
+ 14 | 4  | AAA014
+ 15 | 5  | 
+ 16 | 6  | AAA016
+ 17 | 7  | 
+ 18 | 8  | AAA018
+ 19 | 9  | 
+ 20 | 0  | AAA020
 (10 rows)
 
 -- left outer join + placement of clauses.
@@ -1326,21 +1544,30 @@ SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) LEFT 
 -- non-nullable side is pushed into non-nullable side
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t1.c2, t2.c1, t2.c2 FROM ft4 t1 LEFT JOIN (SELECT * FROM ft5 WHERE c1 < 10) t2 ON (t1.c1 = t2.c1) WHERE t1.c1 < 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Nested Loop Left Join
    Output: t1.c1, t1.c2, ft5.c1, ft5.c2
-   Relations: (public.ft4 t1) LEFT JOIN (public.ft5)
-   Remote SQL: SELECT r1.c1, r1.c2, r4.c1, r4.c2 FROM ("S 1"."T 3" r1 LEFT JOIN "S 1"."T 4" r4 ON (((r1.c1 = r4.c1)) AND ((r4.c1 < 10)))) WHERE ((r1.c1 < 10))
-(4 rows)
+   Join Filter: (t1.c1 = ft5.c1)
+   ->  Foreign Scan on public.ft4 t1
+         Output: t1.c1, t1.c2, t1.c3
+         Filter: (t1.c1 < '10'::number)
+         Remote SQL: SELECT c1, c2 FROM "S 1"."T 3"
+   ->  Materialize
+         Output: ft5.c1, ft5.c2
+         ->  Foreign Scan on public.ft5
+               Output: ft5.c1, ft5.c2
+               Filter: (ft5.c1 < '10'::number)
+               Remote SQL: SELECT c1, c2 FROM "S 1"."T 4"
+(13 rows)
 
 SELECT t1.c1, t1.c2, t2.c1, t2.c2 FROM ft4 t1 LEFT JOIN (SELECT * FROM ft5 WHERE c1 < 10) t2 ON (t1.c1 = t2.c1) WHERE t1.c1 < 10;
  c1 | c2 | c1 | c2 
 ----+----+----+----
-  2 |  3 |    |   
-  4 |  5 |    |   
-  6 |  7 |  6 |  7
-  8 |  9 |    |   
+ 2  | 3  |    | 
+ 4  | 5  |    | 
+ 6  | 7  | 6  | 7
+ 8  | 9  |    | 
 (4 rows)
 
 -- clauses within the nullable side are not pulled up, but the top level clause
@@ -1348,34 +1575,56 @@ SELECT t1.c1, t1.c2, t2.c1, t2.c2 FROM ft4 t1 LEFT JOIN (SELECT * FROM ft5 WHERE
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t1.c2, t2.c1, t2.c2 FROM ft4 t1 LEFT JOIN (SELECT * FROM ft5 WHERE c1 < 10) t2 ON (t1.c1 = t2.c1)
 			WHERE (t2.c1 < 10 OR t2.c1 IS NULL) AND t1.c1 < 10;
-                                                                                              QUERY PLAN                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Nested Loop Left Join
    Output: t1.c1, t1.c2, ft5.c1, ft5.c2
-   Relations: (public.ft4 t1) LEFT JOIN (public.ft5)
-   Remote SQL: SELECT r1.c1, r1.c2, r4.c1, r4.c2 FROM ("S 1"."T 3" r1 LEFT JOIN "S 1"."T 4" r4 ON (((r1.c1 = r4.c1)) AND ((r4.c1 < 10)))) WHERE (((r4.c1 < 10) OR (r4.c1 IS NULL))) AND ((r1.c1 < 10))
-(4 rows)
+   Join Filter: (t1.c1 = ft5.c1)
+   Filter: ((ft5.c1 < '10'::number) OR (ft5.c1 IS NULL))
+   ->  Foreign Scan on public.ft4 t1
+         Output: t1.c1, t1.c2, t1.c3
+         Filter: (t1.c1 < '10'::number)
+         Remote SQL: SELECT c1, c2 FROM "S 1"."T 3"
+   ->  Materialize
+         Output: ft5.c1, ft5.c2
+         ->  Foreign Scan on public.ft5
+               Output: ft5.c1, ft5.c2
+               Filter: (ft5.c1 < '10'::number)
+               Remote SQL: SELECT c1, c2 FROM "S 1"."T 4"
+(14 rows)
 
 SELECT t1.c1, t1.c2, t2.c1, t2.c2 FROM ft4 t1 LEFT JOIN (SELECT * FROM ft5 WHERE c1 < 10) t2 ON (t1.c1 = t2.c1)
 			WHERE (t2.c1 < 10 OR t2.c1 IS NULL) AND t1.c1 < 10;
  c1 | c2 | c1 | c2 
 ----+----+----+----
-  2 |  3 |    |   
-  4 |  5 |    |   
-  6 |  7 |  6 |  7
-  8 |  9 |    |   
+ 2  | 3  |    | 
+ 4  | 5  |    | 
+ 6  | 7  | 6  | 7
+ 8  | 9  |    | 
 (4 rows)
 
 -- right outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft5 t1 RIGHT JOIN ft4 t2 ON (t1.c1 = t2.c1) ORDER BY t2.c1, t1.c1 OFFSET 10 LIMIT 10;
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1
-   Relations: (public.ft4 t2) LEFT JOIN (public.ft5 t1)
-   Remote SQL: SELECT r1.c1, r2.c1 FROM ("S 1"."T 3" r2 LEFT JOIN "S 1"."T 4" r1 ON (((r1.c1 = r2.c1)))) ORDER BY r2.c1 ASC NULLS LAST, r1.c1 ASC NULLS LAST LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.c1, t2.c1
+         Sort Key: t2.c1, t1.c1
+         ->  Hash Left Join
+               Output: t1.c1, t2.c1
+               Hash Cond: (t2.c1 = t1.c1)
+               ->  Foreign Scan on public.ft4 t2
+                     Output: t2.c1, t2.c2, t2.c3
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: t1.c1
+                     ->  Foreign Scan on public.ft5 t1
+                           Output: t1.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(16 rows)
 
 SELECT t1.c1, t2.c1 FROM ft5 t1 RIGHT JOIN ft4 t2 ON (t1.c1 = t2.c1) ORDER BY t2.c1, t1.c1 OFFSET 10 LIMIT 10;
  c1 | c1 
@@ -1395,50 +1644,79 @@ SELECT t1.c1, t2.c1 FROM ft5 t1 RIGHT JOIN ft4 t2 ON (t1.c1 = t2.c1) ORDER BY t2
 -- right outer join three tables
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 RIGHT JOIN ft2 t2 ON (t1.c1 = t2.c1) RIGHT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft4 t3) LEFT JOIN (public.ft2 t2)) LEFT JOIN (public.ft2 t1)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 3" r4 LEFT JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r4.c1)))) LEFT JOIN "S 1"."T 1" r1 ON (((r1."C 1" = r2."C 1")))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Right Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t1.c1 = t2.c1)
+         ->  Foreign Scan on public.ft2 t1
+               Output: t1.c1
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+         ->  Hash
+               Output: t3.c3, t2.c2, t2.c1
+               ->  Hash Right Join
+                     Output: t3.c3, t2.c2, t2.c1
+                     Hash Cond: (t2.c1 = t3.c1)
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c2, t2.c1
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+                     ->  Hash
+                           Output: t3.c3, t3.c1
+                           ->  Foreign Scan on public.ft4 t3
+                                 Output: t3.c3, t3.c1
+                                 Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 RIGHT JOIN ft2 t2 ON (t1.c1 = t2.c1) RIGHT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 22 |  2 | AAA022
- 24 |  4 | AAA024
- 26 |  6 | AAA026
- 28 |  8 | AAA028
- 30 |  0 | AAA030
- 32 |  2 | AAA032
- 34 |  4 | AAA034
- 36 |  6 | AAA036
- 38 |  8 | AAA038
- 40 |  0 | AAA040
+ 22 | 2  | AAA022
+ 24 | 4  | AAA024
+ 26 | 6  | AAA026
+ 28 | 8  | AAA028
+ 30 | 0  | AAA030
+ 32 | 2  | AAA032
+ 34 | 4  | AAA034
+ 36 | 6  | AAA036
+ 38 | 8  | AAA038
+ 40 | 0  | AAA040
 (10 rows)
 
 -- full outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft4 t1 FULL JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 45 LIMIT 10;
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1
-   Relations: (public.ft4 t1) FULL JOIN (public.ft5 t2)
-   Remote SQL: SELECT r1.c1, r2.c1 FROM ("S 1"."T 3" r1 FULL JOIN "S 1"."T 4" r2 ON (((r1.c1 = r2.c1)))) ORDER BY r1.c1 ASC NULLS LAST, r2.c1 ASC NULLS LAST LIMIT 10::bigint OFFSET 45::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.c1, t2.c1
+         Sort Key: t1.c1, t2.c1
+         ->  Hash Full Join
+               Output: t1.c1, t2.c1
+               Hash Cond: (t1.c1 = t2.c1)
+               ->  Foreign Scan on public.ft4 t1
+                     Output: t1.c1, t1.c2, t1.c3
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: t2.c1
+                     ->  Foreign Scan on public.ft5 t2
+                           Output: t2.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(16 rows)
 
 SELECT t1.c1, t2.c1 FROM ft4 t1 FULL JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 45 LIMIT 10;
  c1  | c1 
 -----+----
-  92 |   
-  94 |   
-  96 | 96
-  98 |   
- 100 |   
-     |  3
-     |  9
+ 92  | 
+ 94  | 
+ 96  | 96
+ 98  | 
+ 100 | 
+     | 3
+     | 9
      | 15
      | 21
      | 27
@@ -1448,22 +1726,34 @@ SELECT t1.c1, t2.c1 FROM ft4 t1 FULL JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.
 -- a. the joining relations are both base relations
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1;
-                                                                                                                                  QUERY PLAN                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Sort
    Output: ft4.c1, ft5.c1
-   Relations: (public.ft4) FULL JOIN (public.ft5)
-   Remote SQL: SELECT s4.c1, s5.c1 FROM ((SELECT c1 FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s4(c1) FULL JOIN (SELECT c1 FROM "S 1"."T 4" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s5(c1) ON (((s4.c1 = s5.c1)))) ORDER BY s4.c1 ASC NULLS LAST, s5.c1 ASC NULLS LAST
-(4 rows)
+   Sort Key: ft4.c1, ft5.c1
+   ->  Hash Full Join
+         Output: ft4.c1, ft5.c1
+         Hash Cond: (ft4.c1 = ft5.c1)
+         ->  Foreign Scan on public.ft4
+               Output: ft4.c1, ft4.c2, ft4.c3
+               Filter: ((ft4.c1 >= '50'::number) AND (ft4.c1 <= '60'::number))
+               Remote SQL: SELECT c1 FROM "S 1"."T 3"
+         ->  Hash
+               Output: ft5.c1
+               ->  Foreign Scan on public.ft5
+                     Output: ft5.c1
+                     Filter: ((ft5.c1 >= '50'::number) AND (ft5.c1 <= '60'::number))
+                     Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(16 rows)
 
 SELECT t1.c1, t2.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1;
  c1 | c1 
 ----+----
- 50 |   
- 52 |   
+ 50 | 
+ 52 | 
  54 | 54
- 56 |   
- 58 |   
+ 56 | 
+ 58 | 
  60 | 60
     | 51
     | 57
@@ -1471,13 +1761,23 @@ SELECT t1.c1, t2.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT 1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t2 ON (TRUE) OFFSET 10 LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Limit
    Output: 1
-   Relations: (public.ft4) FULL JOIN (public.ft5)
-   Remote SQL: SELECT NULL FROM ((SELECT NULL FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s4 FULL JOIN (SELECT NULL FROM "S 1"."T 4" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s5 ON (TRUE)) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Merge Full Join
+         Output: 1
+         ->  Foreign Scan on public.ft4
+               Output: ft4.c1, ft4.c2, ft4.c3
+               Filter: ((ft4.c1 >= '50'::number) AND (ft4.c1 <= '60'::number))
+               Remote SQL: SELECT c1 FROM "S 1"."T 3"
+         ->  Materialize
+               Output: ft5.c1, ft5.c2, ft5.c3
+               ->  Foreign Scan on public.ft5
+                     Output: ft5.c1, ft5.c2, ft5.c3
+                     Filter: ((ft5.c1 >= '50'::number) AND (ft5.c1 <= '60'::number))
+                     Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(14 rows)
 
 SELECT 1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t2 ON (TRUE) OFFSET 10 LIMIT 10;
  ?column? 
@@ -1498,44 +1798,86 @@ SELECT 1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELE
 -- relation
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT t2.c1, t3.c1 FROM ft4 t2 LEFT JOIN ft5 t3 ON (t2.c1 = t3.c1) WHERE (t2.c1 between 50 and 60)) ss(a, b) ON (t1.c1 = ss.a) ORDER BY t1.c1, ss.a, ss.b;
-                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Sort
    Output: ft4.c1, t2.c1, t3.c1
-   Relations: (public.ft4) FULL JOIN ((public.ft4 t2) LEFT JOIN (public.ft5 t3))
-   Remote SQL: SELECT s4.c1, s8.c1, s8.c2 FROM ((SELECT c1 FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s4(c1) FULL JOIN (SELECT r5.c1, r6.c1 FROM ("S 1"."T 3" r5 LEFT JOIN "S 1"."T 4" r6 ON (((r5.c1 = r6.c1)))) WHERE ((r5.c1 >= 50)) AND ((r5.c1 <= 60))) s8(c1, c2) ON (((s4.c1 = s8.c1)))) ORDER BY s4.c1 ASC NULLS LAST, s8.c1 ASC NULLS LAST, s8.c2 ASC NULLS LAST
-(4 rows)
+   Sort Key: ft4.c1, t2.c1, t3.c1
+   ->  Hash Full Join
+         Output: ft4.c1, t2.c1, t3.c1
+         Hash Cond: (ft4.c1 = t2.c1)
+         ->  Foreign Scan on public.ft4
+               Output: ft4.c1, ft4.c2, ft4.c3
+               Filter: ((ft4.c1 >= '50'::number) AND (ft4.c1 <= '60'::number))
+               Remote SQL: SELECT c1 FROM "S 1"."T 3"
+         ->  Hash
+               Output: t2.c1, t3.c1
+               ->  Hash Right Join
+                     Output: t2.c1, t3.c1
+                     Hash Cond: (t3.c1 = t2.c1)
+                     ->  Foreign Scan on public.ft5 t3
+                           Output: t3.c1, t3.c2, t3.c3
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+                     ->  Hash
+                           Output: t2.c1
+                           ->  Foreign Scan on public.ft4 t2
+                                 Output: t2.c1
+                                 Filter: ((t2.c1 >= '50'::number) AND (t2.c1 <= '60'::number))
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 3"
+(24 rows)
 
 SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT t2.c1, t3.c1 FROM ft4 t2 LEFT JOIN ft5 t3 ON (t2.c1 = t3.c1) WHERE (t2.c1 between 50 and 60)) ss(a, b) ON (t1.c1 = ss.a) ORDER BY t1.c1, ss.a, ss.b;
  c1 | a  | b  
 ----+----+----
- 50 | 50 |   
- 52 | 52 |   
+ 50 | 50 | 
+ 52 | 52 | 
  54 | 54 | 54
- 56 | 56 |   
- 58 | 58 |   
+ 56 | 56 | 
+ 58 | 58 | 
  60 | 60 | 60
 (6 rows)
 
 -- c. test deparsing the remote query as nested subqueries
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT t2.c1, t3.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t2 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t3 ON (t2.c1 = t3.c1) WHERE t2.c1 IS NULL OR t2.c1 IS NOT NULL) ss(a, b) ON (t1.c1 = ss.a) ORDER BY t1.c1, ss.a, ss.b;
-                                                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Sort
    Output: ft4.c1, ft4_1.c1, ft5.c1
-   Relations: (public.ft4) FULL JOIN ((public.ft4 ft4_1) FULL JOIN (public.ft5))
-   Remote SQL: SELECT s4.c1, s10.c1, s10.c2 FROM ((SELECT c1 FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s4(c1) FULL JOIN (SELECT s8.c1, s9.c1 FROM ((SELECT c1 FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s8(c1) FULL JOIN (SELECT c1 FROM "S 1"."T 4" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s9(c1) ON (((s8.c1 = s9.c1)))) WHERE (((s8.c1 IS NULL) OR (s8.c1 IS NOT NULL)))) s10(c1, c2) ON (((s4.c1 = s10.c1)))) ORDER BY s4.c1 ASC NULLS LAST, s10.c1 ASC NULLS LAST, s10.c2 ASC NULLS LAST
-(4 rows)
+   Sort Key: ft4.c1, ft4_1.c1, ft5.c1
+   ->  Hash Full Join
+         Output: ft4.c1, ft4_1.c1, ft5.c1
+         Hash Cond: (ft4_1.c1 = ft4.c1)
+         ->  Hash Full Join
+               Output: ft4_1.c1, ft5.c1
+               Hash Cond: (ft4_1.c1 = ft5.c1)
+               Filter: ((ft4_1.c1 IS NULL) OR (ft4_1.c1 IS NOT NULL))
+               ->  Foreign Scan on public.ft4 ft4_1
+                     Output: ft4_1.c1, ft4_1.c2, ft4_1.c3
+                     Filter: ((ft4_1.c1 >= '50'::number) AND (ft4_1.c1 <= '60'::number))
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: ft5.c1
+                     ->  Foreign Scan on public.ft5
+                           Output: ft5.c1
+                           Filter: ((ft5.c1 >= '50'::number) AND (ft5.c1 <= '60'::number))
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+         ->  Hash
+               Output: ft4.c1
+               ->  Foreign Scan on public.ft4
+                     Output: ft4.c1
+                     Filter: ((ft4.c1 >= '50'::number) AND (ft4.c1 <= '60'::number))
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+(26 rows)
 
 SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT t2.c1, t3.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t2 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t3 ON (t2.c1 = t3.c1) WHERE t2.c1 IS NULL OR t2.c1 IS NOT NULL) ss(a, b) ON (t1.c1 = ss.a) ORDER BY t1.c1, ss.a, ss.b;
  c1 | a  | b  
 ----+----+----
- 50 | 50 |   
- 52 | 52 |   
+ 50 | 50 | 
+ 52 | 52 | 
  54 | 54 | 54
- 56 | 56 |   
- 58 | 58 |   
+ 56 | 56 | 
+ 58 | 58 | 
  60 | 60 | 60
     |    | 51
     |    | 57
@@ -1544,46 +1886,42 @@ SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1
 -- d. test deparsing rowmarked relations as subqueries
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM "S 1"."T 3" WHERE c1 = 50) t1 INNER JOIN (SELECT t2.c1, t3.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t2 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t3 ON (t2.c1 = t3.c1) WHERE t2.c1 IS NULL OR t2.c1 IS NOT NULL) ss(a, b) ON (TRUE) ORDER BY t1.c1, ss.a, ss.b FOR UPDATE OF t1;
-                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
  LockRows
    Output: "T 3".c1, ft4.c1, ft5.c1, "T 3".ctid, ft4.*, ft5.*
-   ->  Nested Loop
+   ->  Sort
          Output: "T 3".c1, ft4.c1, ft5.c1, "T 3".ctid, ft4.*, ft5.*
-         ->  Foreign Scan
-               Output: ft4.c1, ft4.*, ft5.c1, ft5.*
-               Relations: (public.ft4) FULL JOIN (public.ft5)
-               Remote SQL: SELECT s8.c1, s8.c2, s9.c1, s9.c2 FROM ((SELECT c1, ROW(c1, c2, c3) FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s8(c1, c2) FULL JOIN (SELECT c1, ROW(c1, c2, c3) FROM "S 1"."T 4" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s9(c1, c2) ON (((s8.c1 = s9.c1)))) WHERE (((s8.c1 IS NULL) OR (s8.c1 IS NOT NULL))) ORDER BY s8.c1 ASC NULLS LAST, s9.c1 ASC NULLS LAST
-               ->  Sort
-                     Output: ft4.c1, ft4.*, ft5.c1, ft5.*
-                     Sort Key: ft4.c1, ft5.c1
-                     ->  Hash Full Join
-                           Output: ft4.c1, ft4.*, ft5.c1, ft5.*
-                           Hash Cond: (ft4.c1 = ft5.c1)
-                           Filter: ((ft4.c1 IS NULL) OR (ft4.c1 IS NOT NULL))
-                           ->  Foreign Scan on public.ft4
-                                 Output: ft4.c1, ft4.*
-                                 Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))
-                           ->  Hash
-                                 Output: ft5.c1, ft5.*
-                                 ->  Foreign Scan on public.ft5
-                                       Output: ft5.c1, ft5.*
-                                       Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4" WHERE ((c1 >= 50)) AND ((c1 <= 60))
-         ->  Materialize
-               Output: "T 3".c1, "T 3".ctid
+         Sort Key: ft4.c1, ft5.c1
+         ->  Nested Loop
+               Output: "T 3".c1, ft4.c1, ft5.c1, "T 3".ctid, ft4.*, ft5.*
                ->  Seq Scan on "S 1"."T 3"
                      Output: "T 3".c1, "T 3".ctid
-                     Filter: ("T 3".c1 = 50)
-(28 rows)
+                     Filter: ("T 3".c1 = '50'::number)
+               ->  Hash Full Join
+                     Output: ft4.c1, ft4.*, ft5.c1, ft5.*
+                     Hash Cond: (ft4.c1 = ft5.c1)
+                     Filter: ((ft4.c1 IS NULL) OR (ft4.c1 IS NOT NULL))
+                     ->  Foreign Scan on public.ft4
+                           Output: ft4.c1, ft4.*
+                           Filter: ((ft4.c1 >= '50'::number) AND (ft4.c1 <= '60'::number))
+                           Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
+                     ->  Hash
+                           Output: ft5.c1, ft5.*
+                           ->  Foreign Scan on public.ft5
+                                 Output: ft5.c1, ft5.*
+                                 Filter: ((ft5.c1 >= '50'::number) AND (ft5.c1 <= '60'::number))
+                                 Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
+(24 rows)
 
 SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM "S 1"."T 3" WHERE c1 = 50) t1 INNER JOIN (SELECT t2.c1, t3.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t2 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t3 ON (t2.c1 = t3.c1) WHERE t2.c1 IS NULL OR t2.c1 IS NOT NULL) ss(a, b) ON (TRUE) ORDER BY t1.c1, ss.a, ss.b FOR UPDATE OF t1;
  c1 | a  | b  
 ----+----+----
- 50 | 50 |   
- 50 | 52 |   
+ 50 | 50 | 
+ 50 | 52 | 
  50 | 54 | 54
- 50 | 56 |   
- 50 | 58 |   
+ 50 | 56 | 
+ 50 | 58 | 
  50 | 60 | 60
  50 |    | 51
  50 |    | 57
@@ -1592,23 +1930,44 @@ SELECT t1.c1, ss.a, ss.b FROM (SELECT c1 FROM "S 1"."T 3" WHERE c1 = 50) t1 INNE
 -- full outer join + inner join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1, t3.c1 FROM ft4 t1 INNER JOIN ft5 t2 ON (t1.c1 = t2.c1 + 1 and t1.c1 between 50 and 60) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) ORDER BY t1.c1, t2.c1, t3.c1 LIMIT 10;
-                                                                                                                                                 QUERY PLAN                                                                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1, t3.c1
-   Relations: ((public.ft4 t1) INNER JOIN (public.ft5 t2)) FULL JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1.c1, r2.c1, r4.c1 FROM (("S 1"."T 3" r1 INNER JOIN "S 1"."T 4" r2 ON (((r1.c1 = (r2.c1 + 1))) AND ((r1.c1 >= 50)) AND ((r1.c1 <= 60)))) FULL JOIN "S 1"."T 3" r4 ON (((r2.c1 = r4.c1)))) ORDER BY r1.c1 ASC NULLS LAST, r2.c1 ASC NULLS LAST, r4.c1 ASC NULLS LAST LIMIT 10::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.c1, t2.c1, t3.c1
+         Sort Key: t1.c1, t2.c1, t3.c1
+         ->  Hash Full Join
+               Output: t1.c1, t2.c1, t3.c1
+               Hash Cond: (t2.c1 = t3.c1)
+               ->  Nested Loop
+                     Output: t1.c1, t2.c1
+                     Join Filter: (t1.c1 = (t2.c1 + '1'::number))
+                     ->  Foreign Scan on public.ft5 t2
+                           Output: t2.c1, t2.c2, t2.c3
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+                     ->  Materialize
+                           Output: t1.c1
+                           ->  Foreign Scan on public.ft4 t1
+                                 Output: t1.c1
+                                 Filter: ((t1.c1 >= '50'::number) AND (t1.c1 <= '60'::number))
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: t3.c1
+                     ->  Foreign Scan on public.ft4 t3
+                           Output: t3.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 3"
+(25 rows)
 
 SELECT t1.c1, t2.c1, t3.c1 FROM ft4 t1 INNER JOIN ft5 t2 ON (t1.c1 = t2.c1 + 1 and t1.c1 between 50 and 60) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) ORDER BY t1.c1, t2.c1, t3.c1 LIMIT 10;
  c1 | c1 | c1 
 ----+----+----
- 52 | 51 |   
- 58 | 57 |   
-    |    |  2
-    |    |  4
-    |    |  6
-    |    |  8
+ 52 | 51 | 
+ 58 | 57 | 
+    |    | 2
+    |    | 4
+    |    | 6
+    |    | 8
     |    | 10
     |    | 12
     |    | 14
@@ -1618,202 +1977,333 @@ SELECT t1.c1, t2.c1, t3.c1 FROM ft4 t1 INNER JOIN ft5 t2 ON (t1.c1 = t2.c1 + 1 a
 -- full outer join three tables
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft2 t1) FULL JOIN (public.ft2 t2)) FULL JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 1" r1 FULL JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1")))) FULL JOIN "S 1"."T 3" r4 ON (((r2."C 1" = r4.c1)))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Full Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t2.c1 = t3.c1)
+         ->  Hash Full Join
+               Output: t1.c1, t2.c2, t2.c1
+               Hash Cond: (t1.c1 = t2.c1)
+               ->  Foreign Scan on public.ft2 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t2.c2, t2.c1
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c2, t2.c1
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Hash
+               Output: t3.c3, t3.c1
+               ->  Foreign Scan on public.ft4 t3
+                     Output: t3.c3, t3.c1
+                     Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 11 |  1 | 
- 12 |  2 | AAA012
- 13 |  3 | 
- 14 |  4 | AAA014
- 15 |  5 | 
- 16 |  6 | AAA016
- 17 |  7 | 
- 18 |  8 | AAA018
- 19 |  9 | 
- 20 |  0 | AAA020
+ 11 | 1  | 
+ 12 | 2  | AAA012
+ 13 | 3  | 
+ 14 | 4  | AAA014
+ 15 | 5  | 
+ 16 | 6  | AAA016
+ 17 | 7  | 
+ 18 | 8  | AAA018
+ 19 | 9  | 
+ 20 | 0  | AAA020
 (10 rows)
 
 -- full outer join + right outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) RIGHT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft4 t3) LEFT JOIN (public.ft2 t2)) LEFT JOIN (public.ft2 t1)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 3" r4 LEFT JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r4.c1)))) LEFT JOIN "S 1"."T 1" r1 ON (((r1."C 1" = r2."C 1")))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Right Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t1.c1 = t2.c1)
+         ->  Foreign Scan on public.ft2 t1
+               Output: t1.c1
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+         ->  Hash
+               Output: t3.c3, t2.c2, t2.c1
+               ->  Hash Right Join
+                     Output: t3.c3, t2.c2, t2.c1
+                     Hash Cond: (t2.c1 = t3.c1)
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c2, t2.c1
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+                     ->  Hash
+                           Output: t3.c3, t3.c1
+                           ->  Foreign Scan on public.ft4 t3
+                                 Output: t3.c3, t3.c1
+                                 Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) RIGHT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 22 |  2 | AAA022
- 24 |  4 | AAA024
- 26 |  6 | AAA026
- 28 |  8 | AAA028
- 30 |  0 | AAA030
- 32 |  2 | AAA032
- 34 |  4 | AAA034
- 36 |  6 | AAA036
- 38 |  8 | AAA038
- 40 |  0 | AAA040
+ 22 | 2  | AAA022
+ 24 | 4  | AAA024
+ 26 | 6  | AAA026
+ 28 | 8  | AAA028
+ 30 | 0  | AAA030
+ 32 | 2  | AAA032
+ 34 | 4  | AAA034
+ 36 | 6  | AAA036
+ 38 | 8  | AAA038
+ 40 | 0  | AAA040
 (10 rows)
 
 -- right outer join + full outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 RIGHT JOIN ft2 t2 ON (t1.c1 = t2.c1) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft2 t2) LEFT JOIN (public.ft2 t1)) FULL JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 1" r2 LEFT JOIN "S 1"."T 1" r1 ON (((r1."C 1" = r2."C 1")))) FULL JOIN "S 1"."T 3" r4 ON (((r2."C 1" = r4.c1)))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Full Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t2.c1 = t3.c1)
+         ->  Nested Loop Left Join
+               Output: t2.c2, t2.c1, t1.c1
+               Join Filter: (t1.c1 = t2.c1)
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c2, t2.c1
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+               ->  Materialize
+                     Output: t1.c1
+                     ->  Foreign Scan on public.ft2 t1
+                           Output: t1.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+         ->  Hash
+               Output: t3.c3, t3.c1
+               ->  Foreign Scan on public.ft4 t3
+                     Output: t3.c3, t3.c1
+                     Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 RIGHT JOIN ft2 t2 ON (t1.c1 = t2.c1) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 11 |  1 | 
- 12 |  2 | AAA012
- 13 |  3 | 
- 14 |  4 | AAA014
- 15 |  5 | 
- 16 |  6 | AAA016
- 17 |  7 | 
- 18 |  8 | AAA018
- 19 |  9 | 
- 20 |  0 | AAA020
+ 11 | 1  | 
+ 12 | 2  | AAA012
+ 13 | 3  | 
+ 14 | 4  | AAA014
+ 15 | 5  | 
+ 16 | 6  | AAA016
+ 17 | 7  | 
+ 18 | 8  | AAA018
+ 19 | 9  | 
+ 20 | 0  | AAA020
 (10 rows)
 
 -- full outer join + left outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) LEFT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft2 t1) FULL JOIN (public.ft2 t2)) LEFT JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 1" r1 FULL JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1")))) LEFT JOIN "S 1"."T 3" r4 ON (((r2."C 1" = r4.c1)))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Left Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t2.c1 = t3.c1)
+         ->  Hash Full Join
+               Output: t1.c1, t2.c2, t2.c1
+               Hash Cond: (t1.c1 = t2.c1)
+               ->  Foreign Scan on public.ft2 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t2.c2, t2.c1
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c2, t2.c1
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Hash
+               Output: t3.c3, t3.c1
+               ->  Foreign Scan on public.ft4 t3
+                     Output: t3.c3, t3.c1
+                     Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) LEFT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 11 |  1 | 
- 12 |  2 | AAA012
- 13 |  3 | 
- 14 |  4 | AAA014
- 15 |  5 | 
- 16 |  6 | AAA016
- 17 |  7 | 
- 18 |  8 | AAA018
- 19 |  9 | 
- 20 |  0 | AAA020
+ 11 | 1  | 
+ 12 | 2  | AAA012
+ 13 | 3  | 
+ 14 | 4  | AAA014
+ 15 | 5  | 
+ 16 | 6  | AAA016
+ 17 | 7  | 
+ 18 | 8  | AAA018
+ 19 | 9  | 
+ 20 | 0  | AAA020
 (10 rows)
 
 -- left outer join + full outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft2 t1) LEFT JOIN (public.ft2 t2)) FULL JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 1" r1 LEFT JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1")))) FULL JOIN "S 1"."T 3" r4 ON (((r2."C 1" = r4.c1)))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Full Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t2.c1 = t3.c1)
+         ->  Nested Loop Left Join
+               Output: t1.c1, t2.c2, t2.c1
+               Join Filter: (t1.c1 = t2.c1)
+               ->  Foreign Scan on public.ft2 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Materialize
+                     Output: t2.c2, t2.c1
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c2, t2.c1
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Hash
+               Output: t3.c3, t3.c1
+               ->  Foreign Scan on public.ft4 t3
+                     Output: t3.c3, t3.c1
+                     Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) FULL JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 11 |  1 | 
- 12 |  2 | AAA012
- 13 |  3 | 
- 14 |  4 | AAA014
- 15 |  5 | 
- 16 |  6 | AAA016
- 17 |  7 | 
- 18 |  8 | AAA018
- 19 |  9 | 
- 20 |  0 | AAA020
+ 11 | 1  | 
+ 12 | 2  | AAA012
+ 13 | 3  | 
+ 14 | 4  | AAA014
+ 15 | 5  | 
+ 16 | 6  | AAA016
+ 17 | 7  | 
+ 18 | 8  | AAA018
+ 19 | 9  | 
+ 20 | 0  | AAA020
 (10 rows)
 
 SET enable_memoize TO off;
 -- right outer join + left outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 RIGHT JOIN ft2 t2 ON (t1.c1 = t2.c1) LEFT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: ((public.ft2 t2) LEFT JOIN (public.ft2 t1)) LEFT JOIN (public.ft4 t3)
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM (("S 1"."T 1" r2 LEFT JOIN "S 1"."T 1" r1 ON (((r1."C 1" = r2."C 1")))) LEFT JOIN "S 1"."T 3" r4 ON (((r2."C 1" = r4.c1)))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Left Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t2.c1 = t1.c1)
+         ->  Hash Left Join
+               Output: t2.c2, t2.c1, t3.c3
+               Hash Cond: (t2.c1 = t3.c1)
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c2, t2.c1
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t3.c3, t3.c1
+                     ->  Foreign Scan on public.ft4 t3
+                           Output: t3.c3, t3.c1
+                           Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+         ->  Hash
+               Output: t1.c1
+               ->  Foreign Scan on public.ft2 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(21 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 RIGHT JOIN ft2 t2 ON (t1.c1 = t2.c1) LEFT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 11 |  1 | 
- 12 |  2 | AAA012
- 13 |  3 | 
- 14 |  4 | AAA014
- 15 |  5 | 
- 16 |  6 | AAA016
- 17 |  7 | 
- 18 |  8 | AAA018
- 19 |  9 | 
- 20 |  0 | AAA020
+ 11 | 1  | 
+ 12 | 2  | AAA012
+ 13 | 3  | 
+ 14 | 4  | AAA014
+ 15 | 5  | 
+ 16 | 6  | AAA016
+ 17 | 7  | 
+ 18 | 8  | AAA018
+ 19 | 9  | 
+ 20 | 0  | AAA020
 (10 rows)
 
 RESET enable_memoize;
 -- left outer join + right outer join
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) RIGHT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t3.c3
-   Relations: (public.ft4 t3) LEFT JOIN ((public.ft2 t1) INNER JOIN (public.ft2 t2))
-   Remote SQL: SELECT r1."C 1", r2.c2, r4.c3 FROM ("S 1"."T 3" r4 LEFT JOIN ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1")))) ON (((r2."C 1" = r4.c1)))) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Right Join
+         Output: t1.c1, t2.c2, t3.c3
+         Hash Cond: (t2.c1 = t3.c1)
+         ->  Merge Join
+               Output: t1.c1, t2.c2, t2.c1
+               Merge Cond: (t1.c1 = t2.c1)
+               ->  Sort
+                     Output: t1.c1
+                     Sort Key: t1.c1
+                     ->  Foreign Scan on public.ft2 t1
+                           Output: t1.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Sort
+                     Output: t2.c2, t2.c1
+                     Sort Key: t2.c1
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c2, t2.c1
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Hash
+               Output: t3.c3, t3.c1
+               ->  Foreign Scan on public.ft4 t3
+                     Output: t3.c3, t3.c1
+                     Remote SQL: SELECT c1, c3 FROM "S 1"."T 3"
+(25 rows)
 
 SELECT t1.c1, t2.c2, t3.c3 FROM ft2 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) RIGHT JOIN ft4 t3 ON (t2.c1 = t3.c1) OFFSET 10 LIMIT 10;
  c1 | c2 |   c3   
 ----+----+--------
- 22 |  2 | AAA022
- 24 |  4 | AAA024
- 26 |  6 | AAA026
- 28 |  8 | AAA028
- 30 |  0 | AAA030
- 32 |  2 | AAA032
- 34 |  4 | AAA034
- 36 |  6 | AAA036
- 38 |  8 | AAA038
- 40 |  0 | AAA040
+ 22 | 2  | AAA022
+ 24 | 4  | AAA024
+ 26 | 6  | AAA026
+ 28 | 8  | AAA028
+ 30 | 0  | AAA030
+ 32 | 2  | AAA032
+ 34 | 4  | AAA034
+ 36 | 6  | AAA036
+ 38 | 8  | AAA038
+ 40 | 0  | AAA040
 (10 rows)
 
 -- full outer join + WHERE clause, only matched rows
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft4 t1 FULL JOIN ft5 t2 ON (t1.c1 = t2.c1) WHERE (t1.c1 = t2.c1 OR t1.c1 IS NULL) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Limit
    Output: t1.c1, t2.c1
    ->  Sort
          Output: t1.c1, t2.c1
          Sort Key: t1.c1, t2.c1
-         ->  Foreign Scan
+         ->  Hash Full Join
                Output: t1.c1, t2.c1
-               Relations: (public.ft4 t1) FULL JOIN (public.ft5 t2)
-               Remote SQL: SELECT r1.c1, r2.c1 FROM ("S 1"."T 3" r1 FULL JOIN "S 1"."T 4" r2 ON (((r1.c1 = r2.c1)))) WHERE (((r1.c1 = r2.c1) OR (r1.c1 IS NULL)))
-(9 rows)
+               Hash Cond: (t1.c1 = t2.c1)
+               Filter: ((t1.c1 = t2.c1) OR (t1.c1 IS NULL))
+               ->  Foreign Scan on public.ft4 t1
+                     Output: t1.c1, t1.c2, t1.c3
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: t2.c1
+                     ->  Foreign Scan on public.ft5 t2
+                           Output: t2.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(17 rows)
 
 SELECT t1.c1, t2.c1 FROM ft4 t1 FULL JOIN ft5 t2 ON (t1.c1 = t2.c1) WHERE (t1.c1 = t2.c1 OR t1.c1 IS NULL) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
  c1 | c1 
@@ -1824,8 +2314,8 @@ SELECT t1.c1, t2.c1 FROM ft4 t1 FULL JOIN ft5 t2 ON (t1.c1 = t2.c1) WHERE (t1.c1
  84 | 84
  90 | 90
  96 | 96
-    |  3
-    |  9
+    | 3
+    | 9
     | 15
     | 21
 (10 rows)
@@ -1833,41 +2323,72 @@ SELECT t1.c1, t2.c1 FROM ft4 t1 FULL JOIN ft5 t2 ON (t1.c1 = t2.c1) WHERE (t1.c1
 -- full outer join + WHERE clause with shippable extensions set
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t1.c3 FROM ft1 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) WHERE postgres_fdw_abs(t1.c1) > 0 OFFSET 10 LIMIT 10;
-                                                                                                 QUERY PLAN                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c2, t1.c3
-   Relations: (public.ft1 t1) FULL JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1."C 1", r2.c2, r1.c3 FROM ("S 1"."T 1" r1 FULL JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1")))) WHERE ((public.postgres_fdw_abs(r1."C 1") > 0)) LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Hash Full Join
+         Output: t1.c1, t2.c2, t1.c3
+         Hash Cond: (t2.c1 = t1.c1)
+         Filter: (postgres_fdw_abs(t1.c1) > 0)
+         ->  Foreign Scan on public.ft2 t2
+               Output: t2.c2, t2.c1
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Hash
+               Output: t1.c1, t1.c3
+               ->  Foreign Scan on public.ft1 t1
+                     Output: t1.c1, t1.c3
+                     Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+(14 rows)
 
 ALTER SERVER loopback OPTIONS (DROP extensions);
 -- full outer join + WHERE clause with shippable extensions not set
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2, t1.c3 FROM ft1 t1 FULL JOIN ft2 t2 ON (t1.c1 = t2.c1) WHERE postgres_fdw_abs(t1.c1) > 0 OFFSET 10 LIMIT 10;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Limit
    Output: t1.c1, t2.c2, t1.c3
-   ->  Foreign Scan
+   ->  Hash Full Join
          Output: t1.c1, t2.c2, t1.c3
+         Hash Cond: (t2.c1 = t1.c1)
          Filter: (postgres_fdw_abs(t1.c1) > 0)
-         Relations: (public.ft1 t1) FULL JOIN (public.ft2 t2)
-         Remote SQL: SELECT r1."C 1", r2.c2, r1.c3 FROM ("S 1"."T 1" r1 FULL JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1"))))
-(7 rows)
+         ->  Foreign Scan on public.ft2 t2
+               Output: t2.c2, t2.c1
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Hash
+               Output: t1.c1, t1.c3
+               ->  Foreign Scan on public.ft1 t1
+                     Output: t1.c1, t1.c3
+                     Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+(14 rows)
 
 ALTER SERVER loopback OPTIONS (ADD extensions 'postgres_fdw');
 -- join two tables with FOR UPDATE clause
 -- tests whole-row reference for row marks
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE OF t1;
-                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1."C 1", r2."C 1", r1.c3, CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8) END, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8) END FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")))) ORDER BY r1.c3 ASC NULLS LAST, r1."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint FOR UPDATE OF r1
-(4 rows)
+   ->  LockRows
+         Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+         ->  Sort
+               Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+               Sort Key: t1.c3, t1.c1
+               ->  Hash Join
+                     Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+                     Hash Cond: (t2.c1 = t1.c1)
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c1, t2.*
+                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+                     ->  Hash
+                           Output: t1.c1, t1.c3, t1.*
+                           ->  Foreign Scan on public.ft1 t1
+                                 Output: t1.c1, t1.c3, t1.*
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR UPDATE
+(18 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE OF t1;
  c1  | c1  
@@ -1886,13 +2407,27 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE;
-                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1."C 1", r2."C 1", r1.c3, CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8) END, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8) END FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")))) ORDER BY r1.c3 ASC NULLS LAST, r1."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint FOR UPDATE OF r1 FOR UPDATE OF r2
-(4 rows)
+   ->  LockRows
+         Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+         ->  Sort
+               Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+               Sort Key: t1.c3, t1.c1
+               ->  Hash Join
+                     Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+                     Hash Cond: (t2.c1 = t1.c1)
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c1, t2.*
+                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR UPDATE
+                     ->  Hash
+                           Output: t1.c1, t1.c3, t1.*
+                           ->  Foreign Scan on public.ft1 t1
+                                 Output: t1.c1, t1.c3, t1.*
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR UPDATE
+(18 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE;
  c1  | c1  
@@ -1912,13 +2447,27 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t
 -- join two tables with FOR SHARE clause
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE OF t1;
-                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1."C 1", r2."C 1", r1.c3, CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8) END, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8) END FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")))) ORDER BY r1.c3 ASC NULLS LAST, r1."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint FOR SHARE OF r1
-(4 rows)
+   ->  LockRows
+         Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+         ->  Sort
+               Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+               Sort Key: t1.c3, t1.c1
+               ->  Hash Join
+                     Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+                     Hash Cond: (t2.c1 = t1.c1)
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c1, t2.*
+                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+                     ->  Hash
+                           Output: t1.c1, t1.c3, t1.*
+                           ->  Foreign Scan on public.ft1 t1
+                                 Output: t1.c1, t1.c3, t1.*
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR SHARE
+(18 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE OF t1;
  c1  | c1  
@@ -1937,13 +2486,27 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE;
-                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1."C 1", r2."C 1", r1.c3, CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8) END, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8) END FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")))) ORDER BY r1.c3 ASC NULLS LAST, r1."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint FOR SHARE OF r1 FOR SHARE OF r2
-(4 rows)
+   ->  LockRows
+         Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+         ->  Sort
+               Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+               Sort Key: t1.c3, t1.c1
+               ->  Hash Join
+                     Output: t1.c1, t2.c1, t1.c3, t1.*, t2.*
+                     Hash Cond: (t2.c1 = t1.c1)
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c1, t2.*
+                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR SHARE
+                     ->  Hash
+                           Output: t1.c1, t1.c3, t1.*
+                           ->  Foreign Scan on public.ft1 t1
+                                 Output: t1.c1, t1.c3, t1.*
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR SHARE
+(18 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE;
  c1  | c1  
@@ -1963,65 +2526,93 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t
 -- join in CTE
 EXPLAIN (VERBOSE, COSTS OFF)
 WITH t (c1_1, c1_3, c2_1) AS MATERIALIZED (SELECT t1.c1, t1.c3, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1)) SELECT c1_1, c2_1 FROM t ORDER BY c1_3, c1_1 OFFSET 100 LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Limit
    Output: t.c1_1, t.c2_1, t.c1_3
    CTE t
-     ->  Foreign Scan
+     ->  Hash Join
            Output: t1.c1, t1.c3, t2.c1
-           Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-           Remote SQL: SELECT r1."C 1", r1.c3, r2."C 1" FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1"))))
+           Hash Cond: (t2.c1 = t1.c1)
+           ->  Foreign Scan on public.ft2 t2
+                 Output: t2.c1
+                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+           ->  Hash
+                 Output: t1.c1, t1.c3
+                 ->  Foreign Scan on public.ft1 t1
+                       Output: t1.c1, t1.c3
+                       Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
    ->  Sort
          Output: t.c1_1, t.c2_1, t.c1_3
          Sort Key: t.c1_3, t.c1_1
          ->  CTE Scan on t
                Output: t.c1_1, t.c2_1, t.c1_3
-(12 rows)
+(19 rows)
 
 WITH t (c1_1, c1_3, c2_1) AS MATERIALIZED (SELECT t1.c1, t1.c3, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1)) SELECT c1_1, c2_1 FROM t ORDER BY c1_3, c1_1 OFFSET 100 LIMIT 10;
  c1_1 | c2_1 
 ------+------
-  101 |  101
-  102 |  102
-  103 |  103
-  104 |  104
-  105 |  105
-  106 |  106
-  107 |  107
-  108 |  108
-  109 |  109
-  110 |  110
+ 101  | 101
+ 102  | 102
+ 103  | 103
+ 104  | 104
+ 105  | 105
+ 106  | 106
+ 107  | 107
+ 108  | 108
+ 109  | 109
+ 110  | 110
 (10 rows)
 
 -- ctid with whole-row reference
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.ctid, t1, t2, t1.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Limit
    Output: t1.ctid, t1.*, t2.*, t1.c1, t1.c3
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1.ctid, CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8) END, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8) END, r1."C 1", r1.c3 FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")))) ORDER BY r1.c3 ASC NULLS LAST, r1."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.ctid, t1.*, t2.*, t1.c1, t1.c3
+         Sort Key: t1.c3, t1.c1
+         ->  Hash Join
+               Output: t1.ctid, t1.*, t2.*, t1.c1, t1.c3
+               Hash Cond: (t2.c1 = t1.c1)
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.*, t2.c1
+                     Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t1.ctid, t1.*, t1.c1, t1.c3
+                     ->  Foreign Scan on public.ft1 t1
+                           Output: t1.ctid, t1.*, t1.c1, t1.c3
+                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1"
+(16 rows)
 
 -- SEMI JOIN, not pushed down
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1 FROM ft1 t1 WHERE EXISTS (SELECT 1 FROM ft2 t2 WHERE t1.c1 = t2.c1) ORDER BY t1.c1 OFFSET 100 LIMIT 10;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Limit
    Output: t1.c1
-   ->  Merge Semi Join
+   ->  Sort
          Output: t1.c1
-         Merge Cond: (t1.c1 = t2.c1)
-         ->  Foreign Scan on public.ft1 t1
+         Sort Key: t1.c1
+         ->  Hash Join
                Output: t1.c1
-               Remote SQL: SELECT "C 1" FROM "S 1"."T 1" ORDER BY "C 1" ASC NULLS LAST
-         ->  Foreign Scan on public.ft2 t2
-               Output: t2.c1
-               Remote SQL: SELECT "C 1" FROM "S 1"."T 1" ORDER BY "C 1" ASC NULLS LAST
-(11 rows)
+               Inner Unique: true
+               Hash Cond: (t1.c1 = t2.c1)
+               ->  Foreign Scan on public.ft1 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t2.c1
+                     ->  HashAggregate
+                           Output: t2.c1
+                           Group Key: t2.c1
+                           ->  Foreign Scan on public.ft2 t2
+                                 Output: t2.c1
+                                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(20 rows)
 
 SELECT t1.c1 FROM ft1 t1 WHERE EXISTS (SELECT 1 FROM ft2 t2 WHERE t1.c1 = t2.c1) ORDER BY t1.c1 OFFSET 100 LIMIT 10;
  c1  
@@ -2041,20 +2632,25 @@ SELECT t1.c1 FROM ft1 t1 WHERE EXISTS (SELECT 1 FROM ft2 t2 WHERE t1.c1 = t2.c1)
 -- ANTI JOIN, not pushed down
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1 FROM ft1 t1 WHERE NOT EXISTS (SELECT 1 FROM ft2 t2 WHERE t1.c1 = t2.c2) ORDER BY t1.c1 OFFSET 100 LIMIT 10;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Limit
    Output: t1.c1
-   ->  Merge Anti Join
+   ->  Sort
          Output: t1.c1
-         Merge Cond: (t1.c1 = t2.c2)
-         ->  Foreign Scan on public.ft1 t1
+         Sort Key: t1.c1
+         ->  Hash Right Anti Join
                Output: t1.c1
-               Remote SQL: SELECT "C 1" FROM "S 1"."T 1" ORDER BY "C 1" ASC NULLS LAST
-         ->  Foreign Scan on public.ft2 t2
-               Output: t2.c2
-               Remote SQL: SELECT c2 FROM "S 1"."T 1" ORDER BY c2 ASC NULLS LAST
-(11 rows)
+               Hash Cond: (t2.c2 = t1.c1)
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c2
+                     Remote SQL: SELECT c2 FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t1.c1
+                     ->  Foreign Scan on public.ft1 t1
+                           Output: t1.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(16 rows)
 
 SELECT t1.c1 FROM ft1 t1 WHERE NOT EXISTS (SELECT 1 FROM ft2 t2 WHERE t1.c1 = t2.c2) ORDER BY t1.c1 OFFSET 100 LIMIT 10;
  c1  
@@ -2074,48 +2670,62 @@ SELECT t1.c1 FROM ft1 t1 WHERE NOT EXISTS (SELECT 1 FROM ft2 t2 WHERE t1.c1 = t2
 -- CROSS JOIN can be pushed down
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 CROSS JOIN ft2 t2 ORDER BY t1.c1, t2.c1 OFFSET 100 LIMIT 10;
-                                                                                           QUERY PLAN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Limit
    Output: t1.c1, t2.c1
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1."C 1", r2."C 1" FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (TRUE)) ORDER BY r1."C 1" ASC NULLS LAST, r2."C 1" ASC NULLS LAST LIMIT 10::bigint OFFSET 100::bigint
-(4 rows)
+   ->  Sort
+         Output: t1.c1, t2.c1
+         Sort Key: t1.c1, t2.c1
+         ->  Nested Loop
+               Output: t1.c1, t2.c1
+               ->  Foreign Scan on public.ft1 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Materialize
+                     Output: t2.c1
+                     ->  Foreign Scan on public.ft2 t2
+                           Output: t2.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(15 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 CROSS JOIN ft2 t2 ORDER BY t1.c1, t2.c1 OFFSET 100 LIMIT 10;
  c1 | c1  
 ----+-----
-  1 | 101
-  1 | 102
-  1 | 103
-  1 | 104
-  1 | 105
-  1 | 106
-  1 | 107
-  1 | 108
-  1 | 109
-  1 | 110
+ 1  | 101
+ 1  | 102
+ 1  | 103
+ 1  | 104
+ 1  | 105
+ 1  | 106
+ 1  | 107
+ 1  | 108
+ 1  | 109
+ 1  | 110
 (10 rows)
 
 -- different server, not pushed down. No result expected.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft5 t1 JOIN ft6 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 100 LIMIT 10;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Limit
    Output: t1.c1, t2.c1
-   ->  Merge Join
+   ->  Sort
          Output: t1.c1, t2.c1
-         Merge Cond: (t2.c1 = t1.c1)
-         ->  Foreign Scan on public.ft6 t2
-               Output: t2.c1, t2.c2, t2.c3
-               Remote SQL: SELECT c1 FROM "S 1"."T 4" ORDER BY c1 ASC NULLS LAST
-         ->  Materialize
-               Output: t1.c1, t1.c2, t1.c3
-               ->  Foreign Scan on public.ft5 t1
-                     Output: t1.c1, t1.c2, t1.c3
-                     Remote SQL: SELECT c1 FROM "S 1"."T 4" ORDER BY c1 ASC NULLS LAST
-(13 rows)
+         Sort Key: t1.c1
+         ->  Hash Join
+               Output: t1.c1, t2.c1
+               Hash Cond: (t2.c1 = t1.c1)
+               ->  Foreign Scan on public.ft6 t2
+                     Output: t2.c1, t2.c2, t2.c3
+                     Remote SQL: SELECT c1 FROM "S 1"."T 4"
+               ->  Hash
+                     Output: t1.c1
+                     ->  Foreign Scan on public.ft5 t1
+                           Output: t1.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(16 rows)
 
 SELECT t1.c1, t2.c1 FROM ft5 t1 JOIN ft6 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 100 LIMIT 10;
  c1 | c1 
@@ -2153,16 +2763,16 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 LEFT JOIN ft2 t2 ON (t1.c8 = t2.c8) ORDER BY t1.
 SELECT t1.c1, t2.c1 FROM ft1 t1 LEFT JOIN ft2 t2 ON (t1.c8 = t2.c8) ORDER BY t1.c1, t2.c1 OFFSET 100 LIMIT 10;
  c1 | c1  
 ----+-----
-  1 | 101
-  1 | 102
-  1 | 103
-  1 | 104
-  1 | 105
-  1 | 106
-  1 | 107
-  1 | 108
-  1 | 109
-  1 | 110
+ 1  | 101
+ 1  | 102
+ 1  | 103
+ 1  | 104
+ 1  | 105
+ 1  | 106
+ 1  | 107
+ 1  | 108
+ 1  | 109
+ 1  | 110
 (10 rows)
 
 -- unsafe conditions on one side (c8 has a UDT), not pushed down.
@@ -2210,19 +2820,25 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 LEFT JOIN ft2 t2 ON (t1.c1 = t2.c1) WHERE t1.c8 
 -- into one of the joining sides.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) WHERE t1.c8 = t2.c8 ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Limit
    Output: t1.c1, t2.c1, t1.c3
    ->  Sort
          Output: t1.c1, t2.c1, t1.c3
          Sort Key: t1.c3, t1.c1
-         ->  Foreign Scan
+         ->  Hash Join
                Output: t1.c1, t2.c1, t1.c3
-               Filter: (t1.c8 = t2.c8)
-               Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-               Remote SQL: SELECT r1."C 1", r2."C 1", r1.c3, r1.c8, r2.c8 FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1"))))
-(10 rows)
+               Hash Cond: ((t2.c1 = t1.c1) AND (t2.c8 = t1.c8))
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c1, t2.c8
+                     Remote SQL: SELECT "C 1", c8 FROM "S 1"."T 1"
+               ->  Hash
+                     Output: t1.c1, t1.c3, t1.c8
+                     ->  Foreign Scan on public.ft1 t1
+                           Output: t1.c1, t1.c3, t1.c8
+                           Remote SQL: SELECT "C 1", c3, c8 FROM "S 1"."T 1"
+(16 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) WHERE t1.c8 = t2.c8 ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
  c1  | c1  
@@ -2242,8 +2858,8 @@ SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) WHERE t1.c8 = t2.
 -- Aggregate after UNION, for testing setrefs
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) UNION SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1)) AS t (t1c1, t2c1) GROUP BY t1c1 ORDER BY t1c1 OFFSET 100 LIMIT 10;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Limit
    Output: t1.c1, (avg((t1.c1 + t2.c1)))
    ->  Sort
@@ -2256,36 +2872,50 @@ SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 
                      Output: t1.c1, t2.c1
                      Group Key: t1.c1, t2.c1
                      ->  Append
-                           ->  Foreign Scan
+                           ->  Hash Join
                                  Output: t1.c1, t2.c1
-                                 Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-                                 Remote SQL: SELECT r1."C 1", r2."C 1" FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1"))))
-                           ->  Foreign Scan
+                                 Hash Cond: (t2.c1 = t1.c1)
+                                 ->  Foreign Scan on public.ft2 t2
+                                       Output: t2.c1
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 ->  Hash
+                                       Output: t1.c1
+                                       ->  Foreign Scan on public.ft1 t1
+                                             Output: t1.c1
+                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                           ->  Hash Join
                                  Output: t1_1.c1, t2_1.c1
-                                 Relations: (public.ft1 t1_1) INNER JOIN (public.ft2 t2_1)
-                                 Remote SQL: SELECT r1."C 1", r2."C 1" FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1"))))
-(20 rows)
+                                 Hash Cond: (t2_1.c1 = t1_1.c1)
+                                 ->  Foreign Scan on public.ft2 t2_1
+                                       Output: t2_1.c1
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 ->  Hash
+                                       Output: t1_1.c1
+                                       ->  Foreign Scan on public.ft1 t1_1
+                                             Output: t1_1.c1
+                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(34 rows)
 
 SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) UNION SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1)) AS t (t1c1, t2c1) GROUP BY t1c1 ORDER BY t1c1 OFFSET 100 LIMIT 10;
  t1c1 |         avg          
 ------+----------------------
-  101 | 202.0000000000000000
-  102 | 204.0000000000000000
-  103 | 206.0000000000000000
-  104 | 208.0000000000000000
-  105 | 210.0000000000000000
-  106 | 212.0000000000000000
-  107 | 214.0000000000000000
-  108 | 216.0000000000000000
-  109 | 218.0000000000000000
-  110 | 220.0000000000000000
+ 101  | 202.0000000000000000
+ 102  | 204.0000000000000000
+ 103  | 206.0000000000000000
+ 104  | 208.0000000000000000
+ 105  | 210.0000000000000000
+ 106  | 212.0000000000000000
+ 107  | 214.0000000000000000
+ 108  | 216.0000000000000000
+ 109  | 218.0000000000000000
+ 110  | 220.0000000000000000
 (10 rows)
 
 -- join with lateral reference
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1."C 1" FROM "S 1"."T 1" t1, LATERAL (SELECT DISTINCT t2.c1, t3.c1 FROM ft1 t2, ft2 t3 WHERE t2.c1 = t3.c1 AND t2.c2 = t1.c2) q ORDER BY t1."C 1" OFFSET 10 LIMIT 10;
-                                                                                   QUERY PLAN                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Limit
    Output: t1."C 1"
    ->  Nested Loop
@@ -2299,25 +2929,33 @@ SELECT t1."C 1" FROM "S 1"."T 1" t1, LATERAL (SELECT DISTINCT t2.c1, t3.c1 FROM 
                      ->  HashAggregate
                            Output: t2.c1, t3.c1
                            Group Key: t2.c1
-                           ->  Foreign Scan
+                           ->  Hash Join
                                  Output: t2.c1, t3.c1
-                                 Relations: (public.ft1 t2) INNER JOIN (public.ft2 t3)
-                                 Remote SQL: SELECT r1."C 1", r2."C 1" FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")) AND ((r1.c2 = $1::integer))))
-(17 rows)
+                                 Hash Cond: (t3.c1 = t2.c1)
+                                 ->  Foreign Scan on public.ft2 t3
+                                       Output: t3.c1
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 ->  Hash
+                                       Output: t2.c1
+                                       ->  Foreign Scan on public.ft1 t2
+                                             Output: t2.c1
+                                             Filter: (t2.c2 = t1.c2)
+                                             Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(25 rows)
 
 SELECT t1."C 1" FROM "S 1"."T 1" t1, LATERAL (SELECT DISTINCT t2.c1, t3.c1 FROM ft1 t2, ft2 t3 WHERE t2.c1 = t3.c1 AND t2.c2 = t1.c2) q ORDER BY t1."C 1" OFFSET 10 LIMIT 10;
  C 1 
 -----
-   1
-   1
-   1
-   1
-   1
-   1
-   1
-   1
-   1
-   1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
 (10 rows)
 
 -- non-Var items in targetlist of the nullable rel of a join preventing
@@ -2325,20 +2963,22 @@ SELECT t1."C 1" FROM "S 1"."T 1" t1, LATERAL (SELECT DISTINCT t2.c1, t3.c1 FROM 
 -- unable to push {ft1, ft2}
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT q.a, ft2.c1 FROM (SELECT 13 FROM ft1 WHERE c1 = 13) q(a) RIGHT JOIN ft2 ON (q.a = ft2.c1) WHERE ft2.c1 BETWEEN 10 AND 15;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Nested Loop Left Join
    Output: (13), ft2.c1
-   Join Filter: (13 = ft2.c1)
+   Join Filter: ('13'::number = ft2.c1)
    ->  Foreign Scan on public.ft2
          Output: ft2.c1
-         Remote SQL: SELECT "C 1" FROM "S 1"."T 1" WHERE (("C 1" >= 10)) AND (("C 1" <= 15)) ORDER BY "C 1" ASC NULLS LAST
+         Filter: ((ft2.c1 >= '10'::number) AND (ft2.c1 <= '15'::number))
+         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
    ->  Materialize
          Output: (13)
          ->  Foreign Scan on public.ft1
                Output: 13
-               Remote SQL: SELECT NULL FROM "S 1"."T 1" WHERE (("C 1" = 13))
-(11 rows)
+               Filter: (ft1.c1 = '13'::number)
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(13 rows)
 
 SELECT q.a, ft2.c1 FROM (SELECT 13 FROM ft1 WHERE c1 = 13) q(a) RIGHT JOIN ft2 ON (q.a = ft2.c1) WHERE ft2.c1 BETWEEN 10 AND 15;
  a  | c1 
@@ -2354,41 +2994,59 @@ SELECT q.a, ft2.c1 FROM (SELECT 13 FROM ft1 WHERE c1 = 13) q(a) RIGHT JOIN ft2 O
 -- ok to push {ft1, ft2} but not {ft1, ft2, ft4}
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT ft4.c1, q.* FROM ft4 LEFT JOIN (SELECT 13, ft1.c1, ft2.c1 FROM ft1 RIGHT JOIN ft2 ON (ft1.c1 = ft2.c1) WHERE ft1.c1 = 12) q(a, b, c) ON (ft4.c1 = q.b) WHERE ft4.c1 BETWEEN 10 AND 15;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop Left Join
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Hash Right Join
    Output: ft4.c1, (13), ft1.c1, ft2.c1
-   Join Filter: (ft4.c1 = ft1.c1)
-   ->  Foreign Scan on public.ft4
-         Output: ft4.c1, ft4.c2, ft4.c3
-         Remote SQL: SELECT c1 FROM "S 1"."T 3" WHERE ((c1 >= 10)) AND ((c1 <= 15))
-   ->  Materialize
-         Output: ft1.c1, ft2.c1, (13)
-         ->  Foreign Scan
-               Output: ft1.c1, ft2.c1, 13
-               Relations: (public.ft1) INNER JOIN (public.ft2)
-               Remote SQL: SELECT r4."C 1", r5."C 1" FROM ("S 1"."T 1" r4 INNER JOIN "S 1"."T 1" r5 ON (((r5."C 1" = 12)) AND ((r4."C 1" = 12)))) ORDER BY r4."C 1" ASC NULLS LAST
-(12 rows)
+   Hash Cond: (ft1.c1 = ft4.c1)
+   ->  Nested Loop
+         Output: ft1.c1, ft2.c1, 13
+         ->  Foreign Scan on public.ft1
+               Output: ft1.c1
+               Filter: (ft1.c1 = '12'::number)
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+         ->  Foreign Scan on public.ft2
+               Output: ft2.c1
+               Filter: (ft2.c1 = '12'::number)
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+   ->  Hash
+         Output: ft4.c1
+         ->  Foreign Scan on public.ft4
+               Output: ft4.c1
+               Filter: ((ft4.c1 >= '10'::number) AND (ft4.c1 <= '15'::number))
+               Remote SQL: SELECT c1 FROM "S 1"."T 3"
+(19 rows)
 
 SELECT ft4.c1, q.* FROM ft4 LEFT JOIN (SELECT 13, ft1.c1, ft2.c1 FROM ft1 RIGHT JOIN ft2 ON (ft1.c1 = ft2.c1) WHERE ft1.c1 = 12) q(a, b, c) ON (ft4.c1 = q.b) WHERE ft4.c1 BETWEEN 10 AND 15;
  c1 | a  | b  | c  
 ----+----+----+----
- 10 |    |    |   
  12 | 13 | 12 | 12
- 14 |    |    |   
+ 10 |    |    | 
+ 14 |    |    | 
 (3 rows)
 
 -- join with nullable side with some columns with null values
 UPDATE ft5 SET c3 = null where c1 % 9 = 0;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT ft5, ft5.c1, ft5.c2, ft5.c3, ft4.c1, ft4.c2 FROM ft5 left join ft4 on ft5.c1 = ft4.c1 WHERE ft4.c1 BETWEEN 10 and 30 ORDER BY ft5.c1, ft4.c1;
-                                                                                                                                QUERY PLAN                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Sort
    Output: ft5.*, ft5.c1, ft5.c2, ft5.c3, ft4.c1, ft4.c2
-   Relations: (public.ft5) INNER JOIN (public.ft4)
-   Remote SQL: SELECT CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1.c1, r1.c2, r1.c3) END, r1.c1, r1.c2, r1.c3, r2.c1, r2.c2 FROM ("S 1"."T 4" r1 INNER JOIN "S 1"."T 3" r2 ON (((r1.c1 = r2.c1)) AND ((r2.c1 >= 10)) AND ((r2.c1 <= 30)))) ORDER BY r1.c1 ASC NULLS LAST
-(4 rows)
+   Sort Key: ft5.c1
+   ->  Hash Join
+         Output: ft5.*, ft5.c1, ft5.c2, ft5.c3, ft4.c1, ft4.c2
+         Hash Cond: (ft5.c1 = ft4.c1)
+         ->  Foreign Scan on public.ft5
+               Output: ft5.*, ft5.c1, ft5.c2, ft5.c3
+               Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
+         ->  Hash
+               Output: ft4.c1, ft4.c2
+               ->  Foreign Scan on public.ft4
+                     Output: ft4.c1, ft4.c2
+                     Filter: ((ft4.c1 >= '10'::number) AND (ft4.c1 <= '30'::number))
+                     Remote SQL: SELECT c1, c2 FROM "S 1"."T 3"
+(15 rows)
 
 SELECT ft5, ft5.c1, ft5.c2, ft5.c3, ft4.c1, ft4.c2 FROM ft5 left join ft4 on ft5.c1 = ft4.c1 WHERE ft4.c1 BETWEEN 10 and 30 ORDER BY ft5.c1, ft4.c1;
       ft5       | c1 | c2 |   c3   | c1 | c2 
@@ -2401,7 +3059,7 @@ SELECT ft5, ft5.c1, ft5.c2, ft5.c3, ft4.c1, ft4.c2 FROM ft5 left join ft4 on ft5
 
 -- multi-way join involving multiple merge joins
 -- (this case used to have EPQ-related planning problems)
-CREATE TABLE local_tbl (c1 int NOT NULL, c2 int NOT NULL, c3 text, CONSTRAINT local_tbl_pkey PRIMARY KEY (c1));
+CREATE TABLE local_tbl (c1 number(38,0) NOT NULL, c2 number(38,0) NOT NULL, c3 varchar2(1024), CONSTRAINT local_tbl_pkey PRIMARY KEY (c1));
 INSERT INTO local_tbl SELECT id, id % 10, to_char(id, 'FM0000') FROM generate_series(1, 1000) id;
 ANALYZE local_tbl;
 SET enable_nestloop TO false;
@@ -2409,71 +3067,77 @@ SET enable_hashjoin TO false;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1, ft2, ft4, ft5, local_tbl WHERE ft1.c1 = ft2.c1 AND ft1.c2 = ft4.c1
     AND ft1.c2 = ft5.c1 AND ft1.c2 = local_tbl.c1 AND ft1.c1 < 100 AND ft2.c1 < 100 FOR UPDATE;
-                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                          QUERY PLAN                                                                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  LockRows
    Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft4.c1, ft4.c2, ft4.c3, ft5.c1, ft5.c2, ft5.c3, local_tbl.c1, local_tbl.c2, local_tbl.c3, ft1.*, ft2.*, ft4.*, ft5.*, local_tbl.ctid
    ->  Merge Join
          Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft4.c1, ft4.c2, ft4.c3, ft5.c1, ft5.c2, ft5.c3, local_tbl.c1, local_tbl.c2, local_tbl.c3, ft1.*, ft2.*, ft4.*, ft5.*, local_tbl.ctid
-         Inner Unique: true
-         Merge Cond: (ft1.c2 = local_tbl.c1)
-         ->  Foreign Scan
-               Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*, ft4.c1, ft4.c2, ft4.c3, ft4.*, ft5.c1, ft5.c2, ft5.c3, ft5.*
-               Relations: (((public.ft1) INNER JOIN (public.ft2)) INNER JOIN (public.ft4)) INNER JOIN (public.ft5)
-               Remote SQL: SELECT r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8, CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8) END, r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8) END, r3.c1, r3.c2, r3.c3, CASE WHEN (r3.*)::text IS NOT NULL THEN ROW(r3.c1, r3.c2, r3.c3) END, r4.c1, r4.c2, r4.c3, CASE WHEN (r4.*)::text IS NOT NULL THEN ROW(r4.c1, r4.c2, r4.c3) END FROM ((("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1")) AND ((r2."C 1" < 100)) AND ((r1."C 1" < 100)))) INNER JOIN "S 1"."T 3" r3 ON (((r1.c2 = r3.c1)))) INNER JOIN "S 1"."T 4" r4 ON (((r1.c2 = r4.c1)))) ORDER BY r1.c2 ASC NULLS LAST FOR UPDATE OF r1 FOR UPDATE OF r2 FOR UPDATE OF r3 FOR UPDATE OF r4
-               ->  Merge Join
-                     Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*, ft4.c1, ft4.c2, ft4.c3, ft4.*, ft5.c1, ft5.c2, ft5.c3, ft5.*
-                     Merge Cond: (ft1.c2 = ft5.c1)
-                     ->  Merge Join
-                           Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*, ft4.c1, ft4.c2, ft4.c3, ft4.*
-                           Merge Cond: (ft1.c2 = ft4.c1)
-                           ->  Sort
-                                 Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
-                                 Sort Key: ft1.c2
-                                 ->  Merge Join
-                                       Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
-                                       Merge Cond: (ft1.c1 = ft2.c1)
-                                       ->  Sort
-                                             Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
-                                             Sort Key: ft1.c1
-                                             ->  Foreign Scan on public.ft1
-                                                   Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
-                                                   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" < 100)) FOR UPDATE
-                                       ->  Materialize
-                                             Output: ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
-                                             ->  Foreign Scan on public.ft2
-                                                   Output: ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
-                                                   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" < 100)) ORDER BY "C 1" ASC NULLS LAST FOR UPDATE
-                           ->  Sort
-                                 Output: ft4.c1, ft4.c2, ft4.c3, ft4.*
-                                 Sort Key: ft4.c1
-                                 ->  Foreign Scan on public.ft4
+         Merge Cond: (ft4.c1 = ft1.c2)
+         ->  Merge Join
+               Output: ft4.c1, ft4.c2, ft4.c3, ft4.*, ft5.c1, ft5.c2, ft5.c3, ft5.*, local_tbl.c1, local_tbl.c2, local_tbl.c3, local_tbl.ctid
+               Merge Cond: (local_tbl.c1 = ft4.c1)
+               ->  Index Scan using local_tbl_pkey on public.local_tbl
+                     Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, local_tbl.ctid
+               ->  Sort
+                     Output: ft4.c1, ft4.c2, ft4.c3, ft4.*, ft5.c1, ft5.c2, ft5.c3, ft5.*
+                     Sort Key: ft4.c1
+                     ->  Foreign Scan
+                           Output: ft4.c1, ft4.c2, ft4.c3, ft4.*, ft5.c1, ft5.c2, ft5.c3, ft5.*
+                           Filter: (ft4.c1 = ft5.c1)
+                           Relations: (public.ft4) INNER JOIN (public.ft5)
+                           Remote SQL: SELECT r3.c1, r3.c2, r3.c3, CASE WHEN (r3.*)::text IS NOT NULL THEN ROW(r3.c1, r3.c2, r3.c3) END, r4.c1, r4.c2, r4.c3, CASE WHEN (r4.*)::text IS NOT NULL THEN ROW(r4.c1, r4.c2, r4.c3) END FROM ("S 1"."T 3" r3 INNER JOIN "S 1"."T 4" r4 ON (TRUE)) FOR UPDATE OF r3 FOR UPDATE OF r4
+                           ->  Merge Join
+                                 Output: ft4.c1, ft4.c2, ft4.c3, ft4.*, ft5.c1, ft5.c2, ft5.c3, ft5.*
+                                 Merge Cond: (ft4.c1 = ft5.c1)
+                                 ->  Sort
                                        Output: ft4.c1, ft4.c2, ft4.c3, ft4.*
-                                       Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3" FOR UPDATE
+                                       Sort Key: ft4.c1
+                                       ->  Foreign Scan on public.ft4
+                                             Output: ft4.c1, ft4.c2, ft4.c3, ft4.*
+                                             Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3" FOR UPDATE
+                                 ->  Sort
+                                       Output: ft5.c1, ft5.c2, ft5.c3, ft5.*
+                                       Sort Key: ft5.c1
+                                       ->  Foreign Scan on public.ft5
+                                             Output: ft5.c1, ft5.c2, ft5.c3, ft5.*
+                                             Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4" FOR UPDATE
+         ->  Sort
+               Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
+               Sort Key: ft1.c2
+               ->  Merge Join
+                     Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
+                     Merge Cond: (ft1.c1 = ft2.c1)
                      ->  Sort
-                           Output: ft5.c1, ft5.c2, ft5.c3, ft5.*
-                           Sort Key: ft5.c1
-                           ->  Foreign Scan on public.ft5
-                                 Output: ft5.c1, ft5.c2, ft5.c3, ft5.*
-                                 Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4" FOR UPDATE
-         ->  Index Scan using local_tbl_pkey on public.local_tbl
-               Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, local_tbl.ctid
-(47 rows)
+                           Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
+                           Sort Key: ft1.c1
+                           ->  Foreign Scan on public.ft1
+                                 Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
+                                 Filter: (ft1.c1 < '100'::number)
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR UPDATE
+                     ->  Sort
+                           Output: ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
+                           Sort Key: ft2.c1
+                           ->  Foreign Scan on public.ft2
+                                 Output: ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.*
+                                 Filter: (ft2.c1 < '100'::number)
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" FOR UPDATE
+(53 rows)
 
 SELECT * FROM ft1, ft2, ft4, ft5, local_tbl WHERE ft1.c1 = ft2.c1 AND ft1.c2 = ft4.c1
     AND ft1.c2 = ft5.c1 AND ft1.c2 = local_tbl.c1 AND ft1.c1 < 100 AND ft2.c1 < 100 FOR UPDATE;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  | c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  | c1 | c2 |   c3   | c1 | c2 |   c3   | c1 | c2 |  c3  
-----+----+-------+------------------------------+--------------------------+----+------------+-----+----+----+-------+------------------------------+--------------------------+----+------------+-----+----+----+--------+----+----+--------+----+----+------
-  6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo |  6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 16 |  6 | 00016 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo | 16 |  6 | 00016 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 26 |  6 | 00026 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo | 26 |  6 | 00026 | Tue Jan 27 00:00:00 1970 PST | Tue Jan 27 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 36 |  6 | 00036 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo | 36 |  6 | 00036 | Fri Feb 06 00:00:00 1970 PST | Fri Feb 06 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 46 |  6 | 00046 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo | 46 |  6 | 00046 | Mon Feb 16 00:00:00 1970 PST | Mon Feb 16 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 56 |  6 | 00056 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo | 56 |  6 | 00056 | Thu Feb 26 00:00:00 1970 PST | Thu Feb 26 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 66 |  6 | 00066 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo | 66 |  6 | 00066 | Sun Mar 08 00:00:00 1970 PST | Sun Mar 08 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 76 |  6 | 00076 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo | 76 |  6 | 00076 | Wed Mar 18 00:00:00 1970 PST | Wed Mar 18 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 86 |  6 | 00086 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo | 86 |  6 | 00086 | Sat Mar 28 00:00:00 1970 PST | Sat Mar 28 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
- 96 |  6 | 00096 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo | 96 |  6 | 00096 | Tue Apr 07 00:00:00 1970 PST | Tue Apr 07 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  | c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  | c1 | c2 |   c3   | c1 | c2 |   c3   | c1 | c2 |  c3  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----+----+----+-------+-----------------------------------+----------------------------+----+------------+-----+----+----+--------+----+----+--------+----+----+------
+ 96 | 6  | 00096 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 96 | 6  | 00096 | 1970-04-07 00:00:00.000000 -08:00 | 1970-04-07 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 46 | 6  | 00046 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 46 | 6  | 00046 | 1970-02-16 00:00:00.000000 -08:00 | 1970-02-16 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 26 | 6  | 00026 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 26 | 6  | 00026 | 1970-01-27 00:00:00.000000 -08:00 | 1970-01-27 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 56 | 6  | 00056 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 56 | 6  | 00056 | 1970-02-26 00:00:00.000000 -08:00 | 1970-02-26 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 66 | 6  | 00066 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 66 | 6  | 00066 | 1970-03-08 00:00:00.000000 -08:00 | 1970-03-08 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 16 | 6  | 00016 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 16 | 6  | 00016 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 76 | 6  | 00076 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 76 | 6  | 00076 | 1970-03-18 00:00:00.000000 -08:00 | 1970-03-18 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 86 | 6  | 00086 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 86 | 6  | 00086 | 1970-03-28 00:00:00.000000 -08:00 | 1970-03-28 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 6  | 6  | 00006 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 6  | 6  | 00006 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
+ 36 | 6  | 00036 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 36 | 6  | 00036 | 1970-02-06 00:00:00.000000 -08:00 | 1970-02-06 00:00:00.000000 | 6  | 6          | foo | 6  | 7  | AAA006 | 6  | 7  | AAA006 | 6  | 6  | 0006
 (10 rows)
 
 RESET enable_nestloop;
@@ -2482,45 +3146,38 @@ RESET enable_hashjoin;
 -- return columns needed by the parent ForeignScan node
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM local_tbl LEFT JOIN (SELECT ft1.*, COALESCE(ft1.c3 || ft2.c3, 'foobar') FROM ft1 INNER JOIN ft2 ON (ft1.c1 = ft2.c1 AND ft1.c1 < 100)) ss ON (local_tbl.c1 = ss.c1) ORDER BY local_tbl.c1 FOR UPDATE OF local_tbl;
-                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  LockRows
-   Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, (COALESCE((ft1.c3 || ft2.c3), 'foobar'::text)), local_tbl.ctid, ft1.*, ft2.*
+   Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, (COALESCE(((ft1.c3)::text || (ft2.c3)::text), 'foobar'::text)), local_tbl.ctid, ft1.*, ft2.*
    ->  Merge Left Join
-         Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, (COALESCE((ft1.c3 || ft2.c3), 'foobar'::text)), local_tbl.ctid, ft1.*, ft2.*
+         Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, (COALESCE(((ft1.c3)::text || (ft2.c3)::text), 'foobar'::text)), local_tbl.ctid, ft1.*, ft2.*
          Merge Cond: (local_tbl.c1 = ft1.c1)
          ->  Index Scan using local_tbl_pkey on public.local_tbl
                Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, local_tbl.ctid
-         ->  Materialize
-               Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, (COALESCE((ft1.c3 || ft2.c3), 'foobar'::text))
-               ->  Foreign Scan
-                     Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, COALESCE((ft1.c3 || ft2.c3), 'foobar'::text)
-                     Relations: (public.ft1) INNER JOIN (public.ft2)
-                     Remote SQL: SELECT r4."C 1", r4.c2, r4.c3, r4.c4, r4.c5, r4.c6, r4.c7, r4.c8, CASE WHEN (r4.*)::text IS NOT NULL THEN ROW(r4."C 1", r4.c2, r4.c3, r4.c4, r4.c5, r4.c6, r4.c7, r4.c8) END, CASE WHEN (r5.*)::text IS NOT NULL THEN ROW(r5."C 1", r5.c2, r5.c3, r5.c4, r5.c5, r5.c6, r5.c7, r5.c8) END, r5.c3 FROM ("S 1"."T 1" r4 INNER JOIN "S 1"."T 1" r5 ON (((r5."C 1" = r4."C 1")) AND ((r4."C 1" < 100)))) ORDER BY r4."C 1" ASC NULLS LAST
-                     ->  Result
-                           Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, ft2.c3
-                           ->  Sort
-                                 Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, (COALESCE((ft1.c3 || ft2.c3), 'foobar'::text)), ft2.c3
-                                 Sort Key: ft1.c1
-                                 ->  Hash Join
-                                       Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, COALESCE((ft1.c3 || ft2.c3), 'foobar'::text), ft2.c3
-                                       Hash Cond: (ft1.c1 = ft2.c1)
-                                       ->  Foreign Scan on public.ft1
-                                             Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
-                                             Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" < 100))
-                                       ->  Hash
-                                             Output: ft2.*, ft2.c1, ft2.c3
-                                             ->  Foreign Scan on public.ft2
-                                                   Output: ft2.*, ft2.c1, ft2.c3
-                                                   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
-(29 rows)
+         ->  Sort
+               Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, (COALESCE(((ft1.c3)::text || (ft2.c3)::text), 'foobar'::text))
+               Sort Key: ft1.c1
+               ->  Hash Join
+                     Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, COALESCE(((ft1.c3)::text || (ft2.c3)::text), 'foobar'::text)
+                     Hash Cond: (ft2.c1 = ft1.c1)
+                     ->  Foreign Scan on public.ft2
+                           Output: ft2.*, ft2.c1, ft2.c3
+                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+                     ->  Hash
+                           Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
+                           ->  Foreign Scan on public.ft1
+                                 Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
+                                 Filter: (ft1.c1 < '100'::number)
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(22 rows)
 
 ALTER SERVER loopback OPTIONS (DROP extensions);
 ALTER SERVER loopback OPTIONS (ADD fdw_startup_cost '10000.0');
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM local_tbl LEFT JOIN (SELECT ft1.* FROM ft1 INNER JOIN ft2 ON (ft1.c1 = ft2.c1 AND ft1.c1 < 100 AND (ft1.c1 - postgres_fdw_abs(ft2.c2)) = 0)) ss ON (local_tbl.c3 = ss.c3) ORDER BY local_tbl.c1 FOR UPDATE OF local_tbl;
-                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  LockRows
    Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, local_tbl.ctid, ft1.*, ft2.*
    ->  Nested Loop Left Join
@@ -2530,30 +3187,20 @@ SELECT * FROM local_tbl LEFT JOIN (SELECT ft1.* FROM ft1 INNER JOIN ft2 ON (ft1.
                Output: local_tbl.c1, local_tbl.c2, local_tbl.c3, local_tbl.ctid
          ->  Materialize
                Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*
-               ->  Foreign Scan
+               ->  Hash Join
                      Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*
-                     Filter: ((ft1.c1 - postgres_fdw_abs(ft2.c2)) = 0)
-                     Relations: (public.ft1) INNER JOIN (public.ft2)
-                     Remote SQL: SELECT r4."C 1", r4.c2, r4.c3, r4.c4, r4.c5, r4.c6, r4.c7, r4.c8, CASE WHEN (r4.*)::text IS NOT NULL THEN ROW(r4."C 1", r4.c2, r4.c3, r4.c4, r4.c5, r4.c6, r4.c7, r4.c8) END, CASE WHEN (r5.*)::text IS NOT NULL THEN ROW(r5."C 1", r5.c2, r5.c3, r5.c4, r5.c5, r5.c6, r5.c7, r5.c8) END, r5.c2 FROM ("S 1"."T 1" r4 INNER JOIN "S 1"."T 1" r5 ON (((r5."C 1" = r4."C 1")) AND ((r4."C 1" < 100)))) ORDER BY r4.c3 ASC NULLS LAST
-                     ->  Sort
-                           Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, ft2.c2
-                           Sort Key: ft1.c3
-                           ->  Merge Join
-                                 Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*, ft2.*, ft2.c2
-                                 Merge Cond: (ft1.c1 = ft2.c1)
-                                 Join Filter: ((ft1.c1 - postgres_fdw_abs(ft2.c2)) = 0)
-                                 ->  Sort
-                                       Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
-                                       Sort Key: ft1.c1
-                                       ->  Foreign Scan on public.ft1
-                                             Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
-                                             Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" < 100))
-                                 ->  Materialize
-                                       Output: ft2.*, ft2.c1, ft2.c2
-                                       ->  Foreign Scan on public.ft2
-                                             Output: ft2.*, ft2.c1, ft2.c2
-                                             Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" ORDER BY "C 1" ASC NULLS LAST
-(32 rows)
+                     Hash Cond: (ft2.c1 = ft1.c1)
+                     Join Filter: ((ft1.c1 - (postgres_fdw_abs(ft2.c2))::number) = '0'::number)
+                     ->  Foreign Scan on public.ft2
+                           Output: ft2.*, ft2.c1, ft2.c2
+                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+                     ->  Hash
+                           Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
+                           ->  Foreign Scan on public.ft1
+                                 Output: ft1.c1, ft1.c2, ft1.c3, ft1.c4, ft1.c5, ft1.c6, ft1.c7, ft1.c8, ft1.*
+                                 Filter: (ft1.c1 < '100'::number)
+                                 Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(22 rows)
 
 ALTER SERVER loopback OPTIONS (DROP fdw_startup_cost);
 ALTER SERVER loopback OPTIONS (ADD extensions 'postgres_fdw');
@@ -2591,42 +3238,54 @@ SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN v5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1
 SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN v5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
  c1 | c2 
 ----+----
- 22 |   
+ 22 | 
  24 | 25
- 26 |   
- 28 |   
+ 26 | 
+ 28 | 
  30 | 31
- 32 |   
- 34 |   
+ 32 | 
+ 34 | 
  36 | 37
- 38 |   
- 40 |   
+ 38 | 
+ 40 | 
 (10 rows)
 
 ALTER VIEW v4 OWNER TO regress_view_owner;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN v5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;  -- can be pushed down
-                                                                                              QUERY PLAN                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Limit
    Output: ft4.c1, ft5.c2, ft5.c1
-   Relations: (public.ft4) LEFT JOIN (public.ft5)
-   Remote SQL: SELECT r4.c1, r5.c2, r5.c1 FROM ("S 1"."T 3" r4 LEFT JOIN "S 1"."T 4" r5 ON (((r4.c1 = r5.c1)))) ORDER BY r4.c1 ASC NULLS LAST, r5.c1 ASC NULLS LAST LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Sort
+         Output: ft4.c1, ft5.c2, ft5.c1
+         Sort Key: ft4.c1, ft5.c1
+         ->  Hash Left Join
+               Output: ft4.c1, ft5.c2, ft5.c1
+               Hash Cond: (ft4.c1 = ft5.c1)
+               ->  Foreign Scan on public.ft4
+                     Output: ft4.c1, ft4.c2, ft4.c3
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: ft5.c2, ft5.c1
+                     ->  Foreign Scan on public.ft5
+                           Output: ft5.c2, ft5.c1
+                           Remote SQL: SELECT c1, c2 FROM "S 1"."T 4"
+(16 rows)
 
 SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN v5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
  c1 | c2 
 ----+----
- 22 |   
+ 22 | 
  24 | 25
- 26 |   
- 28 |   
+ 26 | 
+ 28 | 
  30 | 31
- 32 |   
- 34 |   
+ 32 | 
+ 34 | 
  36 | 37
- 38 |   
- 40 |   
+ 38 | 
+ 40 | 
 (10 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -2654,42 +3313,54 @@ SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c
 SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
  c1 | c2 
 ----+----
- 22 |   
+ 22 | 
  24 | 25
- 26 |   
- 28 |   
+ 26 | 
+ 28 | 
  30 | 31
- 32 |   
- 34 |   
+ 32 | 
+ 34 | 
  36 | 37
- 38 |   
- 40 |   
+ 38 | 
+ 40 | 
 (10 rows)
 
 ALTER VIEW v4 OWNER TO CURRENT_USER;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;  -- can be pushed down
-                                                                                              QUERY PLAN                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Limit
    Output: ft4.c1, t2.c2, t2.c1
-   Relations: (public.ft4) LEFT JOIN (public.ft5 t2)
-   Remote SQL: SELECT r4.c1, r2.c2, r2.c1 FROM ("S 1"."T 3" r4 LEFT JOIN "S 1"."T 4" r2 ON (((r4.c1 = r2.c1)))) ORDER BY r4.c1 ASC NULLS LAST, r2.c1 ASC NULLS LAST LIMIT 10::bigint OFFSET 10::bigint
-(4 rows)
+   ->  Sort
+         Output: ft4.c1, t2.c2, t2.c1
+         Sort Key: ft4.c1, t2.c1
+         ->  Hash Left Join
+               Output: ft4.c1, t2.c2, t2.c1
+               Hash Cond: (ft4.c1 = t2.c1)
+               ->  Foreign Scan on public.ft4
+                     Output: ft4.c1, ft4.c2, ft4.c3
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Hash
+                     Output: t2.c2, t2.c1
+                     ->  Foreign Scan on public.ft5 t2
+                           Output: t2.c2, t2.c1
+                           Remote SQL: SELECT c1, c2 FROM "S 1"."T 4"
+(16 rows)
 
 SELECT t1.c1, t2.c2 FROM v4 t1 LEFT JOIN ft5 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c1, t2.c1 OFFSET 10 LIMIT 10;
  c1 | c2 
 ----+----
- 22 |   
+ 22 | 
  24 | 25
- 26 |   
- 28 |   
+ 26 | 
+ 28 | 
  30 | 31
- 32 |   
- 34 |   
+ 32 | 
+ 34 | 
  36 | 37
- 38 |   
- 40 |   
+ 38 | 
+ 40 | 
 (10 rows)
 
 ALTER VIEW v4 OWNER TO regress_view_owner;
@@ -2702,47 +3373,65 @@ DROP ROLE regress_view_owner;
 -- Simple aggregates
 explain (verbose, costs off)
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2;
-                                                                                              QUERY PLAN                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), ((sum(c1)) * ((random() <= '1'::double precision))::integer), c2
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT count(c6), sum("C 1"), avg("C 1"), min(c2), max("C 1"), stddev(c2), c2 FROM "S 1"."T 1" WHERE ((c2 < 5)) GROUP BY 7 ORDER BY count(c6) ASC NULLS LAST, sum("C 1") ASC NULLS LAST
-(4 rows)
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), ((sum(c1)) * (((random() <= '1'::double precision))::integer)::number), c2
+   ->  Sort
+         Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), c2
+         Sort Key: (count(ft1.c6)), (sum(ft1.c1))
+         ->  HashAggregate
+               Output: count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), c2
+               Group Key: ft1.c2
+               ->  Foreign Scan on public.ft1
+                     Output: c6, c1, c2
+                     Filter: (ft1.c2 < '5'::number)
+                     Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1"
+(12 rows)
 
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2;
  count |  sum  |         avg          | min | max  | stddev | sum2  
 -------+-------+----------------------+-----+------+--------+-------
-   100 | 49600 | 496.0000000000000000 |   1 |  991 |      0 | 49600
-   100 | 49700 | 497.0000000000000000 |   2 |  992 |      0 | 49700
-   100 | 49800 | 498.0000000000000000 |   3 |  993 |      0 | 49800
-   100 | 49900 | 499.0000000000000000 |   4 |  994 |      0 | 49900
-   100 | 50500 | 505.0000000000000000 |   0 | 1000 |      0 | 50500
+   100 | 49600 | 496.0000000000000000 | 1   | 991  | 0      | 49600
+   100 | 49700 | 497.0000000000000000 | 2   | 992  | 0      | 49700
+   100 | 49800 | 498.0000000000000000 | 3   | 993  | 0      | 49800
+   100 | 49900 | 499.0000000000000000 | 4   | 994  | 0      | 49900
+   100 | 50500 | 505.0000000000000000 | 0   | 1000 | 0      | 50500
 (5 rows)
 
 explain (verbose, costs off)
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2 limit 1;
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), ((sum(c1)) * ((random() <= '1'::double precision))::integer), c2
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT count(c6), sum("C 1"), avg("C 1"), min(c2), max("C 1"), stddev(c2), c2 FROM "S 1"."T 1" WHERE ((c2 < 5)) GROUP BY 7 ORDER BY count(c6) ASC NULLS LAST, sum("C 1") ASC NULLS LAST LIMIT 1::bigint
-(4 rows)
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), (((sum(c1)) * (((random() <= '1'::double precision))::integer)::number)), c2
+   ->  Result
+         Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), ((sum(c1)) * (((random() <= '1'::double precision))::integer)::number), c2
+         ->  Sort
+               Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), c2
+               Sort Key: (count(ft1.c6)), (sum(ft1.c1))
+               ->  HashAggregate
+                     Output: count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), c2
+                     Group Key: ft1.c2
+                     ->  Foreign Scan on public.ft1
+                           Output: c6, c1, c2
+                           Filter: (ft1.c2 < '5'::number)
+                           Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1"
+(14 rows)
 
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2 limit 1;
  count |  sum  |         avg          | min | max | stddev | sum2  
 -------+-------+----------------------+-----+-----+--------+-------
-   100 | 49600 | 496.0000000000000000 |   1 | 991 |      0 | 49600
+   100 | 49600 | 496.0000000000000000 | 1   | 991 | 0      | 49600
 (1 row)
 
 -- Aggregate is not pushed down as aggregation contains random()
 explain (verbose, costs off)
 select sum(c1 * (random() <= 1)::int) as sum, avg(c1) from ft1;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Aggregate
-   Output: sum((c1 * ((random() <= '1'::double precision))::integer)), avg(c1)
+   Output: sum((c1 * (((random() <= '1'::double precision))::integer)::number)), avg(c1)
    ->  Foreign Scan on public.ft1
          Output: c1
          Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
@@ -2751,13 +3440,23 @@ select sum(c1 * (random() <= 1)::int) as sum, avg(c1) from ft1;
 -- Aggregate over join query
 explain (verbose, costs off)
 select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 = t2.c2) where t1.c2 = 6;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (count(*)), (sum(t1.c1)), (avg(t2.c1))
-   Relations: Aggregate on ((public.ft1 t1) INNER JOIN (public.ft1 t2))
-   Remote SQL: SELECT count(*), sum(r1."C 1"), avg(r2."C 1") FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2.c2 = 6)) AND ((r1.c2 = 6))))
-(4 rows)
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate
+   Output: count(*), sum(t1.c1), avg(t2.c1)
+   ->  Nested Loop
+         Output: t1.c1, t2.c1
+         ->  Foreign Scan on public.ft1 t1
+               Output: t1.c1, t1.c2
+               Filter: (t1.c2 = '6'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Materialize
+               Output: t2.c1, t2.c2
+               ->  Foreign Scan on public.ft1 t2
+                     Output: t2.c1, t2.c2
+                     Filter: (t2.c2 = '6'::number)
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(14 rows)
 
 select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 = t2.c2) where t1.c2 = 6;
  count |   sum   |         avg          
@@ -2768,51 +3467,73 @@ select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 
 -- Not pushed down due to local conditions present in underneath input rel
 explain (verbose, costs off)
 select sum(t1.c1), count(t2.c1) from ft1 t1 inner join ft2 t2 on (t1.c1 = t2.c1) where ((t1.c1 * t2.c1)/(t1.c1 * t2.c1)) * random() <= 1;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    Output: sum(t1.c1), count(t2.c1)
-   ->  Foreign Scan
+   ->  Hash Join
          Output: t1.c1, t2.c1
-         Filter: (((((t1.c1 * t2.c1) / (t1.c1 * t2.c1)))::double precision * random()) <= '1'::double precision)
-         Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-         Remote SQL: SELECT r1."C 1", r2."C 1" FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = r1."C 1"))))
-(7 rows)
+         Hash Cond: (t2.c1 = t1.c1)
+         Join Filter: (((((t1.c1 * t2.c1) / (t1.c1 * t2.c1)))::binary_double * (random())::binary_double) <= '1'::binary_double)
+         ->  Foreign Scan on public.ft2 t2
+               Output: t2.c1
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+         ->  Hash
+               Output: t1.c1
+               ->  Foreign Scan on public.ft1 t1
+                     Output: t1.c1
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(14 rows)
 
 -- GROUP BY clause having expressions
 explain (verbose, costs off)
 select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: ((c2 / 2)), ((sum(c2) * (c2 / 2)))
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT (c2 / 2), (sum(c2) * (c2 / 2)) FROM "S 1"."T 1" GROUP BY 1 ORDER BY (c2 / 2) ASC NULLS LAST
-(4 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort
+   Output: ((c2 / '2'::number)), ((sum(c2) * ((c2 / '2'::number))))
+   Sort Key: ((ft1.c2 / '2'::number))
+   ->  HashAggregate
+         Output: ((c2 / '2'::number)), (sum(c2) * ((c2 / '2'::number)))
+         Group Key: (ft1.c2 / '2'::number)
+         ->  Foreign Scan on public.ft1
+               Output: (c2 / '2'::number), c2
+               Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(9 rows)
 
 select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
- ?column? | ?column? 
-----------+----------
-        0 |        0
-        1 |      500
-        2 |     1800
-        3 |     3900
-        4 |     6800
-(5 rows)
+        ?column?        |         ?column?         
+------------------------+--------------------------
+ 0.00000000000000000000 | 0.00000000000000000000
+ 0.50000000000000000000 | 50.00000000000000000000
+ 1.00000000000000000000 | 200.00000000000000000000
+ 1.5000000000000000     | 450.0000000000000000
+ 2.0000000000000000     | 800.0000000000000000
+ 2.5000000000000000     | 1250.0000000000000000
+ 3.0000000000000000     | 1800.0000000000000000
+ 3.5000000000000000     | 2450.0000000000000000
+ 4.0000000000000000     | 3200.0000000000000000
+ 4.5000000000000000     | 4050.0000000000000000
+(10 rows)
 
 -- Aggregates in subquery are pushed down.
 set enable_incremental_sort = off;
 explain (verbose, costs off)
 select count(x.a), sum(x.a) from (select c2 a, sum(c1) b from ft1 group by c2, sqrt(c1) order by 1, 2) x;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Aggregate
    Output: count(ft1.c2), sum(ft1.c2)
-   ->  Foreign Scan
+   ->  Sort
          Output: ft1.c2, (sum(ft1.c1)), (sqrt((ft1.c1)::double precision))
-         Relations: Aggregate on (public.ft1)
-         Remote SQL: SELECT c2, sum("C 1"), sqrt("C 1") FROM "S 1"."T 1" GROUP BY 1, 3 ORDER BY c2 ASC NULLS LAST, sum("C 1") ASC NULLS LAST
-(6 rows)
+         Sort Key: ft1.c2, (sum(ft1.c1))
+         ->  HashAggregate
+               Output: ft1.c2, sum(ft1.c1), (sqrt((ft1.c1)::double precision))
+               Group Key: ft1.c2, sqrt((ft1.c1)::double precision)
+               ->  Foreign Scan on public.ft1
+                     Output: ft1.c2, sqrt((ft1.c1)::double precision), ft1.c1
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(11 rows)
 
 select count(x.a), sum(x.a) from (select c2 a, sum(c1) b from ft1 group by c2, sqrt(c1) order by 1, 2) x;
  count | sum  
@@ -2824,58 +3545,63 @@ reset enable_incremental_sort;
 -- Aggregate is still pushed down by taking unshippable expression out
 explain (verbose, costs off)
 select c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 from ft1 group by c2 order by 1, 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Sort
-   Output: ((c2 * ((random() <= '1'::double precision))::integer)), ((sum(c1) * c2)), c2
-   Sort Key: ((ft1.c2 * ((random() <= '1'::double precision))::integer)), ((sum(ft1.c1) * ft1.c2))
-   ->  Foreign Scan
-         Output: (c2 * ((random() <= '1'::double precision))::integer), ((sum(c1) * c2)), c2
-         Relations: Aggregate on (public.ft1)
-         Remote SQL: SELECT (sum("C 1") * c2), c2 FROM "S 1"."T 1" GROUP BY 2
-(7 rows)
+   Output: ((c2 * (((random() <= '1'::double precision))::integer)::number)), ((sum(c1) * c2)), c2
+   Sort Key: ((ft1.c2 * (((random() <= '1'::double precision))::integer)::number)), ((sum(ft1.c1) * ft1.c2))
+   ->  HashAggregate
+         Output: (c2 * (((random() <= '1'::double precision))::integer)::number), (sum(c1) * c2), c2
+         Group Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c2, c1
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 select c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 from ft1 group by c2 order by 1, 2;
  sum1 |  sum2  
 ------+--------
-    0 |      0
-    1 |  49600
-    2 |  99400
-    3 | 149400
-    4 | 199600
-    5 | 250000
-    6 | 300600
-    7 | 351400
-    8 | 402400
-    9 | 453600
+ 0    | 0
+ 1    | 49600
+ 2    | 99400
+ 3    | 149400
+ 4    | 199600
+ 5    | 250000
+ 6    | 300600
+ 7    | 351400
+ 8    | 402400
+ 9    | 453600
 (10 rows)
 
 -- Aggregate with unshippable GROUP BY clause are not pushed
 explain (verbose, costs off)
 select c2 * (random() <= 1)::int as c2 from ft2 group by c2 * (random() <= 1)::int order by 1;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Sort
-   Output: ((c2 * ((random() <= '1'::double precision))::integer))
-   Sort Key: ((ft2.c2 * ((random() <= '1'::double precision))::integer))
+   Output: ((c2 * (((random() <= '1'::double precision))::integer)::number))
+   Sort Key: ((ft2.c2 * (((random() <= '1'::double precision))::integer)::number))
    ->  HashAggregate
-         Output: ((c2 * ((random() <= '1'::double precision))::integer))
-         Group Key: (ft2.c2 * ((random() <= '1'::double precision))::integer)
+         Output: ((c2 * (((random() <= '1'::double precision))::integer)::number))
+         Group Key: (ft2.c2 * (((random() <= '1'::double precision))::integer)::number)
          ->  Foreign Scan on public.ft2
-               Output: (c2 * ((random() <= '1'::double precision))::integer)
+               Output: (c2 * (((random() <= '1'::double precision))::integer)::number)
                Remote SQL: SELECT c2 FROM "S 1"."T 1"
 (9 rows)
 
 -- GROUP BY clause in various forms, cardinal, alias and constant expression
 explain (verbose, costs off)
 select count(c2) w, c2 x, 5 y, 7.0 z from ft1 group by 2, y, 9.0::int order by 2;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Sort
    Output: (count(c2)), c2, 5, 7.0, 9
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT count(c2), c2, 5, 7.0, 9 FROM "S 1"."T 1" GROUP BY 2, 3, 5 ORDER BY c2 ASC NULLS LAST
-(4 rows)
+   Sort Key: ft1.c2
+   ->  Foreign Scan
+         Output: (count(c2)), c2, 5, 7.0, 9
+         Relations: Aggregate on (public.ft1)
+         Remote SQL: SELECT count(c2), c2, 5, 7.0, 9 FROM "S 1"."T 1" GROUP BY 2, 3, 5
+(7 rows)
 
 select count(c2) w, c2 x, 5 y, 7.0 z from ft1 group by 2, y, 9.0::int order by 2;
   w  | x | y |  z  
@@ -2896,53 +3622,67 @@ select count(c2) w, c2 x, 5 y, 7.0 z from ft1 group by 2, y, 9.0::int order by 2
 -- Also, ORDER BY contains an aggregate function
 explain (verbose, costs off)
 select c2, c2 from ft1 where c2 > 6 group by 1, 2 order by sum(c1);
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Sort
    Output: c2, c2, (sum(c1))
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT c2, c2, sum("C 1") FROM "S 1"."T 1" WHERE ((c2 > 6)) GROUP BY 1, 2 ORDER BY sum("C 1") ASC NULLS LAST
-(4 rows)
+   Sort Key: (sum(ft1.c1))
+   ->  HashAggregate
+         Output: c2, c2, sum(c1)
+         Group Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c2, c1
+               Filter: (ft1.c2 > '6'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(10 rows)
 
 select c2, c2 from ft1 where c2 > 6 group by 1, 2 order by sum(c1);
  c2 | c2 
 ----+----
-  7 |  7
-  8 |  8
-  9 |  9
+ 7  | 7
+ 8  | 8
+ 9  | 9
 (3 rows)
 
 -- Testing HAVING clause shippability
 explain (verbose, costs off)
 select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800 order by c2;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Sort
    Output: c2, (sum(c1))
-   Relations: Aggregate on (public.ft2)
-   Remote SQL: SELECT c2, sum("C 1") FROM "S 1"."T 1" GROUP BY 1 HAVING ((avg("C 1") < 500::numeric)) AND ((sum("C 1") < 49800)) ORDER BY c2 ASC NULLS LAST
-(4 rows)
+   Sort Key: ft2.c2
+   ->  HashAggregate
+         Output: c2, sum(c1)
+         Group Key: ft2.c2
+         Filter: ((avg(ft2.c1) < '500'::number) AND (sum(ft2.c1) < '49800'::number))
+         ->  Foreign Scan on public.ft2
+               Output: c2, c1
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(10 rows)
 
 select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800 order by c2;
  c2 |  sum  
 ----+-------
-  1 | 49600
-  2 | 49700
+ 1  | 49600
+ 2  | 49700
 (2 rows)
 
 -- Unshippable HAVING clause will be evaluated locally, and other qual in HAVING clause is pushed down
 explain (verbose, costs off)
 select count(*) from (select c5, count(c1) from ft1 group by c5, sqrt(c2) having (avg(c1) / avg(c1)) * random() <= 1 and avg(c1) < 500) x;
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    Output: count(*)
-   ->  Foreign Scan
+   ->  HashAggregate
          Output: ft1.c5, NULL::bigint, (sqrt((ft1.c2)::double precision))
-         Filter: (((((avg(ft1.c1)) / (avg(ft1.c1))))::double precision * random()) <= '1'::double precision)
-         Relations: Aggregate on (public.ft1)
-         Remote SQL: SELECT c5, NULL::bigint, sqrt(c2), avg("C 1") FROM "S 1"."T 1" GROUP BY 1, 3 HAVING ((avg("C 1") < 500::numeric))
-(7 rows)
+         Group Key: ft1.c5, sqrt((ft1.c2)::double precision)
+         Filter: ((avg(ft1.c1) < '500'::number) AND ((((avg(ft1.c1) / avg(ft1.c1)))::binary_double * (random())::binary_double) <= '1'::binary_double))
+         ->  Foreign Scan on public.ft1
+               Output: ft1.c5, sqrt((ft1.c2)::double precision), ft1.c1
+               Remote SQL: SELECT "C 1", c2, c5 FROM "S 1"."T 1"
+(9 rows)
 
 select count(*) from (select c5, count(c1) from ft1 group by c5, sqrt(c2) having (avg(c1) / avg(c1)) * random() <= 1 and avg(c1) < 500) x;
  count 
@@ -2953,15 +3693,15 @@ select count(*) from (select c5, count(c1) from ft1 group by c5, sqrt(c2) having
 -- Aggregate in HAVING clause is not pushable, and thus aggregation is not pushed down
 explain (verbose, costs off)
 select sum(c1) from ft1 group by c2 having avg(c1 * (random() <= 1)::int) > 100 order by 1;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Sort
    Output: (sum(c1)), c2
    Sort Key: (sum(ft1.c1))
    ->  HashAggregate
          Output: sum(c1), c2
          Group Key: ft1.c2
-         Filter: (avg((ft1.c1 * ((random() <= '1'::double precision))::integer)) > '100'::numeric)
+         Filter: (avg((ft1.c1 * (((random() <= '1'::double precision))::integer)::number)) > '100'::number)
          ->  Foreign Scan on public.ft1
                Output: c1, c2
                Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
@@ -2971,15 +3711,16 @@ select sum(c1) from ft1 group by c2 having avg(c1 * (random() <= 1)::int) > 100 
 -- of an initplan) can be trouble, per bug #15781
 explain (verbose, costs off)
 select exists(select 1 from pg_enum), sum(c1) from ft1;
-                    QUERY PLAN                    
---------------------------------------------------
- Foreign Scan
-   Output: $0, (sum(ft1.c1))
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT sum("C 1") FROM "S 1"."T 1"
+                    QUERY PLAN                     
+---------------------------------------------------
+ Aggregate
+   Output: $0, sum(ft1.c1)
    InitPlan 1 (returns $0)
      ->  Seq Scan on pg_catalog.pg_enum
-(6 rows)
+   ->  Foreign Scan on public.ft1
+         Output: ft1.c1
+         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(7 rows)
 
 select exists(select 1 from pg_enum), sum(c1) from ft1;
  exists |  sum   
@@ -3010,13 +3751,22 @@ select exists(select 1 from pg_enum), sum(c1) from ft1 group by 1;
 -- ORDER BY within aggregate, same column used to order
 explain (verbose, costs off)
 select array_agg(c1 order by c1) from ft1 where c1 < 100 group by c2 order by 1;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Sort
    Output: (array_agg(c1 ORDER BY c1)), c2
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT array_agg("C 1" ORDER BY "C 1" ASC NULLS LAST), c2 FROM "S 1"."T 1" WHERE (("C 1" < 100)) GROUP BY 2 ORDER BY array_agg("C 1" ORDER BY "C 1" ASC NULLS LAST) ASC NULLS LAST
-(4 rows)
+   Sort Key: (array_agg(ft1.c1 ORDER BY ft1.c1))
+   ->  GroupAggregate
+         Output: array_agg(c1 ORDER BY c1), c2
+         Group Key: ft1.c2
+         ->  Sort
+               Output: c2, c1
+               Sort Key: ft1.c2, ft1.c1
+               ->  Foreign Scan on public.ft1
+                     Output: c2, c1
+                     Filter: (ft1.c1 < '100'::number)
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(13 rows)
 
 select array_agg(c1 order by c1) from ft1 where c1 < 100 group by c2 order by 1;
            array_agg            
@@ -3036,30 +3786,52 @@ select array_agg(c1 order by c1) from ft1 where c1 < 100 group by c2 order by 1;
 -- ORDER BY within aggregate, different column used to order also using DESC
 explain (verbose, costs off)
 select array_agg(c5 order by c1 desc) from ft2 where c2 = 6 and c1 < 50;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (array_agg(c5 ORDER BY c1 DESC))
-   Relations: Aggregate on (public.ft2)
-   Remote SQL: SELECT array_agg(c5 ORDER BY "C 1" DESC NULLS FIRST) FROM "S 1"."T 1" WHERE (("C 1" < 50)) AND ((c2 = 6))
-(4 rows)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Aggregate
+   Output: array_agg(c5 ORDER BY c1 DESC)
+   ->  Sort
+         Output: c5, c1
+         Sort Key: ft2.c1 DESC
+         ->  Foreign Scan on public.ft2
+               Output: c5, c1
+               Filter: ((ft2.c1 < '50'::number) AND (ft2.c2 = '6'::number))
+               Remote SQL: SELECT "C 1", c2, c5 FROM "S 1"."T 1"
+(9 rows)
 
 select array_agg(c5 order by c1 desc) from ft2 where c2 = 6 and c1 < 50;
-                                                                array_agg                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------
- {"Mon Feb 16 00:00:00 1970","Fri Feb 06 00:00:00 1970","Tue Jan 27 00:00:00 1970","Sat Jan 17 00:00:00 1970","Wed Jan 07 00:00:00 1970"}
+                                                                     array_agg                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ {"1970-02-16 00:00:00.000000","1970-02-06 00:00:00.000000","1970-01-27 00:00:00.000000","1970-01-17 00:00:00.000000","1970-01-07 00:00:00.000000"}
 (1 row)
 
 -- DISTINCT within aggregate
 explain (verbose, costs off)
 select array_agg(distinct (t1.c1)%5) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) where t1.c1 < 20 or (t1.c1 is null and t2.c1 < 5) group by (t2.c1)%3 order by 1;
-                                                                                                                               QUERY PLAN                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (array_agg(DISTINCT (t1.c1 % 5))), ((t2.c1 % 3))
-   Relations: Aggregate on ((public.ft4 t1) FULL JOIN (public.ft5 t2))
-   Remote SQL: SELECT array_agg(DISTINCT (r1.c1 % 5)), (r2.c1 % 3) FROM ("S 1"."T 3" r1 FULL JOIN "S 1"."T 4" r2 ON (((r1.c1 = r2.c1)))) WHERE (((r1.c1 < 20) OR ((r1.c1 IS NULL) AND (r2.c1 < 5)))) GROUP BY 2 ORDER BY array_agg(DISTINCT (r1.c1 % 5)) ASC NULLS LAST
-(4 rows)
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Sort
+   Output: (array_agg(DISTINCT ((t1.c1 % '5'::number)))), ((t2.c1 % '3'::number))
+   Sort Key: (array_agg(DISTINCT ((t1.c1 % '5'::number))))
+   ->  GroupAggregate
+         Output: array_agg(DISTINCT ((t1.c1 % '5'::number))), ((t2.c1 % '3'::number))
+         Group Key: ((t2.c1 % '3'::number))
+         ->  Sort
+               Output: ((t2.c1 % '3'::number)), t1.c1, ((t1.c1 % '5'::number))
+               Sort Key: ((t2.c1 % '3'::number)), ((t1.c1 % '5'::number))
+               ->  Hash Full Join
+                     Output: (t2.c1 % '3'::number), t1.c1, (t1.c1 % '5'::number)
+                     Hash Cond: (t1.c1 = t2.c1)
+                     Filter: ((t1.c1 < '20'::number) OR ((t1.c1 IS NULL) AND (t2.c1 < '5'::number)))
+                     ->  Foreign Scan on public.ft4 t1
+                           Output: t1.c1, t1.c2, t1.c3
+                           Remote SQL: SELECT c1 FROM "S 1"."T 3"
+                     ->  Hash
+                           Output: t2.c1
+                           ->  Foreign Scan on public.ft5 t2
+                                 Output: t2.c1
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(21 rows)
 
 select array_agg(distinct (t1.c1)%5) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) where t1.c1 < 20 or (t1.c1 is null and t2.c1 < 5) group by (t2.c1)%3 order by 1;
   array_agg   
@@ -3071,13 +3843,30 @@ select array_agg(distinct (t1.c1)%5) from ft4 t1 full join ft5 t2 on (t1.c1 = t2
 -- DISTINCT combined with ORDER BY within aggregate
 explain (verbose, costs off)
 select array_agg(distinct (t1.c1)%5 order by (t1.c1)%5) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) where t1.c1 < 20 or (t1.c1 is null and t2.c1 < 5) group by (t2.c1)%3 order by 1;
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (array_agg(DISTINCT (t1.c1 % 5) ORDER BY (t1.c1 % 5))), ((t2.c1 % 3))
-   Relations: Aggregate on ((public.ft4 t1) FULL JOIN (public.ft5 t2))
-   Remote SQL: SELECT array_agg(DISTINCT (r1.c1 % 5) ORDER BY ((r1.c1 % 5)) ASC NULLS LAST), (r2.c1 % 3) FROM ("S 1"."T 3" r1 FULL JOIN "S 1"."T 4" r2 ON (((r1.c1 = r2.c1)))) WHERE (((r1.c1 < 20) OR ((r1.c1 IS NULL) AND (r2.c1 < 5)))) GROUP BY 2 ORDER BY array_agg(DISTINCT (r1.c1 % 5) ORDER BY ((r1.c1 % 5)) ASC NULLS LAST) ASC NULLS LAST
-(4 rows)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: (array_agg(DISTINCT ((t1.c1 % '5'::number)) ORDER BY ((t1.c1 % '5'::number)))), ((t2.c1 % '3'::number))
+   Sort Key: (array_agg(DISTINCT ((t1.c1 % '5'::number)) ORDER BY ((t1.c1 % '5'::number))))
+   ->  GroupAggregate
+         Output: array_agg(DISTINCT ((t1.c1 % '5'::number)) ORDER BY ((t1.c1 % '5'::number))), ((t2.c1 % '3'::number))
+         Group Key: ((t2.c1 % '3'::number))
+         ->  Sort
+               Output: ((t2.c1 % '3'::number)), t1.c1, ((t1.c1 % '5'::number))
+               Sort Key: ((t2.c1 % '3'::number)), ((t1.c1 % '5'::number))
+               ->  Hash Full Join
+                     Output: (t2.c1 % '3'::number), t1.c1, (t1.c1 % '5'::number)
+                     Hash Cond: (t1.c1 = t2.c1)
+                     Filter: ((t1.c1 < '20'::number) OR ((t1.c1 IS NULL) AND (t2.c1 < '5'::number)))
+                     ->  Foreign Scan on public.ft4 t1
+                           Output: t1.c1, t1.c2, t1.c3
+                           Remote SQL: SELECT c1 FROM "S 1"."T 3"
+                     ->  Hash
+                           Output: t2.c1
+                           ->  Foreign Scan on public.ft5 t2
+                                 Output: t2.c1
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(21 rows)
 
 select array_agg(distinct (t1.c1)%5 order by (t1.c1)%5) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) where t1.c1 < 20 or (t1.c1 is null and t2.c1 < 5) group by (t2.c1)%3 order by 1;
   array_agg   
@@ -3088,13 +3877,30 @@ select array_agg(distinct (t1.c1)%5 order by (t1.c1)%5) from ft4 t1 full join ft
 
 explain (verbose, costs off)
 select array_agg(distinct (t1.c1)%5 order by (t1.c1)%5 desc nulls last) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) where t1.c1 < 20 or (t1.c1 is null and t2.c1 < 5) group by (t2.c1)%3 order by 1;
-                                                                                                                                                                      QUERY PLAN                                                                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (array_agg(DISTINCT (t1.c1 % 5) ORDER BY (t1.c1 % 5) DESC NULLS LAST)), ((t2.c1 % 3))
-   Relations: Aggregate on ((public.ft4 t1) FULL JOIN (public.ft5 t2))
-   Remote SQL: SELECT array_agg(DISTINCT (r1.c1 % 5) ORDER BY ((r1.c1 % 5)) DESC NULLS LAST), (r2.c1 % 3) FROM ("S 1"."T 3" r1 FULL JOIN "S 1"."T 4" r2 ON (((r1.c1 = r2.c1)))) WHERE (((r1.c1 < 20) OR ((r1.c1 IS NULL) AND (r2.c1 < 5)))) GROUP BY 2 ORDER BY array_agg(DISTINCT (r1.c1 % 5) ORDER BY ((r1.c1 % 5)) DESC NULLS LAST) ASC NULLS LAST
-(4 rows)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: (array_agg(DISTINCT ((t1.c1 % '5'::number)) ORDER BY ((t1.c1 % '5'::number)) DESC NULLS LAST)), ((t2.c1 % '3'::number))
+   Sort Key: (array_agg(DISTINCT ((t1.c1 % '5'::number)) ORDER BY ((t1.c1 % '5'::number)) DESC NULLS LAST))
+   ->  GroupAggregate
+         Output: array_agg(DISTINCT ((t1.c1 % '5'::number)) ORDER BY ((t1.c1 % '5'::number)) DESC NULLS LAST), ((t2.c1 % '3'::number))
+         Group Key: ((t2.c1 % '3'::number))
+         ->  Sort
+               Output: ((t2.c1 % '3'::number)), t1.c1, ((t1.c1 % '5'::number))
+               Sort Key: ((t2.c1 % '3'::number)), ((t1.c1 % '5'::number)) DESC NULLS LAST
+               ->  Hash Full Join
+                     Output: (t2.c1 % '3'::number), t1.c1, (t1.c1 % '5'::number)
+                     Hash Cond: (t1.c1 = t2.c1)
+                     Filter: ((t1.c1 < '20'::number) OR ((t1.c1 IS NULL) AND (t2.c1 < '5'::number)))
+                     ->  Foreign Scan on public.ft4 t1
+                           Output: t1.c1, t1.c2, t1.c3
+                           Remote SQL: SELECT c1 FROM "S 1"."T 3"
+                     ->  Hash
+                           Output: t2.c1
+                           ->  Foreign Scan on public.ft5 t2
+                                 Output: t2.c1
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(21 rows)
 
 select array_agg(distinct (t1.c1)%5 order by (t1.c1)%5 desc nulls last) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) where t1.c1 < 20 or (t1.c1 is null and t2.c1 < 5) group by (t2.c1)%3 order by 1;
   array_agg   
@@ -3106,13 +3912,18 @@ select array_agg(distinct (t1.c1)%5 order by (t1.c1)%5 desc nulls last) from ft4
 -- FILTER within aggregate
 explain (verbose, costs off)
 select sum(c1) filter (where c1 < 100 and c2 > 5) from ft1 group by c2 order by 1 nulls last;
-                                                                                         QUERY PLAN                                                                                         
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5)))), c2
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT sum("C 1") FILTER (WHERE (("C 1" < 100) AND (c2 > 5))), c2 FROM "S 1"."T 1" GROUP BY 2 ORDER BY sum("C 1") FILTER (WHERE (("C 1" < 100) AND (c2 > 5))) ASC NULLS LAST
-(4 rows)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Sort
+   Output: (sum(c1) FILTER (WHERE ((c1 < '100'::number) AND (c2 > '5'::number)))), c2
+   Sort Key: (sum(ft1.c1) FILTER (WHERE ((ft1.c1 < '100'::number) AND (ft1.c2 > '5'::number))))
+   ->  HashAggregate
+         Output: sum(c1) FILTER (WHERE ((c1 < '100'::number) AND (c2 > '5'::number))), c2
+         Group Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c1, c2
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 select sum(c1) filter (where c1 < 100 and c2 > 5) from ft1 group by c2 order by 1 nulls last;
  sum 
@@ -3121,50 +3932,58 @@ select sum(c1) filter (where c1 < 100 and c2 > 5) from ft1 group by c2 order by 
  520
  530
  540
-    
-    
-    
-    
-    
-    
+ 
+ 
+ 
+ 
+ 
+ 
 (10 rows)
 
 -- DISTINCT, ORDER BY and FILTER within aggregate
 explain (verbose, costs off)
 select sum(c1%3), sum(distinct c1%3 order by c1%3) filter (where c1%3 < 2), c2 from ft1 where c2 = 6 group by c2;
-                                                                                        QUERY PLAN                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (sum((c1 % 3))), (sum(DISTINCT (c1 % 3) ORDER BY (c1 % 3)) FILTER (WHERE ((c1 % 3) < 2))), c2
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT sum(("C 1" % 3)), sum(DISTINCT ("C 1" % 3) ORDER BY (("C 1" % 3)) ASC NULLS LAST) FILTER (WHERE (("C 1" % 3) < 2)), c2 FROM "S 1"."T 1" WHERE ((c2 = 6)) GROUP BY 3
-(4 rows)
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: sum(((c1 % '3'::number))), sum(DISTINCT ((c1 % '3'::number)) ORDER BY ((c1 % '3'::number))) FILTER (WHERE (((c1 % '3'::number)) < '2'::number)), c2
+   ->  Sort
+         Output: c1, c2, ((c1 % '3'::number))
+         Sort Key: ((ft1.c1 % '3'::number))
+         ->  Foreign Scan on public.ft1
+               Output: c1, c2, (c1 % '3'::number)
+               Filter: (ft1.c2 = '6'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 select sum(c1%3), sum(distinct c1%3 order by c1%3) filter (where c1%3 < 2), c2 from ft1 where c2 = 6 group by c2;
  sum | sum | c2 
 -----+-----+----
-  99 |   1 |  6
+ 99  | 1   | 6
 (1 row)
 
 -- Outer query is aggregation query
 explain (verbose, costs off)
 select distinct (select count(*) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Unique
    Output: ((SubPlan 1))
    ->  Sort
          Output: ((SubPlan 1))
          Sort Key: ((SubPlan 1))
-         ->  Foreign Scan
+         ->  Aggregate
                Output: (SubPlan 1)
-               Relations: Aggregate on (public.ft2 t2)
-               Remote SQL: SELECT count(*) FILTER (WHERE ((c2 = 6) AND ("C 1" < 10))) FROM "S 1"."T 1" WHERE (((c2 % 6) = 0))
+               ->  Foreign Scan on public.ft2 t2
+                     Output: t2.c2, t2.c1
+                     Filter: ((t2.c2 % '6'::number) = '0'::number)
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
                SubPlan 1
                  ->  Foreign Scan on public.ft1 t1
-                       Output: (count(*) FILTER (WHERE ((t2.c2 = 6) AND (t2.c1 < 10))))
-                       Remote SQL: SELECT NULL FROM "S 1"."T 1" WHERE (("C 1" = 6))
-(13 rows)
+                       Output: count(*) FILTER (WHERE ((t2.c2 = '6'::number) AND (t2.c1 < '10'::number)))
+                       Filter: (t1.c1 = '6'::number)
+                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(16 rows)
 
 select distinct (select count(*) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
  count 
@@ -3175,8 +3994,8 @@ select distinct (select count(*) filter (where t2.c2 = 6 and t2.c1 < 10) from ft
 -- Inner query is aggregation query
 explain (verbose, costs off)
 select distinct (select count(t1.c1) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Unique
    Output: ((SubPlan 1))
    ->  Sort
@@ -3184,13 +4003,16 @@ select distinct (select count(t1.c1) filter (where t2.c2 = 6 and t2.c1 < 10) fro
          Sort Key: ((SubPlan 1))
          ->  Foreign Scan on public.ft2 t2
                Output: (SubPlan 1)
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE (((c2 % 6) = 0))
+               Filter: ((t2.c2 % '6'::number) = '0'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
                SubPlan 1
-                 ->  Foreign Scan
-                       Output: (count(t1.c1) FILTER (WHERE ((t2.c2 = 6) AND (t2.c1 < 10))))
-                       Relations: Aggregate on (public.ft1 t1)
-                       Remote SQL: SELECT count("C 1") FILTER (WHERE (($1::integer = 6) AND ($2::integer < 10))) FROM "S 1"."T 1" WHERE (("C 1" = 6))
-(13 rows)
+                 ->  Aggregate
+                       Output: count(t1.c1) FILTER (WHERE ((t2.c2 = '6'::number) AND (t2.c1 < '10'::number)))
+                       ->  Foreign Scan on public.ft1 t1
+                             Output: t1.c1
+                             Filter: (t1.c1 = '6'::number)
+                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(16 rows)
 
 select distinct (select count(t1.c1) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
  count 
@@ -3202,13 +4024,13 @@ select distinct (select count(t1.c1) filter (where t2.c2 = 6 and t2.c1 < 10) fro
 -- Aggregate not pushed down as FILTER condition is not pushable
 explain (verbose, costs off)
 select sum(c1) filter (where (c1 / c1) * random() <= 1) from ft1 group by c2 order by 1;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: (sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision))), c2
-   Sort Key: (sum(ft1.c1) FILTER (WHERE ((((ft1.c1 / ft1.c1))::double precision * random()) <= '1'::double precision)))
+   Output: (sum(c1) FILTER (WHERE ((((c1 / c1))::binary_double * (random())::binary_double) <= '1'::binary_double))), c2
+   Sort Key: (sum(ft1.c1) FILTER (WHERE ((((ft1.c1 / ft1.c1))::binary_double * (random())::binary_double) <= '1'::binary_double)))
    ->  HashAggregate
-         Output: sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision)), c2
+         Output: sum(c1) FILTER (WHERE ((((c1 / c1))::binary_double * (random())::binary_double) <= '1'::binary_double)), c2
          Group Key: ft1.c2
          ->  Foreign Scan on public.ft1
                Output: c1, c2
@@ -3217,8 +4039,8 @@ select sum(c1) filter (where (c1 / c1) * random() <= 1) from ft1 group by c2 ord
 
 explain (verbose, costs off)
 select sum(c2) filter (where c2 in (select c2 from ft1 where c2 < 5)) from ft1;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Aggregate
    Output: sum(ft1.c2) FILTER (WHERE (hashed SubPlan 1))
    ->  Foreign Scan on public.ft1
@@ -3227,41 +4049,59 @@ select sum(c2) filter (where c2 in (select c2 from ft1 where c2 < 5)) from ft1;
    SubPlan 1
      ->  Foreign Scan on public.ft1 ft1_1
            Output: ft1_1.c2
-           Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 5))
-(9 rows)
+           Filter: (ft1_1.c2 < '5'::number)
+           Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(10 rows)
 
 -- Ordered-sets within aggregate
 explain (verbose, costs off)
-select c2, rank('10'::pg_catalog.varchar) within group (order by c6), percentile_cont(c2/10::pg_catalog.numeric) within group (order by c1) from ft1 where c2 < 10 group by c2 having percentile_cont(c2/10::pg_catalog.numeric) within group (order by c1) < 500 order by c2;
-                                                                                                                                                                      QUERY PLAN                                                                                                                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: c2, (rank('10'::varchar2) WITHIN GROUP (ORDER BY c6)), (percentile_cont((((c2)::numeric / '10'::numeric))::double precision) WITHIN GROUP (ORDER BY ((c1)::double precision)))
-   Sort Key: ft1.c2
-   ->  Foreign Scan
-         Output: c2, (rank('10'::varchar2) WITHIN GROUP (ORDER BY c6)), (percentile_cont((((c2)::numeric / '10'::numeric))::double precision) WITHIN GROUP (ORDER BY ((c1)::double precision)))
-         Relations: Aggregate on (public.ft1)
-         Remote SQL: SELECT c2, rank('10'::varchar2) WITHIN GROUP (ORDER BY c6 ASC NULLS LAST), percentile_cont((c2 / 10::numeric)) WITHIN GROUP (ORDER BY ("C 1") ASC NULLS LAST) FROM "S 1"."T 1" WHERE ((c2 < 10)) GROUP BY 1 HAVING ((percentile_cont((c2 / 10::numeric)) WITHIN GROUP (ORDER BY ("C 1") ASC NULLS LAST) < 500::double precision))
-(7 rows)
+select c2, rank('10'::pg_catalog.varchar) within group (order by c6), percentile_cont(c2/10::number) within group (order by c1) from ft1 where c2 < 10 group by c2 having percentile_cont(c2/10::number) within group (order by c1) < 500 order by c2;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: c2, rank('10'::varchar2) WITHIN GROUP (ORDER BY c6), percentile_cont(((c2 / '10'::number))::double precision) WITHIN GROUP (ORDER BY ((c1)::double precision))
+   Group Key: ft1.c2
+   Filter: (percentile_cont(((ft1.c2 / '10'::number))::double precision) WITHIN GROUP (ORDER BY ((ft1.c1)::double precision)) < '500'::double precision)
+   ->  Sort
+         Output: c2, c6, c1
+         Sort Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c2, c6, c1
+               Filter: (ft1.c2 < '10'::number)
+               Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1"
+(11 rows)
 
-select c2, rank('10'::pg_catalog.varchar) within group (order by c6), percentile_cont(c2/10::pg_catalog.numeric) within group (order by c1) from ft1 where c2 < 10 group by c2 having percentile_cont(c2/10::pg_catalog.numeric) within group (order by c1) < 500 order by c2;
-ERROR:  type "varchar2" does not exist
-CONTEXT:  remote SQL command: SELECT c2, rank('10'::varchar2) WITHIN GROUP (ORDER BY c6 ASC NULLS LAST), percentile_cont((c2 / 10::numeric)) WITHIN GROUP (ORDER BY ("C 1") ASC NULLS LAST) FROM "S 1"."T 1" WHERE ((c2 < 10)) GROUP BY 1 HAVING ((percentile_cont((c2 / 10::numeric)) WITHIN GROUP (ORDER BY ("C 1") ASC NULLS LAST) < 500::double precision))
+select c2, rank('10'::pg_catalog.varchar) within group (order by c6), percentile_cont(c2/10::number) within group (order by c1) from ft1 where c2 < 10 group by c2 having percentile_cont(c2/10::number) within group (order by c1) < 500 order by c2;
+ c2 | rank | percentile_cont 
+----+------+-----------------
+ 0  |  101 |              10
+ 1  |  101 |             100
+ 2  |    1 |             200
+ 3  |    1 |             300
+ 4  |    1 |             400
+(5 rows)
+
 -- Using multiple arguments within aggregates
 explain (verbose, costs off)
 select c1, rank(c1, c2) within group (order by c1, c2) from ft1 group by c1, c2 having c1 = 6 order by 1;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: c1, (rank(c1, c2) WITHIN GROUP (ORDER BY c1, c2)), c2
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT "C 1", rank("C 1", c2) WITHIN GROUP (ORDER BY "C 1" ASC NULLS LAST, c2 ASC NULLS LAST), c2 FROM "S 1"."T 1" WHERE (("C 1" = 6)) GROUP BY 1, 3
-(4 rows)
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ GroupAggregate
+   Output: c1, rank(c1, c2) WITHIN GROUP (ORDER BY c1, c2), c2
+   Group Key: ft1.c2
+   ->  Sort
+         Output: c2, c1
+         Sort Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c2, c1
+               Filter: (ft1.c1 = '6'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(10 rows)
 
 select c1, rank(c1, c2) within group (order by c1, c2) from ft1 group by c1, c2 having c1 = 6 order by 1;
  c1 | rank 
 ----+------
-  6 |    1
+ 6  |    1
 (1 row)
 
 -- User defined function for user defined aggregate, VARIADIC
@@ -3277,15 +4117,18 @@ set enable_hashagg to false;
 -- Not pushed down due to user defined aggregate
 explain (verbose, costs off)
 select c2, least_agg(c1) from ft1 group by c2 order by c2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  GroupAggregate
    Output: c2, least_agg(VARIADIC ARRAY[c1])
    Group Key: ft1.c2
-   ->  Foreign Scan on public.ft1
+   ->  Sort
          Output: c2, c1
-         Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" ORDER BY c2 ASC NULLS LAST
-(6 rows)
+         Sort Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c2, c1
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 -- Add function and aggregate into extension
 alter extension postgres_fdw add function least_accum(anyelement, variadic anyarray);
@@ -3294,30 +4137,33 @@ alter server loopback options (set extensions 'postgres_fdw');
 -- Now aggregate will be pushed.  Aggregate will display VARIADIC argument.
 explain (verbose, costs off)
 select c2, least_agg(c1) from ft1 where c2 < 100 group by c2 order by c2;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: c2, (least_agg(VARIADIC ARRAY[c1]))
-   Sort Key: ft1.c2
-   ->  Foreign Scan
-         Output: c2, (least_agg(VARIADIC ARRAY[c1]))
-         Relations: Aggregate on (public.ft1)
-         Remote SQL: SELECT c2, public.least_agg(VARIADIC ARRAY["C 1"]) FROM "S 1"."T 1" WHERE ((c2 < 100)) GROUP BY 1
-(7 rows)
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ GroupAggregate
+   Output: c2, least_agg(VARIADIC ARRAY[c1])
+   Group Key: ft1.c2
+   ->  Sort
+         Output: c2, c1
+         Sort Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c2, c1
+               Filter: (ft1.c2 < '100'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(10 rows)
 
 select c2, least_agg(c1) from ft1 where c2 < 100 group by c2 order by c2;
  c2 | least_agg 
 ----+-----------
-  0 |        10
-  1 |         1
-  2 |         2
-  3 |         3
-  4 |         4
-  5 |         5
-  6 |         6
-  7 |         7
-  8 |         8
-  9 |         9
+ 0  | 10
+ 1  | 1
+ 2  | 2
+ 3  | 3
+ 4  | 4
+ 5  | 5
+ 6  | 6
+ 7  | 7
+ 8  | 8
+ 9  | 9
 (10 rows)
 
 -- Remove function and aggregate from extension
@@ -3327,15 +4173,18 @@ alter server loopback options (set extensions 'postgres_fdw');
 -- Not pushed down as we have dropped objects from extension.
 explain (verbose, costs off)
 select c2, least_agg(c1) from ft1 group by c2 order by c2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  GroupAggregate
    Output: c2, least_agg(VARIADIC ARRAY[c1])
    Group Key: ft1.c2
-   ->  Foreign Scan on public.ft1
+   ->  Sort
          Output: c2, c1
-         Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" ORDER BY c2 ASC NULLS LAST
-(6 rows)
+         Sort Key: ft1.c2
+         ->  Foreign Scan on public.ft1
+               Output: c2, c1
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 -- Cleanup
 reset enable_hashagg;
@@ -3347,35 +4196,35 @@ drop function least_accum(anyelement, variadic anyarray);
 -- user defined objects are considered unshippable unless they are part of
 -- the extension.
 create operator public.<^ (
- leftarg = int4,
- rightarg = int4,
- procedure = int4eq
+ leftarg = number(38,0),
+ rightarg = number(38,0),
+ procedure = sys.number_eq
 );
 create operator public.=^ (
- leftarg = int4,
- rightarg = int4,
- procedure = int4lt
+ leftarg = number(38,0),
+ rightarg = number(38,0),
+ procedure = sys.number_lt
 );
 create operator public.>^ (
- leftarg = int4,
- rightarg = int4,
- procedure = int4gt
+ leftarg = number(38,0),
+ rightarg = number(38,0),
+ procedure = sys.number_gt
 );
 create operator family my_op_family using btree;
-create function my_op_cmp(a int, b int) returns int as
-  $$begin return btint4cmp(a, b); end $$ language plpgsql;
+create function my_op_cmp(a number(38,0), b number(38,0)) returns integer as
+  $$begin return sys.number_cmp(a, b); end $$ language plisql;
 /
-create operator class my_op_class for type int using btree family my_op_family as
+create operator class my_op_class for type number(38,0) using btree family my_op_family as
  operator 1 public.<^,
  operator 3 public.=^,
  operator 5 public.>^,
- function 1 my_op_cmp(int, int);
+ function 1 my_op_cmp(number(38,0), number(38,0));
 -- This will not be pushed as user defined sort operator is not part of the
 -- extension yet.
 explain (verbose, costs off)
 select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6 and c1 < 100 group by c2;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  GroupAggregate
    Output: array_agg(c1 ORDER BY c1 USING <^ NULLS LAST), c2
    ->  Sort
@@ -3383,8 +4232,9 @@ select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6
          Sort Key: ft2.c1 USING <^
          ->  Foreign Scan on public.ft2
                Output: c1, c2
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE (("C 1" < 100)) AND ((c2 = 6))
-(8 rows)
+               Filter: ((ft2.c1 < '100'::number) AND (ft2.c2 = '6'::number))
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 -- This should not be pushed either.
 explain (verbose, costs off)
@@ -3403,23 +4253,28 @@ select * from ft2 order by c1 using operator(public.<^);
 ANALYZE ft2;
 -- Add into extension
 alter extension postgres_fdw add operator class my_op_class using btree;
-alter extension postgres_fdw add function my_op_cmp(a int, b int);
+alter extension postgres_fdw add function my_op_cmp(a number(38,0), b number(38,0));
 alter extension postgres_fdw add operator family my_op_family using btree;
-alter extension postgres_fdw add operator public.<^(int, int);
-alter extension postgres_fdw add operator public.=^(int, int);
-alter extension postgres_fdw add operator public.>^(int, int);
+alter extension postgres_fdw add operator public.<^(number(38,0), number(38,0));
+alter extension postgres_fdw add operator public.=^(number(38,0), number(38,0));
+alter extension postgres_fdw add operator public.>^(number(38,0), number(38,0));
 alter server loopback options (set extensions 'postgres_fdw');
 -- Now this will be pushed as sort operator is part of the extension.
 alter server loopback options (add fdw_tuple_cost '0.5');
 explain (verbose, costs off)
 select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6 and c1 < 100 group by c2;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (array_agg(c1 ORDER BY c1 USING <^ NULLS LAST)), c2
-   Relations: Aggregate on (public.ft2)
-   Remote SQL: SELECT array_agg("C 1" ORDER BY "C 1" USING OPERATOR(public.<^) NULLS LAST), c2 FROM "S 1"."T 1" WHERE (("C 1" < 100)) AND ((c2 = 6)) GROUP BY 2
-(4 rows)
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ GroupAggregate
+   Output: array_agg(c1 ORDER BY c1 USING <^ NULLS LAST), c2
+   ->  Sort
+         Output: c1, c2
+         Sort Key: ft2.c1 USING <^
+         ->  Foreign Scan on public.ft2
+               Output: c1, c2
+               Filter: ((ft2.c1 < '100'::number) AND (ft2.c2 = '6'::number))
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6 and c1 < 100 group by c2;
            array_agg            
@@ -3440,17 +4295,17 @@ select * from ft2 order by c1 using operator(public.<^);
 
 -- Remove from extension
 alter extension postgres_fdw drop operator class my_op_class using btree;
-alter extension postgres_fdw drop function my_op_cmp(a int, b int);
+alter extension postgres_fdw drop function my_op_cmp(a number(38,0), b number(38,0));
 alter extension postgres_fdw drop operator family my_op_family using btree;
-alter extension postgres_fdw drop operator public.<^(int, int);
-alter extension postgres_fdw drop operator public.=^(int, int);
-alter extension postgres_fdw drop operator public.>^(int, int);
+alter extension postgres_fdw drop operator public.<^(number(38,0), number(38,0));
+alter extension postgres_fdw drop operator public.=^(number(38,0), number(38,0));
+alter extension postgres_fdw drop operator public.>^(number(38,0), number(38,0));
 alter server loopback options (set extensions 'postgres_fdw');
 -- This will not be pushed as sort operator is now removed from the extension.
 explain (verbose, costs off)
 select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6 and c1 < 100 group by c2;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  GroupAggregate
    Output: array_agg(c1 ORDER BY c1 USING <^ NULLS LAST), c2
    ->  Sort
@@ -3458,27 +4313,28 @@ select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6
          Sort Key: ft2.c1 USING <^
          ->  Foreign Scan on public.ft2
                Output: c1, c2
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE (("C 1" < 100)) AND ((c2 = 6))
-(8 rows)
+               Filter: ((ft2.c1 < '100'::number) AND (ft2.c2 = '6'::number))
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(9 rows)
 
 -- Cleanup
 drop operator class my_op_class using btree;
-drop function my_op_cmp(a int, b int);
+drop function my_op_cmp(a number(38,0), b number(38,0));
 drop operator family my_op_family using btree;
-drop operator public.>^(int, int);
-drop operator public.=^(int, int);
-drop operator public.<^(int, int);
+drop operator public.>^(number(38,0), number(38,0));
+drop operator public.=^(number(38,0), number(38,0));
+drop operator public.<^(number(38,0), number(38,0));
 -- Input relation to aggregate push down hook is not safe to pushdown and thus
 -- the aggregate cannot be pushed down to foreign server.
 explain (verbose, costs off)
 select count(t1.c3) from ft2 t1 left join ft2 t2 on (t1.c1 = random() * t2.c2);
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Aggregate
    Output: count(t1.c3)
    ->  Nested Loop Left Join
          Output: t1.c3
-         Join Filter: ((t1.c1)::double precision = (random() * (t2.c2)::double precision))
+         Join Filter: ((t1.c1)::binary_double = ((random())::binary_double * (t2.c2)::binary_double))
          ->  Foreign Scan on public.ft2 t1
                Output: t1.c3, t1.c1
                Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
@@ -3492,8 +4348,8 @@ select count(t1.c3) from ft2 t1 left join ft2 t2 on (t1.c1 = random() * t2.c2);
 -- Subquery in FROM clause having aggregate
 explain (verbose, costs off)
 select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x where ft1.c2 = x.a group by x.b order by 1, 2;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Sort
    Output: (count(*)), x.b
    Sort Key: (count(*)), x.b
@@ -3511,11 +4367,13 @@ select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x w
                      Output: x.b, x.a
                      ->  Subquery Scan on x
                            Output: x.b, x.a
-                           ->  Foreign Scan
-                                 Output: ft1_1.c2, (sum(ft1_1.c1))
-                                 Relations: Aggregate on (public.ft1 ft1_1)
-                                 Remote SQL: SELECT c2, sum("C 1") FROM "S 1"."T 1" GROUP BY 1
-(21 rows)
+                           ->  HashAggregate
+                                 Output: ft1_1.c2, sum(ft1_1.c1)
+                                 Group Key: ft1_1.c2
+                                 ->  Foreign Scan on public.ft1 ft1_1
+                                       Output: ft1_1.c2, ft1_1.c1
+                                       Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(23 rows)
 
 select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x where ft1.c2 = x.a group by x.b order by 1, 2;
  count |   b   
@@ -3535,33 +4393,61 @@ select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x w
 -- FULL join with IS NULL check in HAVING
 explain (verbose, costs off)
 select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) group by t2.c1 having (avg(t1.c1) is null and sum(t2.c1) < 10) or sum(t2.c1) is null order by 1 nulls last, 2;
-                                                                                                                                    QUERY PLAN                                                                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort
    Output: (avg(t1.c1)), (sum(t2.c1)), t2.c1
-   Relations: Aggregate on ((public.ft4 t1) FULL JOIN (public.ft5 t2))
-   Remote SQL: SELECT avg(r1.c1), sum(r2.c1), r2.c1 FROM ("S 1"."T 3" r1 FULL JOIN "S 1"."T 4" r2 ON (((r1.c1 = r2.c1)))) GROUP BY 3 HAVING ((((avg(r1.c1) IS NULL) AND (sum(r2.c1) < 10)) OR (sum(r2.c1) IS NULL))) ORDER BY avg(r1.c1) ASC NULLS LAST, sum(r2.c1) ASC NULLS LAST
-(4 rows)
+   Sort Key: (avg(t1.c1)), (sum(t2.c1))
+   ->  GroupAggregate
+         Output: avg(t1.c1), sum(t2.c1), t2.c1
+         Group Key: t2.c1
+         Filter: (((avg(t1.c1) IS NULL) AND (sum(t2.c1) < '10'::number)) OR (sum(t2.c1) IS NULL))
+         ->  Sort
+               Output: t2.c1, t1.c1
+               Sort Key: t2.c1
+               ->  Hash Full Join
+                     Output: t2.c1, t1.c1
+                     Hash Cond: (t1.c1 = t2.c1)
+                     ->  Foreign Scan on public.ft4 t1
+                           Output: t1.c1, t1.c2, t1.c3
+                           Remote SQL: SELECT c1 FROM "S 1"."T 3"
+                     ->  Hash
+                           Output: t2.c1
+                           ->  Foreign Scan on public.ft5 t2
+                                 Output: t2.c1
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(21 rows)
 
 select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) group by t2.c1 having (avg(t1.c1) is null and sum(t2.c1) < 10) or sum(t2.c1) is null order by 1 nulls last, 2;
          avg         | sum 
 ---------------------+-----
- 51.0000000000000000 |    
-                     |   3
-                     |   9
+ 51.0000000000000000 | 
+                     | 3
+                     | 9
 (3 rows)
 
 -- Aggregate over FULL join needing to deparse the joining relations as
 -- subqueries.
 explain (verbose, costs off)
 select count(*), sum(t1.c1), avg(t2.c1) from (select c1 from ft4 where c1 between 50 and 60) t1 full join (select c1 from ft5 where c1 between 50 and 60) t2 on (t1.c1 = t2.c1);
-                                                                                                                  QUERY PLAN                                                                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (count(*)), (sum(ft4.c1)), (avg(ft5.c1))
-   Relations: Aggregate on ((public.ft4) FULL JOIN (public.ft5))
-   Remote SQL: SELECT count(*), sum(s4.c1), avg(s5.c1) FROM ((SELECT c1 FROM "S 1"."T 3" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s4(c1) FULL JOIN (SELECT c1 FROM "S 1"."T 4" WHERE ((c1 >= 50)) AND ((c1 <= 60))) s5(c1) ON (((s4.c1 = s5.c1))))
-(4 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Aggregate
+   Output: count(*), sum(ft4.c1), avg(ft5.c1)
+   ->  Hash Full Join
+         Output: ft4.c1, ft5.c1
+         Hash Cond: (ft4.c1 = ft5.c1)
+         ->  Foreign Scan on public.ft4
+               Output: ft4.c1, ft4.c2, ft4.c3
+               Filter: ((ft4.c1 >= '50'::number) AND (ft4.c1 <= '60'::number))
+               Remote SQL: SELECT c1 FROM "S 1"."T 3"
+         ->  Hash
+               Output: ft5.c1
+               ->  Foreign Scan on public.ft5
+                     Output: ft5.c1
+                     Filter: ((ft5.c1 >= '50'::number) AND (ft5.c1 <= '60'::number))
+                     Remote SQL: SELECT c1 FROM "S 1"."T 4"
+(15 rows)
 
 select count(*), sum(t1.c1), avg(t2.c1) from (select c1 from ft4 where c1 between 50 and 60) t1 full join (select c1 from ft5 where c1 between 50 and 60) t2 on (t1.c1 = t2.c1);
  count | sum |         avg         
@@ -3573,16 +4459,17 @@ select count(*), sum(t1.c1), avg(t2.c1) from (select c1 from ft4 where c1 betwee
 -- foreign server.
 explain (verbose, costs off)
 select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Sort
-   Output: (((sum(c2)) * ((random() <= '1'::double precision))::integer))
-   Sort Key: (((sum(ft1.c2)) * ((random() <= '1'::double precision))::integer))
-   ->  Foreign Scan
-         Output: ((sum(c2)) * ((random() <= '1'::double precision))::integer)
-         Relations: Aggregate on (public.ft1)
-         Remote SQL: SELECT sum(c2) FROM "S 1"."T 1"
-(7 rows)
+   Output: ((sum(c2) * (((random() <= '1'::double precision))::integer)::number))
+   Sort Key: ((sum(ft1.c2) * (((random() <= '1'::double precision))::integer)::number))
+   ->  Aggregate
+         Output: (sum(c2) * (((random() <= '1'::double precision))::integer)::number)
+         ->  Foreign Scan on public.ft1
+               Output: c2
+               Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(8 rows)
 
 select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
  sum  
@@ -3594,8 +4481,8 @@ select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
 set enable_hashagg to false;
 explain (verbose, costs off)
 select c2, sum from "S 1"."T 1" t1, lateral (select sum(t2.c1 + t1."C 1") sum from ft2 t2 group by t2.c1) qry where t1.c2 * 2 = qry.sum and t1.c2 < 3 and t1."C 1" < 100 order by 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Sort
    Output: t1.c2, qry.sum
    Sort Key: t1.c2
@@ -3603,22 +4490,27 @@ select c2, sum from "S 1"."T 1" t1, lateral (select sum(t2.c1 + t1."C 1") sum fr
          Output: t1.c2, qry.sum
          ->  Index Scan using t1_pkey on "S 1"."T 1" t1
                Output: t1."C 1", t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
-               Index Cond: (t1."C 1" < 100)
-               Filter: (t1.c2 < 3)
+               Index Cond: (t1."C 1" < '100'::number)
+               Filter: (t1.c2 < '3'::number)
          ->  Subquery Scan on qry
                Output: qry.sum, t2.c1
-               Filter: ((t1.c2 * 2) = qry.sum)
-               ->  Foreign Scan
-                     Output: (sum((t2.c1 + t1."C 1"))), t2.c1
-                     Relations: Aggregate on (public.ft2 t2)
-                     Remote SQL: SELECT sum(("C 1" + $1::integer)), "C 1" FROM "S 1"."T 1" GROUP BY 2
-(16 rows)
+               Filter: ((t1.c2 * '2'::number) = qry.sum)
+               ->  GroupAggregate
+                     Output: sum((t2.c1 + t1."C 1")), t2.c1
+                     Group Key: t2.c1
+                     ->  Sort
+                           Output: t2.c1
+                           Sort Key: t2.c1
+                           ->  Foreign Scan on public.ft2 t2
+                                 Output: t2.c1
+                                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(21 rows)
 
 select c2, sum from "S 1"."T 1" t1, lateral (select sum(t2.c1 + t1."C 1") sum from ft2 t2 group by t2.c1) qry where t1.c2 * 2 = qry.sum and t1.c2 < 3 and t1."C 1" < 100 order by 1;
  c2 | sum 
 ----+-----
-  1 |   2
-  2 |   4
+ 1  | 2
+ 2  | 4
 (2 rows)
 
 reset enable_hashagg;
@@ -3643,16 +4535,18 @@ ORDER BY ref_0."C 1";
          Output: ref_0.c2, ref_0."C 1", ref_1.c3, (ref_0.c2)
          ->  Index Scan using t1_pkey on "S 1"."T 1" ref_0
                Output: ref_0."C 1", ref_0.c2, ref_0.c3, ref_0.c4, ref_0.c5, ref_0.c6, ref_0.c7, ref_0.c8
-               Index Cond: (ref_0."C 1" < 10)
+               Index Cond: (ref_0."C 1" < '10'::number)
          ->  Foreign Scan on public.ft1 ref_1
                Output: ref_1.c3, ref_0.c2
-               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE ((c3 = '00001'))
+               Filter: (ref_1.c3 = '00001'::varchar2)
+               Remote SQL: SELECT c3 FROM "S 1"."T 1"
    ->  Materialize
          Output: ref_3.c3
          ->  Foreign Scan on public.ft2 ref_3
                Output: ref_3.c3
-               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE ((c3 = '00001'))
-(15 rows)
+               Filter: (ref_3.c3 = '00001'::varchar2)
+               Remote SQL: SELECT c3 FROM "S 1"."T 1"
+(17 rows)
 
 SELECT ref_0.c2, subq_1.*
 FROM
@@ -3667,28 +4561,28 @@ WHERE ref_0."C 1" < 10 AND subq_1.c3 = '00001'
 ORDER BY ref_0."C 1";
  c2 | c1 | c2 |  c3   
 ----+----+----+-------
-  1 |  1 |  1 | 00001
-  2 |  2 |  2 | 00001
-  3 |  3 |  3 | 00001
-  4 |  4 |  4 | 00001
-  5 |  5 |  5 | 00001
-  6 |  6 |  6 | 00001
-  7 |  7 |  7 | 00001
-  8 |  8 |  8 | 00001
-  9 |  9 |  9 | 00001
+ 1  | 1  | 1  | 00001
+ 2  | 2  | 2  | 00001
+ 3  | 3  | 3  | 00001
+ 4  | 4  | 4  | 00001
+ 5  | 5  | 5  | 00001
+ 6  | 6  | 6  | 00001
+ 7  | 7  | 7  | 00001
+ 8  | 8  | 8  | 00001
+ 9  | 9  | 9  | 00001
 (9 rows)
 
 -- Check with placeHolderVars
 explain (verbose, costs off)
 select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.c1) from ft1 right join ft2 on (ft1.c1 = ft2.c1)) q(a, b, c) on (ft4.c1 <= q.b);
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Aggregate
    Output: sum(q.a), count(q.b)
    ->  Nested Loop Left Join
          Output: q.a, q.b
          Inner Unique: true
-         Join Filter: ((ft4.c1)::numeric <= q.b)
+         Join Filter: (ft4.c1 <= q.b)
          ->  Foreign Scan on public.ft4
                Output: ft4.c1, ft4.c2, ft4.c3
                Remote SQL: SELECT c1 FROM "S 1"."T 3"
@@ -3696,11 +4590,20 @@ select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.
                Output: q.a, q.b
                ->  Subquery Scan on q
                      Output: q.a, q.b
-                     ->  Foreign Scan
-                           Output: 13, (avg(ft1.c1)), NULL::bigint
-                           Relations: Aggregate on ((public.ft2) LEFT JOIN (public.ft1))
-                           Remote SQL: SELECT 13, avg(r1."C 1"), NULL::bigint FROM ("S 1"."T 1" r2 LEFT JOIN "S 1"."T 1" r1 ON (((r1."C 1" = r2."C 1"))))
-(17 rows)
+                     ->  Aggregate
+                           Output: 13, avg(ft1.c1), NULL::number
+                           ->  Hash Left Join
+                                 Output: ft1.c1
+                                 Hash Cond: (ft2.c1 = ft1.c1)
+                                 ->  Foreign Scan on public.ft2
+                                       Output: ft2.c1
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 ->  Hash
+                                       Output: ft1.c1
+                                       ->  Foreign Scan on public.ft1
+                                             Output: ft1.c1
+                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+(26 rows)
 
 select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.c1) from ft1 right join ft2 on (ft1.c1 = ft2.c1)) q(a, b, c) on (ft4.c1 <= q.b);
  sum | count 
@@ -3712,8 +4615,8 @@ select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.
 -- Grouping sets
 explain (verbose, costs off)
 select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls last;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  Sort
    Output: c2, (sum(c1))
    Sort Key: ft1.c2
@@ -3723,22 +4626,23 @@ select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls la
          Group Key: ()
          ->  Foreign Scan on public.ft1
                Output: c2, c1
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
-(10 rows)
+               Filter: (ft1.c2 < '3'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(11 rows)
 
 select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls last;
  c2 |  sum   
 ----+--------
-  0 |  50500
-  1 |  49600
-  2 |  49700
+ 0  | 50500
+ 1  | 49600
+ 2  | 49700
     | 149800
 (4 rows)
 
 explain (verbose, costs off)
 select c2, sum(c1) from ft1 where c2 < 3 group by cube(c2) order by 1 nulls last;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  Sort
    Output: c2, (sum(c1))
    Sort Key: ft1.c2
@@ -3748,22 +4652,23 @@ select c2, sum(c1) from ft1 where c2 < 3 group by cube(c2) order by 1 nulls last
          Group Key: ()
          ->  Foreign Scan on public.ft1
                Output: c2, c1
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
-(10 rows)
+               Filter: (ft1.c2 < '3'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(11 rows)
 
 select c2, sum(c1) from ft1 where c2 < 3 group by cube(c2) order by 1 nulls last;
  c2 |  sum   
 ----+--------
-  0 |  50500
-  1 |  49600
-  2 |  49700
+ 0  | 50500
+ 1  | 49600
+ 2  | 49700
     | 149800
 (4 rows)
 
 explain (verbose, costs off)
 select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) order by 1 nulls last, 2 nulls last;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Sort
    Output: c2, c6, (sum(c1))
    Sort Key: ft1.c2, ft1.c6
@@ -3773,15 +4678,16 @@ select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) orde
          Hash Key: ft1.c6
          ->  Foreign Scan on public.ft1
                Output: c2, c6, c1
-               Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 3))
-(10 rows)
+               Filter: (ft1.c2 < '3'::number)
+               Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1"
+(11 rows)
 
 select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) order by 1 nulls last, 2 nulls last;
  c2 | c6 |  sum  
 ----+----+-------
-  0 |    | 50500
-  1 |    | 49600
-  2 |    | 49700
+ 0  |    | 50500
+ 1  |    | 49600
+ 2  |    | 49700
     | 0  | 50500
     | 1  | 49600
     | 2  | 49700
@@ -3789,8 +4695,8 @@ select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) orde
 
 explain (verbose, costs off)
 select c2, sum(c1), grouping(c2) from ft1 where c2 < 3 group by c2 order by 1 nulls last;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  Sort
    Output: c2, (sum(c1)), (GROUPING(c2))
    Sort Key: ft1.c2
@@ -3799,153 +4705,176 @@ select c2, sum(c1), grouping(c2) from ft1 where c2 < 3 group by c2 order by 1 nu
          Group Key: ft1.c2
          ->  Foreign Scan on public.ft1
                Output: c2, c1
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
-(9 rows)
+               Filter: (ft1.c2 < '3'::number)
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(10 rows)
 
 select c2, sum(c1), grouping(c2) from ft1 where c2 < 3 group by c2 order by 1 nulls last;
  c2 |  sum  | grouping 
 ----+-------+----------
-  0 | 50500 |        0
-  1 | 49600 |        0
-  2 | 49700 |        0
+ 0  | 50500 |        0
+ 1  | 49600 |        0
+ 2  | 49700 |        0
 (3 rows)
 
 -- DISTINCT itself is not pushed down, whereas underneath aggregate is pushed
 explain (verbose, costs off)
 select distinct sum(c1)/1000 s from ft2 where c2 < 6 group by c2 order by 1;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Unique
-   Output: ((sum(c1) / 1000)), c2
+   Output: ((sum(c1) / '1000'::number)), c2
    ->  Sort
-         Output: ((sum(c1) / 1000)), c2
-         Sort Key: ((sum(ft2.c1) / 1000))
-         ->  Foreign Scan
-               Output: ((sum(c1) / 1000)), c2
-               Relations: Aggregate on (public.ft2)
-               Remote SQL: SELECT (sum("C 1") / 1000), c2 FROM "S 1"."T 1" WHERE ((c2 < 6)) GROUP BY 2
-(9 rows)
+         Output: ((sum(c1) / '1000'::number)), c2
+         Sort Key: ((sum(ft2.c1) / '1000'::number))
+         ->  HashAggregate
+               Output: (sum(c1) / '1000'::number), c2
+               Group Key: ft2.c2
+               ->  Foreign Scan on public.ft2
+                     Output: c1, c2
+                     Filter: (ft2.c2 < '6'::number)
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+(12 rows)
 
 select distinct sum(c1)/1000 s from ft2 where c2 < 6 group by c2 order by 1;
- s  
-----
- 49
- 50
-(2 rows)
+          s          
+---------------------
+ 49.6000000000000000
+ 49.7000000000000000
+ 49.8000000000000000
+ 49.9000000000000000
+ 50.0000000000000000
+ 50.5000000000000000
+(6 rows)
 
 -- WindowAgg
 explain (verbose, costs off)
 select c2, sum(c2), count(c2) over (partition by c2%2) from ft2 where c2 < 10 group by c2 order by 1;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Sort
-   Output: c2, (sum(c2)), (count(c2) OVER (?)), ((c2 % 2))
+   Output: c2, (sum(c2)), (count(c2) OVER (?)), ((c2 % '2'::number))
    Sort Key: ft2.c2
    ->  WindowAgg
-         Output: c2, (sum(c2)), count(c2) OVER (?), ((c2 % 2))
+         Output: c2, (sum(c2)), count(c2) OVER (?), ((c2 % '2'::number))
          ->  Sort
-               Output: c2, ((c2 % 2)), (sum(c2))
-               Sort Key: ((ft2.c2 % 2))
-               ->  Foreign Scan
-                     Output: c2, ((c2 % 2)), (sum(c2))
-                     Relations: Aggregate on (public.ft2)
-                     Remote SQL: SELECT c2, (c2 % 2), sum(c2) FROM "S 1"."T 1" WHERE ((c2 < 10)) GROUP BY 1
-(12 rows)
+               Output: c2, ((c2 % '2'::number)), (sum(c2))
+               Sort Key: ((ft2.c2 % '2'::number))
+               ->  HashAggregate
+                     Output: c2, (c2 % '2'::number), sum(c2)
+                     Group Key: ft2.c2
+                     ->  Foreign Scan on public.ft2
+                           Output: c2
+                           Filter: (ft2.c2 < '10'::number)
+                           Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(15 rows)
 
 select c2, sum(c2), count(c2) over (partition by c2%2) from ft2 where c2 < 10 group by c2 order by 1;
  c2 | sum | count 
 ----+-----+-------
-  0 |   0 |     5
-  1 | 100 |     5
-  2 | 200 |     5
-  3 | 300 |     5
-  4 | 400 |     5
-  5 | 500 |     5
-  6 | 600 |     5
-  7 | 700 |     5
-  8 | 800 |     5
-  9 | 900 |     5
+ 0  | 0   |     5
+ 1  | 100 |     5
+ 2  | 200 |     5
+ 3  | 300 |     5
+ 4  | 400 |     5
+ 5  | 500 |     5
+ 6  | 600 |     5
+ 7  | 700 |     5
+ 8  | 800 |     5
+ 9  | 900 |     5
 (10 rows)
 
 explain (verbose, costs off)
 select c2, array_agg(c2) over (partition by c2%2 order by c2 desc) from ft1 where c2 < 10 group by c2 order by 1;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Sort
-   Output: c2, (array_agg(c2) OVER (?)), ((c2 % 2))
+   Output: c2, (array_agg(c2) OVER (?)), ((c2 % '2'::number))
    Sort Key: ft1.c2
    ->  WindowAgg
-         Output: c2, array_agg(c2) OVER (?), ((c2 % 2))
+         Output: c2, array_agg(c2) OVER (?), ((c2 % '2'::number))
          ->  Sort
-               Output: c2, ((c2 % 2))
-               Sort Key: ((ft1.c2 % 2)), ft1.c2 DESC
-               ->  Foreign Scan
-                     Output: c2, ((c2 % 2))
-                     Relations: Aggregate on (public.ft1)
-                     Remote SQL: SELECT c2, (c2 % 2) FROM "S 1"."T 1" WHERE ((c2 < 10)) GROUP BY 1
-(12 rows)
+               Output: c2, ((c2 % '2'::number))
+               Sort Key: ((ft1.c2 % '2'::number)), ft1.c2 DESC
+               ->  HashAggregate
+                     Output: c2, (c2 % '2'::number)
+                     Group Key: ft1.c2
+                     ->  Foreign Scan on public.ft1
+                           Output: c2
+                           Filter: (ft1.c2 < '10'::number)
+                           Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(15 rows)
 
 select c2, array_agg(c2) over (partition by c2%2 order by c2 desc) from ft1 where c2 < 10 group by c2 order by 1;
  c2 |  array_agg  
 ----+-------------
-  0 | {8,6,4,2,0}
-  1 | {9,7,5,3,1}
-  2 | {8,6,4,2}
-  3 | {9,7,5,3}
-  4 | {8,6,4}
-  5 | {9,7,5}
-  6 | {8,6}
-  7 | {9,7}
-  8 | {8}
-  9 | {9}
+ 0  | {8,6,4,2,0}
+ 1  | {9,7,5,3,1}
+ 2  | {8,6,4,2}
+ 3  | {9,7,5,3}
+ 4  | {8,6,4}
+ 5  | {9,7,5}
+ 6  | {8,6}
+ 7  | {9,7}
+ 8  | {8}
+ 9  | {9}
 (10 rows)
 
 explain (verbose, costs off)
 select c2, array_agg(c2) over (partition by c2%2 order by c2 range between current row and unbounded following) from ft1 where c2 < 10 group by c2 order by 1;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Sort
-   Output: c2, (array_agg(c2) OVER (?)), ((c2 % 2))
+   Output: c2, (array_agg(c2) OVER (?)), ((c2 % '2'::number))
    Sort Key: ft1.c2
    ->  WindowAgg
-         Output: c2, array_agg(c2) OVER (?), ((c2 % 2))
+         Output: c2, array_agg(c2) OVER (?), ((c2 % '2'::number))
          ->  Sort
-               Output: c2, ((c2 % 2))
-               Sort Key: ((ft1.c2 % 2)), ft1.c2
-               ->  Foreign Scan
-                     Output: c2, ((c2 % 2))
-                     Relations: Aggregate on (public.ft1)
-                     Remote SQL: SELECT c2, (c2 % 2) FROM "S 1"."T 1" WHERE ((c2 < 10)) GROUP BY 1
-(12 rows)
+               Output: c2, ((c2 % '2'::number))
+               Sort Key: ((ft1.c2 % '2'::number)), ft1.c2
+               ->  HashAggregate
+                     Output: c2, (c2 % '2'::number)
+                     Group Key: ft1.c2
+                     ->  Foreign Scan on public.ft1
+                           Output: c2
+                           Filter: (ft1.c2 < '10'::number)
+                           Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(15 rows)
 
 select c2, array_agg(c2) over (partition by c2%2 order by c2 range between current row and unbounded following) from ft1 where c2 < 10 group by c2 order by 1;
  c2 |  array_agg  
 ----+-------------
-  0 | {0,2,4,6,8}
-  1 | {1,3,5,7,9}
-  2 | {2,4,6,8}
-  3 | {3,5,7,9}
-  4 | {4,6,8}
-  5 | {5,7,9}
-  6 | {6,8}
-  7 | {7,9}
-  8 | {8}
-  9 | {9}
+ 0  | {0,2,4,6,8}
+ 1  | {1,3,5,7,9}
+ 2  | {2,4,6,8}
+ 3  | {3,5,7,9}
+ 4  | {4,6,8}
+ 5  | {5,7,9}
+ 6  | {6,8}
+ 7  | {7,9}
+ 8  | {8}
+ 9  | {9}
 (10 rows)
 
 -- ===================================================================
 -- parameterized queries
 -- ===================================================================
 -- simple join
-PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM ft1 t1, ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+PREPARE st1(number(38,0), number(38,0)) AS SELECT t1.c3, t2.c3 FROM ft1 t1, ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Nested Loop
    Output: t1.c3, t2.c3
-   Relations: (public.ft1 t1) INNER JOIN (public.ft2 t2)
-   Remote SQL: SELECT r1.c3, r2.c3 FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r2."C 1" = 2)) AND ((r1."C 1" = 1))))
-(4 rows)
+   ->  Foreign Scan on public.ft1 t1
+         Output: t1.c3
+         Filter: (t1.c1 = '1'::number)
+         Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+   ->  Foreign Scan on public.ft2 t2
+         Output: t2.c3
+         Filter: (t2.c1 = '2'::number)
+         Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+(10 rows)
 
 EXECUTE st1(1, 1);
   c3   |  c3   
@@ -3960,10 +4889,10 @@ EXECUTE st1(101, 101);
 (1 row)
 
 -- subquery using stable function (can't be sent to remote)
-PREPARE st2(int) AS SELECT * FROM ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM ft2 t2 WHERE c1 > $1 AND c4::pg_catalog.date = '1970-01-17'::date) ORDER BY c1;
+PREPARE st2(number(38,0)) AS SELECT * FROM ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM ft2 t2 WHERE c1 > $1 AND c4::date = '1970-01-17'::date) ORDER BY c1;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Sort
    Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
    Sort Key: t1.c1
@@ -3972,32 +4901,33 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
          Join Filter: (t2.c3 = t1.c3)
          ->  Foreign Scan on public.ft1 t1
                Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
-               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" < 20))
+               Filter: (t1.c1 < '20'::number)
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
          ->  Materialize
                Output: t2.c3
                ->  Foreign Scan on public.ft2 t2
                      Output: t2.c3
-                     Filter: (((t2.c4)::date)::date = '1970-01-17'::date)
-                     Remote SQL: SELECT c3, c4 FROM "S 1"."T 1" WHERE (("C 1" > 10))
-(15 rows)
+                     Filter: ((t2.c1 > '10'::number) AND ((t2.c4)::date = '1970-01-17'::date))
+                     Remote SQL: SELECT "C 1", c3, c4 FROM "S 1"."T 1"
+(16 rows)
 
 EXECUTE st2(10, 20);
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
- 16 |  6 | 00016 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 16 | 6  | 00016 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
 (1 row)
 
 EXECUTE st2(101, 121);
- c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
------+----+-------+------------------------------+--------------------------+----+------------+-----
- 116 |  6 | 00116 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
+ c1  | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 116 | 6  | 00116 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
 (1 row)
 
 -- subquery using immutable function (can be sent to remote)
-PREPARE st3(int) AS SELECT * FROM ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM ft2 t2 WHERE c1 > $1 AND c5::pg_catalog.date = '1970-01-17'::date) ORDER BY c1;
+PREPARE st3(number(38,0)) AS SELECT * FROM ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM ft2 t2 WHERE c1 > $1 AND c5::date = '1970-01-17'::date) ORDER BY c1;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Sort
    Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
    Sort Key: t1.c1
@@ -4006,19 +4936,20 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
          Join Filter: (t2.c3 = t1.c3)
          ->  Foreign Scan on public.ft1 t1
                Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
-               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" < 20))
+               Filter: (t1.c1 < '20'::number)
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
          ->  Materialize
                Output: t2.c3
                ->  Foreign Scan on public.ft2 t2
                      Output: t2.c3
-                     Filter: (((t2.c5)::date)::date = '1970-01-17'::date)
-                     Remote SQL: SELECT c3, c5 FROM "S 1"."T 1" WHERE (("C 1" > 10))
-(15 rows)
+                     Filter: ((t2.c1 > '10'::number) AND ((t2.c5)::date = '1970-01-17'::date))
+                     Remote SQL: SELECT "C 1", c3, c5 FROM "S 1"."T 1"
+(16 rows)
 
 EXECUTE st3(10, 20);
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
- 16 |  6 | 00016 | Sat Jan 17 00:00:00 1970 PST | Sat Jan 17 00:00:00 1970 | 6  | 6          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 16 | 6  | 00016 | 1970-01-17 00:00:00.000000 -08:00 | 1970-01-17 00:00:00.000000 | 6  | 6          | foo
 (1 row)
 
 EXECUTE st3(20, 30);
@@ -4027,171 +4958,179 @@ EXECUTE st3(20, 30);
 (0 rows)
 
 -- custom plan should be chosen initially
-PREPARE st4(int) AS SELECT * FROM ft1 t1 WHERE t1.c1 = $1;
+PREPARE st4(number(38,0)) AS SELECT * FROM ft1 t1 WHERE t1.c1 = $1;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
-(3 rows)
+   Filter: (t1.c1 = '1'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
-(3 rows)
+   Filter: (t1.c1 = '1'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
-(3 rows)
+   Filter: (t1.c1 = '1'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
-(3 rows)
+   Filter: (t1.c1 = '1'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
-(3 rows)
+   Filter: (t1.c1 = '1'::number)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 -- once we try it enough times, should switch to generic plan
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = $1::integer))
-(3 rows)
+   Filter: (t1.c1 = $1)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 -- value of $1 should not be sent to remote
-PREPARE st5(user_enum,int) AS SELECT * FROM ft1 t1 WHERE c8 = $1 and c1 = $2;
+PREPARE st5(user_enum,number(38,0)) AS SELECT * FROM ft1 t1 WHERE c8 = $1 and c1 = $2;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: (t1.c8 = 'foo'::user_enum)
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
+   Filter: ((t1.c8 = 'foo'::user_enum) AND (t1.c1 = '1'::number))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: (t1.c8 = 'foo'::user_enum)
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
+   Filter: ((t1.c8 = 'foo'::user_enum) AND (t1.c1 = '1'::number))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: (t1.c8 = 'foo'::user_enum)
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
+   Filter: ((t1.c8 = 'foo'::user_enum) AND (t1.c1 = '1'::number))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: (t1.c8 = 'foo'::user_enum)
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
+   Filter: ((t1.c8 = 'foo'::user_enum) AND (t1.c1 = '1'::number))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: (t1.c8 = 'foo'::user_enum)
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = 1))
+   Filter: ((t1.c8 = 'foo'::user_enum) AND (t1.c1 = '1'::number))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Filter: (t1.c8 = $1)
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = $1::integer))
+   Filter: ((t1.c8 = $1) AND (t1.c1 = $2))
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
 (4 rows)
 
 EXECUTE st5('foo', 1);
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 -- altering FDW options requires replanning
 PREPARE st6 AS SELECT * FROM ft1 t1 WHERE t1.c1 = t1.c2;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (("C 1" = c2))
-(3 rows)
+   Filter: (t1.c1 = t1.c2)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(4 rows)
 
 PREPARE st7 AS INSERT INTO ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft1
    Remote SQL: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
    Batch Size: 1
    ->  Result
-         Output: NULL::integer, 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::varchar2, 'ft1       '::char(10), NULL::user_enum
+         Output: NULL::integer, '1001'::number(38,0), '101'::number(38,0), 'foo'::varchar2(1024), NULL::timestamp with time zone, NULL::timestamp, NULL::varchar2, 'ft1       '::char(10), NULL::user_enum
 (5 rows)
 
 ALTER TABLE "S 1"."T 1" RENAME TO "T 0";
 ALTER FOREIGN TABLE ft1 OPTIONS (SET table_name 'T 0');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 0" WHERE (("C 1" = c2))
-(3 rows)
+   Filter: (t1.c1 = t1.c2)
+   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 0"
+(4 rows)
 
 EXECUTE st6;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
-  2 |  2 | 00002 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
-  3 |  3 | 00003 | Sun Jan 04 00:00:00 1970 PST | Sun Jan 04 00:00:00 1970 | 3  | 3          | foo
-  4 |  4 | 00004 | Mon Jan 05 00:00:00 1970 PST | Mon Jan 05 00:00:00 1970 | 4  | 4          | foo
-  5 |  5 | 00005 | Tue Jan 06 00:00:00 1970 PST | Tue Jan 06 00:00:00 1970 | 5  | 5          | foo
-  6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo
-  7 |  7 | 00007 | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  8 |  8 | 00008 | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  9 |  9 | 00009 | Sat Jan 10 00:00:00 1970 PST | Sat Jan 10 00:00:00 1970 | 9  | 9          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+ 2  | 2  | 00002 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
+ 3  | 3  | 00003 | 1970-01-04 00:00:00.000000 -08:00 | 1970-01-04 00:00:00.000000 | 3  | 3          | foo
+ 4  | 4  | 00004 | 1970-01-05 00:00:00.000000 -08:00 | 1970-01-05 00:00:00.000000 | 4  | 4          | foo
+ 5  | 5  | 00005 | 1970-01-06 00:00:00.000000 -08:00 | 1970-01-06 00:00:00.000000 | 5  | 5          | foo
+ 6  | 6  | 00006 | 1970-01-07 00:00:00.000000 -08:00 | 1970-01-07 00:00:00.000000 | 6  | 6          | foo
+ 7  | 7  | 00007 | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 8  | 8  | 00008 | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 9  | 9  | 00009 | 1970-01-10 00:00:00.000000 -08:00 | 1970-01-10 00:00:00.000000 | 9  | 9          | foo
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft1
    Remote SQL: INSERT INTO "S 1"."T 0"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
    Batch Size: 1
    ->  Result
-         Output: NULL::integer, 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::varchar2, 'ft1       '::char(10), NULL::user_enum
+         Output: NULL::integer, '1001'::number(38,0), '101'::number(38,0), 'foo'::varchar2(1024), NULL::timestamp with time zone, NULL::timestamp, NULL::varchar2, 'ft1       '::char(10), NULL::user_enum
 (5 rows)
 
 ALTER TABLE "S 1"."T 0" RENAME TO "T 1";
@@ -4248,9 +5187,9 @@ SELECT * FROM ft1 t1 WHERE t1.tableoid = 'pg_class'::regclass LIMIT 1;
 (6 rows)
 
 SELECT * FROM ft1 t1 WHERE t1.tableoid = 'ft1'::regclass LIMIT 1;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -4263,9 +5202,9 @@ SELECT tableoid::regclass, * FROM ft1 t1 LIMIT 1;
 (3 rows)
 
 SELECT tableoid::regclass, * FROM ft1 t1 LIMIT 1;
- tableoid | c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----------+----+----+-------+------------------------------+--------------------------+----+------------+-----
- ft1      |  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ tableoid | c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----------+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ ft1      | 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -4278,9 +5217,9 @@ SELECT * FROM ft1 t1 WHERE t1.ctid = '(0,2)';
 (3 rows)
 
 SELECT * FROM ft1 t1 WHERE t1.ctid = '(0,2)';
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  2 |  2 | 00002 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 2  | 2  | 00002 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -4293,15 +5232,15 @@ SELECT ctid, * FROM ft1 t1 LIMIT 1;
 (3 rows)
 
 SELECT ctid, * FROM ft1 t1 LIMIT 1;
- ctid  | c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
--------+----+----+-------+------------------------------+--------------------------+----+------------+-----
- (0,1) |  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ ctid  | c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+-------+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ (0,1) | 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 -- ===================================================================
 -- used in PL/pgSQL function
 -- ===================================================================
-CREATE OR REPLACE FUNCTION f_test(p_c1 int) RETURNS int AS $$
+CREATE OR REPLACE FUNCTION f_test(p_c1 number(38,0)) RETURNS int AS $$
 DECLARE
 	v_c1 int;
 BEGIN
@@ -4317,12 +5256,12 @@ SELECT f_test(100);
     100
 (1 row)
 
-DROP FUNCTION f_test(int);
+DROP FUNCTION f_test(number(38,0));
 -- ===================================================================
 -- REINDEX
 -- ===================================================================
 -- remote table is not created here
-CREATE FOREIGN TABLE reindex_foreign (c1 int, c2 int)
+CREATE FOREIGN TABLE reindex_foreign (c1 number(38,0), c2 number(38,0))
   SERVER loopback2 OPTIONS (table_name 'reindex_local');
 REINDEX TABLE reindex_foreign; -- error
 ERROR:  "reindex_foreign" is not a table or materialized view
@@ -4330,7 +5269,7 @@ REINDEX TABLE CONCURRENTLY reindex_foreign; -- error
 ERROR:  "reindex_foreign" is not a table or materialized view
 DROP FOREIGN TABLE reindex_foreign;
 -- partitions and foreign tables
-CREATE TABLE reind_fdw_parent (c1 int) PARTITION BY RANGE (c1);
+CREATE TABLE reind_fdw_parent (c1 number(38,0)) PARTITION BY RANGE (c1);
 CREATE TABLE reind_fdw_0_10 PARTITION OF reind_fdw_parent
   FOR VALUES FROM (0) TO (10);
 CREATE FOREIGN TABLE reind_fdw_10_20 PARTITION OF reind_fdw_parent
@@ -4342,71 +5281,81 @@ DROP TABLE reind_fdw_parent;
 -- ===================================================================
 -- conversion error
 -- ===================================================================
-ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE int;
+ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE number(38,0);
 SELECT * FROM ft1 ftx(x1,x2,x3,x4,x5,x6,x7,x8) WHERE x1 = 1;  -- ERROR
-ERROR:  invalid input syntax for type integer: "foo"
+ERROR:  invalid input syntax for type numeric: "foo"
 CONTEXT:  column "x8" of foreign table "ftx"
 SELECT ftx.x1, ft2.c2, ftx.x8 FROM ft1 ftx(x1,x2,x3,x4,x5,x6,x7,x8), ft2
   WHERE ftx.x1 = ft2.c1 AND ftx.x1 = 1; -- ERROR
-ERROR:  invalid input syntax for type integer: "foo"
+ERROR:  invalid input syntax for type numeric: "foo"
 CONTEXT:  column "x8" of foreign table "ftx"
 SELECT ftx.x1, ft2.c2, ftx FROM ft1 ftx(x1,x2,x3,x4,x5,x6,x7,x8), ft2
   WHERE ftx.x1 = ft2.c1 AND ftx.x1 = 1; -- ERROR
-ERROR:  invalid input syntax for type integer: "foo"
-CONTEXT:  whole-row reference to foreign table "ftx"
+ERROR:  invalid input syntax for type numeric: "foo"
+CONTEXT:  column "x8" of foreign table "ftx"
 SELECT sum(c2), array_agg(c8) FROM ft1 GROUP BY c8; -- ERROR
-ERROR:  invalid input syntax for type integer: "foo"
-CONTEXT:  processing expression at position 2 in select list
+ERROR:  invalid input syntax for type numeric: "foo"
+CONTEXT:  column "c8" of foreign table "ft1"
 ANALYZE ft1; -- ERROR
-ERROR:  invalid input syntax for type integer: "foo"
+ERROR:  invalid input syntax for type numeric: "foo"
 CONTEXT:  column "c8" of foreign table "ft1"
 ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE user_enum;
 -- ===================================================================
 -- local type can be different from remote type in some cases,
 -- in particular if similarly-named operators do equivalent things
 -- ===================================================================
-ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE text;
+ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE varchar2(1024);
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1 WHERE c8 = 'foo' LIMIT 1;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Limit
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE ((c8 = 'foo')) LIMIT 1::bigint
-(3 rows)
+   ->  Foreign Scan on public.ft1
+         Output: c1, c2, c3, c4, c5, c6, c7, c8
+         Filter: (ft1.c8 = 'foo'::varchar2)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(6 rows)
 
 SELECT * FROM ft1 WHERE c8 = 'foo' LIMIT 1;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1 WHERE 'foo' = c8 LIMIT 1;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Limit
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (('foo' = c8)) LIMIT 1::bigint
-(3 rows)
+   ->  Foreign Scan on public.ft1
+         Output: c1, c2, c3, c4, c5, c6, c7, c8
+         Filter: ('foo'::varchar2 = ft1.c8)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(6 rows)
 
 SELECT * FROM ft1 WHERE 'foo' = c8 LIMIT 1;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 -- we declared c8 to be text locally, but it's still the same type on
 -- the remote which will balk if we try to do anything incompatible
 -- with that remote type
 SELECT * FROM ft1 WHERE c8 LIKE 'foo' LIMIT 1; -- ERROR
-ERROR:  operator does not exist: public.user_enum ~~ unknown
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
-CONTEXT:  remote SQL command: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE ((c8 ~~ 'foo')) LIMIT 1::bigint
-SELECT * FROM ft1 WHERE c8::text LIKE 'foo' LIMIT 1; -- ERROR; cast not pushed down
-ERROR:  operator does not exist: public.user_enum ~~ unknown
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
-CONTEXT:  remote SQL command: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE ((c8 ~~ 'foo')) LIMIT 1::bigint
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+(1 row)
+
+SELECT * FROM ft1 WHERE c8::varchar2(1024) LIKE 'foo' LIMIT 1; -- ERROR; cast not pushed down
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
+(1 row)
+
 ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE user_enum;
 -- ===================================================================
 -- subtransaction
@@ -4415,9 +5364,9 @@ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE user_enum;
 BEGIN;
 DECLARE c CURSOR FOR SELECT * FROM ft1 ORDER BY c1;
 FETCH c;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 SAVEPOINT s;
@@ -4427,59 +5376,61 @@ LINE 1: ERROR OUT;
         ^
 ROLLBACK TO s;
 FETCH c;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  2 |  2 | 00002 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 2  | 2  | 00002 | 1970-01-03 00:00:00.000000 -08:00 | 1970-01-03 00:00:00.000000 | 2  | 2          | foo
 (1 row)
 
 SAVEPOINT s;
 SELECT * FROM ft1 WHERE 1 / (c1 - 1) > 0;  -- ERROR
 ERROR:  division by zero
-CONTEXT:  remote SQL command: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1" WHERE (((1 / ("C 1" - 1)) > 0))
 ROLLBACK TO s;
 FETCH c;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  3 |  3 | 00003 | Sun Jan 04 00:00:00 1970 PST | Sun Jan 04 00:00:00 1970 | 3  | 3          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 3  | 3  | 00003 | 1970-01-04 00:00:00.000000 -08:00 | 1970-01-04 00:00:00.000000 | 3  | 3          | foo
 (1 row)
 
 SELECT * FROM ft1 ORDER BY c1 LIMIT 1;
- c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
-----+----+-------+------------------------------+--------------------------+----+------------+-----
-  1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
+ c1 | c2 |  c3   |                c4                 |             c5             | c6 |     c7     | c8  
+----+----+-------+-----------------------------------+----------------------------+----+------------+-----
+ 1  | 1  | 00001 | 1970-01-02 00:00:00.000000 -08:00 | 1970-01-02 00:00:00.000000 | 1  | 1          | foo
 (1 row)
 
 COMMIT;
 -- ===================================================================
 -- test handling of collations
 -- ===================================================================
-create table loct3 (f1 text collate "C" unique, f2 text, f3 varchar(10) unique);
-create foreign table ft3 (f1 text collate "C", f2 text, f3 varchar(10))
+create table loct3 (f1 varchar2(1024) collate "C" unique, f2 varchar2(1024), f3 varchar(10) unique);
+create foreign table ft3 (f1 varchar2(1024) collate "C", f2 varchar2(1024), f3 varchar(10))
   server loopback options (table_name 'loct3', use_remote_estimate 'true');
 -- can be sent to remote
 explain (verbose, costs off) select * from ft3 where f1 = 'foo';
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Foreign Scan on public.ft3
    Output: f1, f2, f3
-   Remote SQL: SELECT f1, f2, f3 FROM public.loct3 WHERE ((f1 = 'foo'))
-(3 rows)
+   Filter: (ft3.f1 = 'foo'::varchar2)
+   Remote SQL: SELECT f1, f2, f3 FROM public.loct3
+(4 rows)
 
 explain (verbose, costs off) select * from ft3 where f1 COLLATE "C" = 'foo';
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Foreign Scan on public.ft3
    Output: f1, f2, f3
-   Remote SQL: SELECT f1, f2, f3 FROM public.loct3 WHERE ((f1 = 'foo'))
-(3 rows)
+   Filter: (ft3.f1 = 'foo'::varchar2)
+   Remote SQL: SELECT f1, f2, f3 FROM public.loct3
+(4 rows)
 
 explain (verbose, costs off) select * from ft3 where f2 = 'foo';
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Foreign Scan on public.ft3
    Output: f1, f2, f3
-   Remote SQL: SELECT f1, f2, f3 FROM public.loct3 WHERE ((f2 = 'foo'))
-(3 rows)
+   Filter: (ft3.f2 = 'foo'::varchar2)
+   Remote SQL: SELECT f1, f2, f3 FROM public.loct3
+(4 rows)
 
 explain (verbose, costs off) select * from ft3 where f3 = 'foo';
                     QUERY PLAN                     
@@ -4505,16 +5456,16 @@ explain (verbose, costs off) select * from ft3 f, loct3 l
          Output: l.f1, l.f2, l.f3
          ->  Index Scan using loct3_f1_key on public.loct3 l
                Output: l.f1, l.f2, l.f3
-               Index Cond: (l.f1 = 'foo'::text)
+               Index Cond: (l.f1 = 'foo'::varchar2)
 (12 rows)
 
 -- can't be sent to remote
 explain (verbose, costs off) select * from ft3 where f1 COLLATE "POSIX" = 'foo';
-                    QUERY PLAN                     
----------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Foreign Scan on public.ft3
    Output: f1, f2, f3
-   Filter: ((ft3.f1)::text = 'foo'::text)
+   Filter: ((ft3.f1)::varchar2(1024) = 'foo'::varchar2)
    Remote SQL: SELECT f1, f2, f3 FROM public.loct3
 (4 rows)
 
@@ -4523,16 +5474,16 @@ explain (verbose, costs off) select * from ft3 where f1 = 'foo' COLLATE "C";
 ---------------------------------------------------
  Foreign Scan on public.ft3
    Output: f1, f2, f3
-   Filter: (ft3.f1 = 'foo'::text COLLATE "C")
+   Filter: (ft3.f1 = 'foo'::varchar2 COLLATE "C")
    Remote SQL: SELECT f1, f2, f3 FROM public.loct3
 (4 rows)
 
 explain (verbose, costs off) select * from ft3 where f2 COLLATE "C" = 'foo';
-                    QUERY PLAN                     
----------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Foreign Scan on public.ft3
    Output: f1, f2, f3
-   Filter: ((ft3.f2)::text = 'foo'::text)
+   Filter: ((ft3.f2)::varchar2(1024) = 'foo'::varchar2)
    Remote SQL: SELECT f1, f2, f3 FROM public.loct3
 (4 rows)
 
@@ -4541,7 +5492,7 @@ explain (verbose, costs off) select * from ft3 where f2 = 'foo' COLLATE "C";
 ---------------------------------------------------
  Foreign Scan on public.ft3
    Output: f1, f2, f3
-   Filter: (ft3.f2 = 'foo'::text COLLATE "C")
+   Filter: (ft3.f2 = 'foo'::varchar2 COLLATE "C")
    Remote SQL: SELECT f1, f2, f3 FROM public.loct3
 (4 rows)
 
@@ -4560,7 +5511,7 @@ explain (verbose, costs off) select * from ft3 f, loct3 l
          Output: l.f1, l.f2, l.f3
          ->  Index Scan using loct3_f1_key on public.loct3 l
                Output: l.f1, l.f2, l.f3
-               Index Cond: (l.f1 = 'foo'::text)
+               Index Cond: (l.f1 = 'foo'::varchar2)
 (12 rows)
 
 -- ===================================================================
@@ -4568,15 +5519,15 @@ explain (verbose, costs off) select * from ft3 f, loct3 l
 -- ===================================================================
 EXPLAIN (verbose, costs off)
 INSERT INTO ft2 (c1,c2,c3) SELECT c1+1000,c2+100, c3 || c3 FROM ft2 LIMIT 20;
-                                                                                                             QUERY PLAN                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft2
    Remote SQL: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
    Batch Size: 1
    ->  Subquery Scan on "*SELECT*"
-         Output: "*SELECT*"."?column?", "*SELECT*"."?column?_1", NULL::integer, "*SELECT*"."?column?_2", NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::varchar2, 'ft2       '::char(10), NULL::user_enum
+         Output: "*SELECT*"."?column?", "*SELECT*"."?column?_1", NULL::integer, "*SELECT*"."?column?_2", NULL::timestamp with time zone, NULL::timestamp, NULL::varchar2, 'ft2       '::char(10), NULL::user_enum
          ->  Foreign Scan on public.ft2 ft2_1
-               Output: (ft2_1.c1 + 1000), (ft2_1.c2 + 100), (ft2_1.c3 || ft2_1.c3)
+               Output: (ft2_1.c1 + '1000'::number), (ft2_1.c2 + '100'::number), ((ft2_1.c3)::text || (ft2_1.c3)::text)
                Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1" LIMIT 20::bigint
 (8 rows)
 
@@ -4593,256 +5544,276 @@ INSERT INTO ft2 (c1,c2,c3)
 INSERT INTO ft2 (c1,c2,c3) VALUES (1104,204,'ddd'), (1105,205,'eee');
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c2 = c2 + 300, c3 = c3 || '_update3' WHERE c1 % 10 = 3;              -- can be pushed down
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Update on public.ft2
-   ->  Foreign Update on public.ft2
-         Remote SQL: UPDATE "S 1"."T 1" SET c2 = (c2 + 300), c3 = (c3 || '_update3') WHERE ((("C 1" % 10) = 3))
-(3 rows)
+   Remote SQL: UPDATE "S 1"."T 1" SET c2 = $2, c3 = $3 WHERE ctid = $1
+   ->  Foreign Scan on public.ft2
+         Output: (c2 + '300'::number), ((c3)::text || '_update3'::text), ctid, ft2.*
+         Filter: ((ft2.c1 % '10'::number) = '3'::number)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
+(6 rows)
 
 UPDATE ft2 SET c2 = c2 + 300, c3 = c3 || '_update3' WHERE c1 % 10 = 3;
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c2 = c2 + 400, c3 = c3 || '_update7' WHERE c1 % 10 = 7 RETURNING *;  -- can be pushed down
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   ->  Foreign Update on public.ft2
-         Remote SQL: UPDATE "S 1"."T 1" SET c2 = (c2 + 400), c3 = (c3 || '_update7') WHERE ((("C 1" % 10) = 7)) RETURNING "C 1", c2, c3, c4, c5, c6, c7, c8
-(4 rows)
+   Remote SQL: UPDATE "S 1"."T 1" SET c2 = $2, c3 = $3 WHERE ctid = $1 RETURNING "C 1", c2, c3, c4, c5, c6, c7, c8
+   ->  Foreign Scan on public.ft2
+         Output: (c2 + '400'::number), ((c3)::text || '_update7'::text), ctid, ft2.*
+         Filter: ((ft2.c1 % '10'::number) = '7'::number)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
+(7 rows)
 
 UPDATE ft2 SET c2 = c2 + 400, c3 = c3 || '_update7' WHERE c1 % 10 = 7 RETURNING *;
-  c1  | c2  |         c3         |              c4              |            c5            | c6 |     c7     | c8  
-------+-----+--------------------+------------------------------+--------------------------+----+------------+-----
-    7 | 407 | 00007_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-   17 | 407 | 00017_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-   27 | 407 | 00027_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-   37 | 407 | 00037_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-   47 | 407 | 00047_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-   57 | 407 | 00057_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-   67 | 407 | 00067_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-   77 | 407 | 00077_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-   87 | 407 | 00087_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-   97 | 407 | 00097_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  107 | 407 | 00107_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  117 | 407 | 00117_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  127 | 407 | 00127_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  137 | 407 | 00137_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  147 | 407 | 00147_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  157 | 407 | 00157_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  167 | 407 | 00167_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  177 | 407 | 00177_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  187 | 407 | 00187_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  197 | 407 | 00197_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  207 | 407 | 00207_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  217 | 407 | 00217_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  227 | 407 | 00227_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  237 | 407 | 00237_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  247 | 407 | 00247_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  257 | 407 | 00257_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  267 | 407 | 00267_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  277 | 407 | 00277_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  287 | 407 | 00287_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  297 | 407 | 00297_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  307 | 407 | 00307_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  317 | 407 | 00317_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  327 | 407 | 00327_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  337 | 407 | 00337_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  347 | 407 | 00347_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  357 | 407 | 00357_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  367 | 407 | 00367_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  377 | 407 | 00377_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  387 | 407 | 00387_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  397 | 407 | 00397_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  407 | 407 | 00407_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  417 | 407 | 00417_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  427 | 407 | 00427_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  437 | 407 | 00437_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  447 | 407 | 00447_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  457 | 407 | 00457_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  467 | 407 | 00467_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  477 | 407 | 00477_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  487 | 407 | 00487_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  497 | 407 | 00497_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  507 | 407 | 00507_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  517 | 407 | 00517_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  527 | 407 | 00527_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  537 | 407 | 00537_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  547 | 407 | 00547_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  557 | 407 | 00557_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  567 | 407 | 00567_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  577 | 407 | 00577_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  587 | 407 | 00587_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  597 | 407 | 00597_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  607 | 407 | 00607_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  617 | 407 | 00617_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  627 | 407 | 00627_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  637 | 407 | 00637_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  647 | 407 | 00647_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  657 | 407 | 00657_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  667 | 407 | 00667_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  677 | 407 | 00677_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  687 | 407 | 00687_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  697 | 407 | 00697_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  707 | 407 | 00707_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  717 | 407 | 00717_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  727 | 407 | 00727_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  737 | 407 | 00737_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  747 | 407 | 00747_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  757 | 407 | 00757_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  767 | 407 | 00767_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  777 | 407 | 00777_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  787 | 407 | 00787_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  797 | 407 | 00797_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  807 | 407 | 00807_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  817 | 407 | 00817_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  827 | 407 | 00827_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  837 | 407 | 00837_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  847 | 407 | 00847_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  857 | 407 | 00857_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  867 | 407 | 00867_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  877 | 407 | 00877_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  887 | 407 | 00887_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  897 | 407 | 00897_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
-  907 | 407 | 00907_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
-  917 | 407 | 00917_update7      | Sun Jan 18 00:00:00 1970 PST | Sun Jan 18 00:00:00 1970 | 7  | 7          | foo
-  927 | 407 | 00927_update7      | Wed Jan 28 00:00:00 1970 PST | Wed Jan 28 00:00:00 1970 | 7  | 7          | foo
-  937 | 407 | 00937_update7      | Sat Feb 07 00:00:00 1970 PST | Sat Feb 07 00:00:00 1970 | 7  | 7          | foo
-  947 | 407 | 00947_update7      | Tue Feb 17 00:00:00 1970 PST | Tue Feb 17 00:00:00 1970 | 7  | 7          | foo
-  957 | 407 | 00957_update7      | Fri Feb 27 00:00:00 1970 PST | Fri Feb 27 00:00:00 1970 | 7  | 7          | foo
-  967 | 407 | 00967_update7      | Mon Mar 09 00:00:00 1970 PST | Mon Mar 09 00:00:00 1970 | 7  | 7          | foo
-  977 | 407 | 00977_update7      | Thu Mar 19 00:00:00 1970 PST | Thu Mar 19 00:00:00 1970 | 7  | 7          | foo
-  987 | 407 | 00987_update7      | Sun Mar 29 00:00:00 1970 PST | Sun Mar 29 00:00:00 1970 | 7  | 7          | foo
-  997 | 407 | 00997_update7      | Wed Apr 08 00:00:00 1970 PST | Wed Apr 08 00:00:00 1970 | 7  | 7          | foo
- 1007 | 507 | 0000700007_update7 |                              |                          |    | ft2        | 
- 1017 | 507 | 0001700017_update7 |                              |                          |    | ft2        | 
+  c1  | c2  |         c3         |                c4                 |             c5             | c6 |     c7     | c8  
+------+-----+--------------------+-----------------------------------+----------------------------+----+------------+-----
+ 7    | 407 | 00007_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 17   | 407 | 00017_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 27   | 407 | 00027_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 37   | 407 | 00037_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 47   | 407 | 00047_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 57   | 407 | 00057_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 67   | 407 | 00067_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 77   | 407 | 00077_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 87   | 407 | 00087_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 97   | 407 | 00097_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 107  | 407 | 00107_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 117  | 407 | 00117_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 127  | 407 | 00127_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 137  | 407 | 00137_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 147  | 407 | 00147_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 157  | 407 | 00157_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 167  | 407 | 00167_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 177  | 407 | 00177_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 187  | 407 | 00187_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 197  | 407 | 00197_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 207  | 407 | 00207_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 217  | 407 | 00217_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 227  | 407 | 00227_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 237  | 407 | 00237_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 247  | 407 | 00247_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 257  | 407 | 00257_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 267  | 407 | 00267_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 277  | 407 | 00277_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 287  | 407 | 00287_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 297  | 407 | 00297_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 307  | 407 | 00307_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 317  | 407 | 00317_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 327  | 407 | 00327_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 337  | 407 | 00337_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 347  | 407 | 00347_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 357  | 407 | 00357_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 367  | 407 | 00367_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 377  | 407 | 00377_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 387  | 407 | 00387_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 397  | 407 | 00397_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 407  | 407 | 00407_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 417  | 407 | 00417_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 427  | 407 | 00427_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 437  | 407 | 00437_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 447  | 407 | 00447_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 457  | 407 | 00457_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 467  | 407 | 00467_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 477  | 407 | 00477_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 487  | 407 | 00487_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 497  | 407 | 00497_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 507  | 407 | 00507_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 517  | 407 | 00517_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 527  | 407 | 00527_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 537  | 407 | 00537_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 547  | 407 | 00547_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 557  | 407 | 00557_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 567  | 407 | 00567_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 577  | 407 | 00577_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 587  | 407 | 00587_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 597  | 407 | 00597_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 607  | 407 | 00607_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 617  | 407 | 00617_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 627  | 407 | 00627_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 637  | 407 | 00637_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 647  | 407 | 00647_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 657  | 407 | 00657_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 667  | 407 | 00667_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 677  | 407 | 00677_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 687  | 407 | 00687_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 697  | 407 | 00697_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 707  | 407 | 00707_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 717  | 407 | 00717_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 727  | 407 | 00727_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 737  | 407 | 00737_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 747  | 407 | 00747_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 757  | 407 | 00757_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 767  | 407 | 00767_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 777  | 407 | 00777_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 787  | 407 | 00787_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 797  | 407 | 00797_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 807  | 407 | 00807_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 817  | 407 | 00817_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 827  | 407 | 00827_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 837  | 407 | 00837_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 847  | 407 | 00847_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 857  | 407 | 00857_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 867  | 407 | 00867_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 877  | 407 | 00877_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 887  | 407 | 00887_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 897  | 407 | 00897_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 907  | 407 | 00907_update7      | 1970-01-08 00:00:00.000000 -08:00 | 1970-01-08 00:00:00.000000 | 7  | 7          | foo
+ 917  | 407 | 00917_update7      | 1970-01-18 00:00:00.000000 -08:00 | 1970-01-18 00:00:00.000000 | 7  | 7          | foo
+ 927  | 407 | 00927_update7      | 1970-01-28 00:00:00.000000 -08:00 | 1970-01-28 00:00:00.000000 | 7  | 7          | foo
+ 937  | 407 | 00937_update7      | 1970-02-07 00:00:00.000000 -08:00 | 1970-02-07 00:00:00.000000 | 7  | 7          | foo
+ 947  | 407 | 00947_update7      | 1970-02-17 00:00:00.000000 -08:00 | 1970-02-17 00:00:00.000000 | 7  | 7          | foo
+ 957  | 407 | 00957_update7      | 1970-02-27 00:00:00.000000 -08:00 | 1970-02-27 00:00:00.000000 | 7  | 7          | foo
+ 967  | 407 | 00967_update7      | 1970-03-09 00:00:00.000000 -08:00 | 1970-03-09 00:00:00.000000 | 7  | 7          | foo
+ 977  | 407 | 00977_update7      | 1970-03-19 00:00:00.000000 -08:00 | 1970-03-19 00:00:00.000000 | 7  | 7          | foo
+ 987  | 407 | 00987_update7      | 1970-03-29 00:00:00.000000 -08:00 | 1970-03-29 00:00:00.000000 | 7  | 7          | foo
+ 997  | 407 | 00997_update7      | 1970-04-08 00:00:00.000000 -08:00 | 1970-04-08 00:00:00.000000 | 7  | 7          | foo
+ 1007 | 507 | 0000700007_update7 |                                   |                            |    | ft2        | 
+ 1017 | 507 | 0001700017_update7 |                                   |                            |    | ft2        | 
 (102 rows)
 
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c2 = ft2.c2 + 500, c3 = ft2.c3 || '_update9', c7 = DEFAULT
   FROM ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 9;                               -- can be pushed down
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
-   ->  Foreign Update
-         Remote SQL: UPDATE "S 1"."T 1" r1 SET c2 = (r1.c2 + 500), c3 = (r1.c3 || '_update9'), c7 = 'ft2       '::char(10) FROM "S 1"."T 1" r2 WHERE ((r1.c2 = r2."C 1")) AND (((r2."C 1" % 10) = 9))
-(3 rows)
+   Remote SQL: UPDATE "S 1"."T 1" SET c2 = $2, c3 = $3, c7 = $4 WHERE ctid = $1
+   ->  Hash Join
+         Output: (ft2.c2 + '500'::number), ((ft2.c3)::text || '_update9'::text), 'ft2       '::char(10), ft2.ctid, ft2.*, ft1.*
+         Hash Cond: (ft2.c2 = ft1.c1)
+         ->  Foreign Scan on public.ft2
+               Output: ft2.c2, ft2.c3, ft2.ctid, ft2.*
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
+         ->  Hash
+               Output: ft1.*, ft1.c1
+               ->  Foreign Scan on public.ft1
+                     Output: ft1.*, ft1.c1
+                     Filter: ((ft1.c1 % '10'::number) = '9'::number)
+                     Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(14 rows)
 
 UPDATE ft2 SET c2 = ft2.c2 + 500, c3 = ft2.c3 || '_update9', c7 = DEFAULT
   FROM ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 9;
 EXPLAIN (verbose, costs off)
   DELETE FROM ft2 WHERE c1 % 10 = 5 RETURNING c1, c4;                               -- can be pushed down
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Delete on public.ft2
    Output: c1, c4
-   ->  Foreign Delete on public.ft2
-         Remote SQL: DELETE FROM "S 1"."T 1" WHERE ((("C 1" % 10) = 5)) RETURNING "C 1", c4
-(4 rows)
+   Remote SQL: DELETE FROM "S 1"."T 1" WHERE ctid = $1 RETURNING "C 1", c4
+   ->  Foreign Scan on public.ft2
+         Output: ctid
+         Filter: ((ft2.c1 % '10'::number) = '5'::number)
+         Remote SQL: SELECT "C 1", ctid FROM "S 1"."T 1" FOR UPDATE
+(7 rows)
 
 DELETE FROM ft2 WHERE c1 % 10 = 5 RETURNING c1, c4;
-  c1  |              c4              
-------+------------------------------
-    5 | Tue Jan 06 00:00:00 1970 PST
-   15 | Fri Jan 16 00:00:00 1970 PST
-   25 | Mon Jan 26 00:00:00 1970 PST
-   35 | Thu Feb 05 00:00:00 1970 PST
-   45 | Sun Feb 15 00:00:00 1970 PST
-   55 | Wed Feb 25 00:00:00 1970 PST
-   65 | Sat Mar 07 00:00:00 1970 PST
-   75 | Tue Mar 17 00:00:00 1970 PST
-   85 | Fri Mar 27 00:00:00 1970 PST
-   95 | Mon Apr 06 00:00:00 1970 PST
-  105 | Tue Jan 06 00:00:00 1970 PST
-  115 | Fri Jan 16 00:00:00 1970 PST
-  125 | Mon Jan 26 00:00:00 1970 PST
-  135 | Thu Feb 05 00:00:00 1970 PST
-  145 | Sun Feb 15 00:00:00 1970 PST
-  155 | Wed Feb 25 00:00:00 1970 PST
-  165 | Sat Mar 07 00:00:00 1970 PST
-  175 | Tue Mar 17 00:00:00 1970 PST
-  185 | Fri Mar 27 00:00:00 1970 PST
-  195 | Mon Apr 06 00:00:00 1970 PST
-  205 | Tue Jan 06 00:00:00 1970 PST
-  215 | Fri Jan 16 00:00:00 1970 PST
-  225 | Mon Jan 26 00:00:00 1970 PST
-  235 | Thu Feb 05 00:00:00 1970 PST
-  245 | Sun Feb 15 00:00:00 1970 PST
-  255 | Wed Feb 25 00:00:00 1970 PST
-  265 | Sat Mar 07 00:00:00 1970 PST
-  275 | Tue Mar 17 00:00:00 1970 PST
-  285 | Fri Mar 27 00:00:00 1970 PST
-  295 | Mon Apr 06 00:00:00 1970 PST
-  305 | Tue Jan 06 00:00:00 1970 PST
-  315 | Fri Jan 16 00:00:00 1970 PST
-  325 | Mon Jan 26 00:00:00 1970 PST
-  335 | Thu Feb 05 00:00:00 1970 PST
-  345 | Sun Feb 15 00:00:00 1970 PST
-  355 | Wed Feb 25 00:00:00 1970 PST
-  365 | Sat Mar 07 00:00:00 1970 PST
-  375 | Tue Mar 17 00:00:00 1970 PST
-  385 | Fri Mar 27 00:00:00 1970 PST
-  395 | Mon Apr 06 00:00:00 1970 PST
-  405 | Tue Jan 06 00:00:00 1970 PST
-  415 | Fri Jan 16 00:00:00 1970 PST
-  425 | Mon Jan 26 00:00:00 1970 PST
-  435 | Thu Feb 05 00:00:00 1970 PST
-  445 | Sun Feb 15 00:00:00 1970 PST
-  455 | Wed Feb 25 00:00:00 1970 PST
-  465 | Sat Mar 07 00:00:00 1970 PST
-  475 | Tue Mar 17 00:00:00 1970 PST
-  485 | Fri Mar 27 00:00:00 1970 PST
-  495 | Mon Apr 06 00:00:00 1970 PST
-  505 | Tue Jan 06 00:00:00 1970 PST
-  515 | Fri Jan 16 00:00:00 1970 PST
-  525 | Mon Jan 26 00:00:00 1970 PST
-  535 | Thu Feb 05 00:00:00 1970 PST
-  545 | Sun Feb 15 00:00:00 1970 PST
-  555 | Wed Feb 25 00:00:00 1970 PST
-  565 | Sat Mar 07 00:00:00 1970 PST
-  575 | Tue Mar 17 00:00:00 1970 PST
-  585 | Fri Mar 27 00:00:00 1970 PST
-  595 | Mon Apr 06 00:00:00 1970 PST
-  605 | Tue Jan 06 00:00:00 1970 PST
-  615 | Fri Jan 16 00:00:00 1970 PST
-  625 | Mon Jan 26 00:00:00 1970 PST
-  635 | Thu Feb 05 00:00:00 1970 PST
-  645 | Sun Feb 15 00:00:00 1970 PST
-  655 | Wed Feb 25 00:00:00 1970 PST
-  665 | Sat Mar 07 00:00:00 1970 PST
-  675 | Tue Mar 17 00:00:00 1970 PST
-  685 | Fri Mar 27 00:00:00 1970 PST
-  695 | Mon Apr 06 00:00:00 1970 PST
-  705 | Tue Jan 06 00:00:00 1970 PST
-  715 | Fri Jan 16 00:00:00 1970 PST
-  725 | Mon Jan 26 00:00:00 1970 PST
-  735 | Thu Feb 05 00:00:00 1970 PST
-  745 | Sun Feb 15 00:00:00 1970 PST
-  755 | Wed Feb 25 00:00:00 1970 PST
-  765 | Sat Mar 07 00:00:00 1970 PST
-  775 | Tue Mar 17 00:00:00 1970 PST
-  785 | Fri Mar 27 00:00:00 1970 PST
-  795 | Mon Apr 06 00:00:00 1970 PST
-  805 | Tue Jan 06 00:00:00 1970 PST
-  815 | Fri Jan 16 00:00:00 1970 PST
-  825 | Mon Jan 26 00:00:00 1970 PST
-  835 | Thu Feb 05 00:00:00 1970 PST
-  845 | Sun Feb 15 00:00:00 1970 PST
-  855 | Wed Feb 25 00:00:00 1970 PST
-  865 | Sat Mar 07 00:00:00 1970 PST
-  875 | Tue Mar 17 00:00:00 1970 PST
-  885 | Fri Mar 27 00:00:00 1970 PST
-  895 | Mon Apr 06 00:00:00 1970 PST
-  905 | Tue Jan 06 00:00:00 1970 PST
-  915 | Fri Jan 16 00:00:00 1970 PST
-  925 | Mon Jan 26 00:00:00 1970 PST
-  935 | Thu Feb 05 00:00:00 1970 PST
-  945 | Sun Feb 15 00:00:00 1970 PST
-  955 | Wed Feb 25 00:00:00 1970 PST
-  965 | Sat Mar 07 00:00:00 1970 PST
-  975 | Tue Mar 17 00:00:00 1970 PST
-  985 | Fri Mar 27 00:00:00 1970 PST
-  995 | Mon Apr 06 00:00:00 1970 PST
+  c1  |                c4                 
+------+-----------------------------------
+ 5    | 1970-01-06 00:00:00.000000 -08:00
+ 15   | 1970-01-16 00:00:00.000000 -08:00
+ 25   | 1970-01-26 00:00:00.000000 -08:00
+ 35   | 1970-02-05 00:00:00.000000 -08:00
+ 45   | 1970-02-15 00:00:00.000000 -08:00
+ 55   | 1970-02-25 00:00:00.000000 -08:00
+ 65   | 1970-03-07 00:00:00.000000 -08:00
+ 75   | 1970-03-17 00:00:00.000000 -08:00
+ 85   | 1970-03-27 00:00:00.000000 -08:00
+ 95   | 1970-04-06 00:00:00.000000 -08:00
+ 105  | 1970-01-06 00:00:00.000000 -08:00
+ 115  | 1970-01-16 00:00:00.000000 -08:00
+ 125  | 1970-01-26 00:00:00.000000 -08:00
+ 135  | 1970-02-05 00:00:00.000000 -08:00
+ 145  | 1970-02-15 00:00:00.000000 -08:00
+ 155  | 1970-02-25 00:00:00.000000 -08:00
+ 165  | 1970-03-07 00:00:00.000000 -08:00
+ 175  | 1970-03-17 00:00:00.000000 -08:00
+ 185  | 1970-03-27 00:00:00.000000 -08:00
+ 195  | 1970-04-06 00:00:00.000000 -08:00
+ 205  | 1970-01-06 00:00:00.000000 -08:00
+ 215  | 1970-01-16 00:00:00.000000 -08:00
+ 225  | 1970-01-26 00:00:00.000000 -08:00
+ 235  | 1970-02-05 00:00:00.000000 -08:00
+ 245  | 1970-02-15 00:00:00.000000 -08:00
+ 255  | 1970-02-25 00:00:00.000000 -08:00
+ 265  | 1970-03-07 00:00:00.000000 -08:00
+ 275  | 1970-03-17 00:00:00.000000 -08:00
+ 285  | 1970-03-27 00:00:00.000000 -08:00
+ 295  | 1970-04-06 00:00:00.000000 -08:00
+ 305  | 1970-01-06 00:00:00.000000 -08:00
+ 315  | 1970-01-16 00:00:00.000000 -08:00
+ 325  | 1970-01-26 00:00:00.000000 -08:00
+ 335  | 1970-02-05 00:00:00.000000 -08:00
+ 345  | 1970-02-15 00:00:00.000000 -08:00
+ 355  | 1970-02-25 00:00:00.000000 -08:00
+ 365  | 1970-03-07 00:00:00.000000 -08:00
+ 375  | 1970-03-17 00:00:00.000000 -08:00
+ 385  | 1970-03-27 00:00:00.000000 -08:00
+ 395  | 1970-04-06 00:00:00.000000 -08:00
+ 405  | 1970-01-06 00:00:00.000000 -08:00
+ 415  | 1970-01-16 00:00:00.000000 -08:00
+ 425  | 1970-01-26 00:00:00.000000 -08:00
+ 435  | 1970-02-05 00:00:00.000000 -08:00
+ 445  | 1970-02-15 00:00:00.000000 -08:00
+ 455  | 1970-02-25 00:00:00.000000 -08:00
+ 465  | 1970-03-07 00:00:00.000000 -08:00
+ 475  | 1970-03-17 00:00:00.000000 -08:00
+ 485  | 1970-03-27 00:00:00.000000 -08:00
+ 495  | 1970-04-06 00:00:00.000000 -08:00
+ 505  | 1970-01-06 00:00:00.000000 -08:00
+ 515  | 1970-01-16 00:00:00.000000 -08:00
+ 525  | 1970-01-26 00:00:00.000000 -08:00
+ 535  | 1970-02-05 00:00:00.000000 -08:00
+ 545  | 1970-02-15 00:00:00.000000 -08:00
+ 555  | 1970-02-25 00:00:00.000000 -08:00
+ 565  | 1970-03-07 00:00:00.000000 -08:00
+ 575  | 1970-03-17 00:00:00.000000 -08:00
+ 585  | 1970-03-27 00:00:00.000000 -08:00
+ 595  | 1970-04-06 00:00:00.000000 -08:00
+ 605  | 1970-01-06 00:00:00.000000 -08:00
+ 615  | 1970-01-16 00:00:00.000000 -08:00
+ 625  | 1970-01-26 00:00:00.000000 -08:00
+ 635  | 1970-02-05 00:00:00.000000 -08:00
+ 645  | 1970-02-15 00:00:00.000000 -08:00
+ 655  | 1970-02-25 00:00:00.000000 -08:00
+ 665  | 1970-03-07 00:00:00.000000 -08:00
+ 675  | 1970-03-17 00:00:00.000000 -08:00
+ 685  | 1970-03-27 00:00:00.000000 -08:00
+ 695  | 1970-04-06 00:00:00.000000 -08:00
+ 705  | 1970-01-06 00:00:00.000000 -08:00
+ 715  | 1970-01-16 00:00:00.000000 -08:00
+ 725  | 1970-01-26 00:00:00.000000 -08:00
+ 735  | 1970-02-05 00:00:00.000000 -08:00
+ 745  | 1970-02-15 00:00:00.000000 -08:00
+ 755  | 1970-02-25 00:00:00.000000 -08:00
+ 765  | 1970-03-07 00:00:00.000000 -08:00
+ 775  | 1970-03-17 00:00:00.000000 -08:00
+ 785  | 1970-03-27 00:00:00.000000 -08:00
+ 795  | 1970-04-06 00:00:00.000000 -08:00
+ 805  | 1970-01-06 00:00:00.000000 -08:00
+ 815  | 1970-01-16 00:00:00.000000 -08:00
+ 825  | 1970-01-26 00:00:00.000000 -08:00
+ 835  | 1970-02-05 00:00:00.000000 -08:00
+ 845  | 1970-02-15 00:00:00.000000 -08:00
+ 855  | 1970-02-25 00:00:00.000000 -08:00
+ 865  | 1970-03-07 00:00:00.000000 -08:00
+ 875  | 1970-03-17 00:00:00.000000 -08:00
+ 885  | 1970-03-27 00:00:00.000000 -08:00
+ 895  | 1970-04-06 00:00:00.000000 -08:00
+ 905  | 1970-01-06 00:00:00.000000 -08:00
+ 915  | 1970-01-16 00:00:00.000000 -08:00
+ 925  | 1970-01-26 00:00:00.000000 -08:00
+ 935  | 1970-02-05 00:00:00.000000 -08:00
+ 945  | 1970-02-15 00:00:00.000000 -08:00
+ 955  | 1970-02-25 00:00:00.000000 -08:00
+ 965  | 1970-03-07 00:00:00.000000 -08:00
+ 975  | 1970-03-17 00:00:00.000000 -08:00
+ 985  | 1970-03-27 00:00:00.000000 -08:00
+ 995  | 1970-04-06 00:00:00.000000 -08:00
  1005 | 
  1015 | 
  1105 | 
@@ -4850,817 +5821,828 @@ DELETE FROM ft2 WHERE c1 % 10 = 5 RETURNING c1, c4;
 
 EXPLAIN (verbose, costs off)
 DELETE FROM ft2 USING ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 2;                -- can be pushed down
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Delete on public.ft2
-   ->  Foreign Delete
-         Remote SQL: DELETE FROM "S 1"."T 1" r1 USING "S 1"."T 1" r2 WHERE ((r1.c2 = r2."C 1")) AND (((r2."C 1" % 10) = 2))
-(3 rows)
+   Remote SQL: DELETE FROM "S 1"."T 1" WHERE ctid = $1
+   ->  Hash Join
+         Output: ft2.ctid, ft1.*
+         Hash Cond: (ft2.c2 = ft1.c1)
+         ->  Foreign Scan on public.ft2
+               Output: ft2.ctid, ft2.c2
+               Remote SQL: SELECT c2, ctid FROM "S 1"."T 1" FOR UPDATE
+         ->  Hash
+               Output: ft1.*, ft1.c1
+               ->  Foreign Scan on public.ft1
+                     Output: ft1.*, ft1.c1
+                     Filter: ((ft1.c1 % '10'::number) = '2'::number)
+                     Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+(14 rows)
 
 DELETE FROM ft2 USING ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 2;
 SELECT c1,c2,c3,c4 FROM ft2 ORDER BY c1;
-  c1  | c2  |         c3         |              c4              
-------+-----+--------------------+------------------------------
-    1 |   1 | 00001              | Fri Jan 02 00:00:00 1970 PST
-    3 | 303 | 00003_update3      | Sun Jan 04 00:00:00 1970 PST
-    4 |   4 | 00004              | Mon Jan 05 00:00:00 1970 PST
-    6 |   6 | 00006              | Wed Jan 07 00:00:00 1970 PST
-    7 | 407 | 00007_update7      | Thu Jan 08 00:00:00 1970 PST
-    8 |   8 | 00008              | Fri Jan 09 00:00:00 1970 PST
-    9 | 509 | 00009_update9      | Sat Jan 10 00:00:00 1970 PST
-   10 |   0 | 00010              | Sun Jan 11 00:00:00 1970 PST
-   11 |   1 | 00011              | Mon Jan 12 00:00:00 1970 PST
-   13 | 303 | 00013_update3      | Wed Jan 14 00:00:00 1970 PST
-   14 |   4 | 00014              | Thu Jan 15 00:00:00 1970 PST
-   16 |   6 | 00016              | Sat Jan 17 00:00:00 1970 PST
-   17 | 407 | 00017_update7      | Sun Jan 18 00:00:00 1970 PST
-   18 |   8 | 00018              | Mon Jan 19 00:00:00 1970 PST
-   19 | 509 | 00019_update9      | Tue Jan 20 00:00:00 1970 PST
-   20 |   0 | 00020              | Wed Jan 21 00:00:00 1970 PST
-   21 |   1 | 00021              | Thu Jan 22 00:00:00 1970 PST
-   23 | 303 | 00023_update3      | Sat Jan 24 00:00:00 1970 PST
-   24 |   4 | 00024              | Sun Jan 25 00:00:00 1970 PST
-   26 |   6 | 00026              | Tue Jan 27 00:00:00 1970 PST
-   27 | 407 | 00027_update7      | Wed Jan 28 00:00:00 1970 PST
-   28 |   8 | 00028              | Thu Jan 29 00:00:00 1970 PST
-   29 | 509 | 00029_update9      | Fri Jan 30 00:00:00 1970 PST
-   30 |   0 | 00030              | Sat Jan 31 00:00:00 1970 PST
-   31 |   1 | 00031              | Sun Feb 01 00:00:00 1970 PST
-   33 | 303 | 00033_update3      | Tue Feb 03 00:00:00 1970 PST
-   34 |   4 | 00034              | Wed Feb 04 00:00:00 1970 PST
-   36 |   6 | 00036              | Fri Feb 06 00:00:00 1970 PST
-   37 | 407 | 00037_update7      | Sat Feb 07 00:00:00 1970 PST
-   38 |   8 | 00038              | Sun Feb 08 00:00:00 1970 PST
-   39 | 509 | 00039_update9      | Mon Feb 09 00:00:00 1970 PST
-   40 |   0 | 00040              | Tue Feb 10 00:00:00 1970 PST
-   41 |   1 | 00041              | Wed Feb 11 00:00:00 1970 PST
-   43 | 303 | 00043_update3      | Fri Feb 13 00:00:00 1970 PST
-   44 |   4 | 00044              | Sat Feb 14 00:00:00 1970 PST
-   46 |   6 | 00046              | Mon Feb 16 00:00:00 1970 PST
-   47 | 407 | 00047_update7      | Tue Feb 17 00:00:00 1970 PST
-   48 |   8 | 00048              | Wed Feb 18 00:00:00 1970 PST
-   49 | 509 | 00049_update9      | Thu Feb 19 00:00:00 1970 PST
-   50 |   0 | 00050              | Fri Feb 20 00:00:00 1970 PST
-   51 |   1 | 00051              | Sat Feb 21 00:00:00 1970 PST
-   53 | 303 | 00053_update3      | Mon Feb 23 00:00:00 1970 PST
-   54 |   4 | 00054              | Tue Feb 24 00:00:00 1970 PST
-   56 |   6 | 00056              | Thu Feb 26 00:00:00 1970 PST
-   57 | 407 | 00057_update7      | Fri Feb 27 00:00:00 1970 PST
-   58 |   8 | 00058              | Sat Feb 28 00:00:00 1970 PST
-   59 | 509 | 00059_update9      | Sun Mar 01 00:00:00 1970 PST
-   60 |   0 | 00060              | Mon Mar 02 00:00:00 1970 PST
-   61 |   1 | 00061              | Tue Mar 03 00:00:00 1970 PST
-   63 | 303 | 00063_update3      | Thu Mar 05 00:00:00 1970 PST
-   64 |   4 | 00064              | Fri Mar 06 00:00:00 1970 PST
-   66 |   6 | 00066              | Sun Mar 08 00:00:00 1970 PST
-   67 | 407 | 00067_update7      | Mon Mar 09 00:00:00 1970 PST
-   68 |   8 | 00068              | Tue Mar 10 00:00:00 1970 PST
-   69 | 509 | 00069_update9      | Wed Mar 11 00:00:00 1970 PST
-   70 |   0 | 00070              | Thu Mar 12 00:00:00 1970 PST
-   71 |   1 | 00071              | Fri Mar 13 00:00:00 1970 PST
-   73 | 303 | 00073_update3      | Sun Mar 15 00:00:00 1970 PST
-   74 |   4 | 00074              | Mon Mar 16 00:00:00 1970 PST
-   76 |   6 | 00076              | Wed Mar 18 00:00:00 1970 PST
-   77 | 407 | 00077_update7      | Thu Mar 19 00:00:00 1970 PST
-   78 |   8 | 00078              | Fri Mar 20 00:00:00 1970 PST
-   79 | 509 | 00079_update9      | Sat Mar 21 00:00:00 1970 PST
-   80 |   0 | 00080              | Sun Mar 22 00:00:00 1970 PST
-   81 |   1 | 00081              | Mon Mar 23 00:00:00 1970 PST
-   83 | 303 | 00083_update3      | Wed Mar 25 00:00:00 1970 PST
-   84 |   4 | 00084              | Thu Mar 26 00:00:00 1970 PST
-   86 |   6 | 00086              | Sat Mar 28 00:00:00 1970 PST
-   87 | 407 | 00087_update7      | Sun Mar 29 00:00:00 1970 PST
-   88 |   8 | 00088              | Mon Mar 30 00:00:00 1970 PST
-   89 | 509 | 00089_update9      | Tue Mar 31 00:00:00 1970 PST
-   90 |   0 | 00090              | Wed Apr 01 00:00:00 1970 PST
-   91 |   1 | 00091              | Thu Apr 02 00:00:00 1970 PST
-   93 | 303 | 00093_update3      | Sat Apr 04 00:00:00 1970 PST
-   94 |   4 | 00094              | Sun Apr 05 00:00:00 1970 PST
-   96 |   6 | 00096              | Tue Apr 07 00:00:00 1970 PST
-   97 | 407 | 00097_update7      | Wed Apr 08 00:00:00 1970 PST
-   98 |   8 | 00098              | Thu Apr 09 00:00:00 1970 PST
-   99 | 509 | 00099_update9      | Fri Apr 10 00:00:00 1970 PST
-  100 |   0 | 00100              | Thu Jan 01 00:00:00 1970 PST
-  101 |   1 | 00101              | Fri Jan 02 00:00:00 1970 PST
-  103 | 303 | 00103_update3      | Sun Jan 04 00:00:00 1970 PST
-  104 |   4 | 00104              | Mon Jan 05 00:00:00 1970 PST
-  106 |   6 | 00106              | Wed Jan 07 00:00:00 1970 PST
-  107 | 407 | 00107_update7      | Thu Jan 08 00:00:00 1970 PST
-  108 |   8 | 00108              | Fri Jan 09 00:00:00 1970 PST
-  109 | 509 | 00109_update9      | Sat Jan 10 00:00:00 1970 PST
-  110 |   0 | 00110              | Sun Jan 11 00:00:00 1970 PST
-  111 |   1 | 00111              | Mon Jan 12 00:00:00 1970 PST
-  113 | 303 | 00113_update3      | Wed Jan 14 00:00:00 1970 PST
-  114 |   4 | 00114              | Thu Jan 15 00:00:00 1970 PST
-  116 |   6 | 00116              | Sat Jan 17 00:00:00 1970 PST
-  117 | 407 | 00117_update7      | Sun Jan 18 00:00:00 1970 PST
-  118 |   8 | 00118              | Mon Jan 19 00:00:00 1970 PST
-  119 | 509 | 00119_update9      | Tue Jan 20 00:00:00 1970 PST
-  120 |   0 | 00120              | Wed Jan 21 00:00:00 1970 PST
-  121 |   1 | 00121              | Thu Jan 22 00:00:00 1970 PST
-  123 | 303 | 00123_update3      | Sat Jan 24 00:00:00 1970 PST
-  124 |   4 | 00124              | Sun Jan 25 00:00:00 1970 PST
-  126 |   6 | 00126              | Tue Jan 27 00:00:00 1970 PST
-  127 | 407 | 00127_update7      | Wed Jan 28 00:00:00 1970 PST
-  128 |   8 | 00128              | Thu Jan 29 00:00:00 1970 PST
-  129 | 509 | 00129_update9      | Fri Jan 30 00:00:00 1970 PST
-  130 |   0 | 00130              | Sat Jan 31 00:00:00 1970 PST
-  131 |   1 | 00131              | Sun Feb 01 00:00:00 1970 PST
-  133 | 303 | 00133_update3      | Tue Feb 03 00:00:00 1970 PST
-  134 |   4 | 00134              | Wed Feb 04 00:00:00 1970 PST
-  136 |   6 | 00136              | Fri Feb 06 00:00:00 1970 PST
-  137 | 407 | 00137_update7      | Sat Feb 07 00:00:00 1970 PST
-  138 |   8 | 00138              | Sun Feb 08 00:00:00 1970 PST
-  139 | 509 | 00139_update9      | Mon Feb 09 00:00:00 1970 PST
-  140 |   0 | 00140              | Tue Feb 10 00:00:00 1970 PST
-  141 |   1 | 00141              | Wed Feb 11 00:00:00 1970 PST
-  143 | 303 | 00143_update3      | Fri Feb 13 00:00:00 1970 PST
-  144 |   4 | 00144              | Sat Feb 14 00:00:00 1970 PST
-  146 |   6 | 00146              | Mon Feb 16 00:00:00 1970 PST
-  147 | 407 | 00147_update7      | Tue Feb 17 00:00:00 1970 PST
-  148 |   8 | 00148              | Wed Feb 18 00:00:00 1970 PST
-  149 | 509 | 00149_update9      | Thu Feb 19 00:00:00 1970 PST
-  150 |   0 | 00150              | Fri Feb 20 00:00:00 1970 PST
-  151 |   1 | 00151              | Sat Feb 21 00:00:00 1970 PST
-  153 | 303 | 00153_update3      | Mon Feb 23 00:00:00 1970 PST
-  154 |   4 | 00154              | Tue Feb 24 00:00:00 1970 PST
-  156 |   6 | 00156              | Thu Feb 26 00:00:00 1970 PST
-  157 | 407 | 00157_update7      | Fri Feb 27 00:00:00 1970 PST
-  158 |   8 | 00158              | Sat Feb 28 00:00:00 1970 PST
-  159 | 509 | 00159_update9      | Sun Mar 01 00:00:00 1970 PST
-  160 |   0 | 00160              | Mon Mar 02 00:00:00 1970 PST
-  161 |   1 | 00161              | Tue Mar 03 00:00:00 1970 PST
-  163 | 303 | 00163_update3      | Thu Mar 05 00:00:00 1970 PST
-  164 |   4 | 00164              | Fri Mar 06 00:00:00 1970 PST
-  166 |   6 | 00166              | Sun Mar 08 00:00:00 1970 PST
-  167 | 407 | 00167_update7      | Mon Mar 09 00:00:00 1970 PST
-  168 |   8 | 00168              | Tue Mar 10 00:00:00 1970 PST
-  169 | 509 | 00169_update9      | Wed Mar 11 00:00:00 1970 PST
-  170 |   0 | 00170              | Thu Mar 12 00:00:00 1970 PST
-  171 |   1 | 00171              | Fri Mar 13 00:00:00 1970 PST
-  173 | 303 | 00173_update3      | Sun Mar 15 00:00:00 1970 PST
-  174 |   4 | 00174              | Mon Mar 16 00:00:00 1970 PST
-  176 |   6 | 00176              | Wed Mar 18 00:00:00 1970 PST
-  177 | 407 | 00177_update7      | Thu Mar 19 00:00:00 1970 PST
-  178 |   8 | 00178              | Fri Mar 20 00:00:00 1970 PST
-  179 | 509 | 00179_update9      | Sat Mar 21 00:00:00 1970 PST
-  180 |   0 | 00180              | Sun Mar 22 00:00:00 1970 PST
-  181 |   1 | 00181              | Mon Mar 23 00:00:00 1970 PST
-  183 | 303 | 00183_update3      | Wed Mar 25 00:00:00 1970 PST
-  184 |   4 | 00184              | Thu Mar 26 00:00:00 1970 PST
-  186 |   6 | 00186              | Sat Mar 28 00:00:00 1970 PST
-  187 | 407 | 00187_update7      | Sun Mar 29 00:00:00 1970 PST
-  188 |   8 | 00188              | Mon Mar 30 00:00:00 1970 PST
-  189 | 509 | 00189_update9      | Tue Mar 31 00:00:00 1970 PST
-  190 |   0 | 00190              | Wed Apr 01 00:00:00 1970 PST
-  191 |   1 | 00191              | Thu Apr 02 00:00:00 1970 PST
-  193 | 303 | 00193_update3      | Sat Apr 04 00:00:00 1970 PST
-  194 |   4 | 00194              | Sun Apr 05 00:00:00 1970 PST
-  196 |   6 | 00196              | Tue Apr 07 00:00:00 1970 PST
-  197 | 407 | 00197_update7      | Wed Apr 08 00:00:00 1970 PST
-  198 |   8 | 00198              | Thu Apr 09 00:00:00 1970 PST
-  199 | 509 | 00199_update9      | Fri Apr 10 00:00:00 1970 PST
-  200 |   0 | 00200              | Thu Jan 01 00:00:00 1970 PST
-  201 |   1 | 00201              | Fri Jan 02 00:00:00 1970 PST
-  203 | 303 | 00203_update3      | Sun Jan 04 00:00:00 1970 PST
-  204 |   4 | 00204              | Mon Jan 05 00:00:00 1970 PST
-  206 |   6 | 00206              | Wed Jan 07 00:00:00 1970 PST
-  207 | 407 | 00207_update7      | Thu Jan 08 00:00:00 1970 PST
-  208 |   8 | 00208              | Fri Jan 09 00:00:00 1970 PST
-  209 | 509 | 00209_update9      | Sat Jan 10 00:00:00 1970 PST
-  210 |   0 | 00210              | Sun Jan 11 00:00:00 1970 PST
-  211 |   1 | 00211              | Mon Jan 12 00:00:00 1970 PST
-  213 | 303 | 00213_update3      | Wed Jan 14 00:00:00 1970 PST
-  214 |   4 | 00214              | Thu Jan 15 00:00:00 1970 PST
-  216 |   6 | 00216              | Sat Jan 17 00:00:00 1970 PST
-  217 | 407 | 00217_update7      | Sun Jan 18 00:00:00 1970 PST
-  218 |   8 | 00218              | Mon Jan 19 00:00:00 1970 PST
-  219 | 509 | 00219_update9      | Tue Jan 20 00:00:00 1970 PST
-  220 |   0 | 00220              | Wed Jan 21 00:00:00 1970 PST
-  221 |   1 | 00221              | Thu Jan 22 00:00:00 1970 PST
-  223 | 303 | 00223_update3      | Sat Jan 24 00:00:00 1970 PST
-  224 |   4 | 00224              | Sun Jan 25 00:00:00 1970 PST
-  226 |   6 | 00226              | Tue Jan 27 00:00:00 1970 PST
-  227 | 407 | 00227_update7      | Wed Jan 28 00:00:00 1970 PST
-  228 |   8 | 00228              | Thu Jan 29 00:00:00 1970 PST
-  229 | 509 | 00229_update9      | Fri Jan 30 00:00:00 1970 PST
-  230 |   0 | 00230              | Sat Jan 31 00:00:00 1970 PST
-  231 |   1 | 00231              | Sun Feb 01 00:00:00 1970 PST
-  233 | 303 | 00233_update3      | Tue Feb 03 00:00:00 1970 PST
-  234 |   4 | 00234              | Wed Feb 04 00:00:00 1970 PST
-  236 |   6 | 00236              | Fri Feb 06 00:00:00 1970 PST
-  237 | 407 | 00237_update7      | Sat Feb 07 00:00:00 1970 PST
-  238 |   8 | 00238              | Sun Feb 08 00:00:00 1970 PST
-  239 | 509 | 00239_update9      | Mon Feb 09 00:00:00 1970 PST
-  240 |   0 | 00240              | Tue Feb 10 00:00:00 1970 PST
-  241 |   1 | 00241              | Wed Feb 11 00:00:00 1970 PST
-  243 | 303 | 00243_update3      | Fri Feb 13 00:00:00 1970 PST
-  244 |   4 | 00244              | Sat Feb 14 00:00:00 1970 PST
-  246 |   6 | 00246              | Mon Feb 16 00:00:00 1970 PST
-  247 | 407 | 00247_update7      | Tue Feb 17 00:00:00 1970 PST
-  248 |   8 | 00248              | Wed Feb 18 00:00:00 1970 PST
-  249 | 509 | 00249_update9      | Thu Feb 19 00:00:00 1970 PST
-  250 |   0 | 00250              | Fri Feb 20 00:00:00 1970 PST
-  251 |   1 | 00251              | Sat Feb 21 00:00:00 1970 PST
-  253 | 303 | 00253_update3      | Mon Feb 23 00:00:00 1970 PST
-  254 |   4 | 00254              | Tue Feb 24 00:00:00 1970 PST
-  256 |   6 | 00256              | Thu Feb 26 00:00:00 1970 PST
-  257 | 407 | 00257_update7      | Fri Feb 27 00:00:00 1970 PST
-  258 |   8 | 00258              | Sat Feb 28 00:00:00 1970 PST
-  259 | 509 | 00259_update9      | Sun Mar 01 00:00:00 1970 PST
-  260 |   0 | 00260              | Mon Mar 02 00:00:00 1970 PST
-  261 |   1 | 00261              | Tue Mar 03 00:00:00 1970 PST
-  263 | 303 | 00263_update3      | Thu Mar 05 00:00:00 1970 PST
-  264 |   4 | 00264              | Fri Mar 06 00:00:00 1970 PST
-  266 |   6 | 00266              | Sun Mar 08 00:00:00 1970 PST
-  267 | 407 | 00267_update7      | Mon Mar 09 00:00:00 1970 PST
-  268 |   8 | 00268              | Tue Mar 10 00:00:00 1970 PST
-  269 | 509 | 00269_update9      | Wed Mar 11 00:00:00 1970 PST
-  270 |   0 | 00270              | Thu Mar 12 00:00:00 1970 PST
-  271 |   1 | 00271              | Fri Mar 13 00:00:00 1970 PST
-  273 | 303 | 00273_update3      | Sun Mar 15 00:00:00 1970 PST
-  274 |   4 | 00274              | Mon Mar 16 00:00:00 1970 PST
-  276 |   6 | 00276              | Wed Mar 18 00:00:00 1970 PST
-  277 | 407 | 00277_update7      | Thu Mar 19 00:00:00 1970 PST
-  278 |   8 | 00278              | Fri Mar 20 00:00:00 1970 PST
-  279 | 509 | 00279_update9      | Sat Mar 21 00:00:00 1970 PST
-  280 |   0 | 00280              | Sun Mar 22 00:00:00 1970 PST
-  281 |   1 | 00281              | Mon Mar 23 00:00:00 1970 PST
-  283 | 303 | 00283_update3      | Wed Mar 25 00:00:00 1970 PST
-  284 |   4 | 00284              | Thu Mar 26 00:00:00 1970 PST
-  286 |   6 | 00286              | Sat Mar 28 00:00:00 1970 PST
-  287 | 407 | 00287_update7      | Sun Mar 29 00:00:00 1970 PST
-  288 |   8 | 00288              | Mon Mar 30 00:00:00 1970 PST
-  289 | 509 | 00289_update9      | Tue Mar 31 00:00:00 1970 PST
-  290 |   0 | 00290              | Wed Apr 01 00:00:00 1970 PST
-  291 |   1 | 00291              | Thu Apr 02 00:00:00 1970 PST
-  293 | 303 | 00293_update3      | Sat Apr 04 00:00:00 1970 PST
-  294 |   4 | 00294              | Sun Apr 05 00:00:00 1970 PST
-  296 |   6 | 00296              | Tue Apr 07 00:00:00 1970 PST
-  297 | 407 | 00297_update7      | Wed Apr 08 00:00:00 1970 PST
-  298 |   8 | 00298              | Thu Apr 09 00:00:00 1970 PST
-  299 | 509 | 00299_update9      | Fri Apr 10 00:00:00 1970 PST
-  300 |   0 | 00300              | Thu Jan 01 00:00:00 1970 PST
-  301 |   1 | 00301              | Fri Jan 02 00:00:00 1970 PST
-  303 | 303 | 00303_update3      | Sun Jan 04 00:00:00 1970 PST
-  304 |   4 | 00304              | Mon Jan 05 00:00:00 1970 PST
-  306 |   6 | 00306              | Wed Jan 07 00:00:00 1970 PST
-  307 | 407 | 00307_update7      | Thu Jan 08 00:00:00 1970 PST
-  308 |   8 | 00308              | Fri Jan 09 00:00:00 1970 PST
-  309 | 509 | 00309_update9      | Sat Jan 10 00:00:00 1970 PST
-  310 |   0 | 00310              | Sun Jan 11 00:00:00 1970 PST
-  311 |   1 | 00311              | Mon Jan 12 00:00:00 1970 PST
-  313 | 303 | 00313_update3      | Wed Jan 14 00:00:00 1970 PST
-  314 |   4 | 00314              | Thu Jan 15 00:00:00 1970 PST
-  316 |   6 | 00316              | Sat Jan 17 00:00:00 1970 PST
-  317 | 407 | 00317_update7      | Sun Jan 18 00:00:00 1970 PST
-  318 |   8 | 00318              | Mon Jan 19 00:00:00 1970 PST
-  319 | 509 | 00319_update9      | Tue Jan 20 00:00:00 1970 PST
-  320 |   0 | 00320              | Wed Jan 21 00:00:00 1970 PST
-  321 |   1 | 00321              | Thu Jan 22 00:00:00 1970 PST
-  323 | 303 | 00323_update3      | Sat Jan 24 00:00:00 1970 PST
-  324 |   4 | 00324              | Sun Jan 25 00:00:00 1970 PST
-  326 |   6 | 00326              | Tue Jan 27 00:00:00 1970 PST
-  327 | 407 | 00327_update7      | Wed Jan 28 00:00:00 1970 PST
-  328 |   8 | 00328              | Thu Jan 29 00:00:00 1970 PST
-  329 | 509 | 00329_update9      | Fri Jan 30 00:00:00 1970 PST
-  330 |   0 | 00330              | Sat Jan 31 00:00:00 1970 PST
-  331 |   1 | 00331              | Sun Feb 01 00:00:00 1970 PST
-  333 | 303 | 00333_update3      | Tue Feb 03 00:00:00 1970 PST
-  334 |   4 | 00334              | Wed Feb 04 00:00:00 1970 PST
-  336 |   6 | 00336              | Fri Feb 06 00:00:00 1970 PST
-  337 | 407 | 00337_update7      | Sat Feb 07 00:00:00 1970 PST
-  338 |   8 | 00338              | Sun Feb 08 00:00:00 1970 PST
-  339 | 509 | 00339_update9      | Mon Feb 09 00:00:00 1970 PST
-  340 |   0 | 00340              | Tue Feb 10 00:00:00 1970 PST
-  341 |   1 | 00341              | Wed Feb 11 00:00:00 1970 PST
-  343 | 303 | 00343_update3      | Fri Feb 13 00:00:00 1970 PST
-  344 |   4 | 00344              | Sat Feb 14 00:00:00 1970 PST
-  346 |   6 | 00346              | Mon Feb 16 00:00:00 1970 PST
-  347 | 407 | 00347_update7      | Tue Feb 17 00:00:00 1970 PST
-  348 |   8 | 00348              | Wed Feb 18 00:00:00 1970 PST
-  349 | 509 | 00349_update9      | Thu Feb 19 00:00:00 1970 PST
-  350 |   0 | 00350              | Fri Feb 20 00:00:00 1970 PST
-  351 |   1 | 00351              | Sat Feb 21 00:00:00 1970 PST
-  353 | 303 | 00353_update3      | Mon Feb 23 00:00:00 1970 PST
-  354 |   4 | 00354              | Tue Feb 24 00:00:00 1970 PST
-  356 |   6 | 00356              | Thu Feb 26 00:00:00 1970 PST
-  357 | 407 | 00357_update7      | Fri Feb 27 00:00:00 1970 PST
-  358 |   8 | 00358              | Sat Feb 28 00:00:00 1970 PST
-  359 | 509 | 00359_update9      | Sun Mar 01 00:00:00 1970 PST
-  360 |   0 | 00360              | Mon Mar 02 00:00:00 1970 PST
-  361 |   1 | 00361              | Tue Mar 03 00:00:00 1970 PST
-  363 | 303 | 00363_update3      | Thu Mar 05 00:00:00 1970 PST
-  364 |   4 | 00364              | Fri Mar 06 00:00:00 1970 PST
-  366 |   6 | 00366              | Sun Mar 08 00:00:00 1970 PST
-  367 | 407 | 00367_update7      | Mon Mar 09 00:00:00 1970 PST
-  368 |   8 | 00368              | Tue Mar 10 00:00:00 1970 PST
-  369 | 509 | 00369_update9      | Wed Mar 11 00:00:00 1970 PST
-  370 |   0 | 00370              | Thu Mar 12 00:00:00 1970 PST
-  371 |   1 | 00371              | Fri Mar 13 00:00:00 1970 PST
-  373 | 303 | 00373_update3      | Sun Mar 15 00:00:00 1970 PST
-  374 |   4 | 00374              | Mon Mar 16 00:00:00 1970 PST
-  376 |   6 | 00376              | Wed Mar 18 00:00:00 1970 PST
-  377 | 407 | 00377_update7      | Thu Mar 19 00:00:00 1970 PST
-  378 |   8 | 00378              | Fri Mar 20 00:00:00 1970 PST
-  379 | 509 | 00379_update9      | Sat Mar 21 00:00:00 1970 PST
-  380 |   0 | 00380              | Sun Mar 22 00:00:00 1970 PST
-  381 |   1 | 00381              | Mon Mar 23 00:00:00 1970 PST
-  383 | 303 | 00383_update3      | Wed Mar 25 00:00:00 1970 PST
-  384 |   4 | 00384              | Thu Mar 26 00:00:00 1970 PST
-  386 |   6 | 00386              | Sat Mar 28 00:00:00 1970 PST
-  387 | 407 | 00387_update7      | Sun Mar 29 00:00:00 1970 PST
-  388 |   8 | 00388              | Mon Mar 30 00:00:00 1970 PST
-  389 | 509 | 00389_update9      | Tue Mar 31 00:00:00 1970 PST
-  390 |   0 | 00390              | Wed Apr 01 00:00:00 1970 PST
-  391 |   1 | 00391              | Thu Apr 02 00:00:00 1970 PST
-  393 | 303 | 00393_update3      | Sat Apr 04 00:00:00 1970 PST
-  394 |   4 | 00394              | Sun Apr 05 00:00:00 1970 PST
-  396 |   6 | 00396              | Tue Apr 07 00:00:00 1970 PST
-  397 | 407 | 00397_update7      | Wed Apr 08 00:00:00 1970 PST
-  398 |   8 | 00398              | Thu Apr 09 00:00:00 1970 PST
-  399 | 509 | 00399_update9      | Fri Apr 10 00:00:00 1970 PST
-  400 |   0 | 00400              | Thu Jan 01 00:00:00 1970 PST
-  401 |   1 | 00401              | Fri Jan 02 00:00:00 1970 PST
-  403 | 303 | 00403_update3      | Sun Jan 04 00:00:00 1970 PST
-  404 |   4 | 00404              | Mon Jan 05 00:00:00 1970 PST
-  406 |   6 | 00406              | Wed Jan 07 00:00:00 1970 PST
-  407 | 407 | 00407_update7      | Thu Jan 08 00:00:00 1970 PST
-  408 |   8 | 00408              | Fri Jan 09 00:00:00 1970 PST
-  409 | 509 | 00409_update9      | Sat Jan 10 00:00:00 1970 PST
-  410 |   0 | 00410              | Sun Jan 11 00:00:00 1970 PST
-  411 |   1 | 00411              | Mon Jan 12 00:00:00 1970 PST
-  413 | 303 | 00413_update3      | Wed Jan 14 00:00:00 1970 PST
-  414 |   4 | 00414              | Thu Jan 15 00:00:00 1970 PST
-  416 |   6 | 00416              | Sat Jan 17 00:00:00 1970 PST
-  417 | 407 | 00417_update7      | Sun Jan 18 00:00:00 1970 PST
-  418 |   8 | 00418              | Mon Jan 19 00:00:00 1970 PST
-  419 | 509 | 00419_update9      | Tue Jan 20 00:00:00 1970 PST
-  420 |   0 | 00420              | Wed Jan 21 00:00:00 1970 PST
-  421 |   1 | 00421              | Thu Jan 22 00:00:00 1970 PST
-  423 | 303 | 00423_update3      | Sat Jan 24 00:00:00 1970 PST
-  424 |   4 | 00424              | Sun Jan 25 00:00:00 1970 PST
-  426 |   6 | 00426              | Tue Jan 27 00:00:00 1970 PST
-  427 | 407 | 00427_update7      | Wed Jan 28 00:00:00 1970 PST
-  428 |   8 | 00428              | Thu Jan 29 00:00:00 1970 PST
-  429 | 509 | 00429_update9      | Fri Jan 30 00:00:00 1970 PST
-  430 |   0 | 00430              | Sat Jan 31 00:00:00 1970 PST
-  431 |   1 | 00431              | Sun Feb 01 00:00:00 1970 PST
-  433 | 303 | 00433_update3      | Tue Feb 03 00:00:00 1970 PST
-  434 |   4 | 00434              | Wed Feb 04 00:00:00 1970 PST
-  436 |   6 | 00436              | Fri Feb 06 00:00:00 1970 PST
-  437 | 407 | 00437_update7      | Sat Feb 07 00:00:00 1970 PST
-  438 |   8 | 00438              | Sun Feb 08 00:00:00 1970 PST
-  439 | 509 | 00439_update9      | Mon Feb 09 00:00:00 1970 PST
-  440 |   0 | 00440              | Tue Feb 10 00:00:00 1970 PST
-  441 |   1 | 00441              | Wed Feb 11 00:00:00 1970 PST
-  443 | 303 | 00443_update3      | Fri Feb 13 00:00:00 1970 PST
-  444 |   4 | 00444              | Sat Feb 14 00:00:00 1970 PST
-  446 |   6 | 00446              | Mon Feb 16 00:00:00 1970 PST
-  447 | 407 | 00447_update7      | Tue Feb 17 00:00:00 1970 PST
-  448 |   8 | 00448              | Wed Feb 18 00:00:00 1970 PST
-  449 | 509 | 00449_update9      | Thu Feb 19 00:00:00 1970 PST
-  450 |   0 | 00450              | Fri Feb 20 00:00:00 1970 PST
-  451 |   1 | 00451              | Sat Feb 21 00:00:00 1970 PST
-  453 | 303 | 00453_update3      | Mon Feb 23 00:00:00 1970 PST
-  454 |   4 | 00454              | Tue Feb 24 00:00:00 1970 PST
-  456 |   6 | 00456              | Thu Feb 26 00:00:00 1970 PST
-  457 | 407 | 00457_update7      | Fri Feb 27 00:00:00 1970 PST
-  458 |   8 | 00458              | Sat Feb 28 00:00:00 1970 PST
-  459 | 509 | 00459_update9      | Sun Mar 01 00:00:00 1970 PST
-  460 |   0 | 00460              | Mon Mar 02 00:00:00 1970 PST
-  461 |   1 | 00461              | Tue Mar 03 00:00:00 1970 PST
-  463 | 303 | 00463_update3      | Thu Mar 05 00:00:00 1970 PST
-  464 |   4 | 00464              | Fri Mar 06 00:00:00 1970 PST
-  466 |   6 | 00466              | Sun Mar 08 00:00:00 1970 PST
-  467 | 407 | 00467_update7      | Mon Mar 09 00:00:00 1970 PST
-  468 |   8 | 00468              | Tue Mar 10 00:00:00 1970 PST
-  469 | 509 | 00469_update9      | Wed Mar 11 00:00:00 1970 PST
-  470 |   0 | 00470              | Thu Mar 12 00:00:00 1970 PST
-  471 |   1 | 00471              | Fri Mar 13 00:00:00 1970 PST
-  473 | 303 | 00473_update3      | Sun Mar 15 00:00:00 1970 PST
-  474 |   4 | 00474              | Mon Mar 16 00:00:00 1970 PST
-  476 |   6 | 00476              | Wed Mar 18 00:00:00 1970 PST
-  477 | 407 | 00477_update7      | Thu Mar 19 00:00:00 1970 PST
-  478 |   8 | 00478              | Fri Mar 20 00:00:00 1970 PST
-  479 | 509 | 00479_update9      | Sat Mar 21 00:00:00 1970 PST
-  480 |   0 | 00480              | Sun Mar 22 00:00:00 1970 PST
-  481 |   1 | 00481              | Mon Mar 23 00:00:00 1970 PST
-  483 | 303 | 00483_update3      | Wed Mar 25 00:00:00 1970 PST
-  484 |   4 | 00484              | Thu Mar 26 00:00:00 1970 PST
-  486 |   6 | 00486              | Sat Mar 28 00:00:00 1970 PST
-  487 | 407 | 00487_update7      | Sun Mar 29 00:00:00 1970 PST
-  488 |   8 | 00488              | Mon Mar 30 00:00:00 1970 PST
-  489 | 509 | 00489_update9      | Tue Mar 31 00:00:00 1970 PST
-  490 |   0 | 00490              | Wed Apr 01 00:00:00 1970 PST
-  491 |   1 | 00491              | Thu Apr 02 00:00:00 1970 PST
-  493 | 303 | 00493_update3      | Sat Apr 04 00:00:00 1970 PST
-  494 |   4 | 00494              | Sun Apr 05 00:00:00 1970 PST
-  496 |   6 | 00496              | Tue Apr 07 00:00:00 1970 PST
-  497 | 407 | 00497_update7      | Wed Apr 08 00:00:00 1970 PST
-  498 |   8 | 00498              | Thu Apr 09 00:00:00 1970 PST
-  499 | 509 | 00499_update9      | Fri Apr 10 00:00:00 1970 PST
-  500 |   0 | 00500              | Thu Jan 01 00:00:00 1970 PST
-  501 |   1 | 00501              | Fri Jan 02 00:00:00 1970 PST
-  503 | 303 | 00503_update3      | Sun Jan 04 00:00:00 1970 PST
-  504 |   4 | 00504              | Mon Jan 05 00:00:00 1970 PST
-  506 |   6 | 00506              | Wed Jan 07 00:00:00 1970 PST
-  507 | 407 | 00507_update7      | Thu Jan 08 00:00:00 1970 PST
-  508 |   8 | 00508              | Fri Jan 09 00:00:00 1970 PST
-  509 | 509 | 00509_update9      | Sat Jan 10 00:00:00 1970 PST
-  510 |   0 | 00510              | Sun Jan 11 00:00:00 1970 PST
-  511 |   1 | 00511              | Mon Jan 12 00:00:00 1970 PST
-  513 | 303 | 00513_update3      | Wed Jan 14 00:00:00 1970 PST
-  514 |   4 | 00514              | Thu Jan 15 00:00:00 1970 PST
-  516 |   6 | 00516              | Sat Jan 17 00:00:00 1970 PST
-  517 | 407 | 00517_update7      | Sun Jan 18 00:00:00 1970 PST
-  518 |   8 | 00518              | Mon Jan 19 00:00:00 1970 PST
-  519 | 509 | 00519_update9      | Tue Jan 20 00:00:00 1970 PST
-  520 |   0 | 00520              | Wed Jan 21 00:00:00 1970 PST
-  521 |   1 | 00521              | Thu Jan 22 00:00:00 1970 PST
-  523 | 303 | 00523_update3      | Sat Jan 24 00:00:00 1970 PST
-  524 |   4 | 00524              | Sun Jan 25 00:00:00 1970 PST
-  526 |   6 | 00526              | Tue Jan 27 00:00:00 1970 PST
-  527 | 407 | 00527_update7      | Wed Jan 28 00:00:00 1970 PST
-  528 |   8 | 00528              | Thu Jan 29 00:00:00 1970 PST
-  529 | 509 | 00529_update9      | Fri Jan 30 00:00:00 1970 PST
-  530 |   0 | 00530              | Sat Jan 31 00:00:00 1970 PST
-  531 |   1 | 00531              | Sun Feb 01 00:00:00 1970 PST
-  533 | 303 | 00533_update3      | Tue Feb 03 00:00:00 1970 PST
-  534 |   4 | 00534              | Wed Feb 04 00:00:00 1970 PST
-  536 |   6 | 00536              | Fri Feb 06 00:00:00 1970 PST
-  537 | 407 | 00537_update7      | Sat Feb 07 00:00:00 1970 PST
-  538 |   8 | 00538              | Sun Feb 08 00:00:00 1970 PST
-  539 | 509 | 00539_update9      | Mon Feb 09 00:00:00 1970 PST
-  540 |   0 | 00540              | Tue Feb 10 00:00:00 1970 PST
-  541 |   1 | 00541              | Wed Feb 11 00:00:00 1970 PST
-  543 | 303 | 00543_update3      | Fri Feb 13 00:00:00 1970 PST
-  544 |   4 | 00544              | Sat Feb 14 00:00:00 1970 PST
-  546 |   6 | 00546              | Mon Feb 16 00:00:00 1970 PST
-  547 | 407 | 00547_update7      | Tue Feb 17 00:00:00 1970 PST
-  548 |   8 | 00548              | Wed Feb 18 00:00:00 1970 PST
-  549 | 509 | 00549_update9      | Thu Feb 19 00:00:00 1970 PST
-  550 |   0 | 00550              | Fri Feb 20 00:00:00 1970 PST
-  551 |   1 | 00551              | Sat Feb 21 00:00:00 1970 PST
-  553 | 303 | 00553_update3      | Mon Feb 23 00:00:00 1970 PST
-  554 |   4 | 00554              | Tue Feb 24 00:00:00 1970 PST
-  556 |   6 | 00556              | Thu Feb 26 00:00:00 1970 PST
-  557 | 407 | 00557_update7      | Fri Feb 27 00:00:00 1970 PST
-  558 |   8 | 00558              | Sat Feb 28 00:00:00 1970 PST
-  559 | 509 | 00559_update9      | Sun Mar 01 00:00:00 1970 PST
-  560 |   0 | 00560              | Mon Mar 02 00:00:00 1970 PST
-  561 |   1 | 00561              | Tue Mar 03 00:00:00 1970 PST
-  563 | 303 | 00563_update3      | Thu Mar 05 00:00:00 1970 PST
-  564 |   4 | 00564              | Fri Mar 06 00:00:00 1970 PST
-  566 |   6 | 00566              | Sun Mar 08 00:00:00 1970 PST
-  567 | 407 | 00567_update7      | Mon Mar 09 00:00:00 1970 PST
-  568 |   8 | 00568              | Tue Mar 10 00:00:00 1970 PST
-  569 | 509 | 00569_update9      | Wed Mar 11 00:00:00 1970 PST
-  570 |   0 | 00570              | Thu Mar 12 00:00:00 1970 PST
-  571 |   1 | 00571              | Fri Mar 13 00:00:00 1970 PST
-  573 | 303 | 00573_update3      | Sun Mar 15 00:00:00 1970 PST
-  574 |   4 | 00574              | Mon Mar 16 00:00:00 1970 PST
-  576 |   6 | 00576              | Wed Mar 18 00:00:00 1970 PST
-  577 | 407 | 00577_update7      | Thu Mar 19 00:00:00 1970 PST
-  578 |   8 | 00578              | Fri Mar 20 00:00:00 1970 PST
-  579 | 509 | 00579_update9      | Sat Mar 21 00:00:00 1970 PST
-  580 |   0 | 00580              | Sun Mar 22 00:00:00 1970 PST
-  581 |   1 | 00581              | Mon Mar 23 00:00:00 1970 PST
-  583 | 303 | 00583_update3      | Wed Mar 25 00:00:00 1970 PST
-  584 |   4 | 00584              | Thu Mar 26 00:00:00 1970 PST
-  586 |   6 | 00586              | Sat Mar 28 00:00:00 1970 PST
-  587 | 407 | 00587_update7      | Sun Mar 29 00:00:00 1970 PST
-  588 |   8 | 00588              | Mon Mar 30 00:00:00 1970 PST
-  589 | 509 | 00589_update9      | Tue Mar 31 00:00:00 1970 PST
-  590 |   0 | 00590              | Wed Apr 01 00:00:00 1970 PST
-  591 |   1 | 00591              | Thu Apr 02 00:00:00 1970 PST
-  593 | 303 | 00593_update3      | Sat Apr 04 00:00:00 1970 PST
-  594 |   4 | 00594              | Sun Apr 05 00:00:00 1970 PST
-  596 |   6 | 00596              | Tue Apr 07 00:00:00 1970 PST
-  597 | 407 | 00597_update7      | Wed Apr 08 00:00:00 1970 PST
-  598 |   8 | 00598              | Thu Apr 09 00:00:00 1970 PST
-  599 | 509 | 00599_update9      | Fri Apr 10 00:00:00 1970 PST
-  600 |   0 | 00600              | Thu Jan 01 00:00:00 1970 PST
-  601 |   1 | 00601              | Fri Jan 02 00:00:00 1970 PST
-  603 | 303 | 00603_update3      | Sun Jan 04 00:00:00 1970 PST
-  604 |   4 | 00604              | Mon Jan 05 00:00:00 1970 PST
-  606 |   6 | 00606              | Wed Jan 07 00:00:00 1970 PST
-  607 | 407 | 00607_update7      | Thu Jan 08 00:00:00 1970 PST
-  608 |   8 | 00608              | Fri Jan 09 00:00:00 1970 PST
-  609 | 509 | 00609_update9      | Sat Jan 10 00:00:00 1970 PST
-  610 |   0 | 00610              | Sun Jan 11 00:00:00 1970 PST
-  611 |   1 | 00611              | Mon Jan 12 00:00:00 1970 PST
-  613 | 303 | 00613_update3      | Wed Jan 14 00:00:00 1970 PST
-  614 |   4 | 00614              | Thu Jan 15 00:00:00 1970 PST
-  616 |   6 | 00616              | Sat Jan 17 00:00:00 1970 PST
-  617 | 407 | 00617_update7      | Sun Jan 18 00:00:00 1970 PST
-  618 |   8 | 00618              | Mon Jan 19 00:00:00 1970 PST
-  619 | 509 | 00619_update9      | Tue Jan 20 00:00:00 1970 PST
-  620 |   0 | 00620              | Wed Jan 21 00:00:00 1970 PST
-  621 |   1 | 00621              | Thu Jan 22 00:00:00 1970 PST
-  623 | 303 | 00623_update3      | Sat Jan 24 00:00:00 1970 PST
-  624 |   4 | 00624              | Sun Jan 25 00:00:00 1970 PST
-  626 |   6 | 00626              | Tue Jan 27 00:00:00 1970 PST
-  627 | 407 | 00627_update7      | Wed Jan 28 00:00:00 1970 PST
-  628 |   8 | 00628              | Thu Jan 29 00:00:00 1970 PST
-  629 | 509 | 00629_update9      | Fri Jan 30 00:00:00 1970 PST
-  630 |   0 | 00630              | Sat Jan 31 00:00:00 1970 PST
-  631 |   1 | 00631              | Sun Feb 01 00:00:00 1970 PST
-  633 | 303 | 00633_update3      | Tue Feb 03 00:00:00 1970 PST
-  634 |   4 | 00634              | Wed Feb 04 00:00:00 1970 PST
-  636 |   6 | 00636              | Fri Feb 06 00:00:00 1970 PST
-  637 | 407 | 00637_update7      | Sat Feb 07 00:00:00 1970 PST
-  638 |   8 | 00638              | Sun Feb 08 00:00:00 1970 PST
-  639 | 509 | 00639_update9      | Mon Feb 09 00:00:00 1970 PST
-  640 |   0 | 00640              | Tue Feb 10 00:00:00 1970 PST
-  641 |   1 | 00641              | Wed Feb 11 00:00:00 1970 PST
-  643 | 303 | 00643_update3      | Fri Feb 13 00:00:00 1970 PST
-  644 |   4 | 00644              | Sat Feb 14 00:00:00 1970 PST
-  646 |   6 | 00646              | Mon Feb 16 00:00:00 1970 PST
-  647 | 407 | 00647_update7      | Tue Feb 17 00:00:00 1970 PST
-  648 |   8 | 00648              | Wed Feb 18 00:00:00 1970 PST
-  649 | 509 | 00649_update9      | Thu Feb 19 00:00:00 1970 PST
-  650 |   0 | 00650              | Fri Feb 20 00:00:00 1970 PST
-  651 |   1 | 00651              | Sat Feb 21 00:00:00 1970 PST
-  653 | 303 | 00653_update3      | Mon Feb 23 00:00:00 1970 PST
-  654 |   4 | 00654              | Tue Feb 24 00:00:00 1970 PST
-  656 |   6 | 00656              | Thu Feb 26 00:00:00 1970 PST
-  657 | 407 | 00657_update7      | Fri Feb 27 00:00:00 1970 PST
-  658 |   8 | 00658              | Sat Feb 28 00:00:00 1970 PST
-  659 | 509 | 00659_update9      | Sun Mar 01 00:00:00 1970 PST
-  660 |   0 | 00660              | Mon Mar 02 00:00:00 1970 PST
-  661 |   1 | 00661              | Tue Mar 03 00:00:00 1970 PST
-  663 | 303 | 00663_update3      | Thu Mar 05 00:00:00 1970 PST
-  664 |   4 | 00664              | Fri Mar 06 00:00:00 1970 PST
-  666 |   6 | 00666              | Sun Mar 08 00:00:00 1970 PST
-  667 | 407 | 00667_update7      | Mon Mar 09 00:00:00 1970 PST
-  668 |   8 | 00668              | Tue Mar 10 00:00:00 1970 PST
-  669 | 509 | 00669_update9      | Wed Mar 11 00:00:00 1970 PST
-  670 |   0 | 00670              | Thu Mar 12 00:00:00 1970 PST
-  671 |   1 | 00671              | Fri Mar 13 00:00:00 1970 PST
-  673 | 303 | 00673_update3      | Sun Mar 15 00:00:00 1970 PST
-  674 |   4 | 00674              | Mon Mar 16 00:00:00 1970 PST
-  676 |   6 | 00676              | Wed Mar 18 00:00:00 1970 PST
-  677 | 407 | 00677_update7      | Thu Mar 19 00:00:00 1970 PST
-  678 |   8 | 00678              | Fri Mar 20 00:00:00 1970 PST
-  679 | 509 | 00679_update9      | Sat Mar 21 00:00:00 1970 PST
-  680 |   0 | 00680              | Sun Mar 22 00:00:00 1970 PST
-  681 |   1 | 00681              | Mon Mar 23 00:00:00 1970 PST
-  683 | 303 | 00683_update3      | Wed Mar 25 00:00:00 1970 PST
-  684 |   4 | 00684              | Thu Mar 26 00:00:00 1970 PST
-  686 |   6 | 00686              | Sat Mar 28 00:00:00 1970 PST
-  687 | 407 | 00687_update7      | Sun Mar 29 00:00:00 1970 PST
-  688 |   8 | 00688              | Mon Mar 30 00:00:00 1970 PST
-  689 | 509 | 00689_update9      | Tue Mar 31 00:00:00 1970 PST
-  690 |   0 | 00690              | Wed Apr 01 00:00:00 1970 PST
-  691 |   1 | 00691              | Thu Apr 02 00:00:00 1970 PST
-  693 | 303 | 00693_update3      | Sat Apr 04 00:00:00 1970 PST
-  694 |   4 | 00694              | Sun Apr 05 00:00:00 1970 PST
-  696 |   6 | 00696              | Tue Apr 07 00:00:00 1970 PST
-  697 | 407 | 00697_update7      | Wed Apr 08 00:00:00 1970 PST
-  698 |   8 | 00698              | Thu Apr 09 00:00:00 1970 PST
-  699 | 509 | 00699_update9      | Fri Apr 10 00:00:00 1970 PST
-  700 |   0 | 00700              | Thu Jan 01 00:00:00 1970 PST
-  701 |   1 | 00701              | Fri Jan 02 00:00:00 1970 PST
-  703 | 303 | 00703_update3      | Sun Jan 04 00:00:00 1970 PST
-  704 |   4 | 00704              | Mon Jan 05 00:00:00 1970 PST
-  706 |   6 | 00706              | Wed Jan 07 00:00:00 1970 PST
-  707 | 407 | 00707_update7      | Thu Jan 08 00:00:00 1970 PST
-  708 |   8 | 00708              | Fri Jan 09 00:00:00 1970 PST
-  709 | 509 | 00709_update9      | Sat Jan 10 00:00:00 1970 PST
-  710 |   0 | 00710              | Sun Jan 11 00:00:00 1970 PST
-  711 |   1 | 00711              | Mon Jan 12 00:00:00 1970 PST
-  713 | 303 | 00713_update3      | Wed Jan 14 00:00:00 1970 PST
-  714 |   4 | 00714              | Thu Jan 15 00:00:00 1970 PST
-  716 |   6 | 00716              | Sat Jan 17 00:00:00 1970 PST
-  717 | 407 | 00717_update7      | Sun Jan 18 00:00:00 1970 PST
-  718 |   8 | 00718              | Mon Jan 19 00:00:00 1970 PST
-  719 | 509 | 00719_update9      | Tue Jan 20 00:00:00 1970 PST
-  720 |   0 | 00720              | Wed Jan 21 00:00:00 1970 PST
-  721 |   1 | 00721              | Thu Jan 22 00:00:00 1970 PST
-  723 | 303 | 00723_update3      | Sat Jan 24 00:00:00 1970 PST
-  724 |   4 | 00724              | Sun Jan 25 00:00:00 1970 PST
-  726 |   6 | 00726              | Tue Jan 27 00:00:00 1970 PST
-  727 | 407 | 00727_update7      | Wed Jan 28 00:00:00 1970 PST
-  728 |   8 | 00728              | Thu Jan 29 00:00:00 1970 PST
-  729 | 509 | 00729_update9      | Fri Jan 30 00:00:00 1970 PST
-  730 |   0 | 00730              | Sat Jan 31 00:00:00 1970 PST
-  731 |   1 | 00731              | Sun Feb 01 00:00:00 1970 PST
-  733 | 303 | 00733_update3      | Tue Feb 03 00:00:00 1970 PST
-  734 |   4 | 00734              | Wed Feb 04 00:00:00 1970 PST
-  736 |   6 | 00736              | Fri Feb 06 00:00:00 1970 PST
-  737 | 407 | 00737_update7      | Sat Feb 07 00:00:00 1970 PST
-  738 |   8 | 00738              | Sun Feb 08 00:00:00 1970 PST
-  739 | 509 | 00739_update9      | Mon Feb 09 00:00:00 1970 PST
-  740 |   0 | 00740              | Tue Feb 10 00:00:00 1970 PST
-  741 |   1 | 00741              | Wed Feb 11 00:00:00 1970 PST
-  743 | 303 | 00743_update3      | Fri Feb 13 00:00:00 1970 PST
-  744 |   4 | 00744              | Sat Feb 14 00:00:00 1970 PST
-  746 |   6 | 00746              | Mon Feb 16 00:00:00 1970 PST
-  747 | 407 | 00747_update7      | Tue Feb 17 00:00:00 1970 PST
-  748 |   8 | 00748              | Wed Feb 18 00:00:00 1970 PST
-  749 | 509 | 00749_update9      | Thu Feb 19 00:00:00 1970 PST
-  750 |   0 | 00750              | Fri Feb 20 00:00:00 1970 PST
-  751 |   1 | 00751              | Sat Feb 21 00:00:00 1970 PST
-  753 | 303 | 00753_update3      | Mon Feb 23 00:00:00 1970 PST
-  754 |   4 | 00754              | Tue Feb 24 00:00:00 1970 PST
-  756 |   6 | 00756              | Thu Feb 26 00:00:00 1970 PST
-  757 | 407 | 00757_update7      | Fri Feb 27 00:00:00 1970 PST
-  758 |   8 | 00758              | Sat Feb 28 00:00:00 1970 PST
-  759 | 509 | 00759_update9      | Sun Mar 01 00:00:00 1970 PST
-  760 |   0 | 00760              | Mon Mar 02 00:00:00 1970 PST
-  761 |   1 | 00761              | Tue Mar 03 00:00:00 1970 PST
-  763 | 303 | 00763_update3      | Thu Mar 05 00:00:00 1970 PST
-  764 |   4 | 00764              | Fri Mar 06 00:00:00 1970 PST
-  766 |   6 | 00766              | Sun Mar 08 00:00:00 1970 PST
-  767 | 407 | 00767_update7      | Mon Mar 09 00:00:00 1970 PST
-  768 |   8 | 00768              | Tue Mar 10 00:00:00 1970 PST
-  769 | 509 | 00769_update9      | Wed Mar 11 00:00:00 1970 PST
-  770 |   0 | 00770              | Thu Mar 12 00:00:00 1970 PST
-  771 |   1 | 00771              | Fri Mar 13 00:00:00 1970 PST
-  773 | 303 | 00773_update3      | Sun Mar 15 00:00:00 1970 PST
-  774 |   4 | 00774              | Mon Mar 16 00:00:00 1970 PST
-  776 |   6 | 00776              | Wed Mar 18 00:00:00 1970 PST
-  777 | 407 | 00777_update7      | Thu Mar 19 00:00:00 1970 PST
-  778 |   8 | 00778              | Fri Mar 20 00:00:00 1970 PST
-  779 | 509 | 00779_update9      | Sat Mar 21 00:00:00 1970 PST
-  780 |   0 | 00780              | Sun Mar 22 00:00:00 1970 PST
-  781 |   1 | 00781              | Mon Mar 23 00:00:00 1970 PST
-  783 | 303 | 00783_update3      | Wed Mar 25 00:00:00 1970 PST
-  784 |   4 | 00784              | Thu Mar 26 00:00:00 1970 PST
-  786 |   6 | 00786              | Sat Mar 28 00:00:00 1970 PST
-  787 | 407 | 00787_update7      | Sun Mar 29 00:00:00 1970 PST
-  788 |   8 | 00788              | Mon Mar 30 00:00:00 1970 PST
-  789 | 509 | 00789_update9      | Tue Mar 31 00:00:00 1970 PST
-  790 |   0 | 00790              | Wed Apr 01 00:00:00 1970 PST
-  791 |   1 | 00791              | Thu Apr 02 00:00:00 1970 PST
-  793 | 303 | 00793_update3      | Sat Apr 04 00:00:00 1970 PST
-  794 |   4 | 00794              | Sun Apr 05 00:00:00 1970 PST
-  796 |   6 | 00796              | Tue Apr 07 00:00:00 1970 PST
-  797 | 407 | 00797_update7      | Wed Apr 08 00:00:00 1970 PST
-  798 |   8 | 00798              | Thu Apr 09 00:00:00 1970 PST
-  799 | 509 | 00799_update9      | Fri Apr 10 00:00:00 1970 PST
-  800 |   0 | 00800              | Thu Jan 01 00:00:00 1970 PST
-  801 |   1 | 00801              | Fri Jan 02 00:00:00 1970 PST
-  803 | 303 | 00803_update3      | Sun Jan 04 00:00:00 1970 PST
-  804 |   4 | 00804              | Mon Jan 05 00:00:00 1970 PST
-  806 |   6 | 00806              | Wed Jan 07 00:00:00 1970 PST
-  807 | 407 | 00807_update7      | Thu Jan 08 00:00:00 1970 PST
-  808 |   8 | 00808              | Fri Jan 09 00:00:00 1970 PST
-  809 | 509 | 00809_update9      | Sat Jan 10 00:00:00 1970 PST
-  810 |   0 | 00810              | Sun Jan 11 00:00:00 1970 PST
-  811 |   1 | 00811              | Mon Jan 12 00:00:00 1970 PST
-  813 | 303 | 00813_update3      | Wed Jan 14 00:00:00 1970 PST
-  814 |   4 | 00814              | Thu Jan 15 00:00:00 1970 PST
-  816 |   6 | 00816              | Sat Jan 17 00:00:00 1970 PST
-  817 | 407 | 00817_update7      | Sun Jan 18 00:00:00 1970 PST
-  818 |   8 | 00818              | Mon Jan 19 00:00:00 1970 PST
-  819 | 509 | 00819_update9      | Tue Jan 20 00:00:00 1970 PST
-  820 |   0 | 00820              | Wed Jan 21 00:00:00 1970 PST
-  821 |   1 | 00821              | Thu Jan 22 00:00:00 1970 PST
-  823 | 303 | 00823_update3      | Sat Jan 24 00:00:00 1970 PST
-  824 |   4 | 00824              | Sun Jan 25 00:00:00 1970 PST
-  826 |   6 | 00826              | Tue Jan 27 00:00:00 1970 PST
-  827 | 407 | 00827_update7      | Wed Jan 28 00:00:00 1970 PST
-  828 |   8 | 00828              | Thu Jan 29 00:00:00 1970 PST
-  829 | 509 | 00829_update9      | Fri Jan 30 00:00:00 1970 PST
-  830 |   0 | 00830              | Sat Jan 31 00:00:00 1970 PST
-  831 |   1 | 00831              | Sun Feb 01 00:00:00 1970 PST
-  833 | 303 | 00833_update3      | Tue Feb 03 00:00:00 1970 PST
-  834 |   4 | 00834              | Wed Feb 04 00:00:00 1970 PST
-  836 |   6 | 00836              | Fri Feb 06 00:00:00 1970 PST
-  837 | 407 | 00837_update7      | Sat Feb 07 00:00:00 1970 PST
-  838 |   8 | 00838              | Sun Feb 08 00:00:00 1970 PST
-  839 | 509 | 00839_update9      | Mon Feb 09 00:00:00 1970 PST
-  840 |   0 | 00840              | Tue Feb 10 00:00:00 1970 PST
-  841 |   1 | 00841              | Wed Feb 11 00:00:00 1970 PST
-  843 | 303 | 00843_update3      | Fri Feb 13 00:00:00 1970 PST
-  844 |   4 | 00844              | Sat Feb 14 00:00:00 1970 PST
-  846 |   6 | 00846              | Mon Feb 16 00:00:00 1970 PST
-  847 | 407 | 00847_update7      | Tue Feb 17 00:00:00 1970 PST
-  848 |   8 | 00848              | Wed Feb 18 00:00:00 1970 PST
-  849 | 509 | 00849_update9      | Thu Feb 19 00:00:00 1970 PST
-  850 |   0 | 00850              | Fri Feb 20 00:00:00 1970 PST
-  851 |   1 | 00851              | Sat Feb 21 00:00:00 1970 PST
-  853 | 303 | 00853_update3      | Mon Feb 23 00:00:00 1970 PST
-  854 |   4 | 00854              | Tue Feb 24 00:00:00 1970 PST
-  856 |   6 | 00856              | Thu Feb 26 00:00:00 1970 PST
-  857 | 407 | 00857_update7      | Fri Feb 27 00:00:00 1970 PST
-  858 |   8 | 00858              | Sat Feb 28 00:00:00 1970 PST
-  859 | 509 | 00859_update9      | Sun Mar 01 00:00:00 1970 PST
-  860 |   0 | 00860              | Mon Mar 02 00:00:00 1970 PST
-  861 |   1 | 00861              | Tue Mar 03 00:00:00 1970 PST
-  863 | 303 | 00863_update3      | Thu Mar 05 00:00:00 1970 PST
-  864 |   4 | 00864              | Fri Mar 06 00:00:00 1970 PST
-  866 |   6 | 00866              | Sun Mar 08 00:00:00 1970 PST
-  867 | 407 | 00867_update7      | Mon Mar 09 00:00:00 1970 PST
-  868 |   8 | 00868              | Tue Mar 10 00:00:00 1970 PST
-  869 | 509 | 00869_update9      | Wed Mar 11 00:00:00 1970 PST
-  870 |   0 | 00870              | Thu Mar 12 00:00:00 1970 PST
-  871 |   1 | 00871              | Fri Mar 13 00:00:00 1970 PST
-  873 | 303 | 00873_update3      | Sun Mar 15 00:00:00 1970 PST
-  874 |   4 | 00874              | Mon Mar 16 00:00:00 1970 PST
-  876 |   6 | 00876              | Wed Mar 18 00:00:00 1970 PST
-  877 | 407 | 00877_update7      | Thu Mar 19 00:00:00 1970 PST
-  878 |   8 | 00878              | Fri Mar 20 00:00:00 1970 PST
-  879 | 509 | 00879_update9      | Sat Mar 21 00:00:00 1970 PST
-  880 |   0 | 00880              | Sun Mar 22 00:00:00 1970 PST
-  881 |   1 | 00881              | Mon Mar 23 00:00:00 1970 PST
-  883 | 303 | 00883_update3      | Wed Mar 25 00:00:00 1970 PST
-  884 |   4 | 00884              | Thu Mar 26 00:00:00 1970 PST
-  886 |   6 | 00886              | Sat Mar 28 00:00:00 1970 PST
-  887 | 407 | 00887_update7      | Sun Mar 29 00:00:00 1970 PST
-  888 |   8 | 00888              | Mon Mar 30 00:00:00 1970 PST
-  889 | 509 | 00889_update9      | Tue Mar 31 00:00:00 1970 PST
-  890 |   0 | 00890              | Wed Apr 01 00:00:00 1970 PST
-  891 |   1 | 00891              | Thu Apr 02 00:00:00 1970 PST
-  893 | 303 | 00893_update3      | Sat Apr 04 00:00:00 1970 PST
-  894 |   4 | 00894              | Sun Apr 05 00:00:00 1970 PST
-  896 |   6 | 00896              | Tue Apr 07 00:00:00 1970 PST
-  897 | 407 | 00897_update7      | Wed Apr 08 00:00:00 1970 PST
-  898 |   8 | 00898              | Thu Apr 09 00:00:00 1970 PST
-  899 | 509 | 00899_update9      | Fri Apr 10 00:00:00 1970 PST
-  900 |   0 | 00900              | Thu Jan 01 00:00:00 1970 PST
-  901 |   1 | 00901              | Fri Jan 02 00:00:00 1970 PST
-  903 | 303 | 00903_update3      | Sun Jan 04 00:00:00 1970 PST
-  904 |   4 | 00904              | Mon Jan 05 00:00:00 1970 PST
-  906 |   6 | 00906              | Wed Jan 07 00:00:00 1970 PST
-  907 | 407 | 00907_update7      | Thu Jan 08 00:00:00 1970 PST
-  908 |   8 | 00908              | Fri Jan 09 00:00:00 1970 PST
-  909 | 509 | 00909_update9      | Sat Jan 10 00:00:00 1970 PST
-  910 |   0 | 00910              | Sun Jan 11 00:00:00 1970 PST
-  911 |   1 | 00911              | Mon Jan 12 00:00:00 1970 PST
-  913 | 303 | 00913_update3      | Wed Jan 14 00:00:00 1970 PST
-  914 |   4 | 00914              | Thu Jan 15 00:00:00 1970 PST
-  916 |   6 | 00916              | Sat Jan 17 00:00:00 1970 PST
-  917 | 407 | 00917_update7      | Sun Jan 18 00:00:00 1970 PST
-  918 |   8 | 00918              | Mon Jan 19 00:00:00 1970 PST
-  919 | 509 | 00919_update9      | Tue Jan 20 00:00:00 1970 PST
-  920 |   0 | 00920              | Wed Jan 21 00:00:00 1970 PST
-  921 |   1 | 00921              | Thu Jan 22 00:00:00 1970 PST
-  923 | 303 | 00923_update3      | Sat Jan 24 00:00:00 1970 PST
-  924 |   4 | 00924              | Sun Jan 25 00:00:00 1970 PST
-  926 |   6 | 00926              | Tue Jan 27 00:00:00 1970 PST
-  927 | 407 | 00927_update7      | Wed Jan 28 00:00:00 1970 PST
-  928 |   8 | 00928              | Thu Jan 29 00:00:00 1970 PST
-  929 | 509 | 00929_update9      | Fri Jan 30 00:00:00 1970 PST
-  930 |   0 | 00930              | Sat Jan 31 00:00:00 1970 PST
-  931 |   1 | 00931              | Sun Feb 01 00:00:00 1970 PST
-  933 | 303 | 00933_update3      | Tue Feb 03 00:00:00 1970 PST
-  934 |   4 | 00934              | Wed Feb 04 00:00:00 1970 PST
-  936 |   6 | 00936              | Fri Feb 06 00:00:00 1970 PST
-  937 | 407 | 00937_update7      | Sat Feb 07 00:00:00 1970 PST
-  938 |   8 | 00938              | Sun Feb 08 00:00:00 1970 PST
-  939 | 509 | 00939_update9      | Mon Feb 09 00:00:00 1970 PST
-  940 |   0 | 00940              | Tue Feb 10 00:00:00 1970 PST
-  941 |   1 | 00941              | Wed Feb 11 00:00:00 1970 PST
-  943 | 303 | 00943_update3      | Fri Feb 13 00:00:00 1970 PST
-  944 |   4 | 00944              | Sat Feb 14 00:00:00 1970 PST
-  946 |   6 | 00946              | Mon Feb 16 00:00:00 1970 PST
-  947 | 407 | 00947_update7      | Tue Feb 17 00:00:00 1970 PST
-  948 |   8 | 00948              | Wed Feb 18 00:00:00 1970 PST
-  949 | 509 | 00949_update9      | Thu Feb 19 00:00:00 1970 PST
-  950 |   0 | 00950              | Fri Feb 20 00:00:00 1970 PST
-  951 |   1 | 00951              | Sat Feb 21 00:00:00 1970 PST
-  953 | 303 | 00953_update3      | Mon Feb 23 00:00:00 1970 PST
-  954 |   4 | 00954              | Tue Feb 24 00:00:00 1970 PST
-  956 |   6 | 00956              | Thu Feb 26 00:00:00 1970 PST
-  957 | 407 | 00957_update7      | Fri Feb 27 00:00:00 1970 PST
-  958 |   8 | 00958              | Sat Feb 28 00:00:00 1970 PST
-  959 | 509 | 00959_update9      | Sun Mar 01 00:00:00 1970 PST
-  960 |   0 | 00960              | Mon Mar 02 00:00:00 1970 PST
-  961 |   1 | 00961              | Tue Mar 03 00:00:00 1970 PST
-  963 | 303 | 00963_update3      | Thu Mar 05 00:00:00 1970 PST
-  964 |   4 | 00964              | Fri Mar 06 00:00:00 1970 PST
-  966 |   6 | 00966              | Sun Mar 08 00:00:00 1970 PST
-  967 | 407 | 00967_update7      | Mon Mar 09 00:00:00 1970 PST
-  968 |   8 | 00968              | Tue Mar 10 00:00:00 1970 PST
-  969 | 509 | 00969_update9      | Wed Mar 11 00:00:00 1970 PST
-  970 |   0 | 00970              | Thu Mar 12 00:00:00 1970 PST
-  971 |   1 | 00971              | Fri Mar 13 00:00:00 1970 PST
-  973 | 303 | 00973_update3      | Sun Mar 15 00:00:00 1970 PST
-  974 |   4 | 00974              | Mon Mar 16 00:00:00 1970 PST
-  976 |   6 | 00976              | Wed Mar 18 00:00:00 1970 PST
-  977 | 407 | 00977_update7      | Thu Mar 19 00:00:00 1970 PST
-  978 |   8 | 00978              | Fri Mar 20 00:00:00 1970 PST
-  979 | 509 | 00979_update9      | Sat Mar 21 00:00:00 1970 PST
-  980 |   0 | 00980              | Sun Mar 22 00:00:00 1970 PST
-  981 |   1 | 00981              | Mon Mar 23 00:00:00 1970 PST
-  983 | 303 | 00983_update3      | Wed Mar 25 00:00:00 1970 PST
-  984 |   4 | 00984              | Thu Mar 26 00:00:00 1970 PST
-  986 |   6 | 00986              | Sat Mar 28 00:00:00 1970 PST
-  987 | 407 | 00987_update7      | Sun Mar 29 00:00:00 1970 PST
-  988 |   8 | 00988              | Mon Mar 30 00:00:00 1970 PST
-  989 | 509 | 00989_update9      | Tue Mar 31 00:00:00 1970 PST
-  990 |   0 | 00990              | Wed Apr 01 00:00:00 1970 PST
-  991 |   1 | 00991              | Thu Apr 02 00:00:00 1970 PST
-  993 | 303 | 00993_update3      | Sat Apr 04 00:00:00 1970 PST
-  994 |   4 | 00994              | Sun Apr 05 00:00:00 1970 PST
-  996 |   6 | 00996              | Tue Apr 07 00:00:00 1970 PST
-  997 | 407 | 00997_update7      | Wed Apr 08 00:00:00 1970 PST
-  998 |   8 | 00998              | Thu Apr 09 00:00:00 1970 PST
-  999 | 509 | 00999_update9      | Fri Apr 10 00:00:00 1970 PST
- 1000 |   0 | 01000              | Thu Jan 01 00:00:00 1970 PST
+  c1  | c2  |         c3         |                c4                 
+------+-----+--------------------+-----------------------------------
+ 1    | 1   | 00001              | 1970-01-02 00:00:00.000000 -08:00
+ 3    | 303 | 00003_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 4    | 4   | 00004              | 1970-01-05 00:00:00.000000 -08:00
+ 6    | 6   | 00006              | 1970-01-07 00:00:00.000000 -08:00
+ 7    | 407 | 00007_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 8    | 8   | 00008              | 1970-01-09 00:00:00.000000 -08:00
+ 9    | 509 | 00009_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 10   | 0   | 00010              | 1970-01-11 00:00:00.000000 -08:00
+ 11   | 1   | 00011              | 1970-01-12 00:00:00.000000 -08:00
+ 13   | 303 | 00013_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 14   | 4   | 00014              | 1970-01-15 00:00:00.000000 -08:00
+ 16   | 6   | 00016              | 1970-01-17 00:00:00.000000 -08:00
+ 17   | 407 | 00017_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 18   | 8   | 00018              | 1970-01-19 00:00:00.000000 -08:00
+ 19   | 509 | 00019_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 20   | 0   | 00020              | 1970-01-21 00:00:00.000000 -08:00
+ 21   | 1   | 00021              | 1970-01-22 00:00:00.000000 -08:00
+ 23   | 303 | 00023_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 24   | 4   | 00024              | 1970-01-25 00:00:00.000000 -08:00
+ 26   | 6   | 00026              | 1970-01-27 00:00:00.000000 -08:00
+ 27   | 407 | 00027_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 28   | 8   | 00028              | 1970-01-29 00:00:00.000000 -08:00
+ 29   | 509 | 00029_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 30   | 0   | 00030              | 1970-01-31 00:00:00.000000 -08:00
+ 31   | 1   | 00031              | 1970-02-01 00:00:00.000000 -08:00
+ 33   | 303 | 00033_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 34   | 4   | 00034              | 1970-02-04 00:00:00.000000 -08:00
+ 36   | 6   | 00036              | 1970-02-06 00:00:00.000000 -08:00
+ 37   | 407 | 00037_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 38   | 8   | 00038              | 1970-02-08 00:00:00.000000 -08:00
+ 39   | 509 | 00039_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 40   | 0   | 00040              | 1970-02-10 00:00:00.000000 -08:00
+ 41   | 1   | 00041              | 1970-02-11 00:00:00.000000 -08:00
+ 43   | 303 | 00043_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 44   | 4   | 00044              | 1970-02-14 00:00:00.000000 -08:00
+ 46   | 6   | 00046              | 1970-02-16 00:00:00.000000 -08:00
+ 47   | 407 | 00047_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 48   | 8   | 00048              | 1970-02-18 00:00:00.000000 -08:00
+ 49   | 509 | 00049_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 50   | 0   | 00050              | 1970-02-20 00:00:00.000000 -08:00
+ 51   | 1   | 00051              | 1970-02-21 00:00:00.000000 -08:00
+ 53   | 303 | 00053_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 54   | 4   | 00054              | 1970-02-24 00:00:00.000000 -08:00
+ 56   | 6   | 00056              | 1970-02-26 00:00:00.000000 -08:00
+ 57   | 407 | 00057_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 58   | 8   | 00058              | 1970-02-28 00:00:00.000000 -08:00
+ 59   | 509 | 00059_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 60   | 0   | 00060              | 1970-03-02 00:00:00.000000 -08:00
+ 61   | 1   | 00061              | 1970-03-03 00:00:00.000000 -08:00
+ 63   | 303 | 00063_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 64   | 4   | 00064              | 1970-03-06 00:00:00.000000 -08:00
+ 66   | 6   | 00066              | 1970-03-08 00:00:00.000000 -08:00
+ 67   | 407 | 00067_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 68   | 8   | 00068              | 1970-03-10 00:00:00.000000 -08:00
+ 69   | 509 | 00069_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 70   | 0   | 00070              | 1970-03-12 00:00:00.000000 -08:00
+ 71   | 1   | 00071              | 1970-03-13 00:00:00.000000 -08:00
+ 73   | 303 | 00073_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 74   | 4   | 00074              | 1970-03-16 00:00:00.000000 -08:00
+ 76   | 6   | 00076              | 1970-03-18 00:00:00.000000 -08:00
+ 77   | 407 | 00077_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 78   | 8   | 00078              | 1970-03-20 00:00:00.000000 -08:00
+ 79   | 509 | 00079_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 80   | 0   | 00080              | 1970-03-22 00:00:00.000000 -08:00
+ 81   | 1   | 00081              | 1970-03-23 00:00:00.000000 -08:00
+ 83   | 303 | 00083_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 84   | 4   | 00084              | 1970-03-26 00:00:00.000000 -08:00
+ 86   | 6   | 00086              | 1970-03-28 00:00:00.000000 -08:00
+ 87   | 407 | 00087_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 88   | 8   | 00088              | 1970-03-30 00:00:00.000000 -08:00
+ 89   | 509 | 00089_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 90   | 0   | 00090              | 1970-04-01 00:00:00.000000 -08:00
+ 91   | 1   | 00091              | 1970-04-02 00:00:00.000000 -08:00
+ 93   | 303 | 00093_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 94   | 4   | 00094              | 1970-04-05 00:00:00.000000 -08:00
+ 96   | 6   | 00096              | 1970-04-07 00:00:00.000000 -08:00
+ 97   | 407 | 00097_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 98   | 8   | 00098              | 1970-04-09 00:00:00.000000 -08:00
+ 99   | 509 | 00099_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 100  | 0   | 00100              | 1970-01-01 00:00:00.000000 -08:00
+ 101  | 1   | 00101              | 1970-01-02 00:00:00.000000 -08:00
+ 103  | 303 | 00103_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 104  | 4   | 00104              | 1970-01-05 00:00:00.000000 -08:00
+ 106  | 6   | 00106              | 1970-01-07 00:00:00.000000 -08:00
+ 107  | 407 | 00107_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 108  | 8   | 00108              | 1970-01-09 00:00:00.000000 -08:00
+ 109  | 509 | 00109_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 110  | 0   | 00110              | 1970-01-11 00:00:00.000000 -08:00
+ 111  | 1   | 00111              | 1970-01-12 00:00:00.000000 -08:00
+ 113  | 303 | 00113_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 114  | 4   | 00114              | 1970-01-15 00:00:00.000000 -08:00
+ 116  | 6   | 00116              | 1970-01-17 00:00:00.000000 -08:00
+ 117  | 407 | 00117_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 118  | 8   | 00118              | 1970-01-19 00:00:00.000000 -08:00
+ 119  | 509 | 00119_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 120  | 0   | 00120              | 1970-01-21 00:00:00.000000 -08:00
+ 121  | 1   | 00121              | 1970-01-22 00:00:00.000000 -08:00
+ 123  | 303 | 00123_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 124  | 4   | 00124              | 1970-01-25 00:00:00.000000 -08:00
+ 126  | 6   | 00126              | 1970-01-27 00:00:00.000000 -08:00
+ 127  | 407 | 00127_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 128  | 8   | 00128              | 1970-01-29 00:00:00.000000 -08:00
+ 129  | 509 | 00129_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 130  | 0   | 00130              | 1970-01-31 00:00:00.000000 -08:00
+ 131  | 1   | 00131              | 1970-02-01 00:00:00.000000 -08:00
+ 133  | 303 | 00133_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 134  | 4   | 00134              | 1970-02-04 00:00:00.000000 -08:00
+ 136  | 6   | 00136              | 1970-02-06 00:00:00.000000 -08:00
+ 137  | 407 | 00137_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 138  | 8   | 00138              | 1970-02-08 00:00:00.000000 -08:00
+ 139  | 509 | 00139_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 140  | 0   | 00140              | 1970-02-10 00:00:00.000000 -08:00
+ 141  | 1   | 00141              | 1970-02-11 00:00:00.000000 -08:00
+ 143  | 303 | 00143_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 144  | 4   | 00144              | 1970-02-14 00:00:00.000000 -08:00
+ 146  | 6   | 00146              | 1970-02-16 00:00:00.000000 -08:00
+ 147  | 407 | 00147_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 148  | 8   | 00148              | 1970-02-18 00:00:00.000000 -08:00
+ 149  | 509 | 00149_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 150  | 0   | 00150              | 1970-02-20 00:00:00.000000 -08:00
+ 151  | 1   | 00151              | 1970-02-21 00:00:00.000000 -08:00
+ 153  | 303 | 00153_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 154  | 4   | 00154              | 1970-02-24 00:00:00.000000 -08:00
+ 156  | 6   | 00156              | 1970-02-26 00:00:00.000000 -08:00
+ 157  | 407 | 00157_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 158  | 8   | 00158              | 1970-02-28 00:00:00.000000 -08:00
+ 159  | 509 | 00159_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 160  | 0   | 00160              | 1970-03-02 00:00:00.000000 -08:00
+ 161  | 1   | 00161              | 1970-03-03 00:00:00.000000 -08:00
+ 163  | 303 | 00163_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 164  | 4   | 00164              | 1970-03-06 00:00:00.000000 -08:00
+ 166  | 6   | 00166              | 1970-03-08 00:00:00.000000 -08:00
+ 167  | 407 | 00167_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 168  | 8   | 00168              | 1970-03-10 00:00:00.000000 -08:00
+ 169  | 509 | 00169_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 170  | 0   | 00170              | 1970-03-12 00:00:00.000000 -08:00
+ 171  | 1   | 00171              | 1970-03-13 00:00:00.000000 -08:00
+ 173  | 303 | 00173_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 174  | 4   | 00174              | 1970-03-16 00:00:00.000000 -08:00
+ 176  | 6   | 00176              | 1970-03-18 00:00:00.000000 -08:00
+ 177  | 407 | 00177_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 178  | 8   | 00178              | 1970-03-20 00:00:00.000000 -08:00
+ 179  | 509 | 00179_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 180  | 0   | 00180              | 1970-03-22 00:00:00.000000 -08:00
+ 181  | 1   | 00181              | 1970-03-23 00:00:00.000000 -08:00
+ 183  | 303 | 00183_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 184  | 4   | 00184              | 1970-03-26 00:00:00.000000 -08:00
+ 186  | 6   | 00186              | 1970-03-28 00:00:00.000000 -08:00
+ 187  | 407 | 00187_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 188  | 8   | 00188              | 1970-03-30 00:00:00.000000 -08:00
+ 189  | 509 | 00189_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 190  | 0   | 00190              | 1970-04-01 00:00:00.000000 -08:00
+ 191  | 1   | 00191              | 1970-04-02 00:00:00.000000 -08:00
+ 193  | 303 | 00193_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 194  | 4   | 00194              | 1970-04-05 00:00:00.000000 -08:00
+ 196  | 6   | 00196              | 1970-04-07 00:00:00.000000 -08:00
+ 197  | 407 | 00197_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 198  | 8   | 00198              | 1970-04-09 00:00:00.000000 -08:00
+ 199  | 509 | 00199_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 200  | 0   | 00200              | 1970-01-01 00:00:00.000000 -08:00
+ 201  | 1   | 00201              | 1970-01-02 00:00:00.000000 -08:00
+ 203  | 303 | 00203_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 204  | 4   | 00204              | 1970-01-05 00:00:00.000000 -08:00
+ 206  | 6   | 00206              | 1970-01-07 00:00:00.000000 -08:00
+ 207  | 407 | 00207_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 208  | 8   | 00208              | 1970-01-09 00:00:00.000000 -08:00
+ 209  | 509 | 00209_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 210  | 0   | 00210              | 1970-01-11 00:00:00.000000 -08:00
+ 211  | 1   | 00211              | 1970-01-12 00:00:00.000000 -08:00
+ 213  | 303 | 00213_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 214  | 4   | 00214              | 1970-01-15 00:00:00.000000 -08:00
+ 216  | 6   | 00216              | 1970-01-17 00:00:00.000000 -08:00
+ 217  | 407 | 00217_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 218  | 8   | 00218              | 1970-01-19 00:00:00.000000 -08:00
+ 219  | 509 | 00219_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 220  | 0   | 00220              | 1970-01-21 00:00:00.000000 -08:00
+ 221  | 1   | 00221              | 1970-01-22 00:00:00.000000 -08:00
+ 223  | 303 | 00223_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 224  | 4   | 00224              | 1970-01-25 00:00:00.000000 -08:00
+ 226  | 6   | 00226              | 1970-01-27 00:00:00.000000 -08:00
+ 227  | 407 | 00227_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 228  | 8   | 00228              | 1970-01-29 00:00:00.000000 -08:00
+ 229  | 509 | 00229_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 230  | 0   | 00230              | 1970-01-31 00:00:00.000000 -08:00
+ 231  | 1   | 00231              | 1970-02-01 00:00:00.000000 -08:00
+ 233  | 303 | 00233_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 234  | 4   | 00234              | 1970-02-04 00:00:00.000000 -08:00
+ 236  | 6   | 00236              | 1970-02-06 00:00:00.000000 -08:00
+ 237  | 407 | 00237_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 238  | 8   | 00238              | 1970-02-08 00:00:00.000000 -08:00
+ 239  | 509 | 00239_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 240  | 0   | 00240              | 1970-02-10 00:00:00.000000 -08:00
+ 241  | 1   | 00241              | 1970-02-11 00:00:00.000000 -08:00
+ 243  | 303 | 00243_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 244  | 4   | 00244              | 1970-02-14 00:00:00.000000 -08:00
+ 246  | 6   | 00246              | 1970-02-16 00:00:00.000000 -08:00
+ 247  | 407 | 00247_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 248  | 8   | 00248              | 1970-02-18 00:00:00.000000 -08:00
+ 249  | 509 | 00249_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 250  | 0   | 00250              | 1970-02-20 00:00:00.000000 -08:00
+ 251  | 1   | 00251              | 1970-02-21 00:00:00.000000 -08:00
+ 253  | 303 | 00253_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 254  | 4   | 00254              | 1970-02-24 00:00:00.000000 -08:00
+ 256  | 6   | 00256              | 1970-02-26 00:00:00.000000 -08:00
+ 257  | 407 | 00257_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 258  | 8   | 00258              | 1970-02-28 00:00:00.000000 -08:00
+ 259  | 509 | 00259_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 260  | 0   | 00260              | 1970-03-02 00:00:00.000000 -08:00
+ 261  | 1   | 00261              | 1970-03-03 00:00:00.000000 -08:00
+ 263  | 303 | 00263_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 264  | 4   | 00264              | 1970-03-06 00:00:00.000000 -08:00
+ 266  | 6   | 00266              | 1970-03-08 00:00:00.000000 -08:00
+ 267  | 407 | 00267_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 268  | 8   | 00268              | 1970-03-10 00:00:00.000000 -08:00
+ 269  | 509 | 00269_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 270  | 0   | 00270              | 1970-03-12 00:00:00.000000 -08:00
+ 271  | 1   | 00271              | 1970-03-13 00:00:00.000000 -08:00
+ 273  | 303 | 00273_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 274  | 4   | 00274              | 1970-03-16 00:00:00.000000 -08:00
+ 276  | 6   | 00276              | 1970-03-18 00:00:00.000000 -08:00
+ 277  | 407 | 00277_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 278  | 8   | 00278              | 1970-03-20 00:00:00.000000 -08:00
+ 279  | 509 | 00279_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 280  | 0   | 00280              | 1970-03-22 00:00:00.000000 -08:00
+ 281  | 1   | 00281              | 1970-03-23 00:00:00.000000 -08:00
+ 283  | 303 | 00283_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 284  | 4   | 00284              | 1970-03-26 00:00:00.000000 -08:00
+ 286  | 6   | 00286              | 1970-03-28 00:00:00.000000 -08:00
+ 287  | 407 | 00287_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 288  | 8   | 00288              | 1970-03-30 00:00:00.000000 -08:00
+ 289  | 509 | 00289_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 290  | 0   | 00290              | 1970-04-01 00:00:00.000000 -08:00
+ 291  | 1   | 00291              | 1970-04-02 00:00:00.000000 -08:00
+ 293  | 303 | 00293_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 294  | 4   | 00294              | 1970-04-05 00:00:00.000000 -08:00
+ 296  | 6   | 00296              | 1970-04-07 00:00:00.000000 -08:00
+ 297  | 407 | 00297_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 298  | 8   | 00298              | 1970-04-09 00:00:00.000000 -08:00
+ 299  | 509 | 00299_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 300  | 0   | 00300              | 1970-01-01 00:00:00.000000 -08:00
+ 301  | 1   | 00301              | 1970-01-02 00:00:00.000000 -08:00
+ 303  | 303 | 00303_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 304  | 4   | 00304              | 1970-01-05 00:00:00.000000 -08:00
+ 306  | 6   | 00306              | 1970-01-07 00:00:00.000000 -08:00
+ 307  | 407 | 00307_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 308  | 8   | 00308              | 1970-01-09 00:00:00.000000 -08:00
+ 309  | 509 | 00309_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 310  | 0   | 00310              | 1970-01-11 00:00:00.000000 -08:00
+ 311  | 1   | 00311              | 1970-01-12 00:00:00.000000 -08:00
+ 313  | 303 | 00313_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 314  | 4   | 00314              | 1970-01-15 00:00:00.000000 -08:00
+ 316  | 6   | 00316              | 1970-01-17 00:00:00.000000 -08:00
+ 317  | 407 | 00317_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 318  | 8   | 00318              | 1970-01-19 00:00:00.000000 -08:00
+ 319  | 509 | 00319_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 320  | 0   | 00320              | 1970-01-21 00:00:00.000000 -08:00
+ 321  | 1   | 00321              | 1970-01-22 00:00:00.000000 -08:00
+ 323  | 303 | 00323_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 324  | 4   | 00324              | 1970-01-25 00:00:00.000000 -08:00
+ 326  | 6   | 00326              | 1970-01-27 00:00:00.000000 -08:00
+ 327  | 407 | 00327_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 328  | 8   | 00328              | 1970-01-29 00:00:00.000000 -08:00
+ 329  | 509 | 00329_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 330  | 0   | 00330              | 1970-01-31 00:00:00.000000 -08:00
+ 331  | 1   | 00331              | 1970-02-01 00:00:00.000000 -08:00
+ 333  | 303 | 00333_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 334  | 4   | 00334              | 1970-02-04 00:00:00.000000 -08:00
+ 336  | 6   | 00336              | 1970-02-06 00:00:00.000000 -08:00
+ 337  | 407 | 00337_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 338  | 8   | 00338              | 1970-02-08 00:00:00.000000 -08:00
+ 339  | 509 | 00339_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 340  | 0   | 00340              | 1970-02-10 00:00:00.000000 -08:00
+ 341  | 1   | 00341              | 1970-02-11 00:00:00.000000 -08:00
+ 343  | 303 | 00343_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 344  | 4   | 00344              | 1970-02-14 00:00:00.000000 -08:00
+ 346  | 6   | 00346              | 1970-02-16 00:00:00.000000 -08:00
+ 347  | 407 | 00347_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 348  | 8   | 00348              | 1970-02-18 00:00:00.000000 -08:00
+ 349  | 509 | 00349_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 350  | 0   | 00350              | 1970-02-20 00:00:00.000000 -08:00
+ 351  | 1   | 00351              | 1970-02-21 00:00:00.000000 -08:00
+ 353  | 303 | 00353_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 354  | 4   | 00354              | 1970-02-24 00:00:00.000000 -08:00
+ 356  | 6   | 00356              | 1970-02-26 00:00:00.000000 -08:00
+ 357  | 407 | 00357_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 358  | 8   | 00358              | 1970-02-28 00:00:00.000000 -08:00
+ 359  | 509 | 00359_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 360  | 0   | 00360              | 1970-03-02 00:00:00.000000 -08:00
+ 361  | 1   | 00361              | 1970-03-03 00:00:00.000000 -08:00
+ 363  | 303 | 00363_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 364  | 4   | 00364              | 1970-03-06 00:00:00.000000 -08:00
+ 366  | 6   | 00366              | 1970-03-08 00:00:00.000000 -08:00
+ 367  | 407 | 00367_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 368  | 8   | 00368              | 1970-03-10 00:00:00.000000 -08:00
+ 369  | 509 | 00369_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 370  | 0   | 00370              | 1970-03-12 00:00:00.000000 -08:00
+ 371  | 1   | 00371              | 1970-03-13 00:00:00.000000 -08:00
+ 373  | 303 | 00373_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 374  | 4   | 00374              | 1970-03-16 00:00:00.000000 -08:00
+ 376  | 6   | 00376              | 1970-03-18 00:00:00.000000 -08:00
+ 377  | 407 | 00377_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 378  | 8   | 00378              | 1970-03-20 00:00:00.000000 -08:00
+ 379  | 509 | 00379_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 380  | 0   | 00380              | 1970-03-22 00:00:00.000000 -08:00
+ 381  | 1   | 00381              | 1970-03-23 00:00:00.000000 -08:00
+ 383  | 303 | 00383_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 384  | 4   | 00384              | 1970-03-26 00:00:00.000000 -08:00
+ 386  | 6   | 00386              | 1970-03-28 00:00:00.000000 -08:00
+ 387  | 407 | 00387_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 388  | 8   | 00388              | 1970-03-30 00:00:00.000000 -08:00
+ 389  | 509 | 00389_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 390  | 0   | 00390              | 1970-04-01 00:00:00.000000 -08:00
+ 391  | 1   | 00391              | 1970-04-02 00:00:00.000000 -08:00
+ 393  | 303 | 00393_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 394  | 4   | 00394              | 1970-04-05 00:00:00.000000 -08:00
+ 396  | 6   | 00396              | 1970-04-07 00:00:00.000000 -08:00
+ 397  | 407 | 00397_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 398  | 8   | 00398              | 1970-04-09 00:00:00.000000 -08:00
+ 399  | 509 | 00399_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 400  | 0   | 00400              | 1970-01-01 00:00:00.000000 -08:00
+ 401  | 1   | 00401              | 1970-01-02 00:00:00.000000 -08:00
+ 403  | 303 | 00403_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 404  | 4   | 00404              | 1970-01-05 00:00:00.000000 -08:00
+ 406  | 6   | 00406              | 1970-01-07 00:00:00.000000 -08:00
+ 407  | 407 | 00407_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 408  | 8   | 00408              | 1970-01-09 00:00:00.000000 -08:00
+ 409  | 509 | 00409_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 410  | 0   | 00410              | 1970-01-11 00:00:00.000000 -08:00
+ 411  | 1   | 00411              | 1970-01-12 00:00:00.000000 -08:00
+ 413  | 303 | 00413_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 414  | 4   | 00414              | 1970-01-15 00:00:00.000000 -08:00
+ 416  | 6   | 00416              | 1970-01-17 00:00:00.000000 -08:00
+ 417  | 407 | 00417_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 418  | 8   | 00418              | 1970-01-19 00:00:00.000000 -08:00
+ 419  | 509 | 00419_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 420  | 0   | 00420              | 1970-01-21 00:00:00.000000 -08:00
+ 421  | 1   | 00421              | 1970-01-22 00:00:00.000000 -08:00
+ 423  | 303 | 00423_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 424  | 4   | 00424              | 1970-01-25 00:00:00.000000 -08:00
+ 426  | 6   | 00426              | 1970-01-27 00:00:00.000000 -08:00
+ 427  | 407 | 00427_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 428  | 8   | 00428              | 1970-01-29 00:00:00.000000 -08:00
+ 429  | 509 | 00429_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 430  | 0   | 00430              | 1970-01-31 00:00:00.000000 -08:00
+ 431  | 1   | 00431              | 1970-02-01 00:00:00.000000 -08:00
+ 433  | 303 | 00433_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 434  | 4   | 00434              | 1970-02-04 00:00:00.000000 -08:00
+ 436  | 6   | 00436              | 1970-02-06 00:00:00.000000 -08:00
+ 437  | 407 | 00437_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 438  | 8   | 00438              | 1970-02-08 00:00:00.000000 -08:00
+ 439  | 509 | 00439_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 440  | 0   | 00440              | 1970-02-10 00:00:00.000000 -08:00
+ 441  | 1   | 00441              | 1970-02-11 00:00:00.000000 -08:00
+ 443  | 303 | 00443_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 444  | 4   | 00444              | 1970-02-14 00:00:00.000000 -08:00
+ 446  | 6   | 00446              | 1970-02-16 00:00:00.000000 -08:00
+ 447  | 407 | 00447_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 448  | 8   | 00448              | 1970-02-18 00:00:00.000000 -08:00
+ 449  | 509 | 00449_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 450  | 0   | 00450              | 1970-02-20 00:00:00.000000 -08:00
+ 451  | 1   | 00451              | 1970-02-21 00:00:00.000000 -08:00
+ 453  | 303 | 00453_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 454  | 4   | 00454              | 1970-02-24 00:00:00.000000 -08:00
+ 456  | 6   | 00456              | 1970-02-26 00:00:00.000000 -08:00
+ 457  | 407 | 00457_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 458  | 8   | 00458              | 1970-02-28 00:00:00.000000 -08:00
+ 459  | 509 | 00459_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 460  | 0   | 00460              | 1970-03-02 00:00:00.000000 -08:00
+ 461  | 1   | 00461              | 1970-03-03 00:00:00.000000 -08:00
+ 463  | 303 | 00463_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 464  | 4   | 00464              | 1970-03-06 00:00:00.000000 -08:00
+ 466  | 6   | 00466              | 1970-03-08 00:00:00.000000 -08:00
+ 467  | 407 | 00467_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 468  | 8   | 00468              | 1970-03-10 00:00:00.000000 -08:00
+ 469  | 509 | 00469_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 470  | 0   | 00470              | 1970-03-12 00:00:00.000000 -08:00
+ 471  | 1   | 00471              | 1970-03-13 00:00:00.000000 -08:00
+ 473  | 303 | 00473_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 474  | 4   | 00474              | 1970-03-16 00:00:00.000000 -08:00
+ 476  | 6   | 00476              | 1970-03-18 00:00:00.000000 -08:00
+ 477  | 407 | 00477_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 478  | 8   | 00478              | 1970-03-20 00:00:00.000000 -08:00
+ 479  | 509 | 00479_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 480  | 0   | 00480              | 1970-03-22 00:00:00.000000 -08:00
+ 481  | 1   | 00481              | 1970-03-23 00:00:00.000000 -08:00
+ 483  | 303 | 00483_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 484  | 4   | 00484              | 1970-03-26 00:00:00.000000 -08:00
+ 486  | 6   | 00486              | 1970-03-28 00:00:00.000000 -08:00
+ 487  | 407 | 00487_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 488  | 8   | 00488              | 1970-03-30 00:00:00.000000 -08:00
+ 489  | 509 | 00489_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 490  | 0   | 00490              | 1970-04-01 00:00:00.000000 -08:00
+ 491  | 1   | 00491              | 1970-04-02 00:00:00.000000 -08:00
+ 493  | 303 | 00493_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 494  | 4   | 00494              | 1970-04-05 00:00:00.000000 -08:00
+ 496  | 6   | 00496              | 1970-04-07 00:00:00.000000 -08:00
+ 497  | 407 | 00497_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 498  | 8   | 00498              | 1970-04-09 00:00:00.000000 -08:00
+ 499  | 509 | 00499_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 500  | 0   | 00500              | 1970-01-01 00:00:00.000000 -08:00
+ 501  | 1   | 00501              | 1970-01-02 00:00:00.000000 -08:00
+ 503  | 303 | 00503_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 504  | 4   | 00504              | 1970-01-05 00:00:00.000000 -08:00
+ 506  | 6   | 00506              | 1970-01-07 00:00:00.000000 -08:00
+ 507  | 407 | 00507_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 508  | 8   | 00508              | 1970-01-09 00:00:00.000000 -08:00
+ 509  | 509 | 00509_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 510  | 0   | 00510              | 1970-01-11 00:00:00.000000 -08:00
+ 511  | 1   | 00511              | 1970-01-12 00:00:00.000000 -08:00
+ 513  | 303 | 00513_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 514  | 4   | 00514              | 1970-01-15 00:00:00.000000 -08:00
+ 516  | 6   | 00516              | 1970-01-17 00:00:00.000000 -08:00
+ 517  | 407 | 00517_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 518  | 8   | 00518              | 1970-01-19 00:00:00.000000 -08:00
+ 519  | 509 | 00519_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 520  | 0   | 00520              | 1970-01-21 00:00:00.000000 -08:00
+ 521  | 1   | 00521              | 1970-01-22 00:00:00.000000 -08:00
+ 523  | 303 | 00523_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 524  | 4   | 00524              | 1970-01-25 00:00:00.000000 -08:00
+ 526  | 6   | 00526              | 1970-01-27 00:00:00.000000 -08:00
+ 527  | 407 | 00527_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 528  | 8   | 00528              | 1970-01-29 00:00:00.000000 -08:00
+ 529  | 509 | 00529_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 530  | 0   | 00530              | 1970-01-31 00:00:00.000000 -08:00
+ 531  | 1   | 00531              | 1970-02-01 00:00:00.000000 -08:00
+ 533  | 303 | 00533_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 534  | 4   | 00534              | 1970-02-04 00:00:00.000000 -08:00
+ 536  | 6   | 00536              | 1970-02-06 00:00:00.000000 -08:00
+ 537  | 407 | 00537_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 538  | 8   | 00538              | 1970-02-08 00:00:00.000000 -08:00
+ 539  | 509 | 00539_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 540  | 0   | 00540              | 1970-02-10 00:00:00.000000 -08:00
+ 541  | 1   | 00541              | 1970-02-11 00:00:00.000000 -08:00
+ 543  | 303 | 00543_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 544  | 4   | 00544              | 1970-02-14 00:00:00.000000 -08:00
+ 546  | 6   | 00546              | 1970-02-16 00:00:00.000000 -08:00
+ 547  | 407 | 00547_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 548  | 8   | 00548              | 1970-02-18 00:00:00.000000 -08:00
+ 549  | 509 | 00549_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 550  | 0   | 00550              | 1970-02-20 00:00:00.000000 -08:00
+ 551  | 1   | 00551              | 1970-02-21 00:00:00.000000 -08:00
+ 553  | 303 | 00553_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 554  | 4   | 00554              | 1970-02-24 00:00:00.000000 -08:00
+ 556  | 6   | 00556              | 1970-02-26 00:00:00.000000 -08:00
+ 557  | 407 | 00557_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 558  | 8   | 00558              | 1970-02-28 00:00:00.000000 -08:00
+ 559  | 509 | 00559_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 560  | 0   | 00560              | 1970-03-02 00:00:00.000000 -08:00
+ 561  | 1   | 00561              | 1970-03-03 00:00:00.000000 -08:00
+ 563  | 303 | 00563_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 564  | 4   | 00564              | 1970-03-06 00:00:00.000000 -08:00
+ 566  | 6   | 00566              | 1970-03-08 00:00:00.000000 -08:00
+ 567  | 407 | 00567_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 568  | 8   | 00568              | 1970-03-10 00:00:00.000000 -08:00
+ 569  | 509 | 00569_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 570  | 0   | 00570              | 1970-03-12 00:00:00.000000 -08:00
+ 571  | 1   | 00571              | 1970-03-13 00:00:00.000000 -08:00
+ 573  | 303 | 00573_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 574  | 4   | 00574              | 1970-03-16 00:00:00.000000 -08:00
+ 576  | 6   | 00576              | 1970-03-18 00:00:00.000000 -08:00
+ 577  | 407 | 00577_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 578  | 8   | 00578              | 1970-03-20 00:00:00.000000 -08:00
+ 579  | 509 | 00579_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 580  | 0   | 00580              | 1970-03-22 00:00:00.000000 -08:00
+ 581  | 1   | 00581              | 1970-03-23 00:00:00.000000 -08:00
+ 583  | 303 | 00583_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 584  | 4   | 00584              | 1970-03-26 00:00:00.000000 -08:00
+ 586  | 6   | 00586              | 1970-03-28 00:00:00.000000 -08:00
+ 587  | 407 | 00587_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 588  | 8   | 00588              | 1970-03-30 00:00:00.000000 -08:00
+ 589  | 509 | 00589_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 590  | 0   | 00590              | 1970-04-01 00:00:00.000000 -08:00
+ 591  | 1   | 00591              | 1970-04-02 00:00:00.000000 -08:00
+ 593  | 303 | 00593_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 594  | 4   | 00594              | 1970-04-05 00:00:00.000000 -08:00
+ 596  | 6   | 00596              | 1970-04-07 00:00:00.000000 -08:00
+ 597  | 407 | 00597_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 598  | 8   | 00598              | 1970-04-09 00:00:00.000000 -08:00
+ 599  | 509 | 00599_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 600  | 0   | 00600              | 1970-01-01 00:00:00.000000 -08:00
+ 601  | 1   | 00601              | 1970-01-02 00:00:00.000000 -08:00
+ 603  | 303 | 00603_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 604  | 4   | 00604              | 1970-01-05 00:00:00.000000 -08:00
+ 606  | 6   | 00606              | 1970-01-07 00:00:00.000000 -08:00
+ 607  | 407 | 00607_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 608  | 8   | 00608              | 1970-01-09 00:00:00.000000 -08:00
+ 609  | 509 | 00609_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 610  | 0   | 00610              | 1970-01-11 00:00:00.000000 -08:00
+ 611  | 1   | 00611              | 1970-01-12 00:00:00.000000 -08:00
+ 613  | 303 | 00613_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 614  | 4   | 00614              | 1970-01-15 00:00:00.000000 -08:00
+ 616  | 6   | 00616              | 1970-01-17 00:00:00.000000 -08:00
+ 617  | 407 | 00617_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 618  | 8   | 00618              | 1970-01-19 00:00:00.000000 -08:00
+ 619  | 509 | 00619_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 620  | 0   | 00620              | 1970-01-21 00:00:00.000000 -08:00
+ 621  | 1   | 00621              | 1970-01-22 00:00:00.000000 -08:00
+ 623  | 303 | 00623_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 624  | 4   | 00624              | 1970-01-25 00:00:00.000000 -08:00
+ 626  | 6   | 00626              | 1970-01-27 00:00:00.000000 -08:00
+ 627  | 407 | 00627_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 628  | 8   | 00628              | 1970-01-29 00:00:00.000000 -08:00
+ 629  | 509 | 00629_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 630  | 0   | 00630              | 1970-01-31 00:00:00.000000 -08:00
+ 631  | 1   | 00631              | 1970-02-01 00:00:00.000000 -08:00
+ 633  | 303 | 00633_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 634  | 4   | 00634              | 1970-02-04 00:00:00.000000 -08:00
+ 636  | 6   | 00636              | 1970-02-06 00:00:00.000000 -08:00
+ 637  | 407 | 00637_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 638  | 8   | 00638              | 1970-02-08 00:00:00.000000 -08:00
+ 639  | 509 | 00639_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 640  | 0   | 00640              | 1970-02-10 00:00:00.000000 -08:00
+ 641  | 1   | 00641              | 1970-02-11 00:00:00.000000 -08:00
+ 643  | 303 | 00643_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 644  | 4   | 00644              | 1970-02-14 00:00:00.000000 -08:00
+ 646  | 6   | 00646              | 1970-02-16 00:00:00.000000 -08:00
+ 647  | 407 | 00647_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 648  | 8   | 00648              | 1970-02-18 00:00:00.000000 -08:00
+ 649  | 509 | 00649_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 650  | 0   | 00650              | 1970-02-20 00:00:00.000000 -08:00
+ 651  | 1   | 00651              | 1970-02-21 00:00:00.000000 -08:00
+ 653  | 303 | 00653_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 654  | 4   | 00654              | 1970-02-24 00:00:00.000000 -08:00
+ 656  | 6   | 00656              | 1970-02-26 00:00:00.000000 -08:00
+ 657  | 407 | 00657_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 658  | 8   | 00658              | 1970-02-28 00:00:00.000000 -08:00
+ 659  | 509 | 00659_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 660  | 0   | 00660              | 1970-03-02 00:00:00.000000 -08:00
+ 661  | 1   | 00661              | 1970-03-03 00:00:00.000000 -08:00
+ 663  | 303 | 00663_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 664  | 4   | 00664              | 1970-03-06 00:00:00.000000 -08:00
+ 666  | 6   | 00666              | 1970-03-08 00:00:00.000000 -08:00
+ 667  | 407 | 00667_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 668  | 8   | 00668              | 1970-03-10 00:00:00.000000 -08:00
+ 669  | 509 | 00669_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 670  | 0   | 00670              | 1970-03-12 00:00:00.000000 -08:00
+ 671  | 1   | 00671              | 1970-03-13 00:00:00.000000 -08:00
+ 673  | 303 | 00673_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 674  | 4   | 00674              | 1970-03-16 00:00:00.000000 -08:00
+ 676  | 6   | 00676              | 1970-03-18 00:00:00.000000 -08:00
+ 677  | 407 | 00677_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 678  | 8   | 00678              | 1970-03-20 00:00:00.000000 -08:00
+ 679  | 509 | 00679_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 680  | 0   | 00680              | 1970-03-22 00:00:00.000000 -08:00
+ 681  | 1   | 00681              | 1970-03-23 00:00:00.000000 -08:00
+ 683  | 303 | 00683_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 684  | 4   | 00684              | 1970-03-26 00:00:00.000000 -08:00
+ 686  | 6   | 00686              | 1970-03-28 00:00:00.000000 -08:00
+ 687  | 407 | 00687_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 688  | 8   | 00688              | 1970-03-30 00:00:00.000000 -08:00
+ 689  | 509 | 00689_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 690  | 0   | 00690              | 1970-04-01 00:00:00.000000 -08:00
+ 691  | 1   | 00691              | 1970-04-02 00:00:00.000000 -08:00
+ 693  | 303 | 00693_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 694  | 4   | 00694              | 1970-04-05 00:00:00.000000 -08:00
+ 696  | 6   | 00696              | 1970-04-07 00:00:00.000000 -08:00
+ 697  | 407 | 00697_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 698  | 8   | 00698              | 1970-04-09 00:00:00.000000 -08:00
+ 699  | 509 | 00699_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 700  | 0   | 00700              | 1970-01-01 00:00:00.000000 -08:00
+ 701  | 1   | 00701              | 1970-01-02 00:00:00.000000 -08:00
+ 703  | 303 | 00703_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 704  | 4   | 00704              | 1970-01-05 00:00:00.000000 -08:00
+ 706  | 6   | 00706              | 1970-01-07 00:00:00.000000 -08:00
+ 707  | 407 | 00707_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 708  | 8   | 00708              | 1970-01-09 00:00:00.000000 -08:00
+ 709  | 509 | 00709_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 710  | 0   | 00710              | 1970-01-11 00:00:00.000000 -08:00
+ 711  | 1   | 00711              | 1970-01-12 00:00:00.000000 -08:00
+ 713  | 303 | 00713_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 714  | 4   | 00714              | 1970-01-15 00:00:00.000000 -08:00
+ 716  | 6   | 00716              | 1970-01-17 00:00:00.000000 -08:00
+ 717  | 407 | 00717_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 718  | 8   | 00718              | 1970-01-19 00:00:00.000000 -08:00
+ 719  | 509 | 00719_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 720  | 0   | 00720              | 1970-01-21 00:00:00.000000 -08:00
+ 721  | 1   | 00721              | 1970-01-22 00:00:00.000000 -08:00
+ 723  | 303 | 00723_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 724  | 4   | 00724              | 1970-01-25 00:00:00.000000 -08:00
+ 726  | 6   | 00726              | 1970-01-27 00:00:00.000000 -08:00
+ 727  | 407 | 00727_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 728  | 8   | 00728              | 1970-01-29 00:00:00.000000 -08:00
+ 729  | 509 | 00729_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 730  | 0   | 00730              | 1970-01-31 00:00:00.000000 -08:00
+ 731  | 1   | 00731              | 1970-02-01 00:00:00.000000 -08:00
+ 733  | 303 | 00733_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 734  | 4   | 00734              | 1970-02-04 00:00:00.000000 -08:00
+ 736  | 6   | 00736              | 1970-02-06 00:00:00.000000 -08:00
+ 737  | 407 | 00737_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 738  | 8   | 00738              | 1970-02-08 00:00:00.000000 -08:00
+ 739  | 509 | 00739_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 740  | 0   | 00740              | 1970-02-10 00:00:00.000000 -08:00
+ 741  | 1   | 00741              | 1970-02-11 00:00:00.000000 -08:00
+ 743  | 303 | 00743_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 744  | 4   | 00744              | 1970-02-14 00:00:00.000000 -08:00
+ 746  | 6   | 00746              | 1970-02-16 00:00:00.000000 -08:00
+ 747  | 407 | 00747_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 748  | 8   | 00748              | 1970-02-18 00:00:00.000000 -08:00
+ 749  | 509 | 00749_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 750  | 0   | 00750              | 1970-02-20 00:00:00.000000 -08:00
+ 751  | 1   | 00751              | 1970-02-21 00:00:00.000000 -08:00
+ 753  | 303 | 00753_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 754  | 4   | 00754              | 1970-02-24 00:00:00.000000 -08:00
+ 756  | 6   | 00756              | 1970-02-26 00:00:00.000000 -08:00
+ 757  | 407 | 00757_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 758  | 8   | 00758              | 1970-02-28 00:00:00.000000 -08:00
+ 759  | 509 | 00759_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 760  | 0   | 00760              | 1970-03-02 00:00:00.000000 -08:00
+ 761  | 1   | 00761              | 1970-03-03 00:00:00.000000 -08:00
+ 763  | 303 | 00763_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 764  | 4   | 00764              | 1970-03-06 00:00:00.000000 -08:00
+ 766  | 6   | 00766              | 1970-03-08 00:00:00.000000 -08:00
+ 767  | 407 | 00767_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 768  | 8   | 00768              | 1970-03-10 00:00:00.000000 -08:00
+ 769  | 509 | 00769_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 770  | 0   | 00770              | 1970-03-12 00:00:00.000000 -08:00
+ 771  | 1   | 00771              | 1970-03-13 00:00:00.000000 -08:00
+ 773  | 303 | 00773_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 774  | 4   | 00774              | 1970-03-16 00:00:00.000000 -08:00
+ 776  | 6   | 00776              | 1970-03-18 00:00:00.000000 -08:00
+ 777  | 407 | 00777_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 778  | 8   | 00778              | 1970-03-20 00:00:00.000000 -08:00
+ 779  | 509 | 00779_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 780  | 0   | 00780              | 1970-03-22 00:00:00.000000 -08:00
+ 781  | 1   | 00781              | 1970-03-23 00:00:00.000000 -08:00
+ 783  | 303 | 00783_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 784  | 4   | 00784              | 1970-03-26 00:00:00.000000 -08:00
+ 786  | 6   | 00786              | 1970-03-28 00:00:00.000000 -08:00
+ 787  | 407 | 00787_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 788  | 8   | 00788              | 1970-03-30 00:00:00.000000 -08:00
+ 789  | 509 | 00789_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 790  | 0   | 00790              | 1970-04-01 00:00:00.000000 -08:00
+ 791  | 1   | 00791              | 1970-04-02 00:00:00.000000 -08:00
+ 793  | 303 | 00793_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 794  | 4   | 00794              | 1970-04-05 00:00:00.000000 -08:00
+ 796  | 6   | 00796              | 1970-04-07 00:00:00.000000 -08:00
+ 797  | 407 | 00797_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 798  | 8   | 00798              | 1970-04-09 00:00:00.000000 -08:00
+ 799  | 509 | 00799_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 800  | 0   | 00800              | 1970-01-01 00:00:00.000000 -08:00
+ 801  | 1   | 00801              | 1970-01-02 00:00:00.000000 -08:00
+ 803  | 303 | 00803_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 804  | 4   | 00804              | 1970-01-05 00:00:00.000000 -08:00
+ 806  | 6   | 00806              | 1970-01-07 00:00:00.000000 -08:00
+ 807  | 407 | 00807_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 808  | 8   | 00808              | 1970-01-09 00:00:00.000000 -08:00
+ 809  | 509 | 00809_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 810  | 0   | 00810              | 1970-01-11 00:00:00.000000 -08:00
+ 811  | 1   | 00811              | 1970-01-12 00:00:00.000000 -08:00
+ 813  | 303 | 00813_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 814  | 4   | 00814              | 1970-01-15 00:00:00.000000 -08:00
+ 816  | 6   | 00816              | 1970-01-17 00:00:00.000000 -08:00
+ 817  | 407 | 00817_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 818  | 8   | 00818              | 1970-01-19 00:00:00.000000 -08:00
+ 819  | 509 | 00819_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 820  | 0   | 00820              | 1970-01-21 00:00:00.000000 -08:00
+ 821  | 1   | 00821              | 1970-01-22 00:00:00.000000 -08:00
+ 823  | 303 | 00823_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 824  | 4   | 00824              | 1970-01-25 00:00:00.000000 -08:00
+ 826  | 6   | 00826              | 1970-01-27 00:00:00.000000 -08:00
+ 827  | 407 | 00827_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 828  | 8   | 00828              | 1970-01-29 00:00:00.000000 -08:00
+ 829  | 509 | 00829_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 830  | 0   | 00830              | 1970-01-31 00:00:00.000000 -08:00
+ 831  | 1   | 00831              | 1970-02-01 00:00:00.000000 -08:00
+ 833  | 303 | 00833_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 834  | 4   | 00834              | 1970-02-04 00:00:00.000000 -08:00
+ 836  | 6   | 00836              | 1970-02-06 00:00:00.000000 -08:00
+ 837  | 407 | 00837_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 838  | 8   | 00838              | 1970-02-08 00:00:00.000000 -08:00
+ 839  | 509 | 00839_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 840  | 0   | 00840              | 1970-02-10 00:00:00.000000 -08:00
+ 841  | 1   | 00841              | 1970-02-11 00:00:00.000000 -08:00
+ 843  | 303 | 00843_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 844  | 4   | 00844              | 1970-02-14 00:00:00.000000 -08:00
+ 846  | 6   | 00846              | 1970-02-16 00:00:00.000000 -08:00
+ 847  | 407 | 00847_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 848  | 8   | 00848              | 1970-02-18 00:00:00.000000 -08:00
+ 849  | 509 | 00849_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 850  | 0   | 00850              | 1970-02-20 00:00:00.000000 -08:00
+ 851  | 1   | 00851              | 1970-02-21 00:00:00.000000 -08:00
+ 853  | 303 | 00853_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 854  | 4   | 00854              | 1970-02-24 00:00:00.000000 -08:00
+ 856  | 6   | 00856              | 1970-02-26 00:00:00.000000 -08:00
+ 857  | 407 | 00857_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 858  | 8   | 00858              | 1970-02-28 00:00:00.000000 -08:00
+ 859  | 509 | 00859_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 860  | 0   | 00860              | 1970-03-02 00:00:00.000000 -08:00
+ 861  | 1   | 00861              | 1970-03-03 00:00:00.000000 -08:00
+ 863  | 303 | 00863_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 864  | 4   | 00864              | 1970-03-06 00:00:00.000000 -08:00
+ 866  | 6   | 00866              | 1970-03-08 00:00:00.000000 -08:00
+ 867  | 407 | 00867_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 868  | 8   | 00868              | 1970-03-10 00:00:00.000000 -08:00
+ 869  | 509 | 00869_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 870  | 0   | 00870              | 1970-03-12 00:00:00.000000 -08:00
+ 871  | 1   | 00871              | 1970-03-13 00:00:00.000000 -08:00
+ 873  | 303 | 00873_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 874  | 4   | 00874              | 1970-03-16 00:00:00.000000 -08:00
+ 876  | 6   | 00876              | 1970-03-18 00:00:00.000000 -08:00
+ 877  | 407 | 00877_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 878  | 8   | 00878              | 1970-03-20 00:00:00.000000 -08:00
+ 879  | 509 | 00879_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 880  | 0   | 00880              | 1970-03-22 00:00:00.000000 -08:00
+ 881  | 1   | 00881              | 1970-03-23 00:00:00.000000 -08:00
+ 883  | 303 | 00883_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 884  | 4   | 00884              | 1970-03-26 00:00:00.000000 -08:00
+ 886  | 6   | 00886              | 1970-03-28 00:00:00.000000 -08:00
+ 887  | 407 | 00887_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 888  | 8   | 00888              | 1970-03-30 00:00:00.000000 -08:00
+ 889  | 509 | 00889_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 890  | 0   | 00890              | 1970-04-01 00:00:00.000000 -08:00
+ 891  | 1   | 00891              | 1970-04-02 00:00:00.000000 -08:00
+ 893  | 303 | 00893_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 894  | 4   | 00894              | 1970-04-05 00:00:00.000000 -08:00
+ 896  | 6   | 00896              | 1970-04-07 00:00:00.000000 -08:00
+ 897  | 407 | 00897_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 898  | 8   | 00898              | 1970-04-09 00:00:00.000000 -08:00
+ 899  | 509 | 00899_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 900  | 0   | 00900              | 1970-01-01 00:00:00.000000 -08:00
+ 901  | 1   | 00901              | 1970-01-02 00:00:00.000000 -08:00
+ 903  | 303 | 00903_update3      | 1970-01-04 00:00:00.000000 -08:00
+ 904  | 4   | 00904              | 1970-01-05 00:00:00.000000 -08:00
+ 906  | 6   | 00906              | 1970-01-07 00:00:00.000000 -08:00
+ 907  | 407 | 00907_update7      | 1970-01-08 00:00:00.000000 -08:00
+ 908  | 8   | 00908              | 1970-01-09 00:00:00.000000 -08:00
+ 909  | 509 | 00909_update9      | 1970-01-10 00:00:00.000000 -08:00
+ 910  | 0   | 00910              | 1970-01-11 00:00:00.000000 -08:00
+ 911  | 1   | 00911              | 1970-01-12 00:00:00.000000 -08:00
+ 913  | 303 | 00913_update3      | 1970-01-14 00:00:00.000000 -08:00
+ 914  | 4   | 00914              | 1970-01-15 00:00:00.000000 -08:00
+ 916  | 6   | 00916              | 1970-01-17 00:00:00.000000 -08:00
+ 917  | 407 | 00917_update7      | 1970-01-18 00:00:00.000000 -08:00
+ 918  | 8   | 00918              | 1970-01-19 00:00:00.000000 -08:00
+ 919  | 509 | 00919_update9      | 1970-01-20 00:00:00.000000 -08:00
+ 920  | 0   | 00920              | 1970-01-21 00:00:00.000000 -08:00
+ 921  | 1   | 00921              | 1970-01-22 00:00:00.000000 -08:00
+ 923  | 303 | 00923_update3      | 1970-01-24 00:00:00.000000 -08:00
+ 924  | 4   | 00924              | 1970-01-25 00:00:00.000000 -08:00
+ 926  | 6   | 00926              | 1970-01-27 00:00:00.000000 -08:00
+ 927  | 407 | 00927_update7      | 1970-01-28 00:00:00.000000 -08:00
+ 928  | 8   | 00928              | 1970-01-29 00:00:00.000000 -08:00
+ 929  | 509 | 00929_update9      | 1970-01-30 00:00:00.000000 -08:00
+ 930  | 0   | 00930              | 1970-01-31 00:00:00.000000 -08:00
+ 931  | 1   | 00931              | 1970-02-01 00:00:00.000000 -08:00
+ 933  | 303 | 00933_update3      | 1970-02-03 00:00:00.000000 -08:00
+ 934  | 4   | 00934              | 1970-02-04 00:00:00.000000 -08:00
+ 936  | 6   | 00936              | 1970-02-06 00:00:00.000000 -08:00
+ 937  | 407 | 00937_update7      | 1970-02-07 00:00:00.000000 -08:00
+ 938  | 8   | 00938              | 1970-02-08 00:00:00.000000 -08:00
+ 939  | 509 | 00939_update9      | 1970-02-09 00:00:00.000000 -08:00
+ 940  | 0   | 00940              | 1970-02-10 00:00:00.000000 -08:00
+ 941  | 1   | 00941              | 1970-02-11 00:00:00.000000 -08:00
+ 943  | 303 | 00943_update3      | 1970-02-13 00:00:00.000000 -08:00
+ 944  | 4   | 00944              | 1970-02-14 00:00:00.000000 -08:00
+ 946  | 6   | 00946              | 1970-02-16 00:00:00.000000 -08:00
+ 947  | 407 | 00947_update7      | 1970-02-17 00:00:00.000000 -08:00
+ 948  | 8   | 00948              | 1970-02-18 00:00:00.000000 -08:00
+ 949  | 509 | 00949_update9      | 1970-02-19 00:00:00.000000 -08:00
+ 950  | 0   | 00950              | 1970-02-20 00:00:00.000000 -08:00
+ 951  | 1   | 00951              | 1970-02-21 00:00:00.000000 -08:00
+ 953  | 303 | 00953_update3      | 1970-02-23 00:00:00.000000 -08:00
+ 954  | 4   | 00954              | 1970-02-24 00:00:00.000000 -08:00
+ 956  | 6   | 00956              | 1970-02-26 00:00:00.000000 -08:00
+ 957  | 407 | 00957_update7      | 1970-02-27 00:00:00.000000 -08:00
+ 958  | 8   | 00958              | 1970-02-28 00:00:00.000000 -08:00
+ 959  | 509 | 00959_update9      | 1970-03-01 00:00:00.000000 -08:00
+ 960  | 0   | 00960              | 1970-03-02 00:00:00.000000 -08:00
+ 961  | 1   | 00961              | 1970-03-03 00:00:00.000000 -08:00
+ 963  | 303 | 00963_update3      | 1970-03-05 00:00:00.000000 -08:00
+ 964  | 4   | 00964              | 1970-03-06 00:00:00.000000 -08:00
+ 966  | 6   | 00966              | 1970-03-08 00:00:00.000000 -08:00
+ 967  | 407 | 00967_update7      | 1970-03-09 00:00:00.000000 -08:00
+ 968  | 8   | 00968              | 1970-03-10 00:00:00.000000 -08:00
+ 969  | 509 | 00969_update9      | 1970-03-11 00:00:00.000000 -08:00
+ 970  | 0   | 00970              | 1970-03-12 00:00:00.000000 -08:00
+ 971  | 1   | 00971              | 1970-03-13 00:00:00.000000 -08:00
+ 973  | 303 | 00973_update3      | 1970-03-15 00:00:00.000000 -08:00
+ 974  | 4   | 00974              | 1970-03-16 00:00:00.000000 -08:00
+ 976  | 6   | 00976              | 1970-03-18 00:00:00.000000 -08:00
+ 977  | 407 | 00977_update7      | 1970-03-19 00:00:00.000000 -08:00
+ 978  | 8   | 00978              | 1970-03-20 00:00:00.000000 -08:00
+ 979  | 509 | 00979_update9      | 1970-03-21 00:00:00.000000 -08:00
+ 980  | 0   | 00980              | 1970-03-22 00:00:00.000000 -08:00
+ 981  | 1   | 00981              | 1970-03-23 00:00:00.000000 -08:00
+ 983  | 303 | 00983_update3      | 1970-03-25 00:00:00.000000 -08:00
+ 984  | 4   | 00984              | 1970-03-26 00:00:00.000000 -08:00
+ 986  | 6   | 00986              | 1970-03-28 00:00:00.000000 -08:00
+ 987  | 407 | 00987_update7      | 1970-03-29 00:00:00.000000 -08:00
+ 988  | 8   | 00988              | 1970-03-30 00:00:00.000000 -08:00
+ 989  | 509 | 00989_update9      | 1970-03-31 00:00:00.000000 -08:00
+ 990  | 0   | 00990              | 1970-04-01 00:00:00.000000 -08:00
+ 991  | 1   | 00991              | 1970-04-02 00:00:00.000000 -08:00
+ 993  | 303 | 00993_update3      | 1970-04-04 00:00:00.000000 -08:00
+ 994  | 4   | 00994              | 1970-04-05 00:00:00.000000 -08:00
+ 996  | 6   | 00996              | 1970-04-07 00:00:00.000000 -08:00
+ 997  | 407 | 00997_update7      | 1970-04-08 00:00:00.000000 -08:00
+ 998  | 8   | 00998              | 1970-04-09 00:00:00.000000 -08:00
+ 999  | 509 | 00999_update9      | 1970-04-10 00:00:00.000000 -08:00
+ 1000 | 0   | 01000              | 1970-01-01 00:00:00.000000 -08:00
  1001 | 101 | 0000100001         | 
  1003 | 403 | 0000300003_update3 | 
  1004 | 104 | 0000400004         | 
@@ -5684,14 +6666,14 @@ SELECT c1,c2,c3,c4 FROM ft2 ORDER BY c1;
 
 EXPLAIN (verbose, costs off)
 INSERT INTO ft2 (c1,c2,c3) VALUES (1200,999,'foo') RETURNING tableoid::regclass;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft2
    Output: (ft2.tableoid)::regclass
    Remote SQL: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
    Batch Size: 1
    ->  Result
-         Output: 1200, 999, NULL::integer, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::varchar2, 'ft2       '::char(10), NULL::user_enum
+         Output: '1200'::number(38,0), '999'::number(38,0), NULL::integer, 'foo'::varchar2(1024), NULL::timestamp with time zone, NULL::timestamp, NULL::varchar2, 'ft2       '::char(10), NULL::user_enum
 (6 rows)
 
 INSERT INTO ft2 (c1,c2,c3) VALUES (1200,999,'foo') RETURNING tableoid::regclass;
@@ -5702,13 +6684,16 @@ INSERT INTO ft2 (c1,c2,c3) VALUES (1200,999,'foo') RETURNING tableoid::regclass;
 
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c3 = 'bar' WHERE c1 = 1200 RETURNING tableoid::regclass;             -- can be pushed down
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Update on public.ft2
    Output: (tableoid)::regclass
-   ->  Foreign Update on public.ft2
-         Remote SQL: UPDATE "S 1"."T 1" SET c3 = 'bar'::text WHERE (("C 1" = 1200))
-(4 rows)
+   Remote SQL: UPDATE "S 1"."T 1" SET c3 = $2 WHERE ctid = $1
+   ->  Foreign Scan on public.ft2
+         Output: 'bar'::varchar2(1024), ctid, ft2.*
+         Filter: (ft2.c1 = '1200'::number)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
+(7 rows)
 
 UPDATE ft2 SET c3 = 'bar' WHERE c1 = 1200 RETURNING tableoid::regclass;
  tableoid 
@@ -5722,9 +6707,12 @@ DELETE FROM ft2 WHERE c1 = 1200 RETURNING tableoid::regclass;                   
 --------------------------------------------------------------------
  Delete on public.ft2
    Output: (tableoid)::regclass
-   ->  Foreign Delete on public.ft2
-         Remote SQL: DELETE FROM "S 1"."T 1" WHERE (("C 1" = 1200))
-(4 rows)
+   Remote SQL: DELETE FROM "S 1"."T 1" WHERE ctid = $1
+   ->  Foreign Scan on public.ft2
+         Output: ctid
+         Filter: (ft2.c1 = '1200'::number)
+         Remote SQL: SELECT "C 1", ctid FROM "S 1"."T 1" FOR UPDATE
+(7 rows)
 
 DELETE FROM ft2 WHERE c1 = 1200 RETURNING tableoid::regclass;
  tableoid 
@@ -5740,50 +6728,70 @@ UPDATE ft2 SET c3 = 'foo'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 1200 AND ft2.c2 = ft4.c1
   RETURNING ft2, ft2.*, ft4, ft4.*;       -- can be pushed down
-                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                            QUERY PLAN                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
    Output: ft2.*, ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft4.*, ft4.c1, ft4.c2, ft4.c3
-   ->  Foreign Update
-         Remote SQL: UPDATE "S 1"."T 1" r1 SET c3 = 'foo'::text FROM ("S 1"."T 3" r2 INNER JOIN "S 1"."T 4" r3 ON (TRUE)) WHERE ((r2.c1 = r3.c1)) AND ((r1.c2 = r2.c1)) AND ((r1."C 1" > 1200)) RETURNING r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2.c1, r2.c2, r2.c3) END, r2.c1, r2.c2, r2.c3
-(4 rows)
+   Remote SQL: UPDATE "S 1"."T 1" SET c3 = $2 WHERE ctid = $1 RETURNING "C 1", c2, c3, c4, c5, c6, c7, c8
+   ->  Nested Loop
+         Output: 'foo'::varchar2(1024), ft2.ctid, ft2.*, ft4.*, ft5.*, ft4.c1, ft4.c2, ft4.c3
+         Join Filter: (ft2.c2 = ft4.c1)
+         ->  Foreign Scan on public.ft2
+               Output: ft2.ctid, ft2.*, ft2.c2
+               Filter: (ft2.c1 > '1200'::number)
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
+         ->  Foreign Scan
+               Output: ft4.*, ft4.c1, ft4.c2, ft4.c3, ft5.*, ft5.c1
+               Filter: (ft4.c1 = ft5.c1)
+               Relations: (public.ft4) INNER JOIN (public.ft5)
+               Remote SQL: SELECT CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2.c1, r2.c2, r2.c3) END, r2.c1, r2.c2, r2.c3, CASE WHEN (r3.*)::text IS NOT NULL THEN ROW(r3.c1, r3.c2, r3.c3) END, r3.c1 FROM ("S 1"."T 3" r2 INNER JOIN "S 1"."T 4" r3 ON (TRUE))
+               ->  Hash Join
+                     Output: ft4.*, ft4.c1, ft4.c2, ft4.c3, ft5.*, ft5.c1
+                     Hash Cond: (ft4.c1 = ft5.c1)
+                     ->  Foreign Scan on public.ft4
+                           Output: ft4.*, ft4.c1, ft4.c2, ft4.c3
+                           Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
+                     ->  Hash
+                           Output: ft5.*, ft5.c1
+                           ->  Foreign Scan on public.ft5
+                                 Output: ft5.*, ft5.c1
+                                 Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
+(26 rows)
 
 UPDATE ft2 SET c3 = 'foo'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 1200 AND ft2.c2 = ft4.c1
   RETURNING ft2, ft2.*, ft4, ft4.*;
-              ft2               |  c1  | c2 | c3  | c4 | c5 | c6 |     c7     | c8 |      ft4       | c1 | c2 |   c3   
---------------------------------+------+----+-----+----+----+----+------------+----+----------------+----+----+--------
- (1206,6,foo,,,,"ft2       ",)  | 1206 |  6 | foo |    |    |    | ft2        |    | (6,7,AAA006)   |  6 |  7 | AAA006
- (1212,12,foo,,,,"ft2       ",) | 1212 | 12 | foo |    |    |    | ft2        |    | (12,13,AAA012) | 12 | 13 | AAA012
- (1218,18,foo,,,,"ft2       ",) | 1218 | 18 | foo |    |    |    | ft2        |    | (18,19,AAA018) | 18 | 19 | AAA018
- (1224,24,foo,,,,"ft2       ",) | 1224 | 24 | foo |    |    |    | ft2        |    | (24,25,AAA024) | 24 | 25 | AAA024
- (1230,30,foo,,,,"ft2       ",) | 1230 | 30 | foo |    |    |    | ft2        |    | (30,31,AAA030) | 30 | 31 | AAA030
- (1236,36,foo,,,,"ft2       ",) | 1236 | 36 | foo |    |    |    | ft2        |    | (36,37,AAA036) | 36 | 37 | AAA036
- (1242,42,foo,,,,"ft2       ",) | 1242 | 42 | foo |    |    |    | ft2        |    | (42,43,AAA042) | 42 | 43 | AAA042
- (1248,48,foo,,,,"ft2       ",) | 1248 | 48 | foo |    |    |    | ft2        |    | (48,49,AAA048) | 48 | 49 | AAA048
- (1254,54,foo,,,,"ft2       ",) | 1254 | 54 | foo |    |    |    | ft2        |    | (54,55,AAA054) | 54 | 55 | AAA054
- (1260,60,foo,,,,"ft2       ",) | 1260 | 60 | foo |    |    |    | ft2        |    | (60,61,AAA060) | 60 | 61 | AAA060
- (1266,66,foo,,,,"ft2       ",) | 1266 | 66 | foo |    |    |    | ft2        |    | (66,67,AAA066) | 66 | 67 | AAA066
- (1272,72,foo,,,,"ft2       ",) | 1272 | 72 | foo |    |    |    | ft2        |    | (72,73,AAA072) | 72 | 73 | AAA072
- (1278,78,foo,,,,"ft2       ",) | 1278 | 78 | foo |    |    |    | ft2        |    | (78,79,AAA078) | 78 | 79 | AAA078
- (1284,84,foo,,,,"ft2       ",) | 1284 | 84 | foo |    |    |    | ft2        |    | (84,85,AAA084) | 84 | 85 | AAA084
- (1290,90,foo,,,,"ft2       ",) | 1290 | 90 | foo |    |    |    | ft2        |    | (90,91,AAA090) | 90 | 91 | AAA090
- (1296,96,foo,,,,"ft2       ",) | 1296 | 96 | foo |    |    |    | ft2        |    | (96,97,AAA096) | 96 | 97 | AAA096
-(16 rows)
-
+ERROR:  cursor can only scan forward
+HINT:  Declare it with SCROLL option to enable backward scan.
+CONTEXT:  remote SQL command: MOVE BACKWARD ALL IN c4
 EXPLAIN (verbose, costs off)
 DELETE FROM ft2
   USING ft4 LEFT JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 1200 AND ft2.c1 % 10 = 0 AND ft2.c2 = ft4.c1
   RETURNING 100;                          -- can be pushed down
-                                                                                            QUERY PLAN                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Delete on public.ft2
    Output: 100
-   ->  Foreign Delete
-         Remote SQL: DELETE FROM "S 1"."T 1" r1 USING ("S 1"."T 3" r2 LEFT JOIN "S 1"."T 4" r3 ON (((r2.c1 = r3.c1)))) WHERE ((r1.c2 = r2.c1)) AND ((r1."C 1" > 1200)) AND (((r1."C 1" % 10) = 0))
-(4 rows)
+   Remote SQL: DELETE FROM "S 1"."T 1" WHERE ctid = $1
+   ->  Nested Loop Left Join
+         Output: ft2.ctid, ft4.*, ft5.*
+         Join Filter: (ft4.c1 = ft5.c1)
+         ->  Nested Loop
+               Output: ft2.ctid, ft4.*, ft4.c1
+               Join Filter: (ft2.c2 = ft4.c1)
+               ->  Foreign Scan on public.ft2
+                     Output: ft2.ctid, ft2.c2
+                     Filter: ((ft2.c1 > '1200'::number) AND ((ft2.c1 % '10'::number) = '0'::number))
+                     Remote SQL: SELECT "C 1", c2, ctid FROM "S 1"."T 1" FOR UPDATE
+               ->  Foreign Scan on public.ft4
+                     Output: ft4.*, ft4.c1
+                     Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
+         ->  Foreign Scan on public.ft5
+               Output: ft5.*, ft5.c1
+               Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
+(19 rows)
 
 DELETE FROM ft2
   USING ft4 LEFT JOIN ft5 ON (ft4.c1 = ft5.c1)
@@ -5812,18 +6820,20 @@ UPDATE ft2 AS target SET (c2, c7) = (
         FROM ft2 AS src
         WHERE target.c1 = src.c1
 ) WHERE c1 > 1100;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Update on public.ft2 target
    Remote SQL: UPDATE "S 1"."T 1" SET c2 = $2, c7 = $3 WHERE ctid = $1
    ->  Foreign Scan on public.ft2 target
          Output: $1, $2, (SubPlan 1 (returns $1,$2)), target.ctid, target.*
-         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" WHERE (("C 1" > 1100)) FOR UPDATE
+         Filter: (target.c1 > '1100'::number)
+         Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
          SubPlan 1 (returns $1,$2)
            ->  Foreign Scan on public.ft2 src
-                 Output: (src.c2 * 10), src.c7
-                 Remote SQL: SELECT c2, c7 FROM "S 1"."T 1" WHERE (($1::integer = "C 1"))
-(9 rows)
+                 Output: (src.c2 * '10'::number), src.c7
+                 Filter: (target.c1 = src.c1)
+                 Remote SQL: SELECT "C 1", c2, c7 FROM "S 1"."T 1"
+(11 rows)
 
 UPDATE ft2 AS target SET (c2, c7) = (
     SELECT c2 * 10, c7
@@ -5840,26 +6850,23 @@ UPDATE ft2 AS target SET (c2) = (
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE ft2 d SET c2 = CASE WHEN random() >= 0 THEN d.c2 ELSE 0 END
   FROM ft2 AS t WHERE d.c1 = t.c1 AND d.c1 > 1000;
-                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
  Update on public.ft2 d
    Remote SQL: UPDATE "S 1"."T 1" SET c2 = $2 WHERE ctid = $1
-   ->  Foreign Scan
-         Output: CASE WHEN (random() >= '0'::double precision) THEN d.c2 ELSE 0 END, d.ctid, d.*, t.*
-         Relations: (public.ft2 d) INNER JOIN (public.ft2 t)
-         Remote SQL: SELECT r1.c2, r1.ctid, CASE WHEN (r1.*)::text IS NOT NULL THEN ROW(r1."C 1", r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8) END, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2."C 1", r2.c2, r2.c3, r2.c4, r2.c5, r2.c6, r2.c7, r2.c8) END FROM ("S 1"."T 1" r1 INNER JOIN "S 1"."T 1" r2 ON (((r1."C 1" = r2."C 1")) AND ((r1."C 1" > 1000)))) FOR UPDATE OF r1
-         ->  Hash Join
-               Output: d.c2, d.ctid, d.*, t.*
-               Hash Cond: (d.c1 = t.c1)
+   ->  Hash Join
+         Output: CASE WHEN (random() >= '0'::double precision) THEN d.c2 ELSE '0'::number END, d.ctid, d.*, t.*
+         Hash Cond: (t.c1 = d.c1)
+         ->  Foreign Scan on public.ft2 t
+               Output: t.*, t.c1
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
+         ->  Hash
+               Output: d.c2, d.ctid, d.*, d.c1
                ->  Foreign Scan on public.ft2 d
                      Output: d.c2, d.ctid, d.*, d.c1
-                     Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" WHERE (("C 1" > 1000)) ORDER BY "C 1" ASC NULLS LAST FOR UPDATE
-               ->  Hash
-                     Output: t.*, t.c1
-                     ->  Foreign Scan on public.ft2 t
-                           Output: t.*, t.c1
-                           Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
-(17 rows)
+                     Filter: (d.c1 > '1000'::number)
+                     Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
+(14 rows)
 
 UPDATE ft2 d SET c2 = CASE WHEN random() >= 0 THEN d.c2 ELSE 0 END
   FROM ft2 AS t WHERE d.c1 = t.c1 AND d.c1 > 1000;
@@ -5876,7 +6883,7 @@ UPDATE ft2 SET c3 = 'bar' WHERE postgres_fdw_abs(c1) > 2000 RETURNING *;        
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: UPDATE "S 1"."T 1" SET c3 = $2 WHERE ctid = $1 RETURNING "C 1", c2, c3, c4, c5, c6, c7, c8
    ->  Foreign Scan on public.ft2
-         Output: 'bar'::text, ctid, ft2.*
+         Output: 'bar'::varchar2(1024), ctid, ft2.*
          Filter: (postgres_fdw_abs(ft2.c1) > 2000)
          Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
 (7 rows)
@@ -5884,16 +6891,16 @@ UPDATE ft2 SET c3 = 'bar' WHERE postgres_fdw_abs(c1) > 2000 RETURNING *;        
 UPDATE ft2 SET c3 = 'bar' WHERE postgres_fdw_abs(c1) > 2000 RETURNING *;
   c1  | c2 | c3  | c4 | c5 | c6 |     c7     | c8 
 ------+----+-----+----+----+----+------------+----
- 2001 |  1 | bar |    |    |    | ft2        | 
- 2002 |  2 | bar |    |    |    | ft2        | 
- 2003 |  3 | bar |    |    |    | ft2        | 
- 2004 |  4 | bar |    |    |    | ft2        | 
- 2005 |  5 | bar |    |    |    | ft2        | 
- 2006 |  6 | bar |    |    |    | ft2        | 
- 2007 |  7 | bar |    |    |    | ft2        | 
- 2008 |  8 | bar |    |    |    | ft2        | 
- 2009 |  9 | bar |    |    |    | ft2        | 
- 2010 |  0 | bar |    |    |    | ft2        | 
+ 2001 | 1  | bar |    |    |    | ft2        | 
+ 2002 | 2  | bar |    |    |    | ft2        | 
+ 2003 | 3  | bar |    |    |    | ft2        | 
+ 2004 | 4  | bar |    |    |    | ft2        | 
+ 2005 | 5  | bar |    |    |    | ft2        | 
+ 2006 | 6  | bar |    |    |    | ft2        | 
+ 2007 | 7  | bar |    |    |    | ft2        | 
+ 2008 | 8  | bar |    |    |    | ft2        | 
+ 2009 | 9  | bar |    |    |    | ft2        | 
+ 2010 | 0  | bar |    |    |    | ft2        | 
 (10 rows)
 
 EXPLAIN (verbose, costs off)
@@ -5901,21 +6908,23 @@ UPDATE ft2 SET c3 = 'baz'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 2000 AND ft2.c2 === ft4.c1
   RETURNING ft2.*, ft4.*, ft5.*;                                                    -- can't be pushed down
-                                                                                                                                          QUERY PLAN                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                   QUERY PLAN                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
    Output: ft2.c1, ft2.c2, ft2.c3, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft4.c1, ft4.c2, ft4.c3, ft5.c1, ft5.c2, ft5.c3
    Remote SQL: UPDATE "S 1"."T 1" SET c3 = $2 WHERE ctid = $1 RETURNING "C 1", c2, c3, c4, c5, c6, c7, c8
    ->  Nested Loop
-         Output: 'baz'::text, ft2.ctid, ft2.*, ft4.*, ft5.*, ft4.c1, ft4.c2, ft4.c3, ft5.c1, ft5.c2, ft5.c3
+         Output: 'baz'::varchar2(1024), ft2.ctid, ft2.*, ft4.*, ft5.*, ft4.c1, ft4.c2, ft4.c3, ft5.c1, ft5.c2, ft5.c3
          Join Filter: (ft2.c2 === ft4.c1)
          ->  Foreign Scan on public.ft2
                Output: ft2.ctid, ft2.*, ft2.c2
-               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" WHERE (("C 1" > 2000)) FOR UPDATE
+               Filter: (ft2.c1 > '2000'::number)
+               Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" FOR UPDATE
          ->  Foreign Scan
                Output: ft4.*, ft4.c1, ft4.c2, ft4.c3, ft5.*, ft5.c1, ft5.c2, ft5.c3
+               Filter: (ft4.c1 = ft5.c1)
                Relations: (public.ft4) INNER JOIN (public.ft5)
-               Remote SQL: SELECT CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2.c1, r2.c2, r2.c3) END, r2.c1, r2.c2, r2.c3, CASE WHEN (r3.*)::text IS NOT NULL THEN ROW(r3.c1, r3.c2, r3.c3) END, r3.c1, r3.c2, r3.c3 FROM ("S 1"."T 3" r2 INNER JOIN "S 1"."T 4" r3 ON (((r2.c1 = r3.c1))))
+               Remote SQL: SELECT CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2.c1, r2.c2, r2.c3) END, r2.c1, r2.c2, r2.c3, CASE WHEN (r3.*)::text IS NOT NULL THEN ROW(r3.c1, r3.c2, r3.c3) END, r3.c1, r3.c2, r3.c3 FROM ("S 1"."T 3" r2 INNER JOIN "S 1"."T 4" r3 ON (TRUE))
                ->  Hash Join
                      Output: ft4.*, ft4.c1, ft4.c2, ft4.c3, ft5.*, ft5.c1, ft5.c2, ft5.c3
                      Hash Cond: (ft4.c1 = ft5.c1)
@@ -5927,47 +6936,50 @@ UPDATE ft2 SET c3 = 'baz'
                            ->  Foreign Scan on public.ft5
                                  Output: ft5.*, ft5.c1, ft5.c2, ft5.c3
                                  Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
-(24 rows)
+(26 rows)
 
 UPDATE ft2 SET c3 = 'baz'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 2000 AND ft2.c2 === ft4.c1
   RETURNING ft2.*, ft4.*, ft5.*;
-  c1  | c2 | c3  | c4 | c5 | c6 |     c7     | c8 | c1 | c2 |   c3   | c1 | c2 |   c3   
-------+----+-----+----+----+----+------------+----+----+----+--------+----+----+--------
- 2006 |  6 | baz |    |    |    | ft2        |    |  6 |  7 | AAA006 |  6 |  7 | AAA006
-(1 row)
-
+ERROR:  cursor can only scan forward
+HINT:  Declare it with SCROLL option to enable backward scan.
+CONTEXT:  remote SQL command: MOVE BACKWARD ALL IN c4
 EXPLAIN (verbose, costs off)
 DELETE FROM ft2
   USING ft4 INNER JOIN ft5 ON (ft4.c1 === ft5.c1)
   WHERE ft2.c1 > 2000 AND ft2.c2 = ft4.c1
   RETURNING ft2.c1, ft2.c2, ft2.c3;       -- can't be pushed down
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Delete on public.ft2
    Output: ft2.c1, ft2.c2, ft2.c3
    Remote SQL: DELETE FROM "S 1"."T 1" WHERE ctid = $1 RETURNING "C 1", c2, c3
-   ->  Foreign Scan
+   ->  Hash Join
          Output: ft2.ctid, ft4.*, ft5.*
-         Filter: (ft4.c1 === ft5.c1)
-         Relations: ((public.ft2) INNER JOIN (public.ft4)) INNER JOIN (public.ft5)
-         Remote SQL: SELECT r1.ctid, CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2.c1, r2.c2, r2.c3) END, CASE WHEN (r3.*)::text IS NOT NULL THEN ROW(r3.c1, r3.c2, r3.c3) END, r2.c1, r3.c1 FROM (("S 1"."T 1" r1 INNER JOIN "S 1"."T 3" r2 ON (((r1.c2 = r2.c1)) AND ((r1."C 1" > 2000)))) INNER JOIN "S 1"."T 4" r3 ON (TRUE)) FOR UPDATE OF r1
-         ->  Nested Loop
-               Output: ft2.ctid, ft4.*, ft5.*, ft4.c1, ft5.c1
+         Hash Cond: (ft4.c1 = ft2.c2)
+         ->  Foreign Scan
+               Output: ft4.*, ft4.c1, ft5.*
+               Filter: (ft4.c1 === ft5.c1)
+               Relations: (public.ft4) INNER JOIN (public.ft5)
+               Remote SQL: SELECT CASE WHEN (r2.*)::text IS NOT NULL THEN ROW(r2.c1, r2.c2, r2.c3) END, r2.c1, CASE WHEN (r3.*)::text IS NOT NULL THEN ROW(r3.c1, r3.c2, r3.c3) END, r3.c1 FROM ("S 1"."T 3" r2 INNER JOIN "S 1"."T 4" r3 ON (TRUE))
                ->  Nested Loop
-                     Output: ft2.ctid, ft4.*, ft4.c1
-                     Join Filter: (ft2.c2 = ft4.c1)
-                     ->  Foreign Scan on public.ft2
-                           Output: ft2.ctid, ft2.c2
-                           Remote SQL: SELECT c2, ctid FROM "S 1"."T 1" WHERE (("C 1" > 2000)) FOR UPDATE
+                     Output: ft4.*, ft4.c1, ft5.*, ft5.c1
                      ->  Foreign Scan on public.ft4
                            Output: ft4.*, ft4.c1
                            Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
-               ->  Foreign Scan on public.ft5
-                     Output: ft5.*, ft5.c1
-                     Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
-(22 rows)
+                     ->  Materialize
+                           Output: ft5.*, ft5.c1
+                           ->  Foreign Scan on public.ft5
+                                 Output: ft5.*, ft5.c1
+                                 Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
+         ->  Hash
+               Output: ft2.ctid, ft2.c2
+               ->  Foreign Scan on public.ft2
+                     Output: ft2.ctid, ft2.c2
+                     Filter: (ft2.c1 > '2000'::number)
+                     Remote SQL: SELECT "C 1", c2, ctid FROM "S 1"."T 1" FOR UPDATE
+(27 rows)
 
 DELETE FROM ft2
   USING ft4 INNER JOIN ft5 ON (ft4.c1 === ft5.c1)
@@ -5975,7 +6987,7 @@ DELETE FROM ft2
   RETURNING ft2.c1, ft2.c2, ft2.c3;
   c1  | c2 | c3  
 ------+----+-----
- 2006 |  6 | baz
+ 2006 | 6  | bar
 (1 row)
 
 DELETE FROM ft2 WHERE ft2.c1 > 2000;
@@ -6003,110 +7015,110 @@ INSERT INTO ft2 (c1,c2,c3,c6) VALUES (1218, 818, 'ggg', '(--;') RETURNING *;
 (1 row)
 
 UPDATE ft2 SET c2 = c2 + 600 WHERE c1 % 10 = 8 AND c1 < 1200 RETURNING *;
-  c1  | c2  |           c3           |              c4              |            c5            | c6 |     c7     | c8  
-------+-----+------------------------+------------------------------+--------------------------+----+------------+-----
-    8 | 608 | 00008_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-   18 | 608 | 00018_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-   28 | 608 | 00028_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-   38 | 608 | 00038_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-   48 | 608 | 00048_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-   58 | 608 | 00058_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-   68 | 608 | 00068_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-   78 | 608 | 00078_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-   88 | 608 | 00088_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-   98 | 608 | 00098_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  108 | 608 | 00108_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  118 | 608 | 00118_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  128 | 608 | 00128_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  138 | 608 | 00138_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  148 | 608 | 00148_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  158 | 608 | 00158_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  168 | 608 | 00168_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  178 | 608 | 00178_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  188 | 608 | 00188_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  198 | 608 | 00198_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  208 | 608 | 00208_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  218 | 608 | 00218_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  228 | 608 | 00228_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  238 | 608 | 00238_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  248 | 608 | 00248_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  258 | 608 | 00258_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  268 | 608 | 00268_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  278 | 608 | 00278_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  288 | 608 | 00288_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  298 | 608 | 00298_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  308 | 608 | 00308_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  318 | 608 | 00318_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  328 | 608 | 00328_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  338 | 608 | 00338_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  348 | 608 | 00348_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  358 | 608 | 00358_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  368 | 608 | 00368_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  378 | 608 | 00378_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  388 | 608 | 00388_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  398 | 608 | 00398_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  408 | 608 | 00408_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  418 | 608 | 00418_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  428 | 608 | 00428_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  438 | 608 | 00438_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  448 | 608 | 00448_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  458 | 608 | 00458_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  468 | 608 | 00468_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  478 | 608 | 00478_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  488 | 608 | 00488_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  498 | 608 | 00498_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  508 | 608 | 00508_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  518 | 608 | 00518_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  528 | 608 | 00528_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  538 | 608 | 00538_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  548 | 608 | 00548_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  558 | 608 | 00558_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  568 | 608 | 00568_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  578 | 608 | 00578_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  588 | 608 | 00588_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  598 | 608 | 00598_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  608 | 608 | 00608_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  618 | 608 | 00618_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  628 | 608 | 00628_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  638 | 608 | 00638_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  648 | 608 | 00648_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  658 | 608 | 00658_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  668 | 608 | 00668_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  678 | 608 | 00678_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  688 | 608 | 00688_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  698 | 608 | 00698_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  708 | 608 | 00708_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  718 | 608 | 00718_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  728 | 608 | 00728_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  738 | 608 | 00738_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  748 | 608 | 00748_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  758 | 608 | 00758_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  768 | 608 | 00768_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  778 | 608 | 00778_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  788 | 608 | 00788_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  798 | 608 | 00798_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  808 | 608 | 00808_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  818 | 608 | 00818_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  828 | 608 | 00828_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  838 | 608 | 00838_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  848 | 608 | 00848_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  858 | 608 | 00858_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  868 | 608 | 00868_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  878 | 608 | 00878_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  888 | 608 | 00888_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  898 | 608 | 00898_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
-  908 | 608 | 00908_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
-  918 | 608 | 00918_trig_update      | Mon Jan 19 00:00:00 1970 PST | Mon Jan 19 00:00:00 1970 | 8  | 8          | foo
-  928 | 608 | 00928_trig_update      | Thu Jan 29 00:00:00 1970 PST | Thu Jan 29 00:00:00 1970 | 8  | 8          | foo
-  938 | 608 | 00938_trig_update      | Sun Feb 08 00:00:00 1970 PST | Sun Feb 08 00:00:00 1970 | 8  | 8          | foo
-  948 | 608 | 00948_trig_update      | Wed Feb 18 00:00:00 1970 PST | Wed Feb 18 00:00:00 1970 | 8  | 8          | foo
-  958 | 608 | 00958_trig_update      | Sat Feb 28 00:00:00 1970 PST | Sat Feb 28 00:00:00 1970 | 8  | 8          | foo
-  968 | 608 | 00968_trig_update      | Tue Mar 10 00:00:00 1970 PST | Tue Mar 10 00:00:00 1970 | 8  | 8          | foo
-  978 | 608 | 00978_trig_update      | Fri Mar 20 00:00:00 1970 PST | Fri Mar 20 00:00:00 1970 | 8  | 8          | foo
-  988 | 608 | 00988_trig_update      | Mon Mar 30 00:00:00 1970 PST | Mon Mar 30 00:00:00 1970 | 8  | 8          | foo
-  998 | 608 | 00998_trig_update      | Thu Apr 09 00:00:00 1970 PST | Thu Apr 09 00:00:00 1970 | 8  | 8          | foo
- 1008 | 708 | 0000800008_trig_update |                              |                          |    | ft2        | 
- 1018 | 708 | 0001800018_trig_update |                              |                          |    | ft2        | 
+  c1  | c2  |           c3           |                c4                 |             c5             | c6 |     c7     | c8  
+------+-----+------------------------+-----------------------------------+----------------------------+----+------------+-----
+ 8    | 608 | 00008_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 18   | 608 | 00018_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 28   | 608 | 00028_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 38   | 608 | 00038_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 48   | 608 | 00048_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 58   | 608 | 00058_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 68   | 608 | 00068_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 78   | 608 | 00078_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 88   | 608 | 00088_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 98   | 608 | 00098_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 108  | 608 | 00108_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 118  | 608 | 00118_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 128  | 608 | 00128_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 138  | 608 | 00138_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 148  | 608 | 00148_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 158  | 608 | 00158_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 168  | 608 | 00168_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 178  | 608 | 00178_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 188  | 608 | 00188_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 198  | 608 | 00198_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 208  | 608 | 00208_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 218  | 608 | 00218_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 228  | 608 | 00228_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 238  | 608 | 00238_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 248  | 608 | 00248_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 258  | 608 | 00258_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 268  | 608 | 00268_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 278  | 608 | 00278_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 288  | 608 | 00288_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 298  | 608 | 00298_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 308  | 608 | 00308_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 318  | 608 | 00318_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 328  | 608 | 00328_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 338  | 608 | 00338_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 348  | 608 | 00348_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 358  | 608 | 00358_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 368  | 608 | 00368_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 378  | 608 | 00378_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 388  | 608 | 00388_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 398  | 608 | 00398_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 408  | 608 | 00408_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 418  | 608 | 00418_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 428  | 608 | 00428_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 438  | 608 | 00438_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 448  | 608 | 00448_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 458  | 608 | 00458_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 468  | 608 | 00468_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 478  | 608 | 00478_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 488  | 608 | 00488_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 498  | 608 | 00498_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 508  | 608 | 00508_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 518  | 608 | 00518_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 528  | 608 | 00528_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 538  | 608 | 00538_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 548  | 608 | 00548_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 558  | 608 | 00558_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 568  | 608 | 00568_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 578  | 608 | 00578_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 588  | 608 | 00588_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 598  | 608 | 00598_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 608  | 608 | 00608_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 618  | 608 | 00618_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 628  | 608 | 00628_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 638  | 608 | 00638_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 648  | 608 | 00648_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 658  | 608 | 00658_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 668  | 608 | 00668_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 678  | 608 | 00678_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 688  | 608 | 00688_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 698  | 608 | 00698_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 708  | 608 | 00708_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 718  | 608 | 00718_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 728  | 608 | 00728_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 738  | 608 | 00738_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 748  | 608 | 00748_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 758  | 608 | 00758_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 768  | 608 | 00768_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 778  | 608 | 00778_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 788  | 608 | 00788_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 798  | 608 | 00798_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 808  | 608 | 00808_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 818  | 608 | 00818_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 828  | 608 | 00828_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 838  | 608 | 00838_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 848  | 608 | 00848_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 858  | 608 | 00858_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 868  | 608 | 00868_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 878  | 608 | 00878_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 888  | 608 | 00888_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 898  | 608 | 00898_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 908  | 608 | 00908_trig_update      | 1970-01-09 00:00:00.000000 -08:00 | 1970-01-09 00:00:00.000000 | 8  | 8          | foo
+ 918  | 608 | 00918_trig_update      | 1970-01-19 00:00:00.000000 -08:00 | 1970-01-19 00:00:00.000000 | 8  | 8          | foo
+ 928  | 608 | 00928_trig_update      | 1970-01-29 00:00:00.000000 -08:00 | 1970-01-29 00:00:00.000000 | 8  | 8          | foo
+ 938  | 608 | 00938_trig_update      | 1970-02-08 00:00:00.000000 -08:00 | 1970-02-08 00:00:00.000000 | 8  | 8          | foo
+ 948  | 608 | 00948_trig_update      | 1970-02-18 00:00:00.000000 -08:00 | 1970-02-18 00:00:00.000000 | 8  | 8          | foo
+ 958  | 608 | 00958_trig_update      | 1970-02-28 00:00:00.000000 -08:00 | 1970-02-28 00:00:00.000000 | 8  | 8          | foo
+ 968  | 608 | 00968_trig_update      | 1970-03-10 00:00:00.000000 -08:00 | 1970-03-10 00:00:00.000000 | 8  | 8          | foo
+ 978  | 608 | 00978_trig_update      | 1970-03-20 00:00:00.000000 -08:00 | 1970-03-20 00:00:00.000000 | 8  | 8          | foo
+ 988  | 608 | 00988_trig_update      | 1970-03-30 00:00:00.000000 -08:00 | 1970-03-30 00:00:00.000000 | 8  | 8          | foo
+ 998  | 608 | 00998_trig_update      | 1970-04-09 00:00:00.000000 -08:00 | 1970-04-09 00:00:00.000000 | 8  | 8          | foo
+ 1008 | 708 | 0000800008_trig_update |                                   |                            |    | ft2        | 
+ 1018 | 708 | 0001800018_trig_update |                                   |                            |    | ft2        | 
 (102 rows)
 
 -- Test errors thrown on remote side during update
@@ -6122,20 +7134,20 @@ INSERT INTO ft1(c1, c2) VALUES(11, 12) ON CONFLICT (c1, c2) DO UPDATE SET c3 = '
 ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
 INSERT INTO ft1(c1, c2) VALUES(1111, -2);  -- c2positive
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
-DETAIL:  Failing row contains (1111, -2, null, null, null, null, ft1       , null).
+DETAIL:  Failing row contains (1111, -2, _trig_update, null, null, null, ft1       , null).
 CONTEXT:  remote SQL command: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 UPDATE ft1 SET c2 = -c2 WHERE c1 = 1;  -- c2positive
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
-DETAIL:  Failing row contains (1, -1, 00001_trig_update, 1970-01-02 08:00:00+00, 1970-01-02 00:00:00, 1, 1         , foo).
-CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = (- c2) WHERE (("C 1" = 1))
+DETAIL:  Failing row contains (1, -1, 00001_trig_update, 1970-01-02 08:00:00.000000 +00:00, 1970-01-02 00:00:00.000000, 1, 1         , foo).
+CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = $2 WHERE ctid = $1
 -- Test savepoint/rollback behavior
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   0 |   100
-   1 |   100
-   4 |   100
-   6 |   100
+ 0   |   100
+ 1   |   100
+ 4   |   100
+ 6   |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6150,10 +7162,10 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 select c2, count(*) from "S 1"."T 1" where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   0 |   100
-   1 |   100
-   4 |   100
-   6 |   100
+ 0   |   100
+ 1   |   100
+ 4   |   100
+ 6   |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6170,10 +7182,10 @@ update ft2 set c2 = 42 where c2 = 0;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   4 |   100
-   6 |   100
-  42 |   100
+ 1   |   100
+ 4   |   100
+ 6   |   100
+ 42  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6190,10 +7202,10 @@ update ft2 set c2 = 44 where c2 = 4;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6209,10 +7221,10 @@ release savepoint s1;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6229,10 +7241,10 @@ update ft2 set c2 = 46 where c2 = 6;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-  42 |   100
-  44 |   100
-  46 |   100
+ 1   |   100
+ 42  |   100
+ 44  |   100
+ 46  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6248,10 +7260,10 @@ rollback to savepoint s2;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6267,10 +7279,10 @@ release savepoint s2;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6285,16 +7297,16 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 savepoint s3;
 update ft2 set c2 = -2 where c2 = 42 and c1 = 10; -- fail on remote side
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
-DETAIL:  Failing row contains (10, -2, 00010_trig_update_trig_update, 1970-01-11 08:00:00+00, 1970-01-11 00:00:00, 0, 0         , foo).
-CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = (-2) WHERE ((c2 = 42)) AND (("C 1" = 10))
+DETAIL:  Failing row contains (10, -2, 00010_trig_update_trig_update, 1970-01-11 08:00:00.000000 +00:00, 1970-01-11 00:00:00.000000, 0, 0         , foo).
+CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = $2 WHERE ctid = $1
 rollback to savepoint s3;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6310,10 +7322,10 @@ release savepoint s3;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6329,10 +7341,10 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 select c2, count(*) from "S 1"."T 1" where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   0 |   100
-   1 |   100
-   4 |   100
-   6 |   100
+ 0   |   100
+ 1   |   100
+ 4   |   100
+ 6   |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6348,10 +7360,10 @@ commit;
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6366,10 +7378,10 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 select c2, count(*) from "S 1"."T 1" where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
-   1 |   100
-   6 |   100
-  42 |   100
-  44 |   100
+ 1   |   100
+ 6   |   100
+ 42  |   100
+ 44  |   100
  100 |     2
  101 |     2
  104 |     2
@@ -6399,18 +7411,18 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 ORDER BY c6 DESC NULLS LAST, c1 O
 (8 rows)
 
 SELECT * FROM ft1 ORDER BY c6 DESC NULLS LAST, c1 OFFSET 795  LIMIT 10;
-  c1  | c2  |         c3         |              c4              |            c5            |  c6  |     c7     | c8  
-------+-----+--------------------+------------------------------+--------------------------+------+------------+-----
-  960 |  42 | 00960_trig_update  | Mon Mar 02 00:00:00 1970 PST | Mon Mar 02 00:00:00 1970 | 0    | 0          | foo
-  970 |  42 | 00970_trig_update  | Thu Mar 12 00:00:00 1970 PST | Thu Mar 12 00:00:00 1970 | 0    | 0          | foo
-  980 |  42 | 00980_trig_update  | Sun Mar 22 00:00:00 1970 PST | Sun Mar 22 00:00:00 1970 | 0    | 0          | foo
-  990 |  42 | 00990_trig_update  | Wed Apr 01 00:00:00 1970 PST | Wed Apr 01 00:00:00 1970 | 0    | 0          | foo
- 1000 |  42 | 01000_trig_update  | Thu Jan 01 00:00:00 1970 PST | Thu Jan 01 00:00:00 1970 | 0    | 0          | foo
- 1218 | 818 | ggg_trig_update    |                              |                          | (--; | ft2        | 
- 1001 | 101 | 0000100001         |                              |                          |      | ft2        | 
- 1003 | 403 | 0000300003_update3 |                              |                          |      | ft2        | 
- 1004 | 104 | 0000400004         |                              |                          |      | ft2        | 
- 1006 | 106 | 0000600006         |                              |                          |      | ft2        | 
+  c1  | c2  |         c3         |                c4                 |             c5             |  c6  |     c7     | c8  
+------+-----+--------------------+-----------------------------------+----------------------------+------+------------+-----
+ 960  | 42  | 00960_trig_update  | 1970-03-02 00:00:00.000000 -08:00 | 1970-03-02 00:00:00.000000 | 0    | 0          | foo
+ 970  | 42  | 00970_trig_update  | 1970-03-12 00:00:00.000000 -08:00 | 1970-03-12 00:00:00.000000 | 0    | 0          | foo
+ 980  | 42  | 00980_trig_update  | 1970-03-22 00:00:00.000000 -08:00 | 1970-03-22 00:00:00.000000 | 0    | 0          | foo
+ 990  | 42  | 00990_trig_update  | 1970-04-01 00:00:00.000000 -08:00 | 1970-04-01 00:00:00.000000 | 0    | 0          | foo
+ 1000 | 42  | 01000_trig_update  | 1970-01-01 00:00:00.000000 -08:00 | 1970-01-01 00:00:00.000000 | 0    | 0          | foo
+ 1218 | 818 | ggg_trig_update    |                                   |                            | (--; | ft2        | 
+ 1001 | 101 | 0000100001         |                                   |                            |      | ft2        | 
+ 1003 | 403 | 0000300003_update3 |                                   |                            |      | ft2        | 
+ 1004 | 104 | 0000400004         |                                   |                            |      | ft2        | 
+ 1006 | 106 | 0000600006         |                                   |                            |      | ft2        | 
 (10 rows)
 
 -- ORDER BY DESC NULLS FIRST options
@@ -6428,18 +7440,18 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 ORDER BY c6 DESC NULLS FIRST, c1 
 (8 rows)
 
 SELECT * FROM ft1 ORDER BY c6 DESC NULLS FIRST, c1 OFFSET 15 LIMIT 10;
-  c1  | c2  |       c3        |              c4              |            c5            | c6 |     c7     | c8  
-------+-----+-----------------+------------------------------+--------------------------+----+------------+-----
- 1020 | 100 | 0002000020      |                              |                          |    | ft2        | 
- 1101 | 201 | aaa             |                              |                          |    | ft2        | 
- 1103 | 503 | ccc_update3     |                              |                          |    | ft2        | 
- 1104 | 204 | ddd             |                              |                          |    | ft2        | 
- 1208 | 818 | fff_trig_update |                              |                          |    | ft2        | 
-    9 | 509 | 00009_update9   | Sat Jan 10 00:00:00 1970 PST | Sat Jan 10 00:00:00 1970 | 9  | ft2        | foo
-   19 | 509 | 00019_update9   | Tue Jan 20 00:00:00 1970 PST | Tue Jan 20 00:00:00 1970 | 9  | ft2        | foo
-   29 | 509 | 00029_update9   | Fri Jan 30 00:00:00 1970 PST | Fri Jan 30 00:00:00 1970 | 9  | ft2        | foo
-   39 | 509 | 00039_update9   | Mon Feb 09 00:00:00 1970 PST | Mon Feb 09 00:00:00 1970 | 9  | ft2        | foo
-   49 | 509 | 00049_update9   | Thu Feb 19 00:00:00 1970 PST | Thu Feb 19 00:00:00 1970 | 9  | ft2        | foo
+  c1  | c2  |       c3        |                c4                 |             c5             | c6 |     c7     | c8  
+------+-----+-----------------+-----------------------------------+----------------------------+----+------------+-----
+ 1020 | 100 | 0002000020      |                                   |                            |    | ft2        | 
+ 1101 | 201 | aaa             |                                   |                            |    | ft2        | 
+ 1103 | 503 | ccc_update3     |                                   |                            |    | ft2        | 
+ 1104 | 204 | ddd             |                                   |                            |    | ft2        | 
+ 1208 | 818 | fff_trig_update |                                   |                            |    | ft2        | 
+ 9    | 509 | 00009_update9   | 1970-01-10 00:00:00.000000 -08:00 | 1970-01-10 00:00:00.000000 | 9  | ft2        | foo
+ 19   | 509 | 00019_update9   | 1970-01-20 00:00:00.000000 -08:00 | 1970-01-20 00:00:00.000000 | 9  | ft2        | foo
+ 29   | 509 | 00029_update9   | 1970-01-30 00:00:00.000000 -08:00 | 1970-01-30 00:00:00.000000 | 9  | ft2        | foo
+ 39   | 509 | 00039_update9   | 1970-02-09 00:00:00.000000 -08:00 | 1970-02-09 00:00:00.000000 | 9  | ft2        | foo
+ 49   | 509 | 00049_update9   | 1970-02-19 00:00:00.000000 -08:00 | 1970-02-19 00:00:00.000000 | 9  | ft2        | foo
 (10 rows)
 
 -- ORDER BY ASC NULLS FIRST options
@@ -6457,18 +7469,18 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 ORDER BY c6 ASC NULLS FIRST, c1 O
 (8 rows)
 
 SELECT * FROM ft1 ORDER BY c6 ASC NULLS FIRST, c1 OFFSET 15 LIMIT 10;
-  c1  | c2  |        c3         |              c4              |            c5            |  c6  |     c7     | c8  
-------+-----+-------------------+------------------------------+--------------------------+------+------------+-----
- 1020 | 100 | 0002000020        |                              |                          |      | ft2        | 
- 1101 | 201 | aaa               |                              |                          |      | ft2        | 
- 1103 | 503 | ccc_update3       |                              |                          |      | ft2        | 
- 1104 | 204 | ddd               |                              |                          |      | ft2        | 
- 1208 | 818 | fff_trig_update   |                              |                          |      | ft2        | 
- 1218 | 818 | ggg_trig_update   |                              |                          | (--; | ft2        | 
-   10 |  42 | 00010_trig_update | Sun Jan 11 00:00:00 1970 PST | Sun Jan 11 00:00:00 1970 | 0    | 0          | foo
-   20 |  42 | 00020_trig_update | Wed Jan 21 00:00:00 1970 PST | Wed Jan 21 00:00:00 1970 | 0    | 0          | foo
-   30 |  42 | 00030_trig_update | Sat Jan 31 00:00:00 1970 PST | Sat Jan 31 00:00:00 1970 | 0    | 0          | foo
-   40 |  42 | 00040_trig_update | Tue Feb 10 00:00:00 1970 PST | Tue Feb 10 00:00:00 1970 | 0    | 0          | foo
+  c1  | c2  |        c3         |                c4                 |             c5             |  c6  |     c7     | c8  
+------+-----+-------------------+-----------------------------------+----------------------------+------+------------+-----
+ 1020 | 100 | 0002000020        |                                   |                            |      | ft2        | 
+ 1101 | 201 | aaa               |                                   |                            |      | ft2        | 
+ 1103 | 503 | ccc_update3       |                                   |                            |      | ft2        | 
+ 1104 | 204 | ddd               |                                   |                            |      | ft2        | 
+ 1208 | 818 | fff_trig_update   |                                   |                            |      | ft2        | 
+ 1218 | 818 | ggg_trig_update   |                                   |                            | (--; | ft2        | 
+ 10   | 42  | 00010_trig_update | 1970-01-11 00:00:00.000000 -08:00 | 1970-01-11 00:00:00.000000 | 0    | 0          | foo
+ 20   | 42  | 00020_trig_update | 1970-01-21 00:00:00.000000 -08:00 | 1970-01-21 00:00:00.000000 | 0    | 0          | foo
+ 30   | 42  | 00030_trig_update | 1970-01-31 00:00:00.000000 -08:00 | 1970-01-31 00:00:00.000000 | 0    | 0          | foo
+ 40   | 42  | 00040_trig_update | 1970-02-10 00:00:00.000000 -08:00 | 1970-02-10 00:00:00.000000 | 0    | 0          | foo
 (10 rows)
 
 -- ===================================================================
@@ -6477,13 +7489,14 @@ SELECT * FROM ft1 ORDER BY c6 ASC NULLS FIRST, c1 OFFSET 15 LIMIT 10;
 -- Consistent check constraints provide consistent results
 ALTER FOREIGN TABLE ft1 ADD CONSTRAINT ft1_c2positive CHECK (c2 >= 0);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT count(*) FROM ft1 WHERE c2 < 0;
-                           QUERY PLAN                            
------------------------------------------------------------------
- Foreign Scan
-   Output: (count(*))
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT count(*) FROM "S 1"."T 1" WHERE ((c2 < 0))
-(4 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   Output: count(*)
+   ->  Foreign Scan on public.ft1
+         Filter: (ft1.c2 < '0'::number)
+         Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(5 rows)
 
 SELECT count(*) FROM ft1 WHERE c2 < 0;
  count 
@@ -6511,23 +7524,24 @@ RESET constraint_exclusion;
 -- check constraint is enforced on the remote side, not locally
 INSERT INTO ft1(c1, c2) VALUES(1111, -2);  -- c2positive
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
-DETAIL:  Failing row contains (1111, -2, null, null, null, null, ft1       , null).
+DETAIL:  Failing row contains (1111, -2, _trig_update, null, null, null, ft1       , null).
 CONTEXT:  remote SQL command: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 UPDATE ft1 SET c2 = -c2 WHERE c1 = 1;  -- c2positive
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
-DETAIL:  Failing row contains (1, -1, 00001_trig_update, 1970-01-02 08:00:00+00, 1970-01-02 00:00:00, 1, 1         , foo).
-CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = (- c2) WHERE (("C 1" = 1))
+DETAIL:  Failing row contains (1, -1, 00001_trig_update, 1970-01-02 08:00:00.000000 +00:00, 1970-01-02 00:00:00.000000, 1, 1         , foo).
+CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = $2 WHERE ctid = $1
 ALTER FOREIGN TABLE ft1 DROP CONSTRAINT ft1_c2positive;
 -- But inconsistent check constraints provide inconsistent results
 ALTER FOREIGN TABLE ft1 ADD CONSTRAINT ft1_c2negative CHECK (c2 < 0);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT count(*) FROM ft1 WHERE c2 >= 0;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Foreign Scan
-   Output: (count(*))
-   Relations: Aggregate on (public.ft1)
-   Remote SQL: SELECT count(*) FROM "S 1"."T 1" WHERE ((c2 >= 0))
-(4 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   Output: count(*)
+   ->  Foreign Scan on public.ft1
+         Filter: (ft1.c2 >= '0'::number)
+         Remote SQL: SELECT c2 FROM "S 1"."T 1"
+(5 rows)
 
 SELECT count(*) FROM ft1 WHERE c2 >= 0;
  count 
@@ -6561,7 +7575,7 @@ ALTER FOREIGN TABLE ft1 DROP CONSTRAINT ft1_c2negative;
 -- ===================================================================
 CREATE FUNCTION row_before_insupd_trigfunc() RETURNS trigger AS $$BEGIN NEW.a := NEW.a + 10; RETURN NEW; END$$ LANGUAGE plpgsql;
 /
-CREATE TABLE base_tbl (a int, b int);
+CREATE TABLE base_tbl (a number(38,0), b number(38,0));
 ALTER TABLE base_tbl SET (autovacuum_enabled = 'false');
 CREATE TRIGGER row_before_insupd_trigger BEFORE INSERT OR UPDATE ON base_tbl FOR EACH ROW EXECUTE PROCEDURE row_before_insupd_trigfunc();
 CREATE FOREIGN TABLE foreign_tbl (a int, b int)
@@ -6673,12 +7687,12 @@ NOTICE:  drop cascades to view rw_view
 DROP TRIGGER row_before_insupd_trigger ON base_tbl;
 DROP TABLE base_tbl;
 -- test WCO for partitions
-CREATE TABLE child_tbl (a int, b int);
+CREATE TABLE child_tbl (a number(38,0), b number(38,0));
 ALTER TABLE child_tbl SET (autovacuum_enabled = 'false');
 CREATE TRIGGER row_before_insupd_trigger BEFORE INSERT OR UPDATE ON child_tbl FOR EACH ROW EXECUTE PROCEDURE row_before_insupd_trigfunc();
-CREATE FOREIGN TABLE foreign_tbl (a int, b int)
+CREATE FOREIGN TABLE foreign_tbl (a number(38,0), b number(38,0))
   SERVER loopback OPTIONS (table_name 'child_tbl');
-CREATE TABLE parent_tbl (a int, b int) PARTITION BY RANGE(a);
+CREATE TABLE parent_tbl (a number(38,0), b number(38,0)) PARTITION BY RANGE(a);
 ALTER TABLE parent_tbl ATTACH PARTITION foreign_tbl FOR VALUES FROM (0) TO (100);
 -- Detach and re-attach once, to stress the concurrent detach case.
 ALTER TABLE parent_tbl DETACH PARTITION foreign_tbl CONCURRENTLY;
@@ -6686,11 +7700,11 @@ ALTER TABLE parent_tbl ATTACH PARTITION foreign_tbl FOR VALUES FROM (0) TO (100)
 CREATE VIEW rw_view AS SELECT * FROM parent_tbl
   WHERE a < b WITH CHECK OPTION;
 \d+ rw_view
-                           View "public.rw_view"
- Column |  Type   | Collation | Nullable | Default | Storage | Description 
---------+---------+-----------+----------+---------+---------+-------------
- a      | integer |           |          |         | plain   | 
- b      | integer |           |          |         | plain   | 
+                             View "public.rw_view"
+ Column |     Type     | Collation | Nullable | Default | Storage | Description 
+--------+--------------+-----------+----------+---------+---------+-------------
+ a      | number(38,0) |           |          |         | main    | 
+ b      | number(38,0) |           |          |         | main    | 
 View definition:
  SELECT a,
     b
@@ -6700,11 +7714,11 @@ Options: check_option=cascaded
 
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO rw_view VALUES (0, 5);
-         QUERY PLAN          
------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Insert on public.parent_tbl
    ->  Result
-         Output: 0, 5
+         Output: '0'::number(38,0), '5'::number(38,0)
 (3 rows)
 
 INSERT INTO rw_view VALUES (0, 5); -- should fail
@@ -6712,11 +7726,11 @@ ERROR:  new row violates check option for view "rw_view"
 DETAIL:  Failing row contains (10, 5).
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO rw_view VALUES (0, 15);
-         QUERY PLAN          
------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Insert on public.parent_tbl
    ->  Result
-         Output: 0, 15
+         Output: '0'::number(38,0), '15'::number(38,0)
 (3 rows)
 
 INSERT INTO rw_view VALUES (0, 15); -- ok
@@ -6728,30 +7742,32 @@ SELECT * FROM foreign_tbl;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE rw_view SET b = b + 5;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Update on public.parent_tbl
    Foreign Update on public.foreign_tbl parent_tbl_1
      Remote SQL: UPDATE public.child_tbl SET b = $2 WHERE ctid = $1 RETURNING a, b
    ->  Foreign Scan on public.foreign_tbl parent_tbl_1
-         Output: (parent_tbl_1.b + 5), parent_tbl_1.tableoid, parent_tbl_1.ctid, parent_tbl_1.*
-         Remote SQL: SELECT a, b, ctid FROM public.child_tbl WHERE ((a < b)) FOR UPDATE
-(6 rows)
+         Output: (parent_tbl_1.b + '5'::number), parent_tbl_1.tableoid, parent_tbl_1.ctid, parent_tbl_1.*
+         Filter: (parent_tbl_1.a < parent_tbl_1.b)
+         Remote SQL: SELECT a, b, ctid FROM public.child_tbl FOR UPDATE
+(7 rows)
 
 UPDATE rw_view SET b = b + 5; -- should fail
 ERROR:  new row violates check option for view "rw_view"
 DETAIL:  Failing row contains (20, 20).
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE rw_view SET b = b + 15;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Update on public.parent_tbl
    Foreign Update on public.foreign_tbl parent_tbl_1
      Remote SQL: UPDATE public.child_tbl SET b = $2 WHERE ctid = $1 RETURNING a, b
    ->  Foreign Scan on public.foreign_tbl parent_tbl_1
-         Output: (parent_tbl_1.b + 15), parent_tbl_1.tableoid, parent_tbl_1.ctid, parent_tbl_1.*
-         Remote SQL: SELECT a, b, ctid FROM public.child_tbl WHERE ((a < b)) FOR UPDATE
-(6 rows)
+         Output: (parent_tbl_1.b + '15'::number), parent_tbl_1.tableoid, parent_tbl_1.ctid, parent_tbl_1.*
+         Filter: (parent_tbl_1.a < parent_tbl_1.b)
+         Remote SQL: SELECT a, b, ctid FROM public.child_tbl FOR UPDATE
+(7 rows)
 
 UPDATE rw_view SET b = b + 15; -- ok
 SELECT * FROM foreign_tbl;
@@ -6788,33 +7804,34 @@ NOTICE:  drop cascades to view rw_view
 DROP FUNCTION row_before_insupd_trigfunc;
 -- Try a more complex permutation of WCO where there are multiple levels of
 -- partitioned tables with columns not all in the same order
-CREATE TABLE parent_tbl (a int, b text, c numeric) PARTITION BY RANGE(a);
-CREATE TABLE sub_parent (c numeric, a int, b text) PARTITION BY RANGE(a);
+CREATE TABLE parent_tbl (a number(38,0), b varchar2(1024), c number) PARTITION BY RANGE(a);
+CREATE TABLE sub_parent (c number, a number(38,0), b varchar2(1024)) PARTITION BY RANGE(a);
 ALTER TABLE parent_tbl ATTACH PARTITION sub_parent FOR VALUES FROM (1) TO (10);
-CREATE TABLE child_local (b text, c numeric, a int);
-CREATE FOREIGN TABLE child_foreign (b text, c numeric, a int)
+CREATE TABLE child_local (b varchar2(1024), c number, a number(38,0));
+CREATE FOREIGN TABLE child_foreign (b varchar2(1024), c number, a number(38,0))
   SERVER loopback OPTIONS (table_name 'child_local');
 ALTER TABLE sub_parent ATTACH PARTITION child_foreign FOR VALUES FROM (1) TO (10);
 CREATE VIEW rw_view AS SELECT * FROM parent_tbl WHERE a < 5 WITH CHECK OPTION;
 INSERT INTO parent_tbl (a) VALUES(1),(5);
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE rw_view SET b = 'text', c = 123.456;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Update on public.parent_tbl
    Foreign Update on public.child_foreign parent_tbl_1
      Remote SQL: UPDATE public.child_local SET b = $2, c = $3 WHERE ctid = $1 RETURNING a
    ->  Foreign Scan on public.child_foreign parent_tbl_1
-         Output: 'text'::text, 123.456, parent_tbl_1.tableoid, parent_tbl_1.ctid, parent_tbl_1.*
-         Remote SQL: SELECT b, c, a, ctid FROM public.child_local WHERE ((a < 5)) FOR UPDATE
-(6 rows)
+         Output: 'text'::varchar2(1024), '123.456'::number, parent_tbl_1.tableoid, parent_tbl_1.ctid, parent_tbl_1.*
+         Filter: (parent_tbl_1.a < '5'::number)
+         Remote SQL: SELECT b, c, a, ctid FROM public.child_local FOR UPDATE
+(7 rows)
 
 UPDATE rw_view SET b = 'text', c = 123.456;
 SELECT * FROM parent_tbl ORDER BY a;
  a |  b   |    c    
 ---+------+---------
  1 | text | 123.456
- 5 |      |        
+ 5 |      | 
 (2 rows)
 
 DROP VIEW rw_view;
@@ -6825,9 +7842,9 @@ DROP TABLE parent_tbl;
 -- ===================================================================
 -- test serial columns (ie, sequence-based defaults)
 -- ===================================================================
-create table loc1 (f1 serial, f2 text);
+create table loc1 (f1 serial, f2 varchar2(1024));
 alter table loc1 set (autovacuum_enabled = 'false');
-create foreign table rem1 (f1 serial, f2 text)
+create foreign table rem1 (f1 serial, f2 varchar2(1024))
   server loopback options(table_name 'loc1');
 select pg_catalog.setval('rem1_f1_seq', 10, false);
  setval 
@@ -6861,12 +7878,12 @@ select * from rem1;
 -- test generated columns
 -- ===================================================================
 create table gloc1 (
-  a int,
-  b int generated always as (a * 2) stored);
+  a number(38,0),
+  b number(38,0) generated always as (a * 2) stored);
 alter table gloc1 set (autovacuum_enabled = 'false');
 create foreign table grem1 (
-  a int,
-  b int generated always as (a * 2) stored)
+  a number(38,0),
+  b number(38,0) generated always as (a * 2) stored)
   server loopback options(table_name 'gloc1');
 explain (verbose, costs off)
 insert into grem1 (a) values (1), (2);
@@ -6876,33 +7893,34 @@ insert into grem1 (a) values (1), (2);
    Remote SQL: INSERT INTO public.gloc1(a, b) VALUES ($1, DEFAULT)
    Batch Size: 1
    ->  Values Scan on "*VALUES*"
-         Output: "*VALUES*".column1, NULL::integer
+         Output: "*VALUES*".column1, NULL::number
 (5 rows)
 
 insert into grem1 (a) values (1), (2);
 explain (verbose, costs off)
 update grem1 set a = 22 where a = 2;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Update on public.grem1
    Remote SQL: UPDATE public.gloc1 SET a = $2, b = DEFAULT WHERE ctid = $1
    ->  Foreign Scan on public.grem1
-         Output: 22, ctid, grem1.*
-         Remote SQL: SELECT a, b, ctid FROM public.gloc1 WHERE ((a = 2)) FOR UPDATE
-(5 rows)
+         Output: '22'::number(38,0), ctid, grem1.*
+         Filter: (grem1.a = '2'::number)
+         Remote SQL: SELECT a, b, ctid FROM public.gloc1 FOR UPDATE
+(6 rows)
 
 update grem1 set a = 22 where a = 2;
 select * from gloc1;
  a  | b  
 ----+----
-  1 |  2
+ 1  | 2
  22 | 44
 (2 rows)
 
 select * from grem1;
  a  | b  
 ----+----
-  1 |  2
+ 1  | 2
  22 | 44
 (2 rows)
 
@@ -6934,7 +7952,7 @@ insert into grem1 (a) values (1), (2);
    Remote SQL: INSERT INTO public.gloc1(a, b) VALUES ($1, DEFAULT)
    Batch Size: 10
    ->  Values Scan on "*VALUES*"
-         Output: "*VALUES*".column1, NULL::integer
+         Output: "*VALUES*".column1, NULL::number
 (5 rows)
 
 insert into grem1 (a) values (1), (2);
@@ -6956,12 +7974,12 @@ delete from grem1;
 -- batch insert with foreign partitions.
 -- This schema uses two partitions, one local and one remote with a modulo
 -- to loop across all of them in batches.
-create table tab_batch_local (id int, data text);
+create table tab_batch_local (id number(38,0), data varchar2(1024));
 insert into tab_batch_local select i, 'test'|| i from generate_series(1, 45) i;
-create table tab_batch_sharded (id int, data text) partition by hash(id);
+create table tab_batch_sharded (id number(38,0), data varchar2(1024)) partition by hash(id);
 create table tab_batch_sharded_p0 partition of tab_batch_sharded
   for values with (modulus 2, remainder 0);
-create table tab_batch_sharded_p1_remote (id int, data text);
+create table tab_batch_sharded_p1_remote (id number(38,0), data varchar(1024));
 create foreign table tab_batch_sharded_p1 partition of tab_batch_sharded
   for values with (modulus 2, remainder 1)
   server loopback options (table_name 'tab_batch_sharded_p1_remote');
@@ -7383,11 +8401,11 @@ CREATE TRIGGER trig_stmt_before
 	FOR EACH STATEMENT EXECUTE PROCEDURE trigger_func();
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-                        QUERY PLAN                        
-----------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Update on public.rem1
    ->  Foreign Update on public.rem1
-         Remote SQL: UPDATE public.loc1 SET f2 = ''::text
+         Remote SQL: UPDATE public.loc1 SET f2 = ''::varchar2(1024)
 (3 rows)
 
 EXPLAIN (verbose, costs off)
@@ -7405,11 +8423,11 @@ CREATE TRIGGER trig_stmt_after
 	FOR EACH STATEMENT EXECUTE PROCEDURE trigger_func();
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-                        QUERY PLAN                        
-----------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Update on public.rem1
    ->  Foreign Update on public.rem1
-         Remote SQL: UPDATE public.loc1 SET f2 = ''::text
+         Remote SQL: UPDATE public.loc1 SET f2 = ''::varchar2(1024)
 (3 rows)
 
 EXPLAIN (verbose, costs off)
@@ -7428,11 +8446,11 @@ BEFORE INSERT ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-                        QUERY PLAN                        
-----------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Update on public.rem1
    ->  Foreign Update on public.rem1
-         Remote SQL: UPDATE public.loc1 SET f2 = ''::text
+         Remote SQL: UPDATE public.loc1 SET f2 = ''::varchar2(1024)
 (3 rows)
 
 EXPLAIN (verbose, costs off)
@@ -7450,11 +8468,11 @@ AFTER INSERT ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-                        QUERY PLAN                        
-----------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Update on public.rem1
    ->  Foreign Update on public.rem1
-         Remote SQL: UPDATE public.loc1 SET f2 = ''::text
+         Remote SQL: UPDATE public.loc1 SET f2 = ''::varchar2(1024)
 (3 rows)
 
 EXPLAIN (verbose, costs off)
@@ -7478,7 +8496,7 @@ UPDATE rem1 set f2 = '';          -- can't be pushed down
  Update on public.rem1
    Remote SQL: UPDATE public.loc1 SET f1 = $2, f2 = $3 WHERE ctid = $1
    ->  Foreign Scan on public.rem1
-         Output: ''::text, ctid, rem1.*
+         Output: ''::varchar2(1024), ctid, rem1.*
          Remote SQL: SELECT f1, f2, ctid FROM public.loc1 FOR UPDATE
 (5 rows)
 
@@ -7502,7 +8520,7 @@ UPDATE rem1 set f2 = '';          -- can't be pushed down
  Update on public.rem1
    Remote SQL: UPDATE public.loc1 SET f2 = $2 WHERE ctid = $1 RETURNING f1, f2
    ->  Foreign Scan on public.rem1
-         Output: ''::text, ctid, rem1.*
+         Output: ''::varchar2(1024), ctid, rem1.*
          Remote SQL: SELECT f1, f2, ctid FROM public.loc1 FOR UPDATE
 (5 rows)
 
@@ -7522,11 +8540,11 @@ BEFORE DELETE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-                        QUERY PLAN                        
-----------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Update on public.rem1
    ->  Foreign Update on public.rem1
-         Remote SQL: UPDATE public.loc1 SET f2 = ''::text
+         Remote SQL: UPDATE public.loc1 SET f2 = ''::varchar2(1024)
 (3 rows)
 
 EXPLAIN (verbose, costs off)
@@ -7546,11 +8564,11 @@ AFTER DELETE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-                        QUERY PLAN                        
-----------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Update on public.rem1
    ->  Foreign Update on public.rem1
-         Remote SQL: UPDATE public.loc1 SET f2 = ''::text
+         Remote SQL: UPDATE public.loc1 SET f2 = ''::varchar2(1024)
 (3 rows)
 
 EXPLAIN (verbose, costs off)
@@ -7568,11 +8586,11 @@ DROP TRIGGER trig_row_after_delete ON rem1;
 -- ===================================================================
 -- test inheritance features
 -- ===================================================================
-CREATE TABLE a (aa TEXT);
-CREATE TABLE loct (aa TEXT, bb TEXT);
+CREATE TABLE a (aa varchar2(1024));
+CREATE TABLE loct (aa varchar2(1024), bb varchar2(1024));
 ALTER TABLE a SET (autovacuum_enabled = 'false');
 ALTER TABLE loct SET (autovacuum_enabled = 'false');
-CREATE FOREIGN TABLE b (bb TEXT) INHERITS (a)
+CREATE FOREIGN TABLE b (bb varchar2(1024)) INHERITS (a)
   SERVER loopback OPTIONS (table_name 'loct');
 INSERT INTO a(aa) VALUES('aaa');
 INSERT INTO a(aa) VALUES('aaaa');
@@ -7711,15 +8729,15 @@ DROP TABLE a CASCADE;
 NOTICE:  drop cascades to foreign table b
 DROP TABLE loct;
 -- Check SELECT FOR UPDATE/SHARE with an inherited source table
-create table loct1 (f1 int, f2 int, f3 int);
-create table loct2 (f1 int, f2 int, f3 int);
+create table loct1 (f1 number(38,0), f2 number(38,0), f3 number(38,0));
+create table loct2 (f1 number(38,0), f2 number(38,0), f3 number(38,0));
 alter table loct1 set (autovacuum_enabled = 'false');
 alter table loct2 set (autovacuum_enabled = 'false');
-create table foo (f1 int, f2 int);
-create foreign table foo2 (f3 int) inherits (foo)
+create table foo (f1 number(38,0), f2 number(38,0));
+create foreign table foo2 (f3 number(38,0)) inherits (foo)
   server loopback options (table_name 'loct1');
-create table bar (f1 int, f2 int);
-create foreign table bar2 (f3 int) inherits (bar)
+create table bar (f1 number(38,0), f2 number(38,0));
+create foreign table bar2 (f3 number(38,0)) inherits (bar)
   server loopback options (table_name 'loct2');
 alter table foo set (autovacuum_enabled = 'false');
 alter table bar set (autovacuum_enabled = 'false');
@@ -7765,10 +8783,10 @@ select * from bar where f1 in (select f1 from foo) for update;
 select * from bar where f1 in (select f1 from foo) for update;
  f1 | f2 
 ----+----
-  1 | 11
-  2 | 22
-  3 | 33
-  4 | 44
+ 1  | 11
+ 2  | 22
+ 3  | 33
+ 4  | 44
 (4 rows)
 
 explain (verbose, costs off)
@@ -7803,16 +8821,16 @@ select * from bar where f1 in (select f1 from foo) for share;
 select * from bar where f1 in (select f1 from foo) for share;
  f1 | f2 
 ----+----
-  1 | 11
-  2 | 22
-  3 | 33
-  4 | 44
+ 1  | 11
+ 2  | 22
+ 3  | 33
+ 4  | 44
 (4 rows)
 
 -- Now check SELECT FOR UPDATE/SHARE with an inherited source table,
 -- where the parent is itself a foreign table
-create table loct4 (f1 int, f2 int, f3 int);
-create foreign table foo2child (f3 int) inherits (foo2)
+create table loct4 (f1 number(38,0), f2 number(38,0), f3 number(38,0));
+create foreign table foo2child (f3 number(38,0)) inherits (foo2)
   server loopback options (table_name 'loct4');
 NOTICE:  moving and merging column "f3" with inherited definition
 DETAIL:  User-specified column moved to the position of the inherited column.
@@ -7849,13 +8867,13 @@ select * from bar where f1 in (select f1 from foo2) for share;
 select * from bar where f1 in (select f1 from foo2) for share;
  f1 | f2 
 ----+----
-  2 | 22
-  4 | 44
+ 2  | 22
+ 4  | 44
 (2 rows)
 
 drop foreign table foo2child;
 -- And with a local child relation of the foreign table parent
-create table foo2child (f3 int) inherits (foo2);
+create table foo2child (f3 number(38,0)) inherits (foo2);
 NOTICE:  moving and merging column "f3" with inherited definition
 DETAIL:  User-specified column moved to the position of the inherited column.
 explain (verbose, costs off)
@@ -7890,22 +8908,22 @@ select * from bar where f1 in (select f1 from foo2) for share;
 select * from bar where f1 in (select f1 from foo2) for share;
  f1 | f2 
 ----+----
-  2 | 22
-  4 | 44
+ 2  | 22
+ 4  | 44
 (2 rows)
 
 drop table foo2child;
 -- Check UPDATE with inherited target and an inherited source table
 explain (verbose, costs off)
 update bar set f2 = f2 + 100 where f1 in (select f1 from foo);
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Update on public.bar
    Update on public.bar bar_1
    Foreign Update on public.bar2 bar_2
      Remote SQL: UPDATE public.loct2 SET f2 = $2 WHERE ctid = $1
    ->  Hash Join
-         Output: (bar.f2 + 100), foo.ctid, bar.tableoid, bar.ctid, (NULL::record), foo.*, foo.tableoid
+         Output: (bar.f2 + '100'::number), foo.ctid, bar.tableoid, bar.ctid, (NULL::record), foo.*, foo.tableoid
          Inner Unique: true
          Hash Cond: (bar.f1 = foo.f1)
          ->  Append
@@ -7931,12 +8949,12 @@ update bar set f2 = f2 + 100 where f1 in (select f1 from foo);
 select tableoid::regclass, * from bar order by 1,2;
  tableoid | f1 | f2  
 ----------+----+-----
- bar      |  1 | 111
- bar      |  2 | 122
- bar      |  6 |  66
- bar2     |  3 | 133
- bar2     |  4 | 144
- bar2     |  7 |  77
+ bar      | 1  | 111
+ bar      | 2  | 122
+ bar      | 6  | 66
+ bar2     | 3  | 133
+ bar2     | 4  | 144
+ bar2     | 7  | 77
 (6 rows)
 
 -- Check UPDATE with inherited target and an appendrel subquery
@@ -7945,39 +8963,35 @@ update bar set f2 = f2 + 100
 from
   ( select f1 from foo union all select f1+3 from foo ) ss
 where bar.f1 = ss.f1;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
  Update on public.bar
    Update on public.bar bar_1
    Foreign Update on public.bar2 bar_2
      Remote SQL: UPDATE public.loct2 SET f2 = $2 WHERE ctid = $1
-   ->  Merge Join
-         Output: (bar.f2 + 100), (ROW(foo.f1)), bar.tableoid, bar.ctid, (NULL::record)
-         Merge Cond: (bar.f1 = foo.f1)
-         ->  Sort
+   ->  Hash Join
+         Output: (bar.f2 + '100'::number), (ROW(foo.f1)), bar.tableoid, bar.ctid, (NULL::record)
+         Hash Cond: (foo.f1 = bar.f1)
+         ->  Append
+               ->  Seq Scan on public.foo
+                     Output: ROW(foo.f1), foo.f1
+               ->  Foreign Scan on public.foo2 foo_1
+                     Output: ROW(foo_1.f1), foo_1.f1
+                     Remote SQL: SELECT f1 FROM public.loct1
+               ->  Seq Scan on public.foo foo_2
+                     Output: ROW((foo_2.f1 + '3'::number)), (foo_2.f1 + '3'::number)
+               ->  Foreign Scan on public.foo2 foo_3
+                     Output: ROW((foo_3.f1 + '3'::number)), (foo_3.f1 + '3'::number)
+                     Remote SQL: SELECT f1 FROM public.loct1
+         ->  Hash
                Output: bar.f2, bar.f1, bar.tableoid, bar.ctid, (NULL::record)
-               Sort Key: bar.f1
                ->  Append
                      ->  Seq Scan on public.bar bar_1
                            Output: bar_1.f2, bar_1.f1, bar_1.tableoid, bar_1.ctid, NULL::record
                      ->  Foreign Scan on public.bar2 bar_2
                            Output: bar_2.f2, bar_2.f1, bar_2.tableoid, bar_2.ctid, bar_2.*
                            Remote SQL: SELECT f1, f2, f3, ctid FROM public.loct2 FOR UPDATE
-         ->  Sort
-               Output: (ROW(foo.f1)), foo.f1
-               Sort Key: foo.f1
-               ->  Append
-                     ->  Seq Scan on public.foo
-                           Output: ROW(foo.f1), foo.f1
-                     ->  Foreign Scan on public.foo2 foo_1
-                           Output: ROW(foo_1.f1), foo_1.f1
-                           Remote SQL: SELECT f1 FROM public.loct1
-                     ->  Seq Scan on public.foo foo_2
-                           Output: ROW((foo_2.f1 + 3)), (foo_2.f1 + 3)
-                     ->  Foreign Scan on public.foo2 foo_3
-                           Output: ROW((foo_3.f1 + 3)), (foo_3.f1 + 3)
-                           Remote SQL: SELECT f1 FROM public.loct1
-(30 rows)
+(26 rows)
 
 update bar set f2 = f2 + 100
 from
@@ -7986,12 +9000,12 @@ where bar.f1 = ss.f1;
 select tableoid::regclass, * from bar order by 1,2;
  tableoid | f1 | f2  
 ----------+----+-----
- bar      |  1 | 211
- bar      |  2 | 222
- bar      |  6 | 166
- bar2     |  3 | 233
- bar2     |  4 | 244
- bar2     |  7 | 177
+ bar      | 1  | 211
+ bar      | 2  | 222
+ bar      | 6  | 166
+ bar2     | 3  | 233
+ bar2     | 4  | 244
+ bar2     | 7  | 177
 (6 rows)
 
 -- Test forcing the remote server to produce sorted data for a merge join,
@@ -8011,8 +9025,8 @@ analyze loct1;
 -- inner join; expressions in the clauses appear in the equivalence class list
 explain (verbose, costs off)
 	select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Limit
    Output: foo.f1, loct1.f1, foo.f2
    ->  Sort
@@ -8025,12 +9039,15 @@ explain (verbose, costs off)
                      Sort Key: foo.f1
                      ->  Index Scan using i_foo_f1 on public.foo foo_1
                            Output: foo_1.f1, foo_1.f2
-                     ->  Foreign Scan on public.foo2 foo_2
+                     ->  Sort
                            Output: foo_2.f1, foo_2.f2
-                           Remote SQL: SELECT f1, f2 FROM public.loct1 ORDER BY f1 ASC NULLS LAST
+                           Sort Key: foo_2.f1
+                           ->  Foreign Scan on public.foo2 foo_2
+                                 Output: foo_2.f1, foo_2.f2
+                                 Remote SQL: SELECT f1, f2 FROM public.loct1
                ->  Index Only Scan using i_loct1_f1 on public.loct1
                      Output: loct1.f1
-(17 rows)
+(20 rows)
 
 select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
  f1 | f1 
@@ -8051,8 +9068,8 @@ select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.
 -- list but no output change as compared to the previous query
 explain (verbose, costs off)
 	select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Limit
    Output: foo.f1, loct1.f1, foo.f2
    ->  Sort
@@ -8065,26 +9082,29 @@ explain (verbose, costs off)
                      Sort Key: foo.f1
                      ->  Index Scan using i_foo_f1 on public.foo foo_1
                            Output: foo_1.f1, foo_1.f2
-                     ->  Foreign Scan on public.foo2 foo_2
+                     ->  Sort
                            Output: foo_2.f1, foo_2.f2
-                           Remote SQL: SELECT f1, f2 FROM public.loct1 ORDER BY f1 ASC NULLS LAST
+                           Sort Key: foo_2.f1
+                           ->  Foreign Scan on public.foo2 foo_2
+                                 Output: foo_2.f1, foo_2.f2
+                                 Remote SQL: SELECT f1, f2 FROM public.loct1
                ->  Index Only Scan using i_loct1_f1 on public.loct1
                      Output: loct1.f1
-(17 rows)
+(20 rows)
 
 select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
  f1 | f1 
 ----+----
  10 | 10
- 11 |   
+ 11 | 
  12 | 12
- 13 |   
+ 13 | 
  14 | 14
- 15 |   
+ 15 | 
  16 | 16
- 17 |   
+ 17 | 
  18 | 18
- 19 |   
+ 19 | 
 (10 rows)
 
 RESET enable_hashjoin;
@@ -8095,7 +9115,7 @@ declare c cursor for select * from bar where f1 = 7;
 fetch from c;
  f1 | f2  
 ----+-----
-  7 | 177
+ 7  | 177
 (1 row)
 
 update bar set f2 = null where current of c;
@@ -8103,56 +9123,61 @@ ERROR:  WHERE CURRENT OF is not supported for this table type
 rollback;
 explain (verbose, costs off)
 delete from foo where f1 < 5 returning *;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Delete on public.foo
    Output: foo_1.f1, foo_1.f2
    Delete on public.foo foo_1
    Foreign Delete on public.foo2 foo_2
+     Remote SQL: DELETE FROM public.loct1 WHERE ctid = $1 RETURNING f1, f2
    ->  Append
          ->  Index Scan using i_foo_f1 on public.foo foo_1
                Output: foo_1.tableoid, foo_1.ctid
-               Index Cond: (foo_1.f1 < 5)
-         ->  Foreign Delete on public.foo2 foo_2
-               Remote SQL: DELETE FROM public.loct1 WHERE ((f1 < 5)) RETURNING f1, f2
-(10 rows)
+               Index Cond: (foo_1.f1 < '5'::number)
+         ->  Foreign Scan on public.foo2 foo_2
+               Output: foo_2.tableoid, foo_2.ctid
+               Filter: (foo_2.f1 < '5'::number)
+               Remote SQL: SELECT f1, ctid FROM public.loct1 FOR UPDATE
+(13 rows)
 
 delete from foo where f1 < 5 returning *;
  f1 | f2 
 ----+----
-  1 |  1
-  3 |  3
-  0 |  0
-  2 |  2
-  4 |  4
+ 1  | 1
+ 3  | 3
+ 0  | 0
+ 2  | 2
+ 4  | 4
 (5 rows)
 
 explain (verbose, costs off)
 update bar set f2 = f2 + 100 returning *;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Update on public.bar
    Output: bar_1.f1, bar_1.f2
    Update on public.bar bar_1
    Foreign Update on public.bar2 bar_2
+     Remote SQL: UPDATE public.loct2 SET f2 = $2 WHERE ctid = $1 RETURNING f1, f2
    ->  Result
-         Output: (bar.f2 + 100), bar.tableoid, bar.ctid, (NULL::record)
+         Output: (bar.f2 + '100'::number), bar.tableoid, bar.ctid, (NULL::record)
          ->  Append
                ->  Seq Scan on public.bar bar_1
                      Output: bar_1.f2, bar_1.tableoid, bar_1.ctid, NULL::record
-               ->  Foreign Update on public.bar2 bar_2
-                     Remote SQL: UPDATE public.loct2 SET f2 = (f2 + 100) RETURNING f1, f2
-(11 rows)
+               ->  Foreign Scan on public.bar2 bar_2
+                     Output: bar_2.f2, bar_2.tableoid, bar_2.ctid, bar_2.*
+                     Remote SQL: SELECT f1, f2, f3, ctid FROM public.loct2 FOR UPDATE
+(13 rows)
 
 update bar set f2 = f2 + 100 returning *;
  f1 | f2  
 ----+-----
-  1 | 311
-  2 | 322
-  6 | 266
-  3 | 333
-  4 | 344
-  7 | 277
+ 1  | 311
+ 2  | 322
+ 6  | 266
+ 3  | 333
+ 4  | 344
+ 7  | 277
 (6 rows)
 
 -- Test that UPDATE/DELETE with inherited target works with row-level triggers
@@ -8171,7 +9196,7 @@ update bar set f2 = f2 + 100;
    Foreign Update on public.bar2 bar_2
      Remote SQL: UPDATE public.loct2 SET f1 = $2, f2 = $3, f3 = $4 WHERE ctid = $1 RETURNING f1, f2, f3
    ->  Result
-         Output: (bar.f2 + 100), bar.tableoid, bar.ctid, (NULL::record)
+         Output: (bar.f2 + '100'::number), bar.tableoid, bar.ctid, (NULL::record)
          ->  Append
                ->  Seq Scan on public.bar bar_1
                      Output: bar_1.f2, bar_1.tableoid, bar_1.ctid, NULL::record
@@ -8195,8 +9220,8 @@ NOTICE:  trig_row_after(23, skidoo) AFTER ROW UPDATE ON bar2
 NOTICE:  OLD: (7,277,77),NEW: (7,377,77)
 explain (verbose, costs off)
 delete from bar where f2 < 400;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Delete on public.bar
    Delete on public.bar bar_1
    Foreign Delete on public.bar2 bar_2
@@ -8204,11 +9229,12 @@ delete from bar where f2 < 400;
    ->  Append
          ->  Seq Scan on public.bar bar_1
                Output: bar_1.tableoid, bar_1.ctid, NULL::record
-               Filter: (bar_1.f2 < 400)
+               Filter: (bar_1.f2 < '400'::number)
          ->  Foreign Scan on public.bar2 bar_2
                Output: bar_2.tableoid, bar_2.ctid, bar_2.*
-               Remote SQL: SELECT f1, f2, f3, ctid FROM public.loct2 WHERE ((f2 < 400)) FOR UPDATE
-(11 rows)
+               Filter: (bar_2.f2 < '400'::number)
+               Remote SQL: SELECT f1, f2, f3, ctid FROM public.loct2 FOR UPDATE
+(12 rows)
 
 delete from bar where f2 < 400;
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW DELETE ON bar2
@@ -8223,12 +9249,96 @@ NOTICE:  drop cascades to foreign table bar2
 drop table loct1;
 drop table loct2;
 -- Test pushing down UPDATE/DELETE joins to the remote server
-create table parent (a int, b text);
-create table loct1 (a int, b text);
-create table loct2 (a int, b text);
-create foreign table remt1 (a int, b text)
+create table parent (a number(38,0), b varchar2(1024 byte));
+create table loct1 (a number(38,0), b varchar2(1024 byte));
+create table loct2 (a number(38,0), b varchar2(1024 byte));
+create foreign table remt1 (a number(38,0), b varchar2(1024 byte))
   server loopback options (table_name 'loct1');
-create foreign table remt2 (a int, b text)
+create foreign table remt2 (a number(38,0), b varchar2(1024 byte))
+  server loopback options (table_name 'loct2');
+alter foreign table remt1 inherit parent;
+insert into remt1 values (1, 'foo');
+insert into remt1 values (2, 'bar');
+insert into remt2 values (1, 'foo');
+insert into remt2 values (2, 'bar');
+analyze remt1;
+analyze remt2;
+explain (verbose, costs off)
+update parent set b = parent.b || remt2.b from remt2 where parent.a = remt2.a returning *;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Update on public.parent
+   Output: parent_1.a, parent_1.b, remt2.a, remt2.b
+   Update on public.parent parent_1
+   Foreign Update on public.remt1 parent_2
+     Remote SQL: UPDATE public.loct1 SET b = $2 WHERE ctid = $1 RETURNING a, b
+   ->  Nested Loop
+         Output: ((parent.b)::text || (remt2.b)::text), remt2.*, remt2.a, remt2.b, parent.tableoid, parent.ctid, (NULL::record)
+         Join Filter: (parent.a = remt2.a)
+         ->  Append
+               ->  Seq Scan on public.parent parent_1
+                     Output: parent_1.b, parent_1.a, parent_1.tableoid, parent_1.ctid, NULL::record
+               ->  Foreign Scan on public.remt1 parent_2
+                     Output: parent_2.b, parent_2.a, parent_2.tableoid, parent_2.ctid, parent_2.*
+                     Remote SQL: SELECT a, b, ctid FROM public.loct1 FOR UPDATE
+         ->  Materialize
+               Output: remt2.b, remt2.*, remt2.a
+               ->  Foreign Scan on public.remt2
+                     Output: remt2.b, remt2.*, remt2.a
+                     Remote SQL: SELECT a, b FROM public.loct2
+(19 rows)
+
+update parent set b = parent.b || remt2.b from remt2 where parent.a = remt2.a returning *;
+ a |   b    | a |  b  
+---+--------+---+-----
+ 1 | foofoo | 1 | foo
+ 2 | barbar | 2 | bar
+(2 rows)
+
+explain (verbose, costs off)
+delete from parent using remt2 where parent.a = remt2.a returning parent;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Delete on public.parent
+   Output: parent_1.*
+   Delete on public.parent parent_1
+   Foreign Delete on public.remt1 parent_2
+     Remote SQL: DELETE FROM public.loct1 WHERE ctid = $1 RETURNING a, b
+   ->  Nested Loop
+         Output: remt2.*, parent.tableoid, parent.ctid
+         Join Filter: (parent.a = remt2.a)
+         ->  Append
+               ->  Seq Scan on public.parent parent_1
+                     Output: parent_1.a, parent_1.tableoid, parent_1.ctid
+               ->  Foreign Scan on public.remt1 parent_2
+                     Output: parent_2.a, parent_2.tableoid, parent_2.ctid
+                     Remote SQL: SELECT a, ctid FROM public.loct1 FOR UPDATE
+         ->  Materialize
+               Output: remt2.*, remt2.a
+               ->  Foreign Scan on public.remt2
+                     Output: remt2.*, remt2.a
+                     Remote SQL: SELECT a, b FROM public.loct2
+(19 rows)
+
+delete from parent using remt2 where parent.a = remt2.a returning parent;
+   parent   
+------------
+ (1,foofoo)
+ (2,barbar)
+(2 rows)
+
+-- cleanup
+drop foreign table remt1;
+drop foreign table remt2;
+drop table loct1;
+drop table loct2;
+drop table parent;
+create table parent (a number(38,0), b varchar2(1024 char));
+create table loct1 (a number(38,0), b varchar2(1024 char));
+create table loct2 (a number(38,0), b varchar2(1024 char));
+create foreign table remt1 (a number(38,0), b varchar2(1024 char))
+  server loopback options (table_name 'loct1');
+create foreign table remt2 (a number(38,0), b varchar2(1024 char))
   server loopback options (table_name 'loct2');
 alter foreign table remt1 inherit parent;
 insert into remt1 values (1, 'foo');
@@ -8311,11 +9421,11 @@ drop table parent;
 -- test tuple routing for foreign-table partitions
 -- ===================================================================
 -- Test insert tuple routing
-create table itrtest (a int, b text) partition by list (a);
-create table loct1 (a int check (a in (1)), b text);
-create foreign table remp1 (a int check (a in (1)), b text) server loopback options (table_name 'loct1');
-create table loct2 (a int check (a in (2)), b text);
-create foreign table remp2 (b text, a int check (a in (2))) server loopback options (table_name 'loct2');
+create table itrtest (a number(38,0), b varchar2(1024)) partition by list (a);
+create table loct1 (a number(38,0) check (a in (1)), b varchar2(1024));
+create foreign table remp1 (a number(38,0) check (a in (1)), b varchar2(1024)) server loopback options (table_name 'loct1');
+create table loct2 (a number(38,0) check (a in (2)), b varchar2(1024));
+create foreign table remp2 (b varchar2(1024), a number(38,0) check (a in (2))) server loopback options (table_name 'loct2');
 alter table itrtest attach partition remp1 for values in (1);
 alter table itrtest attach partition remp2 for values in (2);
 insert into itrtest values (1, 'foo');
@@ -8439,10 +9549,10 @@ drop table itrtest;
 drop table loct1;
 drop table loct2;
 -- Test update tuple routing
-create table utrtest (a int, b text) partition by list (a);
-create table loct (a int check (a in (1)), b text);
-create foreign table remp (a int check (a in (1)), b text) server loopback options (table_name 'loct');
-create table locp (a int check (a in (2)), b text);
+create table utrtest (a number(38,0), b varchar2(1024)) partition by list (a);
+create table loct (a number(38,0) check (a in (1)), b varchar2(1024));
+create foreign table remp (a number(38,0) check (a in (1)), b varchar2(1024)) server loopback options (table_name 'loct');
+create table locp (a number(38,0) check (a in (2)), b varchar2(1024));
 alter table utrtest attach partition remp for values in (1);
 alter table utrtest attach partition locp for values in (2);
 insert into utrtest values (1, 'foo');
@@ -8470,7 +9580,7 @@ select tableoid::regclass, * FROM locp;
 update utrtest set a = 2 where b = 'foo' returning *;
 ERROR:  new row for relation "loct" violates check constraint "loct_a_check"
 DETAIL:  Failing row contains (2, foo).
-CONTEXT:  remote SQL command: UPDATE public.loct SET a = 2 WHERE ((b = 'foo')) RETURNING a, b
+CONTEXT:  remote SQL command: UPDATE public.loct SET a = $2 WHERE ctid = $1 RETURNING a, b
 -- But the reverse is allowed
 update utrtest set a = 1 where b = 'qux' returning *;
 ERROR:  cannot route tuples into foreign table to be updated "remp"
@@ -8503,19 +9613,22 @@ insert into utrtest values (2, 'qux');
 -- Check case where the foreign partition is a subplan target rel
 explain (verbose, costs off)
 update utrtest set a = 1 where a = 1 or a = 2 returning *;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Update on public.utrtest
    Output: utrtest_1.a, utrtest_1.b
    Foreign Update on public.remp utrtest_1
+     Remote SQL: UPDATE public.loct SET a = $2 WHERE ctid = $1 RETURNING a, b
    Update on public.locp utrtest_2
    ->  Append
-         ->  Foreign Update on public.remp utrtest_1
-               Remote SQL: UPDATE public.loct SET a = 1 WHERE (((a = 1) OR (a = 2))) RETURNING a, b
+         ->  Foreign Scan on public.remp utrtest_1
+               Output: '1'::number(38,0), utrtest_1.tableoid, utrtest_1.ctid, utrtest_1.*
+               Filter: ((utrtest_1.a = '1'::number) OR (utrtest_1.a = '2'::number))
+               Remote SQL: SELECT a, b, ctid FROM public.loct FOR UPDATE
          ->  Seq Scan on public.locp utrtest_2
-               Output: 1, utrtest_2.tableoid, utrtest_2.ctid, NULL::record
-               Filter: ((utrtest_2.a = 1) OR (utrtest_2.a = 2))
-(10 rows)
+               Output: '1'::number(38,0), utrtest_2.tableoid, utrtest_2.ctid, NULL::record
+               Filter: ((utrtest_2.a = '1'::number) OR (utrtest_2.a = '2'::number))
+(13 rows)
 
 -- The new values are concatenated with ' triggered !'
 update utrtest set a = 1 where a = 1 or a = 2 returning *;
@@ -8525,14 +9638,14 @@ insert into utrtest values (2, 'qux');
 -- Check case where the foreign partition isn't a subplan target rel
 explain (verbose, costs off)
 update utrtest set a = 1 where a = 2 returning *;
-                      QUERY PLAN                       
--------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Update on public.utrtest
    Output: utrtest_1.a, utrtest_1.b
    Update on public.locp utrtest_1
    ->  Seq Scan on public.locp utrtest_1
-         Output: 1, utrtest_1.tableoid, utrtest_1.ctid
-         Filter: (utrtest_1.a = 2)
+         Output: '1'::number(38,0), utrtest_1.tableoid, utrtest_1.ctid
+         Filter: (utrtest_1.a = '2'::number)
 (6 rows)
 
 -- The new values are concatenated with ' triggered !'
@@ -8552,17 +9665,17 @@ insert into utrtest values (2, 'qux');
 -- with a direct modification plan
 explain (verbose, costs off)
 update utrtest set a = 1 returning *;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Update on public.utrtest
    Output: utrtest_1.a, utrtest_1.b
    Foreign Update on public.remp utrtest_1
    Update on public.locp utrtest_2
    ->  Append
          ->  Foreign Update on public.remp utrtest_1
-               Remote SQL: UPDATE public.loct SET a = 1 RETURNING a, b
+               Remote SQL: UPDATE public.loct SET a = '1'::number(38,0) RETURNING a, b
          ->  Seq Scan on public.locp utrtest_2
-               Output: 1, utrtest_2.tableoid, utrtest_2.ctid, NULL::record
+               Output: '1'::number(38,0), utrtest_2.tableoid, utrtest_2.ctid, NULL::record
 (9 rows)
 
 update utrtest set a = 1 returning *;
@@ -8573,16 +9686,16 @@ insert into utrtest values (2, 'qux');
 -- with a non-direct modification plan
 explain (verbose, costs off)
 update utrtest set a = 1 from (values (1), (2)) s(x) where a = s.x returning *;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
  Update on public.utrtest
    Output: utrtest_1.a, utrtest_1.b, "*VALUES*".column1
    Foreign Update on public.remp utrtest_1
      Remote SQL: UPDATE public.loct SET a = $2 WHERE ctid = $1 RETURNING a, b
    Update on public.locp utrtest_2
    ->  Hash Join
-         Output: 1, "*VALUES*".*, "*VALUES*".column1, utrtest.tableoid, utrtest.ctid, utrtest.*
-         Hash Cond: (utrtest.a = "*VALUES*".column1)
+         Output: '1'::number(38,0), "*VALUES*".*, "*VALUES*".column1, utrtest.tableoid, utrtest.ctid, utrtest.*
+         Hash Cond: (utrtest.a = ("*VALUES*".column1)::number)
          ->  Append
                ->  Foreign Scan on public.remp utrtest_1
                      Output: utrtest_1.a, utrtest_1.tableoid, utrtest_1.ctid, utrtest_1.*
@@ -8604,7 +9717,7 @@ alter table utrtest detach partition remp;
 drop foreign table remp;
 alter table loct drop constraint loct_a_check;
 alter table loct add check (a in (3));
-create foreign table remp (a int check (a in (3)), b text) server loopback options (table_name 'loct');
+create foreign table remp (a number(38,0) check (a in (3)), b varchar2(1024)) server loopback options (table_name 'loct');
 alter table utrtest attach partition remp for values in (3);
 insert into utrtest values (2, 'qux');
 insert into utrtest values (3, 'xyzzy');
@@ -8612,17 +9725,17 @@ insert into utrtest values (3, 'xyzzy');
 -- with a direct modification plan
 explain (verbose, costs off)
 update utrtest set a = 3 returning *;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Update on public.utrtest
    Output: utrtest_1.a, utrtest_1.b
    Update on public.locp utrtest_1
    Foreign Update on public.remp utrtest_2
    ->  Append
          ->  Seq Scan on public.locp utrtest_1
-               Output: 3, utrtest_1.tableoid, utrtest_1.ctid, NULL::record
+               Output: '3'::number(38,0), utrtest_1.tableoid, utrtest_1.ctid, NULL::record
          ->  Foreign Update on public.remp utrtest_2
-               Remote SQL: UPDATE public.loct SET a = 3 RETURNING a, b
+               Remote SQL: UPDATE public.loct SET a = '3'::number(38,0) RETURNING a, b
 (9 rows)
 
 update utrtest set a = 3 returning *; -- ERROR
@@ -8630,16 +9743,16 @@ ERROR:  cannot route tuples into foreign table to be updated "remp"
 -- with a non-direct modification plan
 explain (verbose, costs off)
 update utrtest set a = 3 from (values (2), (3)) s(x) where a = s.x returning *;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Update on public.utrtest
    Output: utrtest_1.a, utrtest_1.b, "*VALUES*".column1
    Update on public.locp utrtest_1
    Foreign Update on public.remp utrtest_2
      Remote SQL: UPDATE public.loct SET a = $2 WHERE ctid = $1 RETURNING a, b
    ->  Hash Join
-         Output: 3, "*VALUES*".*, "*VALUES*".column1, utrtest.tableoid, utrtest.ctid, (NULL::record)
-         Hash Cond: (utrtest.a = "*VALUES*".column1)
+         Output: '3'::number(38,0), "*VALUES*".*, "*VALUES*".column1, utrtest.tableoid, utrtest.ctid, (NULL::record)
+         Hash Cond: (utrtest.a = ("*VALUES*".column1)::number)
          ->  Append
                ->  Seq Scan on public.locp utrtest_1
                      Output: utrtest_1.a, utrtest_1.tableoid, utrtest_1.ctid, NULL::record
@@ -8657,11 +9770,11 @@ ERROR:  cannot route tuples into foreign table to be updated "remp"
 drop table utrtest;
 drop table loct;
 -- Test copy tuple routing
-create table ctrtest (a int, b text) partition by list (a);
-create table loct1 (a int check (a in (1)), b text);
-create foreign table remp1 (a int check (a in (1)), b text) server loopback options (table_name 'loct1');
-create table loct2 (a int check (a in (2)), b text);
-create foreign table remp2 (b text, a int check (a in (2))) server loopback options (table_name 'loct2');
+create table ctrtest (a number(38,0), b varchar2(1024)) partition by list (a);
+create table loct1 (a number(38,0) check (a in (1)), b varchar2(1024));
+create foreign table remp1 (a number(38,0) check (a in (1)), b varchar2(1024)) server loopback options (table_name 'loct1');
+create table loct2 (a number(38,0) check (a in (2)), b varchar2(1024));
+create foreign table remp2 (b varchar2(1024), a number(38,0) check (a in (2))) server loopback options (table_name 'loct2');
 alter table ctrtest attach partition remp1 for values in (1);
 alter table ctrtest attach partition remp2 for values in (2);
 copy ctrtest from stdin;
@@ -8732,16 +9845,16 @@ drop table loct2;
 -- ===================================================================
 -- test COPY FROM
 -- ===================================================================
-create table loc2 (f1 int, f2 text);
+create table loc2 (f1 number(38,0), f2 varchar2(1024));
 alter table loc2 set (autovacuum_enabled = 'false');
-create foreign table rem2 (f1 int, f2 text) server loopback options(table_name 'loc2');
+create foreign table rem2 (f1 number(38,0), f2 varchar2(1024)) server loopback options(table_name 'loc2');
 -- Test basic functionality
 copy rem2 from stdin;
 select * from rem2;
  f1 | f2  
 ----+-----
-  1 | foo
-  2 | bar
+ 1  | foo
+ 2  | bar
 (2 rows)
 
 delete from rem2;
@@ -8758,8 +9871,8 @@ COPY rem2, line 1: "-1	xyzzy"
 select * from rem2;
  f1 | f2  
 ----+-----
-  1 | foo
-  2 | bar
+ 1  | foo
+ 2  | bar
 (2 rows)
 
 alter foreign table rem2 drop constraint rem2_f1positive;
@@ -8788,8 +9901,8 @@ NOTICE:  trigger_func(<NULL>) called: action = INSERT, when = AFTER, level = STA
 select * from rem2;
  f1 | f2  
 ----+-----
-  1 | foo
-  2 | bar
+ 1  | foo
+ 2  | bar
 (2 rows)
 
 drop trigger trig_row_before on rem2;
@@ -8804,8 +9917,8 @@ copy rem2 from stdin;
 select * from rem2;
  f1 |       f2        
 ----+-----------------
-  1 | foo triggered !
-  2 | bar triggered !
+ 1  | foo triggered !
+ 2  | bar triggered !
 (2 rows)
 
 drop trigger trig_row_before_insert on rem2;
@@ -8829,8 +9942,8 @@ copy rem2 from stdin;
 select * from rem2;
  f1 |       f2        
 ----+-----------------
-  1 | foo triggered !
-  2 | bar triggered !
+ 1  | foo triggered !
+ 2  | bar triggered !
 (2 rows)
 
 drop trigger trig_row_before_insert on loc2;
@@ -8865,8 +9978,8 @@ NOTICE:  NEW: (2,"bar triggered !")
 select * from rem2;
  f1 |       f2        
 ----+-----------------
-  1 | foo triggered !
-  2 | bar triggered !
+ 1  | foo triggered !
+ 2  | bar triggered !
 (2 rows)
 
 drop trigger rem2_trig_row_before on rem2;
@@ -8874,17 +9987,17 @@ drop trigger rem2_trig_row_after on rem2;
 drop trigger loc2_trig_row_before_insert on loc2;
 delete from rem2;
 -- test COPY FROM with foreign table created in the same transaction
-create table loc3 (f1 int, f2 text);
+create table loc3 (f1 number(38,0), f2 varchar(1024));
 begin;
-create foreign table rem3 (f1 int, f2 text)
+create foreign table rem3 (f1 number(38,0), f2 varchar(1024))
 	server loopback options(table_name 'loc3');
 copy rem3 from stdin;
 commit;
 select * from rem3;
  f1 | f2  
 ----+-----
-  1 | foo
-  2 | bar
+ 1  | foo
+ 2  | bar
 (2 rows)
 
 drop foreign table rem3;
@@ -8896,9 +10009,9 @@ copy rem2 from stdin;
 select * from rem2;
  f1 | f2  
 ----+-----
-  1 | foo
-  2 | bar
-  3 | baz
+ 1  | foo
+ 2  | bar
+ 3  | baz
 (3 rows)
 
 delete from rem2;
@@ -8915,9 +10028,9 @@ COPY rem2
 select * from rem2;
  f1 | f2  
 ----+-----
-  1 | foo
-  2 | bar
-  3 | baz
+ 1  | foo
+ 2  | bar
+ 3  | baz
 (3 rows)
 
 alter foreign table rem2 drop constraint rem2_f1positive;
@@ -8931,9 +10044,9 @@ copy rem2 from stdin;
 select * from rem2;
  f1 |       f2        
 ----+-----------------
-  1 | foo triggered !
-  2 | bar triggered !
-  3 | baz triggered !
+ 1  | foo triggered !
+ 2  | bar triggered !
+ 3  | baz triggered !
 (3 rows)
 
 drop trigger trig_row_before_insert on loc2;
@@ -8964,27 +10077,27 @@ alter server loopback options (drop batch_size);
 -- ===================================================================
 -- test for TRUNCATE
 -- ===================================================================
-CREATE TABLE tru_rtable0 (id int primary key);
-CREATE FOREIGN TABLE tru_ftable (id int)
+CREATE TABLE tru_rtable0 (id number(38,0) primary key);
+CREATE FOREIGN TABLE tru_ftable (id number(38,0))
        SERVER loopback OPTIONS (table_name 'tru_rtable0');
 INSERT INTO tru_rtable0 (SELECT x FROM generate_series(1,10) x);
 CREATE TABLE tru_ptable (id int) PARTITION BY HASH(id);
 CREATE TABLE tru_ptable__p0 PARTITION OF tru_ptable
                             FOR VALUES WITH (MODULUS 2, REMAINDER 0);
-CREATE TABLE tru_rtable1 (id int primary key);
+CREATE TABLE tru_rtable1 (id number(38,0) primary key);
 CREATE FOREIGN TABLE tru_ftable__p1 PARTITION OF tru_ptable
                                     FOR VALUES WITH (MODULUS 2, REMAINDER 1)
        SERVER loopback OPTIONS (table_name 'tru_rtable1');
 INSERT INTO tru_ptable (SELECT x FROM generate_series(11,20) x);
-CREATE TABLE tru_pk_table(id int primary key);
-CREATE TABLE tru_fk_table(fkey int references tru_pk_table(id));
+CREATE TABLE tru_pk_table(id number(38,0) primary key);
+CREATE TABLE tru_fk_table(fkey number(38,0) references tru_pk_table(id));
 INSERT INTO tru_pk_table (SELECT x FROM generate_series(1,10) x);
 INSERT INTO tru_fk_table (SELECT x % 10 + 1 FROM generate_series(5,25) x);
-CREATE FOREIGN TABLE tru_pk_ftable (id int)
+CREATE FOREIGN TABLE tru_pk_ftable (id number(38,0))
        SERVER loopback OPTIONS (table_name 'tru_pk_table');
-CREATE TABLE tru_rtable_parent (id int);
-CREATE TABLE tru_rtable_child (id int);
-CREATE FOREIGN TABLE tru_ftable_parent (id int)
+CREATE TABLE tru_rtable_parent (id number(38,0));
+CREATE TABLE tru_rtable_child (id number(38,0));
+CREATE FOREIGN TABLE tru_ftable_parent (id number(38,0))
        SERVER loopback OPTIONS (table_name 'tru_rtable_parent');
 CREATE FOREIGN TABLE tru_ftable_child () INHERITS (tru_ftable_parent)
        SERVER loopback OPTIONS (table_name 'tru_rtable_child');
@@ -8994,7 +10107,7 @@ INSERT INTO tru_rtable_child  (SELECT x FROM generate_series(10, 18) x);
 SELECT sum(id) FROM tru_ftable;        -- 55
  sum 
 -----
-  55
+ 55
 (1 row)
 
 TRUNCATE tru_ftable;
@@ -9061,7 +10174,7 @@ SELECT count(*) FROM tru_rtable1;		-- 0
 SELECT sum(id) FROM tru_pk_ftable;      -- 55
  sum 
 -----
-  55
+ 55
 (1 row)
 
 TRUNCATE tru_pk_ftable;	-- failed by FK reference
@@ -9134,7 +10247,7 @@ INSERT INTO tru_rtable0_child (SELECT x FROM generate_series(10,14) x);
 SELECT sum(id) FROM tru_ftable;   -- 95
  sum 
 -----
-  95
+ 95
 (1 row)
 
 -- Both parent and child tables in the foreign server are truncated
@@ -9170,15 +10283,15 @@ tru_rtable_parent,tru_rtable_child, tru_rtable0_child;
 -- test IMPORT FOREIGN SCHEMA
 -- ===================================================================
 CREATE SCHEMA import_source;
-CREATE TABLE import_source.t1 (c1 int, c2 varchar NOT NULL);
-CREATE TABLE import_source.t2 (c1 int default 42, c2 varchar NULL, c3 text collate "POSIX");
-CREATE TYPE typ1 AS (m1 int, m2 varchar);
+CREATE TABLE import_source.t1 (c1 number(38,0), c2 pg_catalog.varchar(42) NOT NULL);
+CREATE TABLE import_source.t2 (c1 number(38,0) default 42, c2 pg_catalog.varchar(42) NULL, c3 varchar2(1024) collate "POSIX");
+CREATE TYPE typ1 AS (m1 number(38,0), m2 pg_catalog.varchar(42));
 CREATE TABLE import_source.t3 (c1 timestamptz default now(), c2 typ1);
-CREATE TABLE import_source."x 4" (c1 float8, "C 2" text, c3 varchar(42));
-CREATE TABLE import_source."x 5" (c1 float8);
+CREATE TABLE import_source."x 4" (c1 binary_double, "C 2" varchar2(1024), c3 varchar(42));
+CREATE TABLE import_source."x 5" (c1 binary_double);
 ALTER TABLE import_source."x 5" DROP COLUMN c1;
-CREATE TABLE import_source."x 6" (c1 int, c2 int generated always as (c1 * 2) stored);
-CREATE TABLE import_source.t4 (c1 int) PARTITION BY RANGE (c1);
+CREATE TABLE import_source."x 6" (c1 number(38,0), c2 number(38,0) generated always as (c1 * 2) stored);
+CREATE TABLE import_source.t4 (c1 number(38,0)) PARTITION BY RANGE (c1);
 CREATE TABLE import_source.t4_part PARTITION OF import_source.t4
   FOR VALUES FROM (1) TO (100);
 CREATE TABLE import_source.t4_part2 PARTITION OF import_source.t4
@@ -9199,20 +10312,20 @@ IMPORT FOREIGN SCHEMA import_source FROM SERVER loopback INTO import_dest1;
 (7 rows)
 
 \d import_dest1.*
-                        Foreign table "import_dest1.t1"
- Column |      Type      | Collation | Nullable | Default |    FDW options     
---------+----------------+-----------+----------+---------+--------------------
- c1     | integer        |           |          |         | (column_name 'c1')
- c2     | varchar2(4000) |           | not null |         | (column_name 'c2')
+                       Foreign table "import_dest1.t1"
+ Column |     Type     | Collation | Nullable | Default |    FDW options     
+--------+--------------+-----------+----------+---------+--------------------
+ c1     | number(38,0) |           |          |         | (column_name 'c1')
+ c2     | varchar2(42) |           | not null |         | (column_name 'c2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't1')
 
                         Foreign table "import_dest1.t2"
  Column |      Type      | Collation | Nullable | Default |    FDW options     
 --------+----------------+-----------+----------+---------+--------------------
- c1     | integer        |           |          |         | (column_name 'c1')
- c2     | varchar2(4000) |           |          |         | (column_name 'c2')
- c3     | text           | POSIX     |          |         | (column_name 'c3')
+ c1     | number(38,0)   |           |          |         | (column_name 'c1')
+ c2     | varchar2(42)   |           |          |         | (column_name 'c2')
+ c3     | varchar2(1024) | POSIX     |          |         | (column_name 'c3')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't2')
 
@@ -9224,19 +10337,19 @@ FDW options: (schema_name 'import_source', table_name 't2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't3')
 
-                    Foreign table "import_dest1.t4"
- Column |  Type   | Collation | Nullable | Default |    FDW options     
---------+---------+-----------+----------+---------+--------------------
- c1     | integer |           |          |         | (column_name 'c1')
+                       Foreign table "import_dest1.t4"
+ Column |     Type     | Collation | Nullable | Default |    FDW options     
+--------+--------------+-----------+----------+---------+--------------------
+ c1     | number(38,0) |           |          |         | (column_name 'c1')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't4')
 
-                         Foreign table "import_dest1.x 4"
- Column |       Type       | Collation | Nullable | Default |     FDW options     
---------+------------------+-----------+----------+---------+---------------------
- c1     | double precision |           |          |         | (column_name 'c1')
- C 2    | text             |           |          |         | (column_name 'C 2')
- c3     | varchar2(42)     |           |          |         | (column_name 'c3')
+                        Foreign table "import_dest1.x 4"
+ Column |      Type      | Collation | Nullable | Default |     FDW options     
+--------+----------------+-----------+----------+---------+---------------------
+ c1     | binary_double  |           |          |         | (column_name 'c1')
+ C 2    | varchar2(1024) |           |          |         | (column_name 'C 2')
+ c3     | varchar2(42)   |           |          |         | (column_name 'c3')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 4')
 
@@ -9246,11 +10359,11 @@ FDW options: (schema_name 'import_source', table_name 'x 4')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 5')
 
-                                  Foreign table "import_dest1.x 6"
- Column |  Type   | Collation | Nullable |               Default               |    FDW options     
---------+---------+-----------+----------+-------------------------------------+--------------------
- c1     | integer |           |          |                                     | (column_name 'c1')
- c2     | integer |           |          | generated always as (c1 * 2) stored | (column_name 'c2')
+                                         Foreign table "import_dest1.x 6"
+ Column |     Type     | Collation | Nullable |                    Default                    |    FDW options     
+--------+--------------+-----------+----------+-----------------------------------------------+--------------------
+ c1     | number(38,0) |           |          |                                               | (column_name 'c1')
+ c2     | number(38,0) |           |          | generated always as ((c1 * 2::number)) stored | (column_name 'c2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 6')
 
@@ -9272,20 +10385,20 @@ IMPORT FOREIGN SCHEMA import_source FROM SERVER loopback INTO import_dest2
 (7 rows)
 
 \d import_dest2.*
-                        Foreign table "import_dest2.t1"
- Column |      Type      | Collation | Nullable | Default |    FDW options     
---------+----------------+-----------+----------+---------+--------------------
- c1     | integer        |           |          |         | (column_name 'c1')
- c2     | varchar2(4000) |           | not null |         | (column_name 'c2')
+                       Foreign table "import_dest2.t1"
+ Column |     Type     | Collation | Nullable | Default |    FDW options     
+--------+--------------+-----------+----------+---------+--------------------
+ c1     | number(38,0) |           |          |         | (column_name 'c1')
+ c2     | varchar2(42) |           | not null |         | (column_name 'c2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't1')
 
                         Foreign table "import_dest2.t2"
  Column |      Type      | Collation | Nullable | Default |    FDW options     
 --------+----------------+-----------+----------+---------+--------------------
- c1     | integer        |           |          | 42      | (column_name 'c1')
- c2     | varchar2(4000) |           |          |         | (column_name 'c2')
- c3     | text           | POSIX     |          |         | (column_name 'c3')
+ c1     | number(38,0)   |           |          | 42      | (column_name 'c1')
+ c2     | varchar2(42)   |           |          |         | (column_name 'c2')
+ c3     | varchar2(1024) | POSIX     |          |         | (column_name 'c3')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't2')
 
@@ -9297,19 +10410,19 @@ FDW options: (schema_name 'import_source', table_name 't2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't3')
 
-                    Foreign table "import_dest2.t4"
- Column |  Type   | Collation | Nullable | Default |    FDW options     
---------+---------+-----------+----------+---------+--------------------
- c1     | integer |           |          |         | (column_name 'c1')
+                       Foreign table "import_dest2.t4"
+ Column |     Type     | Collation | Nullable | Default |    FDW options     
+--------+--------------+-----------+----------+---------+--------------------
+ c1     | number(38,0) |           |          |         | (column_name 'c1')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't4')
 
-                         Foreign table "import_dest2.x 4"
- Column |       Type       | Collation | Nullable | Default |     FDW options     
---------+------------------+-----------+----------+---------+---------------------
- c1     | double precision |           |          |         | (column_name 'c1')
- C 2    | text             |           |          |         | (column_name 'C 2')
- c3     | varchar2(42)     |           |          |         | (column_name 'c3')
+                        Foreign table "import_dest2.x 4"
+ Column |      Type      | Collation | Nullable | Default |     FDW options     
+--------+----------------+-----------+----------+---------+---------------------
+ c1     | binary_double  |           |          |         | (column_name 'c1')
+ C 2    | varchar2(1024) |           |          |         | (column_name 'C 2')
+ c3     | varchar2(42)   |           |          |         | (column_name 'c3')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 4')
 
@@ -9319,11 +10432,11 @@ FDW options: (schema_name 'import_source', table_name 'x 4')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 5')
 
-                                  Foreign table "import_dest2.x 6"
- Column |  Type   | Collation | Nullable |               Default               |    FDW options     
---------+---------+-----------+----------+-------------------------------------+--------------------
- c1     | integer |           |          |                                     | (column_name 'c1')
- c2     | integer |           |          | generated always as (c1 * 2) stored | (column_name 'c2')
+                                         Foreign table "import_dest2.x 6"
+ Column |     Type     | Collation | Nullable |                    Default                    |    FDW options     
+--------+--------------+-----------+----------+-----------------------------------------------+--------------------
+ c1     | number(38,0) |           |          |                                               | (column_name 'c1')
+ c2     | number(38,0) |           |          | generated always as ((c1 * 2::number)) stored | (column_name 'c2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 6')
 
@@ -9344,20 +10457,20 @@ IMPORT FOREIGN SCHEMA import_source FROM SERVER loopback INTO import_dest3
 (7 rows)
 
 \d import_dest3.*
-                        Foreign table "import_dest3.t1"
- Column |      Type      | Collation | Nullable | Default |    FDW options     
---------+----------------+-----------+----------+---------+--------------------
- c1     | integer        |           |          |         | (column_name 'c1')
- c2     | varchar2(4000) |           |          |         | (column_name 'c2')
+                       Foreign table "import_dest3.t1"
+ Column |     Type     | Collation | Nullable | Default |    FDW options     
+--------+--------------+-----------+----------+---------+--------------------
+ c1     | number(38,0) |           |          |         | (column_name 'c1')
+ c2     | varchar2(42) |           |          |         | (column_name 'c2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't1')
 
                         Foreign table "import_dest3.t2"
  Column |      Type      | Collation | Nullable | Default |    FDW options     
 --------+----------------+-----------+----------+---------+--------------------
- c1     | integer        |           |          |         | (column_name 'c1')
- c2     | varchar2(4000) |           |          |         | (column_name 'c2')
- c3     | text           |           |          |         | (column_name 'c3')
+ c1     | number(38,0)   |           |          |         | (column_name 'c1')
+ c2     | varchar2(42)   |           |          |         | (column_name 'c2')
+ c3     | varchar2(1024) |           |          |         | (column_name 'c3')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't2')
 
@@ -9369,19 +10482,19 @@ FDW options: (schema_name 'import_source', table_name 't2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't3')
 
-                    Foreign table "import_dest3.t4"
- Column |  Type   | Collation | Nullable | Default |    FDW options     
---------+---------+-----------+----------+---------+--------------------
- c1     | integer |           |          |         | (column_name 'c1')
+                       Foreign table "import_dest3.t4"
+ Column |     Type     | Collation | Nullable | Default |    FDW options     
+--------+--------------+-----------+----------+---------+--------------------
+ c1     | number(38,0) |           |          |         | (column_name 'c1')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 't4')
 
-                         Foreign table "import_dest3.x 4"
- Column |       Type       | Collation | Nullable | Default |     FDW options     
---------+------------------+-----------+----------+---------+---------------------
- c1     | double precision |           |          |         | (column_name 'c1')
- C 2    | text             |           |          |         | (column_name 'C 2')
- c3     | varchar2(42)     |           |          |         | (column_name 'c3')
+                        Foreign table "import_dest3.x 4"
+ Column |      Type      | Collation | Nullable | Default |     FDW options     
+--------+----------------+-----------+----------+---------+---------------------
+ c1     | binary_double  |           |          |         | (column_name 'c1')
+ C 2    | varchar2(1024) |           |          |         | (column_name 'C 2')
+ c3     | varchar2(42)   |           |          |         | (column_name 'c3')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 4')
 
@@ -9391,11 +10504,11 @@ FDW options: (schema_name 'import_source', table_name 'x 4')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 5')
 
-                    Foreign table "import_dest3.x 6"
- Column |  Type   | Collation | Nullable | Default |    FDW options     
---------+---------+-----------+----------+---------+--------------------
- c1     | integer |           |          |         | (column_name 'c1')
- c2     | integer |           |          |         | (column_name 'c2')
+                      Foreign table "import_dest3.x 6"
+ Column |     Type     | Collation | Nullable | Default |    FDW options     
+--------+--------------+-----------+----------+---------+--------------------
+ c1     | number(38,0) |           |          |         | (column_name 'c1')
+ c2     | number(38,0) |           |          |         | (column_name 'c2')
 Server: loopback
 FDW options: (schema_name 'import_source', table_name 'x 6')
 
@@ -9439,7 +10552,7 @@ ERROR:  server "nowhere" does not exist
 -- Check case of a type present only on the remote server.
 -- We can fake this by dropping the type locally in our transaction.
 CREATE TYPE "Colors" AS ENUM ('red', 'green', 'blue');
-CREATE TABLE import_source.t5 (c1 int, c2 text collate "C", "Col" "Colors");
+CREATE TABLE import_source.t5 (c1 number(38,0), c2 varchar2(1024) collate "C", "Col" "Colors");
 CREATE SCHEMA import_dest5;
 BEGIN;
 DROP TYPE "Colors" CASCADE;
@@ -9450,8 +10563,8 @@ ERROR:  type "public.Colors" does not exist
 LINE 4:   "Col" public."Colors" OPTIONS (column_name 'Col')
                 ^
 QUERY:  CREATE FOREIGN TABLE t5 (
-  c1 integer OPTIONS (column_name 'c1'),
-  c2 text OPTIONS (column_name 'c2') COLLATE pg_catalog."C",
+  c1 number(38,0) OPTIONS (column_name 'c1'),
+  c2 varchar2(1024) OPTIONS (column_name 'c2') COLLATE pg_catalog."C",
   "Col" public."Colors" OPTIONS (column_name 'Col')
 ) SERVER loopback
 OPTIONS (schema_name 'import_source', table_name 't5');
@@ -9487,7 +10600,7 @@ AND srvoptions @> array['fetch_size=202'];
      1
 (1 row)
 
-CREATE FOREIGN TABLE table30000 ( x int ) SERVER fetch101 OPTIONS ( fetch_size '30000' );
+CREATE FOREIGN TABLE table30000 ( x number(38,0) ) SERVER fetch101 OPTIONS ( fetch_size '30000' );
 SELECT COUNT(*)
 FROM pg_foreign_table
 WHERE ftrelid = 'table30000'::regclass
@@ -9521,7 +10634,7 @@ ROLLBACK;
 -- test partitionwise joins
 -- ===================================================================
 SET enable_partitionwise_join=on;
-CREATE TABLE fprt1 (a int, b int, c varchar) PARTITION BY RANGE(a);
+CREATE TABLE fprt1 (a number(38,0), b number(38,0), c pg_catalog.varchar(42)) PARTITION BY RANGE(a);
 CREATE TABLE fprt1_p1 (LIKE fprt1);
 CREATE TABLE fprt1_p2 (LIKE fprt1);
 ALTER TABLE fprt1_p1 SET (autovacuum_enabled = 'false');
@@ -9535,14 +10648,14 @@ CREATE FOREIGN TABLE ftprt1_p2 PARTITION OF fprt1 FOR VALUES FROM (250) TO (500)
 ANALYZE fprt1;
 ANALYZE fprt1_p1;
 ANALYZE fprt1_p2;
-CREATE TABLE fprt2 (a int, b int, c varchar) PARTITION BY RANGE(b);
+CREATE TABLE fprt2 (a number(38,0), b number(38,0), c pg_catalog.varchar(42)) PARTITION BY RANGE(b);
 CREATE TABLE fprt2_p1 (LIKE fprt2);
 CREATE TABLE fprt2_p2 (LIKE fprt2);
 ALTER TABLE fprt2_p1 SET (autovacuum_enabled = 'false');
 ALTER TABLE fprt2_p2 SET (autovacuum_enabled = 'false');
 INSERT INTO fprt2_p1 SELECT i, i, to_char(i/50, 'FM0000') FROM generate_series(0, 249, 3) i;
 INSERT INTO fprt2_p2 SELECT i, i, to_char(i/50, 'FM0000') FROM generate_series(250, 499, 3) i;
-CREATE FOREIGN TABLE ftprt2_p1 (b int, c varchar, a int)
+CREATE FOREIGN TABLE ftprt2_p1 (b number(38,0), c pg_catalog.varchar(42), a number(38,0))
 	SERVER loopback OPTIONS (table_name 'fprt2_p1', use_remote_estimate 'true');
 ALTER TABLE fprt2 ATTACH PARTITION ftprt2_p1 FOR VALUES FROM (0) TO (250);
 CREATE FOREIGN TABLE ftprt2_p2 PARTITION OF fprt2 FOR VALUES FROM (250) TO (500)
@@ -9553,21 +10666,33 @@ ANALYZE fprt2_p2;
 -- inner join three tables
 EXPLAIN (COSTS OFF)
 SELECT t1.a,t2.b,t3.c FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) INNER JOIN fprt1 t3 ON (t2.b = t3.a) WHERE t1.a % 25 =0 ORDER BY 1,2,3;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Sort
    Sort Key: t1.a, t3.c
    ->  Append
-         ->  Foreign Scan
-               Relations: ((ftprt1_p1 t1_1) INNER JOIN (ftprt2_p1 t2_1)) INNER JOIN (ftprt1_p1 t3_1)
-         ->  Foreign Scan
-               Relations: ((ftprt1_p2 t1_2) INNER JOIN (ftprt2_p2 t2_2)) INNER JOIN (ftprt1_p2 t3_2)
-(7 rows)
+         ->  Nested Loop
+               Join Filter: (t1_1.a = t3_1.a)
+               ->  Nested Loop
+                     Join Filter: (t1_1.a = t2_1.b)
+                     ->  Foreign Scan on ftprt1_p1 t1_1
+                           Filter: ((a % '25'::number) = '0'::number)
+                     ->  Foreign Scan on ftprt2_p1 t2_1
+               ->  Foreign Scan on ftprt1_p1 t3_1
+         ->  Nested Loop
+               Join Filter: (t1_2.a = t3_2.a)
+               ->  Nested Loop
+                     Join Filter: (t1_2.a = t2_2.b)
+                     ->  Foreign Scan on ftprt1_p2 t1_2
+                           Filter: ((a % '25'::number) = '0'::number)
+                     ->  Foreign Scan on ftprt2_p2 t2_2
+               ->  Foreign Scan on ftprt1_p2 t3_2
+(19 rows)
 
 SELECT t1.a,t2.b,t3.c FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) INNER JOIN fprt1 t3 ON (t2.b = t3.a) WHERE t1.a % 25 =0 ORDER BY 1,2,3;
   a  |  b  |  c   
 -----+-----+------
-   0 |   0 | 0000
+ 0   | 0   | 0000
  150 | 150 | 0003
  250 | 250 | 0005
  400 | 400 | 0008
@@ -9576,16 +10701,30 @@ SELECT t1.a,t2.b,t3.c FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) INNER J
 -- left outer join + nullable clause
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.a,t2.b,t2.c FROM fprt1 t1 LEFT JOIN (SELECT * FROM fprt2 WHERE a < 10) t2 ON (t1.a = t2.b and t1.b = t2.a) WHERE t1.a < 10 ORDER BY 1,2,3;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Incremental Sort
    Output: t1.a, fprt2.b, fprt2.c
    Sort Key: t1.a, fprt2.b, fprt2.c
-   ->  Foreign Scan
+   Presorted Key: t1.a
+   ->  Merge Left Join
          Output: t1.a, fprt2.b, fprt2.c
-         Relations: (public.ftprt1_p1 t1) LEFT JOIN (public.ftprt2_p1 fprt2)
-         Remote SQL: SELECT r5.a, r6.b, r6.c FROM (public.fprt1_p1 r5 LEFT JOIN public.fprt2_p1 r6 ON (((r5.a = r6.b)) AND ((r5.b = r6.a)) AND ((r6.a < 10)))) WHERE ((r5.a < 10))
-(7 rows)
+         Merge Cond: ((t1.a = fprt2.b) AND (t1.b = fprt2.a))
+         ->  Sort
+               Output: t1.a, t1.b
+               Sort Key: t1.a, t1.b
+               ->  Foreign Scan on public.ftprt1_p1 t1
+                     Output: t1.a, t1.b
+                     Filter: (t1.a < '10'::number)
+                     Remote SQL: SELECT a, b FROM public.fprt1_p1
+         ->  Sort
+               Output: fprt2.b, fprt2.c, fprt2.a
+               Sort Key: fprt2.b, fprt2.a
+               ->  Foreign Scan on public.ftprt2_p1 fprt2
+                     Output: fprt2.b, fprt2.c, fprt2.a
+                     Filter: (fprt2.a < '10'::number)
+                     Remote SQL: SELECT b, c, a FROM public.fprt2_p1
+(21 rows)
 
 SELECT t1.a,t2.b,t2.c FROM fprt1 t1 LEFT JOIN (SELECT * FROM fprt2 WHERE a < 10) t2 ON (t1.a = t2.b and t1.b = t2.a) WHERE t1.a < 10 ORDER BY 1,2,3;
  a | b |  c   
@@ -9600,20 +10739,24 @@ SELECT t1.a,t2.b,t2.c FROM fprt1 t1 LEFT JOIN (SELECT * FROM fprt2 WHERE a < 10)
 -- with whole-row reference; partitionwise join does not apply
 EXPLAIN (COSTS OFF)
 SELECT t1.wr, t2.wr FROM (SELECT t1 wr, a FROM fprt1 t1 WHERE t1.a % 25 = 0) t1 FULL JOIN (SELECT t2 wr, b FROM fprt2 t2 WHERE t2.b % 25 = 0) t2 ON (t1.a = t2.b) ORDER BY 1,2;
-                       QUERY PLAN                       
---------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Sort
    Sort Key: ((t1.*)::fprt1), ((t2.*)::fprt2)
    ->  Hash Full Join
          Hash Cond: (t1.a = t2.b)
          ->  Append
                ->  Foreign Scan on ftprt1_p1 t1_1
+                     Filter: ((a % '25'::number) = '0'::number)
                ->  Foreign Scan on ftprt1_p2 t1_2
+                     Filter: ((a % '25'::number) = '0'::number)
          ->  Hash
                ->  Append
                      ->  Foreign Scan on ftprt2_p1 t2_1
+                           Filter: ((b % '25'::number) = '0'::number)
                      ->  Foreign Scan on ftprt2_p2 t2_2
-(11 rows)
+                           Filter: ((b % '25'::number) = '0'::number)
+(15 rows)
 
 SELECT t1.wr, t2.wr FROM (SELECT t1 wr, a FROM fprt1 t1 WHERE t1.a % 25 = 0) t1 FULL JOIN (SELECT t2 wr, b FROM fprt2 t2 WHERE t2.b % 25 = 0) t2 ON (t1.a = t2.b) ORDER BY 1,2;
        wr       |       wr       
@@ -9637,21 +10780,27 @@ SELECT t1.wr, t2.wr FROM (SELECT t1 wr, a FROM fprt1 t1 WHERE t1.a % 25 = 0) t1 
 -- join with lateral reference
 EXPLAIN (COSTS OFF)
 SELECT t1.a,t1.b FROM fprt1 t1, LATERAL (SELECT t2.a, t2.b FROM fprt2 t2 WHERE t1.a = t2.b AND t1.b = t2.a) q WHERE t1.a%25 = 0 ORDER BY 1,2;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Sort
    Sort Key: t1.a, t1.b
    ->  Append
-         ->  Foreign Scan
-               Relations: (ftprt1_p1 t1_1) INNER JOIN (ftprt2_p1 t2_1)
-         ->  Foreign Scan
-               Relations: (ftprt1_p2 t1_2) INNER JOIN (ftprt2_p2 t2_2)
-(7 rows)
+         ->  Nested Loop
+               Join Filter: ((t1_1.a = t2_1.b) AND (t1_1.b = t2_1.a))
+               ->  Foreign Scan on ftprt1_p1 t1_1
+                     Filter: ((a % '25'::number) = '0'::number)
+               ->  Foreign Scan on ftprt2_p1 t2_1
+         ->  Nested Loop
+               Join Filter: ((t1_2.a = t2_2.b) AND (t1_2.b = t2_2.a))
+               ->  Foreign Scan on ftprt1_p2 t1_2
+                     Filter: ((a % '25'::number) = '0'::number)
+               ->  Foreign Scan on ftprt2_p2 t2_2
+(13 rows)
 
 SELECT t1.a,t1.b FROM fprt1 t1, LATERAL (SELECT t2.a, t2.b FROM fprt2 t2 WHERE t1.a = t2.b AND t1.b = t2.a) q WHERE t1.a%25 = 0 ORDER BY 1,2;
   a  |  b  
 -----+-----
-   0 |   0
+ 0   | 0
  150 | 150
  250 | 250
  400 | 400
@@ -9660,28 +10809,32 @@ SELECT t1.a,t1.b FROM fprt1 t1, LATERAL (SELECT t2.a, t2.b FROM fprt2 t2 WHERE t
 -- with PHVs, partitionwise join selected but no join pushdown
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.phv, t2.b, t2.phv FROM (SELECT 't1_phv' phv, * FROM fprt1 WHERE a % 25 = 0) t1 FULL JOIN (SELECT 't2_phv' phv, * FROM fprt2 WHERE b % 25 = 0) t2 ON (t1.a = t2.b) ORDER BY t1.a, t2.b;
-                        QUERY PLAN                         
------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Sort
    Sort Key: fprt1.a, fprt2.b
    ->  Append
          ->  Hash Full Join
                Hash Cond: (fprt1_1.a = fprt2_1.b)
                ->  Foreign Scan on ftprt1_p1 fprt1_1
+                     Filter: ((a % '25'::number) = '0'::number)
                ->  Hash
                      ->  Foreign Scan on ftprt2_p1 fprt2_1
+                           Filter: ((b % '25'::number) = '0'::number)
          ->  Hash Full Join
                Hash Cond: (fprt1_2.a = fprt2_2.b)
                ->  Foreign Scan on ftprt1_p2 fprt1_2
+                     Filter: ((a % '25'::number) = '0'::number)
                ->  Hash
                      ->  Foreign Scan on ftprt2_p2 fprt2_2
-(13 rows)
+                           Filter: ((b % '25'::number) = '0'::number)
+(17 rows)
 
 SELECT t1.a, t1.phv, t2.b, t2.phv FROM (SELECT 't1_phv' phv, * FROM fprt1 WHERE a % 25 = 0) t1 FULL JOIN (SELECT 't2_phv' phv, * FROM fprt2 WHERE b % 25 = 0) t2 ON (t1.a = t2.b) ORDER BY t1.a, t2.b;
   a  |  phv   |  b  |  phv   
 -----+--------+-----+--------
-   0 | t1_phv |   0 | t2_phv
-  50 | t1_phv |     | 
+ 0   | t1_phv | 0   | t2_phv
+ 50  | t1_phv |     | 
  100 | t1_phv |     | 
  150 | t1_phv | 150 | t2_phv
  200 | t1_phv |     | 
@@ -9690,7 +10843,7 @@ SELECT t1.a, t1.phv, t2.b, t2.phv FROM (SELECT 't1_phv' phv, * FROM fprt1 WHERE 
  350 | t1_phv |     | 
  400 | t1_phv | 400 | t2_phv
  450 | t1_phv |     | 
-     |        |  75 | t2_phv
+     |        | 75  | t2_phv
      |        | 225 | t2_phv
      |        | 325 | t2_phv
      |        | 475 | t2_phv
@@ -9699,8 +10852,8 @@ SELECT t1.a, t1.phv, t2.b, t2.phv FROM (SELECT 't1_phv' phv, * FROM fprt1 WHERE 
 -- test FOR UPDATE; partitionwise join does not apply
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t2.b FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) WHERE t1.a % 25 = 0 ORDER BY 1,2 FOR UPDATE OF t1;
-                          QUERY PLAN                          
---------------------------------------------------------------
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
  LockRows
    ->  Sort
          Sort Key: t1.a
@@ -9712,13 +10865,15 @@ SELECT t1.a, t2.b FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) WHERE t1.a 
                ->  Hash
                      ->  Append
                            ->  Foreign Scan on ftprt1_p1 t1_1
+                                 Filter: ((a % '25'::number) = '0'::number)
                            ->  Foreign Scan on ftprt1_p2 t1_2
-(12 rows)
+                                 Filter: ((a % '25'::number) = '0'::number)
+(14 rows)
 
 SELECT t1.a, t2.b FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) WHERE t1.a % 25 = 0 ORDER BY 1,2 FOR UPDATE OF t1;
   a  |  b  
 -----+-----
-   0 |   0
+ 0   | 0
  150 | 150
  250 | 250
  400 | 400
@@ -9728,7 +10883,7 @@ RESET enable_partitionwise_join;
 -- ===================================================================
 -- test partitionwise aggregates
 -- ===================================================================
-CREATE TABLE pagg_tab (a int, b int, c text) PARTITION BY RANGE(a);
+CREATE TABLE pagg_tab (a number(38,0), b number(38,0), c varchar2(1024)) PARTITION BY RANGE(a);
 CREATE TABLE pagg_tab_p1 (LIKE pagg_tab);
 CREATE TABLE pagg_tab_p2 (LIKE pagg_tab);
 CREATE TABLE pagg_tab_p3 (LIKE pagg_tab);
@@ -9754,7 +10909,7 @@ SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 O
    Sort Key: pagg_tab.a
    ->  HashAggregate
          Group Key: pagg_tab.a
-         Filter: (avg(pagg_tab.b) < '22'::numeric)
+         Filter: (avg(pagg_tab.b) < '22'::number)
          ->  Append
                ->  Foreign Scan on fpagg_tab_p1 pagg_tab_1
                ->  Foreign Scan on fpagg_tab_p2 pagg_tab_2
@@ -9765,28 +10920,34 @@ SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 O
 SET enable_partitionwise_aggregate TO true;
 EXPLAIN (COSTS OFF)
 SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Sort
    Sort Key: pagg_tab.a
    ->  Append
-         ->  Foreign Scan
-               Relations: Aggregate on (fpagg_tab_p1 pagg_tab)
-         ->  Foreign Scan
-               Relations: Aggregate on (fpagg_tab_p2 pagg_tab_1)
-         ->  Foreign Scan
-               Relations: Aggregate on (fpagg_tab_p3 pagg_tab_2)
-(9 rows)
+         ->  HashAggregate
+               Group Key: pagg_tab.a
+               Filter: (avg(pagg_tab.b) < '22'::number)
+               ->  Foreign Scan on fpagg_tab_p1 pagg_tab
+         ->  HashAggregate
+               Group Key: pagg_tab_1.a
+               Filter: (avg(pagg_tab_1.b) < '22'::number)
+               ->  Foreign Scan on fpagg_tab_p2 pagg_tab_1
+         ->  HashAggregate
+               Group Key: pagg_tab_2.a
+               Filter: (avg(pagg_tab_2.b) < '22'::number)
+               ->  Foreign Scan on fpagg_tab_p3 pagg_tab_2
+(15 rows)
 
 SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
  a  | sum  | min | count 
 ----+------+-----+-------
-  0 | 2000 |   0 |   100
-  1 | 2100 |   1 |   100
- 10 | 2000 |   0 |   100
- 11 | 2100 |   1 |   100
- 20 | 2000 |   0 |   100
- 21 | 2100 |   1 |   100
+ 0  | 2000 | 0   |   100
+ 1  | 2100 | 1   |   100
+ 10 | 2000 | 0   |   100
+ 11 | 2100 | 1   |   100
+ 20 | 2000 | 0   |   100
+ 21 | 2100 | 1   |   100
 (6 rows)
 
 -- Check with whole-row reference
@@ -9802,21 +10963,21 @@ SELECT a, count(t1) FROM pagg_tab t1 GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
          ->  HashAggregate
                Output: t1.a, count(((t1.*)::pagg_tab))
                Group Key: t1.a
-               Filter: (avg(t1.b) < '22'::numeric)
+               Filter: (avg(t1.b) < '22'::number)
                ->  Foreign Scan on public.fpagg_tab_p1 t1
                      Output: t1.a, t1.*, t1.b
                      Remote SQL: SELECT a, b, c FROM public.pagg_tab_p1
          ->  HashAggregate
                Output: t1_1.a, count(((t1_1.*)::pagg_tab))
                Group Key: t1_1.a
-               Filter: (avg(t1_1.b) < '22'::numeric)
+               Filter: (avg(t1_1.b) < '22'::number)
                ->  Foreign Scan on public.fpagg_tab_p2 t1_1
                      Output: t1_1.a, t1_1.*, t1_1.b
                      Remote SQL: SELECT a, b, c FROM public.pagg_tab_p2
          ->  HashAggregate
                Output: t1_2.a, count(((t1_2.*)::pagg_tab))
                Group Key: t1_2.a
-               Filter: (avg(t1_2.b) < '22'::numeric)
+               Filter: (avg(t1_2.b) < '22'::number)
                ->  Foreign Scan on public.fpagg_tab_p3 t1_2
                      Output: t1_2.a, t1_2.*, t1_2.b
                      Remote SQL: SELECT a, b, c FROM public.pagg_tab_p3
@@ -9825,8 +10986,8 @@ SELECT a, count(t1) FROM pagg_tab t1 GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
 SELECT a, count(t1) FROM pagg_tab t1 GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
  a  | count 
 ----+-------
-  0 |   100
-  1 |   100
+ 0  |   100
+ 1  |   100
  10 |   100
  11 |   100
  20 |   100
@@ -9836,24 +10997,18 @@ SELECT a, count(t1) FROM pagg_tab t1 GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
 -- When GROUP BY clause does not match with PARTITION KEY.
 EXPLAIN (COSTS OFF)
 SELECT b, avg(a), max(a), count(*) FROM pagg_tab GROUP BY b HAVING sum(a) < 700 ORDER BY 1;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Sort
    Sort Key: pagg_tab.b
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: pagg_tab.b
-         Filter: (sum(pagg_tab.a) < 700)
+         Filter: (sum(pagg_tab.a) < '700'::number)
          ->  Append
-               ->  Partial HashAggregate
-                     Group Key: pagg_tab.b
-                     ->  Foreign Scan on fpagg_tab_p1 pagg_tab
-               ->  Partial HashAggregate
-                     Group Key: pagg_tab_1.b
-                     ->  Foreign Scan on fpagg_tab_p2 pagg_tab_1
-               ->  Partial HashAggregate
-                     Group Key: pagg_tab_2.b
-                     ->  Foreign Scan on fpagg_tab_p3 pagg_tab_2
-(15 rows)
+               ->  Foreign Scan on fpagg_tab_p1 pagg_tab_1
+               ->  Foreign Scan on fpagg_tab_p2 pagg_tab_2
+               ->  Foreign Scan on fpagg_tab_p3 pagg_tab_3
+(9 rows)
 
 -- ===================================================================
 -- access rights and superuser
@@ -9873,7 +11028,7 @@ DO $d$
     BEGIN
         EXECUTE $$CREATE SERVER loopback_nopw FOREIGN DATA WRAPPER postgres_fdw
             OPTIONS (dbname '$$||current_database()||$$',
-                     port '$$||current_setting('port')||$$'
+                     port '$$||current_setting('ivorysql.port')||$$'
             )$$;
     END;
 $d$;
@@ -9881,9 +11036,9 @@ $d$;
 CREATE USER MAPPING FOR public SERVER loopback_nopw;
 CREATE USER MAPPING FOR CURRENT_USER SERVER loopback_nopw;
 CREATE FOREIGN TABLE pg_temp.ft1_nopw (
-	c1 int NOT NULL,
-	c2 int NOT NULL,
-	c3 text,
+	c1 number(38,0) NOT NULL,
+	c2 number(38,0) NOT NULL,
+	c3 varchar2(1024),
 	c4 timestamptz,
 	c5 timestamp,
 	c6 varchar(10),
@@ -10279,7 +11434,7 @@ AND srvoptions @> array['batch_size=20'];
      1
 (1 row)
 
-CREATE FOREIGN TABLE table30 ( x int ) SERVER batch10 OPTIONS ( batch_size '30' );
+CREATE FOREIGN TABLE table30 ( x number(38,0) ) SERVER batch10 OPTIONS ( batch_size '30' );
 SELECT COUNT(*)
 FROM pg_foreign_table
 WHERE ftrelid = 'table30'::regclass
@@ -10309,8 +11464,8 @@ AND ftoptions @> array['batch_size=40'];
 (1 row)
 
 ROLLBACK;
-CREATE TABLE batch_table ( x int );
-CREATE FOREIGN TABLE ftable ( x int ) SERVER loopback OPTIONS ( table_name 'batch_table', batch_size '10' );
+CREATE TABLE batch_table ( x number(38,0) );
+CREATE FOREIGN TABLE ftable ( x number(38,0) ) SERVER loopback OPTIONS ( table_name 'batch_table', batch_size '10' );
 EXPLAIN (VERBOSE, COSTS OFF) INSERT INTO ftable SELECT * FROM generate_series(1, 10) i;
                          QUERY PLAN                          
 -------------------------------------------------------------
@@ -10335,7 +11490,7 @@ SELECT COUNT(*) FROM ftable;
 TRUNCATE batch_table;
 DROP FOREIGN TABLE ftable;
 -- try if large batches exceed max number of bind parameters
-CREATE FOREIGN TABLE ftable ( x int ) SERVER loopback OPTIONS ( table_name 'batch_table', batch_size '100000' );
+CREATE FOREIGN TABLE ftable ( x number(38,0) ) SERVER loopback OPTIONS ( table_name 'batch_table', batch_size '100000' );
 INSERT INTO ftable SELECT * FROM generate_series(1, 70000) i;
 SELECT COUNT(*) FROM ftable;
  count 
@@ -10346,7 +11501,7 @@ SELECT COUNT(*) FROM ftable;
 TRUNCATE batch_table;
 DROP FOREIGN TABLE ftable;
 -- Disable batch insert
-CREATE FOREIGN TABLE ftable ( x int ) SERVER loopback OPTIONS ( table_name 'batch_table', batch_size '1' );
+CREATE FOREIGN TABLE ftable ( x number(38,0) ) SERVER loopback OPTIONS ( table_name 'batch_table', batch_size '1' );
 EXPLAIN (VERBOSE, COSTS OFF) INSERT INTO ftable VALUES (1), (2);
                          QUERY PLAN                          
 -------------------------------------------------------------
@@ -10395,7 +11550,7 @@ DROP TRIGGER trig_row_before ON ftable;
 DROP FOREIGN TABLE ftable;
 DROP TABLE batch_table;
 -- Use partitioning
-CREATE TABLE batch_table ( x int ) PARTITION BY HASH (x);
+CREATE TABLE batch_table ( x number(38,0) ) PARTITION BY HASH (x);
 CREATE TABLE batch_table_p0 (LIKE batch_table);
 CREATE FOREIGN TABLE batch_table_p0f
 	PARTITION OF batch_table
@@ -10441,7 +11596,7 @@ CREATE FOREIGN TABLE batch_cp_upd_test3_f
 	OPTIONS (table_name 'batch_cp_upd_test3', batch_size '1');
 -- Create statement triggers on remote tables that "log" any INSERTs
 -- performed on them.
-CREATE TABLE cmdlog (cmd text);
+CREATE TABLE cmdlog (cmd varchar2(1024));
 CREATE FUNCTION log_stmt() RETURNS TRIGGER LANGUAGE plpgsql AS $$
 	BEGIN INSERT INTO public.cmdlog VALUES (TG_OP || ' on ' || TG_RELNAME); RETURN NULL; END;
 $$;
@@ -10487,7 +11642,7 @@ DROP TABLE cmdlog;
 DROP FUNCTION log_stmt();
 -- Use partitioning
 ALTER SERVER loopback OPTIONS (ADD batch_size '10');
-CREATE TABLE batch_table ( x int, field1 text, field2 text) PARTITION BY HASH (x);
+CREATE TABLE batch_table ( x number(38,0), field1 varchar2(1024), field2 varchar2(1024)) PARTITION BY HASH (x);
 CREATE TABLE batch_table_p0 (LIKE batch_table);
 ALTER TABLE batch_table_p0 ADD CONSTRAINT p0_pkey PRIMARY KEY (x);
 CREATE FOREIGN TABLE batch_table_p0f
@@ -10512,15 +11667,15 @@ SELECT COUNT(*) FROM batch_table;
 SELECT * FROM batch_table ORDER BY x;
  x  | field1 | field2 
 ----+--------+--------
-  1 | test1  | test1
-  2 | test2  | test2
-  3 | test3  | test3
-  4 | test4  | test4
-  5 | test5  | test5
-  6 | test6  | test6
-  7 | test7  | test7
-  8 | test8  | test8
-  9 | test9  | test9
+ 1  | test1  | test1
+ 2  | test2  | test2
+ 3  | test3  | test3
+ 4  | test4  | test4
+ 5  | test5  | test5
+ 6  | test6  | test6
+ 7  | test7  | test7
+ 8  | test8  | test8
+ 9  | test9  | test9
  10 | test10 | test10
  11 | test11 | test11
  12 | test12 | test12
@@ -10570,11 +11725,11 @@ DROP TABLE batch_table_p0;
 DROP TABLE batch_table_p1;
 ALTER SERVER loopback OPTIONS (DROP batch_size);
 -- Test that pending inserts are handled properly when needed
-CREATE TABLE batch_table (a text, b int);
-CREATE FOREIGN TABLE ftable (a text, b int)
+CREATE TABLE batch_table (a varchar2(1024), b number(38,0));
+CREATE FOREIGN TABLE ftable (a varchar2(1024), b number(38,0))
 	SERVER loopback
 	OPTIONS (table_name 'batch_table', batch_size '2');
-CREATE TABLE ltable (a text, b int);
+CREATE TABLE ltable (a varchar2(1024), b number(38,0));
 CREATE FUNCTION ftable_rowcount_trigf() RETURNS trigger LANGUAGE plpgsql AS
 $$
 begin
@@ -10657,8 +11812,8 @@ DROP FOREIGN TABLE ftable;
 DROP TABLE batch_table;
 DROP TRIGGER ftable_rowcount_trigger ON ltable;
 DROP TABLE ltable;
-CREATE TABLE parent (a text, b int) PARTITION BY LIST (a);
-CREATE TABLE batch_table (a text, b int);
+CREATE TABLE parent (a varchar2(1024), b number(38,0)) PARTITION BY LIST (a);
+CREATE TABLE batch_table (a varchar2(1024), b number(38,0));
 CREATE FOREIGN TABLE ftable
 	PARTITION OF parent
 	FOR VALUES IN ('AAA')
@@ -10695,9 +11850,9 @@ DROP FUNCTION ftable_rowcount_trigf;
 ALTER SERVER loopback OPTIONS (DROP extensions);
 ALTER SERVER loopback OPTIONS (ADD async_capable 'true');
 ALTER SERVER loopback2 OPTIONS (ADD async_capable 'true');
-CREATE TABLE async_pt (a int, b int, c text) PARTITION BY RANGE (a);
-CREATE TABLE base_tbl1 (a int, b int, c text);
-CREATE TABLE base_tbl2 (a int, b int, c text);
+CREATE TABLE async_pt (a number(38,0), b number(38,0), c varchar2(1024)) PARTITION BY RANGE (a);
+CREATE TABLE base_tbl1 (a number(38,0), b number(38,0), c varchar2(1024));
+CREATE TABLE base_tbl2 (a number(38,0), b number(38,0), c varchar2(1024));
 CREATE FOREIGN TABLE async_p1 PARTITION OF async_pt FOR VALUES FROM (1000) TO (2000)
   SERVER loopback OPTIONS (table_name 'base_tbl1');
 CREATE FOREIGN TABLE async_p2 PARTITION OF async_pt FOR VALUES FROM (2000) TO (3000)
@@ -10706,26 +11861,28 @@ INSERT INTO async_p1 SELECT 1000 + i, i, to_char(i, 'FM0000') FROM generate_seri
 INSERT INTO async_p2 SELECT 2000 + i, i, to_char(i, 'FM0000') FROM generate_series(0, 999, 5) i;
 ANALYZE async_pt;
 -- simple queries
-CREATE TABLE result_tbl (a int, b int, c text);
+CREATE TABLE result_tbl (a number(38,0), b number(38,0), c varchar2(1024));
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO result_tbl SELECT * FROM async_pt WHERE b % 100 = 0;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Insert on public.result_tbl
    ->  Append
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE (((b % 100) = 0))
+               Filter: ((async_pt_1.b % '100'::number) = '0'::number)
+               Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
                Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-               Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE (((b % 100) = 0))
-(8 rows)
+               Filter: ((async_pt_2.b % '100'::number) = '0'::number)
+               Remote SQL: SELECT a, b, c FROM public.base_tbl2
+(10 rows)
 
 INSERT INTO result_tbl SELECT * FROM async_pt WHERE b % 100 = 0;
 SELECT * FROM result_tbl ORDER BY a;
   a   |  b  |  c   
 ------+-----+------
- 1000 |   0 | 0000
+ 1000 | 0   | 0000
  1100 | 100 | 0100
  1200 | 200 | 0200
  1300 | 300 | 0300
@@ -10735,7 +11892,7 @@ SELECT * FROM result_tbl ORDER BY a;
  1700 | 700 | 0700
  1800 | 800 | 0800
  1900 | 900 | 0900
- 2000 |   0 | 0000
+ 2000 | 0   | 0000
  2100 | 100 | 0100
  2200 | 200 | 0200
  2300 | 300 | 0300
@@ -10756,11 +11913,11 @@ INSERT INTO result_tbl SELECT * FROM async_pt WHERE b === 505;
    ->  Append
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-               Filter: (async_pt_1.b === 505)
+               Filter: (async_pt_1.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
                Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-               Filter: (async_pt_2.b === 505)
+               Filter: (async_pt_2.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl2
 (10 rows)
 
@@ -10775,17 +11932,17 @@ SELECT * FROM result_tbl ORDER BY a;
 DELETE FROM result_tbl;
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO result_tbl SELECT a, b, 'AAA' || c FROM async_pt WHERE b === 505;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Insert on public.result_tbl
    ->  Append
          ->  Async Foreign Scan on public.async_p1 async_pt_1
-               Output: async_pt_1.a, async_pt_1.b, ('AAA'::text || async_pt_1.c)
-               Filter: (async_pt_1.b === 505)
+               Output: async_pt_1.a, async_pt_1.b, ('AAA'::text || (async_pt_1.c)::text)
+               Filter: (async_pt_1.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
-               Output: async_pt_2.a, async_pt_2.b, ('AAA'::text || async_pt_2.c)
-               Filter: (async_pt_2.b === 505)
+               Output: async_pt_2.a, async_pt_2.b, ('AAA'::text || (async_pt_2.c)::text)
+               Filter: (async_pt_2.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl2
 (10 rows)
 
@@ -10799,7 +11956,7 @@ SELECT * FROM result_tbl ORDER BY a;
 
 DELETE FROM result_tbl;
 -- Check case where multiple partitions use the same connection
-CREATE TABLE base_tbl3 (a int, b int, c text);
+CREATE TABLE base_tbl3 (a number(38,0), b number(38,0), c varchar2(1024));
 CREATE FOREIGN TABLE async_p3 PARTITION OF async_pt FOR VALUES FROM (3000) TO (4000)
   SERVER loopback2 OPTIONS (table_name 'base_tbl3');
 INSERT INTO async_p3 SELECT 3000 + i, i, to_char(i, 'FM0000') FROM generate_series(0, 999, 5) i;
@@ -10812,15 +11969,15 @@ INSERT INTO result_tbl SELECT * FROM async_pt WHERE b === 505;
    ->  Append
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-               Filter: (async_pt_1.b === 505)
+               Filter: (async_pt_1.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
                Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-               Filter: (async_pt_2.b === 505)
+               Filter: (async_pt_2.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl2
          ->  Async Foreign Scan on public.async_p3 async_pt_3
                Output: async_pt_3.a, async_pt_3.b, async_pt_3.c
-               Filter: (async_pt_3.b === 505)
+               Filter: (async_pt_3.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl3
 (14 rows)
 
@@ -10848,15 +12005,15 @@ INSERT INTO result_tbl SELECT * FROM async_pt WHERE b === 505;
    ->  Append
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-               Filter: (async_pt_1.b === 505)
+               Filter: (async_pt_1.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
                Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-               Filter: (async_pt_2.b === 505)
+               Filter: (async_pt_2.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl2
          ->  Seq Scan on public.async_p3 async_pt_3
                Output: async_pt_3.a, async_pt_3.b, async_pt_3.c
-               Filter: (async_pt_3.b === 505)
+               Filter: (async_pt_3.b === '505'::number)
 (13 rows)
 
 INSERT INTO result_tbl SELECT * FROM async_pt WHERE b === 505;
@@ -10871,21 +12028,33 @@ SELECT * FROM result_tbl ORDER BY a;
 DELETE FROM result_tbl;
 -- partitionwise joins
 SET enable_partitionwise_join TO true;
-CREATE TABLE join_tbl (a1 int, b1 int, c1 text, a2 int, b2 int, c2 text);
+CREATE TABLE join_tbl (a1 number(38,0), b1 number(38,0), c1 varchar2(1024), a2 number(38,0), b2 number(38,0), c2 varchar2(1024));
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO join_tbl SELECT * FROM async_pt t1, async_pt t2 WHERE t1.a = t2.a AND t1.b = t2.b AND t1.b % 100 = 0;
-                                                                                           QUERY PLAN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
  Insert on public.join_tbl
    ->  Append
-         ->  Async Foreign Scan
+         ->  Nested Loop
                Output: t1_1.a, t1_1.b, t1_1.c, t2_1.a, t2_1.b, t2_1.c
-               Relations: (public.async_p1 t1_1) INNER JOIN (public.async_p1 t2_1)
-               Remote SQL: SELECT r5.a, r5.b, r5.c, r8.a, r8.b, r8.c FROM (public.base_tbl1 r5 INNER JOIN public.base_tbl1 r8 ON (((r5.a = r8.a)) AND ((r5.b = r8.b)) AND (((r5.b % 100) = 0))))
-         ->  Async Foreign Scan
+               Join Filter: ((t1_1.a = t2_1.a) AND (t1_1.b = t2_1.b))
+               ->  Foreign Scan on public.async_p1 t1_1
+                     Output: t1_1.a, t1_1.b, t1_1.c
+                     Filter: ((t1_1.b % '100'::number) = '0'::number)
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl1
+               ->  Foreign Scan on public.async_p1 t2_1
+                     Output: t2_1.a, t2_1.b, t2_1.c
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl1
+         ->  Nested Loop
                Output: t1_2.a, t1_2.b, t1_2.c, t2_2.a, t2_2.b, t2_2.c
-               Relations: (public.async_p2 t1_2) INNER JOIN (public.async_p2 t2_2)
-               Remote SQL: SELECT r6.a, r6.b, r6.c, r9.a, r9.b, r9.c FROM (public.base_tbl2 r6 INNER JOIN public.base_tbl2 r9 ON (((r6.a = r9.a)) AND ((r6.b = r9.b)) AND (((r6.b % 100) = 0))))
+               Join Filter: ((t1_2.a = t2_2.a) AND (t1_2.b = t2_2.b))
+               ->  Foreign Scan on public.async_p2 t1_2
+                     Output: t1_2.a, t1_2.b, t1_2.c
+                     Filter: ((t1_2.b % '100'::number) = '0'::number)
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl2
+               ->  Foreign Scan on public.async_p2 t2_2
+                     Output: t2_2.a, t2_2.b, t2_2.c
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl2
          ->  Hash Join
                Output: t1_3.a, t1_3.b, t1_3.c, t2_3.a, t2_3.b, t2_3.c
                Hash Cond: ((t2_3.a = t1_3.a) AND (t2_3.b = t1_3.b))
@@ -10895,14 +12064,14 @@ INSERT INTO join_tbl SELECT * FROM async_pt t1, async_pt t2 WHERE t1.a = t2.a AN
                      Output: t1_3.a, t1_3.b, t1_3.c
                      ->  Seq Scan on public.async_p3 t1_3
                            Output: t1_3.a, t1_3.b, t1_3.c
-                           Filter: ((t1_3.b % 100) = 0)
-(20 rows)
+                           Filter: ((t1_3.b % '100'::number) = '0'::number)
+(32 rows)
 
 INSERT INTO join_tbl SELECT * FROM async_pt t1, async_pt t2 WHERE t1.a = t2.a AND t1.b = t2.b AND t1.b % 100 = 0;
 SELECT * FROM join_tbl ORDER BY a1;
   a1  | b1  |  c1  |  a2  | b2  |  c2  
 ------+-----+------+------+-----+------
- 1000 |   0 | 0000 | 1000 |   0 | 0000
+ 1000 | 0   | 0000 | 1000 | 0   | 0000
  1100 | 100 | 0100 | 1100 | 100 | 0100
  1200 | 200 | 0200 | 1200 | 200 | 0200
  1300 | 300 | 0300 | 1300 | 300 | 0300
@@ -10912,7 +12081,7 @@ SELECT * FROM join_tbl ORDER BY a1;
  1700 | 700 | 0700 | 1700 | 700 | 0700
  1800 | 800 | 0800 | 1800 | 800 | 0800
  1900 | 900 | 0900 | 1900 | 900 | 0900
- 2000 |   0 | 0000 | 2000 |   0 | 0000
+ 2000 | 0   | 0000 | 2000 | 0   | 0000
  2100 | 100 | 0100 | 2100 | 100 | 0100
  2200 | 200 | 0200 | 2200 | 200 | 0200
  2300 | 300 | 0300 | 2300 | 300 | 0300
@@ -10922,7 +12091,7 @@ SELECT * FROM join_tbl ORDER BY a1;
  2700 | 700 | 0700 | 2700 | 700 | 0700
  2800 | 800 | 0800 | 2800 | 800 | 0800
  2900 | 900 | 0900 | 2900 | 900 | 0900
- 3000 |   0 | 0000 | 3000 |   0 | 0000
+ 3000 | 0   | 0000 | 3000 | 0   | 0000
  3100 | 100 | 0100 | 3100 | 100 | 0100
  3200 | 200 | 0200 | 3200 | 200 | 0200
  3300 | 300 | 0300 | 3300 | 300 | 0300
@@ -10937,20 +12106,32 @@ SELECT * FROM join_tbl ORDER BY a1;
 DELETE FROM join_tbl;
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO join_tbl SELECT t1.a, t1.b, 'AAA' || t1.c, t2.a, t2.b, 'AAA' || t2.c FROM async_pt t1, async_pt t2 WHERE t1.a = t2.a AND t1.b = t2.b AND t1.b % 100 = 0;
-                                                                                           QUERY PLAN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
  Insert on public.join_tbl
    ->  Append
-         ->  Async Foreign Scan
-               Output: t1_1.a, t1_1.b, ('AAA'::text || t1_1.c), t2_1.a, t2_1.b, ('AAA'::text || t2_1.c)
-               Relations: (public.async_p1 t1_1) INNER JOIN (public.async_p1 t2_1)
-               Remote SQL: SELECT r5.a, r5.b, r5.c, r8.a, r8.b, r8.c FROM (public.base_tbl1 r5 INNER JOIN public.base_tbl1 r8 ON (((r5.a = r8.a)) AND ((r5.b = r8.b)) AND (((r5.b % 100) = 0))))
-         ->  Async Foreign Scan
-               Output: t1_2.a, t1_2.b, ('AAA'::text || t1_2.c), t2_2.a, t2_2.b, ('AAA'::text || t2_2.c)
-               Relations: (public.async_p2 t1_2) INNER JOIN (public.async_p2 t2_2)
-               Remote SQL: SELECT r6.a, r6.b, r6.c, r9.a, r9.b, r9.c FROM (public.base_tbl2 r6 INNER JOIN public.base_tbl2 r9 ON (((r6.a = r9.a)) AND ((r6.b = r9.b)) AND (((r6.b % 100) = 0))))
+         ->  Nested Loop
+               Output: t1_1.a, t1_1.b, ('AAA'::text || (t1_1.c)::text), t2_1.a, t2_1.b, ('AAA'::text || (t2_1.c)::text)
+               Join Filter: ((t1_1.a = t2_1.a) AND (t1_1.b = t2_1.b))
+               ->  Foreign Scan on public.async_p1 t1_1
+                     Output: t1_1.a, t1_1.b, t1_1.c
+                     Filter: ((t1_1.b % '100'::number) = '0'::number)
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl1
+               ->  Foreign Scan on public.async_p1 t2_1
+                     Output: t2_1.a, t2_1.b, t2_1.c
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl1
+         ->  Nested Loop
+               Output: t1_2.a, t1_2.b, ('AAA'::text || (t1_2.c)::text), t2_2.a, t2_2.b, ('AAA'::text || (t2_2.c)::text)
+               Join Filter: ((t1_2.a = t2_2.a) AND (t1_2.b = t2_2.b))
+               ->  Foreign Scan on public.async_p2 t1_2
+                     Output: t1_2.a, t1_2.b, t1_2.c
+                     Filter: ((t1_2.b % '100'::number) = '0'::number)
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl2
+               ->  Foreign Scan on public.async_p2 t2_2
+                     Output: t2_2.a, t2_2.b, t2_2.c
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl2
          ->  Hash Join
-               Output: t1_3.a, t1_3.b, ('AAA'::text || t1_3.c), t2_3.a, t2_3.b, ('AAA'::text || t2_3.c)
+               Output: t1_3.a, t1_3.b, ('AAA'::text || (t1_3.c)::text), t2_3.a, t2_3.b, ('AAA'::text || (t2_3.c)::text)
                Hash Cond: ((t2_3.a = t1_3.a) AND (t2_3.b = t1_3.b))
                ->  Seq Scan on public.async_p3 t2_3
                      Output: t2_3.a, t2_3.b, t2_3.c
@@ -10958,14 +12139,14 @@ INSERT INTO join_tbl SELECT t1.a, t1.b, 'AAA' || t1.c, t2.a, t2.b, 'AAA' || t2.c
                      Output: t1_3.a, t1_3.b, t1_3.c
                      ->  Seq Scan on public.async_p3 t1_3
                            Output: t1_3.a, t1_3.b, t1_3.c
-                           Filter: ((t1_3.b % 100) = 0)
-(20 rows)
+                           Filter: ((t1_3.b % '100'::number) = '0'::number)
+(32 rows)
 
 INSERT INTO join_tbl SELECT t1.a, t1.b, 'AAA' || t1.c, t2.a, t2.b, 'AAA' || t2.c FROM async_pt t1, async_pt t2 WHERE t1.a = t2.a AND t1.b = t2.b AND t1.b % 100 = 0;
 SELECT * FROM join_tbl ORDER BY a1;
   a1  | b1  |   c1    |  a2  | b2  |   c2    
 ------+-----+---------+------+-----+---------
- 1000 |   0 | AAA0000 | 1000 |   0 | AAA0000
+ 1000 | 0   | AAA0000 | 1000 | 0   | AAA0000
  1100 | 100 | AAA0100 | 1100 | 100 | AAA0100
  1200 | 200 | AAA0200 | 1200 | 200 | AAA0200
  1300 | 300 | AAA0300 | 1300 | 300 | AAA0300
@@ -10975,7 +12156,7 @@ SELECT * FROM join_tbl ORDER BY a1;
  1700 | 700 | AAA0700 | 1700 | 700 | AAA0700
  1800 | 800 | AAA0800 | 1800 | 800 | AAA0800
  1900 | 900 | AAA0900 | 1900 | 900 | AAA0900
- 2000 |   0 | AAA0000 | 2000 |   0 | AAA0000
+ 2000 | 0   | AAA0000 | 2000 | 0   | AAA0000
  2100 | 100 | AAA0100 | 2100 | 100 | AAA0100
  2200 | 200 | AAA0200 | 2200 | 200 | AAA0200
  2300 | 300 | AAA0300 | 2300 | 300 | AAA0300
@@ -10985,7 +12166,7 @@ SELECT * FROM join_tbl ORDER BY a1;
  2700 | 700 | AAA0700 | 2700 | 700 | AAA0700
  2800 | 800 | AAA0800 | 2800 | 800 | AAA0800
  2900 | 900 | AAA0900 | 2900 | 900 | AAA0900
- 3000 |   0 | AAA0000 | 3000 |   0 | AAA0000
+ 3000 | 0   | AAA0000 | 3000 | 0   | AAA0000
  3100 | 100 | AAA0100 | 3100 | 100 | AAA0100
  3200 | 200 | AAA0200 | 3200 | 200 | AAA0200
  3300 | 300 | AAA0300 | 3300 | 300 | AAA0300
@@ -11003,15 +12184,16 @@ RESET enable_partitionwise_join;
 SET enable_hashjoin TO false;
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO join_tbl SELECT * FROM async_p1 t1, async_pt t2 WHERE t1.a = t2.a AND t1.b = t2.b AND t1.b % 100 = 0;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Insert on public.join_tbl
    ->  Nested Loop
          Output: t1.a, t1.b, t1.c, t2.a, t2.b, t2.c
          Join Filter: ((t1.a = t2.a) AND (t1.b = t2.b))
          ->  Foreign Scan on public.async_p1 t1
                Output: t1.a, t1.b, t1.c
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE (((b % 100) = 0))
+               Filter: ((t1.b % '100'::number) = '0'::number)
+               Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Append
                ->  Async Foreign Scan on public.async_p1 t2_1
                      Output: t2_1.a, t2_1.b, t2_1.c
@@ -11021,13 +12203,13 @@ INSERT INTO join_tbl SELECT * FROM async_p1 t1, async_pt t2 WHERE t1.a = t2.a AN
                      Remote SQL: SELECT a, b, c FROM public.base_tbl2
                ->  Seq Scan on public.async_p3 t2_3
                      Output: t2_3.a, t2_3.b, t2_3.c
-(16 rows)
+(17 rows)
 
 INSERT INTO join_tbl SELECT * FROM async_p1 t1, async_pt t2 WHERE t1.a = t2.a AND t1.b = t2.b AND t1.b % 100 = 0;
 SELECT * FROM join_tbl ORDER BY a1;
   a1  | b1  |  c1  |  a2  | b2  |  c2  
 ------+-----+------+------+-----+------
- 1000 |   0 | 0000 | 1000 |   0 | 0000
+ 1000 | 0   | 0000 | 1000 | 0   | 0000
  1100 | 100 | 0100 | 1100 | 100 | 0100
  1200 | 200 | 0200 | 1200 | 200 | 0200
  1300 | 300 | 0300 | 1300 | 300 | 0300
@@ -11044,45 +12226,48 @@ RESET enable_hashjoin;
 -- Test interaction of async execution with plan-time partition pruning
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM async_pt WHERE a < 3000;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Append
    ->  Async Foreign Scan on public.async_p1 async_pt_1
          Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-         Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE ((a < 3000))
+         Filter: (async_pt_1.a < '3000'::number)
+         Remote SQL: SELECT a, b, c FROM public.base_tbl1
    ->  Async Foreign Scan on public.async_p2 async_pt_2
          Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-         Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE ((a < 3000))
-(7 rows)
+         Filter: (async_pt_2.a < '3000'::number)
+         Remote SQL: SELECT a, b, c FROM public.base_tbl2
+(9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM async_pt WHERE a < 2000;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Foreign Scan on public.async_p1 async_pt
    Output: async_pt.a, async_pt.b, async_pt.c
-   Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE ((a < 2000))
-(3 rows)
+   Filter: (async_pt.a < '2000'::number)
+   Remote SQL: SELECT a, b, c FROM public.base_tbl1
+(4 rows)
 
 -- Test interaction of async execution with run-time partition pruning
 SET plan_cache_mode TO force_generic_plan;
-PREPARE async_pt_query (int, int) AS
+PREPARE async_pt_query (number(38,0), number(38,0)) AS
   INSERT INTO result_tbl SELECT * FROM async_pt WHERE a < $1 AND b === $2;
 EXPLAIN (VERBOSE, COSTS OFF)
 EXECUTE async_pt_query (3000, 505);
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Insert on public.result_tbl
    ->  Append
          Subplans Removed: 1
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-               Filter: (async_pt_1.b === $2)
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE ((a < $1::integer))
+               Filter: ((async_pt_1.a < $1) AND (async_pt_1.b === $2))
+               Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
                Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-               Filter: (async_pt_2.b === $2)
-               Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE ((a < $1::integer))
+               Filter: ((async_pt_2.a < $1) AND (async_pt_2.b === $2))
+               Remote SQL: SELECT a, b, c FROM public.base_tbl2
 (11 rows)
 
 EXECUTE async_pt_query (3000, 505);
@@ -11096,15 +12281,15 @@ SELECT * FROM result_tbl ORDER BY a;
 DELETE FROM result_tbl;
 EXPLAIN (VERBOSE, COSTS OFF)
 EXECUTE async_pt_query (2000, 505);
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Insert on public.result_tbl
    ->  Append
          Subplans Removed: 2
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-               Filter: (async_pt_1.b === $2)
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE ((a < $1::integer))
+               Filter: ((async_pt_1.a < $1) AND (async_pt_1.b === $2))
+               Remote SQL: SELECT a, b, c FROM public.base_tbl1
 (7 rows)
 
 EXECUTE async_pt_query (2000, 505);
@@ -11116,7 +12301,7 @@ SELECT * FROM result_tbl ORDER BY a;
 
 DELETE FROM result_tbl;
 RESET plan_cache_mode;
-CREATE TABLE local_tbl(a int, b int, c text);
+CREATE TABLE local_tbl(a number(38,0), b number(38,0), c varchar2(1024));
 INSERT INTO local_tbl VALUES (1505, 505, 'foo'), (2505, 505, 'bar');
 ANALYZE local_tbl;
 CREATE INDEX base_tbl1_idx ON base_tbl1 (a);
@@ -11129,39 +12314,43 @@ ALTER FOREIGN TABLE async_p1 OPTIONS (use_remote_estimate 'true');
 ALTER FOREIGN TABLE async_p2 OPTIONS (use_remote_estimate 'true');
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM local_tbl, async_pt WHERE local_tbl.a = async_pt.a AND local_tbl.c = 'bar';
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Nested Loop
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Hash Join
    Output: local_tbl.a, local_tbl.b, local_tbl.c, async_pt.a, async_pt.b, async_pt.c
-   ->  Seq Scan on public.local_tbl
-         Output: local_tbl.a, local_tbl.b, local_tbl.c
-         Filter: (local_tbl.c = 'bar'::text)
+   Hash Cond: (async_pt.a = local_tbl.a)
    ->  Append
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE ((a = $1::integer))
+               Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
                Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-               Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE ((a = $1::integer))
+               Remote SQL: SELECT a, b, c FROM public.base_tbl2
          ->  Seq Scan on public.async_p3 async_pt_3
                Output: async_pt_3.a, async_pt_3.b, async_pt_3.c
-               Filter: (async_pt_3.a = local_tbl.a)
-(15 rows)
+   ->  Hash
+         Output: local_tbl.a, local_tbl.b, local_tbl.c
+         ->  Seq Scan on public.local_tbl
+               Output: local_tbl.a, local_tbl.b, local_tbl.c
+               Filter: (local_tbl.c = 'bar'::varchar2)
+(17 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT * FROM local_tbl, async_pt WHERE local_tbl.a = async_pt.a AND local_tbl.c = 'bar';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Nested Loop (actual rows=1 loops=1)
-   ->  Seq Scan on local_tbl (actual rows=1 loops=1)
-         Filter: (c = 'bar'::text)
-         Rows Removed by Filter: 1
-   ->  Append (actual rows=1 loops=1)
-         ->  Async Foreign Scan on async_p1 async_pt_1 (never executed)
-         ->  Async Foreign Scan on async_p2 async_pt_2 (actual rows=1 loops=1)
-         ->  Seq Scan on async_p3 async_pt_3 (never executed)
-               Filter: (a = local_tbl.a)
-(9 rows)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Hash Join (actual rows=1 loops=1)
+   Hash Cond: (async_pt.a = local_tbl.a)
+   ->  Append (actual rows=600 loops=1)
+         ->  Async Foreign Scan on async_p1 async_pt_1 (actual rows=200 loops=1)
+         ->  Async Foreign Scan on async_p2 async_pt_2 (actual rows=200 loops=1)
+         ->  Seq Scan on async_p3 async_pt_3 (actual rows=200 loops=1)
+   ->  Hash (actual rows=1 loops=1)
+         Buckets: 1024  Batches: 1  Memory Usage: 9kB
+         ->  Seq Scan on local_tbl (actual rows=1 loops=1)
+               Filter: (c = 'bar'::varchar2)
+               Rows Removed by Filter: 1
+(11 rows)
 
 SELECT * FROM local_tbl, async_pt WHERE local_tbl.a = async_pt.a AND local_tbl.c = 'bar';
   a   |  b  |  c  |  a   |  b  |  c   
@@ -11181,20 +12370,28 @@ INSERT INTO result_tbl
 (SELECT a, b, 'AAA' || c FROM async_p1 ORDER BY a LIMIT 10)
 UNION
 (SELECT a, b, 'AAA' || c FROM async_p2 WHERE b < 10);
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Insert on public.result_tbl
-   ->  HashAggregate
-         Output: async_p1.a, async_p1.b, (('AAA'::text || async_p1.c))
-         Group Key: async_p1.a, async_p1.b, (('AAA'::text || async_p1.c))
-         ->  Append
-               ->  Async Foreign Scan on public.async_p1
-                     Output: async_p1.a, async_p1.b, ('AAA'::text || async_p1.c)
-                     Remote SQL: SELECT a, b, c FROM public.base_tbl1 ORDER BY a ASC NULLS LAST LIMIT 10::bigint
-               ->  Async Foreign Scan on public.async_p2
-                     Output: async_p2.a, async_p2.b, ('AAA'::text || async_p2.c)
-                     Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE ((b < 10))
-(11 rows)
+   ->  Subquery Scan on "*SELECT*"
+         Output: "*SELECT*".a, "*SELECT*".b, "*SELECT*"."?column?"
+         ->  HashAggregate
+               Output: async_p1.a, async_p1.b, (('AAA'::text || (async_p1.c)::text))
+               Group Key: async_p1.a, async_p1.b, (('AAA'::text || (async_p1.c)::text))
+               ->  Append
+                     ->  Limit
+                           Output: async_p1.a, async_p1.b, (('AAA'::text || (async_p1.c)::text))
+                           ->  Sort
+                                 Output: async_p1.a, async_p1.b, (('AAA'::text || (async_p1.c)::text))
+                                 Sort Key: async_p1.a
+                                 ->  Foreign Scan on public.async_p1
+                                       Output: async_p1.a, async_p1.b, ('AAA'::text || (async_p1.c)::text)
+                                       Remote SQL: SELECT a, b, c FROM public.base_tbl1
+                     ->  Async Foreign Scan on public.async_p2
+                           Output: async_p2.a, async_p2.b, ('AAA'::text || (async_p2.c)::text)
+                           Filter: (async_p2.b < '10'::number)
+                           Remote SQL: SELECT a, b, c FROM public.base_tbl2
+(19 rows)
 
 INSERT INTO result_tbl
 (SELECT a, b, 'AAA' || c FROM async_p1 ORDER BY a LIMIT 10)
@@ -11203,8 +12400,8 @@ UNION
 SELECT * FROM result_tbl ORDER BY a;
   a   | b  |    c    
 ------+----+---------
- 1000 |  0 | AAA0000
- 1005 |  5 | AAA0005
+ 1000 | 0  | AAA0000
+ 1005 | 5  | AAA0005
  1010 | 10 | AAA0010
  1015 | 15 | AAA0015
  1020 | 20 | AAA0020
@@ -11213,8 +12410,8 @@ SELECT * FROM result_tbl ORDER BY a;
  1035 | 35 | AAA0035
  1040 | 40 | AAA0040
  1045 | 45 | AAA0045
- 2000 |  0 | AAA0000
- 2005 |  5 | AAA0005
+ 2000 | 0  | AAA0000
+ 2005 | 5  | AAA0005
 (12 rows)
 
 DELETE FROM result_tbl;
@@ -11223,17 +12420,25 @@ INSERT INTO result_tbl
 (SELECT a, b, 'AAA' || c FROM async_p1 ORDER BY a LIMIT 10)
 UNION ALL
 (SELECT a, b, 'AAA' || c FROM async_p2 WHERE b < 10);
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Insert on public.result_tbl
-   ->  Append
-         ->  Async Foreign Scan on public.async_p1
-               Output: async_p1.a, async_p1.b, ('AAA'::text || async_p1.c)
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 ORDER BY a ASC NULLS LAST LIMIT 10::bigint
-         ->  Async Foreign Scan on public.async_p2
-               Output: async_p2.a, async_p2.b, ('AAA'::text || async_p2.c)
-               Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE ((b < 10))
-(8 rows)
+   ->  Result
+         Output: async_p1.a, async_p1.b, (('AAA'::text || (async_p1.c)::text))
+         ->  Append
+               ->  Limit
+                     Output: async_p1.a, async_p1.b, (('AAA'::text || (async_p1.c)::text))
+                     ->  Sort
+                           Output: async_p1.a, async_p1.b, (('AAA'::text || (async_p1.c)::text))
+                           Sort Key: async_p1.a
+                           ->  Foreign Scan on public.async_p1
+                                 Output: async_p1.a, async_p1.b, ('AAA'::text || (async_p1.c)::text)
+                                 Remote SQL: SELECT a, b, c FROM public.base_tbl1
+               ->  Async Foreign Scan on public.async_p2
+                     Output: async_p2.a, async_p2.b, ('AAA'::text || (async_p2.c)::text)
+                     Filter: (async_p2.b < '10'::number)
+                     Remote SQL: SELECT a, b, c FROM public.base_tbl2
+(16 rows)
 
 INSERT INTO result_tbl
 (SELECT a, b, 'AAA' || c FROM async_p1 ORDER BY a LIMIT 10)
@@ -11242,8 +12447,8 @@ UNION ALL
 SELECT * FROM result_tbl ORDER BY a;
   a   | b  |    c    
 ------+----+---------
- 1000 |  0 | AAA0000
- 1005 |  5 | AAA0005
+ 1000 | 0  | AAA0000
+ 1005 | 5  | AAA0005
  1010 | 10 | AAA0010
  1015 | 15 | AAA0015
  1020 | 20 | AAA0020
@@ -11252,8 +12457,8 @@ SELECT * FROM result_tbl ORDER BY a;
  1035 | 35 | AAA0035
  1040 | 40 | AAA0040
  1045 | 45 | AAA0045
- 2000 |  0 | AAA0000
- 2005 |  5 | AAA0005
+ 2000 | 0  | AAA0000
+ 2005 | 5  | AAA0005
 (12 rows)
 
 DELETE FROM result_tbl;
@@ -11306,22 +12511,24 @@ UNION ALL
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ((SELECT * FROM async_p1 WHERE b < 10) UNION ALL (SELECT * FROM async_p2 WHERE b < 10)) s WHERE CURRENT_USER = SESSION_USER;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Append
    ->  Result
          Output: async_p1.a, async_p1.b, async_p1.c
          One-Time Filter: (CURRENT_USER = SESSION_USER)
          ->  Foreign Scan on public.async_p1
                Output: async_p1.a, async_p1.b, async_p1.c
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE ((b < 10))
+               Filter: (async_p1.b < '10'::number)
+               Remote SQL: SELECT a, b, c FROM public.base_tbl1
    ->  Result
          Output: async_p2.a, async_p2.b, async_p2.c
          One-Time Filter: (CURRENT_USER = SESSION_USER)
          ->  Foreign Scan on public.async_p2
                Output: async_p2.a, async_p2.b, async_p2.c
-               Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE ((b < 10))
-(13 rows)
+               Filter: (async_p2.b < '10'::number)
+               Remote SQL: SELECT a, b, c FROM public.base_tbl2
+(15 rows)
 
 -- Test that pending requests are processed properly
 SET enable_mergejoin TO false;
@@ -11336,15 +12543,15 @@ SELECT * FROM async_pt t1, async_p2 t2 WHERE t1.a = t2.a AND t1.b === 505;
    ->  Append
          ->  Async Foreign Scan on public.async_p1 t1_1
                Output: t1_1.a, t1_1.b, t1_1.c
-               Filter: (t1_1.b === 505)
+               Filter: (t1_1.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 t1_2
                Output: t1_2.a, t1_2.b, t1_2.c
-               Filter: (t1_2.b === 505)
+               Filter: (t1_2.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl2
          ->  Seq Scan on public.async_p3 t1_3
                Output: t1_3.a, t1_3.b, t1_3.c
-               Filter: (t1_3.b === 505)
+               Filter: (t1_3.b === '505'::number)
    ->  Materialize
          Output: t2.a, t2.b, t2.c
          ->  Foreign Scan on public.async_p2 t2
@@ -11358,13 +12565,13 @@ SELECT * FROM async_pt t1, async_p2 t2 WHERE t1.a = t2.a AND t1.b === 505;
  2505 | 505 | 0505 | 2505 | 505 | 0505
 (1 row)
 
-CREATE TABLE local_tbl (a int, b int, c text);
+CREATE TABLE local_tbl (a number(38,0), b number(38,0), c varchar2(1024));
 INSERT INTO local_tbl VALUES (1505, 505, 'foo');
 ANALYZE local_tbl;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM local_tbl t1 LEFT JOIN (SELECT *, (SELECT count(*) FROM async_pt WHERE a < 3000) FROM async_pt WHERE a < 3000) t2 ON t1.a = t2.a;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Nested Loop Left Join
    Output: t1.a, t1.b, t1.c, async_pt.a, async_pt.b, async_pt.c, ($0)
    Join Filter: (t1.a = async_pt.a)
@@ -11373,19 +12580,23 @@ SELECT * FROM local_tbl t1 LEFT JOIN (SELECT *, (SELECT count(*) FROM async_pt W
            Output: count(*)
            ->  Append
                  ->  Async Foreign Scan on public.async_p1 async_pt_4
-                       Remote SQL: SELECT NULL FROM public.base_tbl1 WHERE ((a < 3000))
+                       Filter: (async_pt_4.a < '3000'::number)
+                       Remote SQL: SELECT a FROM public.base_tbl1
                  ->  Async Foreign Scan on public.async_p2 async_pt_5
-                       Remote SQL: SELECT NULL FROM public.base_tbl2 WHERE ((a < 3000))
+                       Filter: (async_pt_5.a < '3000'::number)
+                       Remote SQL: SELECT a FROM public.base_tbl2
    ->  Seq Scan on public.local_tbl t1
          Output: t1.a, t1.b, t1.c
    ->  Append
          ->  Async Foreign Scan on public.async_p1 async_pt_1
                Output: async_pt_1.a, async_pt_1.b, async_pt_1.c, $0
-               Remote SQL: SELECT a, b, c FROM public.base_tbl1 WHERE ((a < 3000))
+               Filter: (async_pt_1.a < '3000'::number)
+               Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 async_pt_2
                Output: async_pt_2.a, async_pt_2.b, async_pt_2.c, $0
-               Remote SQL: SELECT a, b, c FROM public.base_tbl2 WHERE ((a < 3000))
-(20 rows)
+               Filter: (async_pt_2.a < '3000'::number)
+               Remote SQL: SELECT a, b, c FROM public.base_tbl2
+(24 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT * FROM local_tbl t1 LEFT JOIN (SELECT *, (SELECT count(*) FROM async_pt WHERE a < 3000) FROM async_pt WHERE a < 3000) t2 ON t1.a = t2.a;
@@ -11398,12 +12609,16 @@ SELECT * FROM local_tbl t1 LEFT JOIN (SELECT *, (SELECT count(*) FROM async_pt W
      ->  Aggregate (actual rows=1 loops=1)
            ->  Append (actual rows=400 loops=1)
                  ->  Async Foreign Scan on async_p1 async_pt_4 (actual rows=200 loops=1)
+                       Filter: (a < '3000'::number)
                  ->  Async Foreign Scan on async_p2 async_pt_5 (actual rows=200 loops=1)
+                       Filter: (a < '3000'::number)
    ->  Seq Scan on local_tbl t1 (actual rows=1 loops=1)
    ->  Append (actual rows=400 loops=1)
          ->  Async Foreign Scan on async_p1 async_pt_1 (actual rows=200 loops=1)
+               Filter: (a < '3000'::number)
          ->  Async Foreign Scan on async_p2 async_pt_2 (actual rows=200 loops=1)
-(12 rows)
+               Filter: (a < '3000'::number)
+(16 rows)
 
 SELECT * FROM local_tbl t1 LEFT JOIN (SELECT *, (SELECT count(*) FROM async_pt WHERE a < 3000) FROM async_pt WHERE a < 3000) t2 ON t1.a = t2.a;
   a   |  b  |  c  |  a   |  b  |  c   | count 
@@ -11420,15 +12635,15 @@ SELECT * FROM async_pt t1 WHERE t1.b === 505 LIMIT 1;
    ->  Append
          ->  Async Foreign Scan on public.async_p1 t1_1
                Output: t1_1.a, t1_1.b, t1_1.c
-               Filter: (t1_1.b === 505)
+               Filter: (t1_1.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl1
          ->  Async Foreign Scan on public.async_p2 t1_2
                Output: t1_2.a, t1_2.b, t1_2.c
-               Filter: (t1_2.b === 505)
+               Filter: (t1_2.b === '505'::number)
                Remote SQL: SELECT a, b, c FROM public.base_tbl2
          ->  Seq Scan on public.async_p3 t1_3
                Output: t1_3.a, t1_3.b, t1_3.c
-               Filter: (t1_3.b === 505)
+               Filter: (t1_3.b === '505'::number)
 (14 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
@@ -11438,11 +12653,11 @@ SELECT * FROM async_pt t1 WHERE t1.b === 505 LIMIT 1;
  Limit (actual rows=1 loops=1)
    ->  Append (actual rows=1 loops=1)
          ->  Async Foreign Scan on async_p1 t1_1 (actual rows=0 loops=1)
-               Filter: (b === 505)
+               Filter: (b === '505'::number)
          ->  Async Foreign Scan on async_p2 t1_2 (actual rows=0 loops=1)
-               Filter: (b === 505)
+               Filter: (b === '505'::number)
          ->  Seq Scan on async_p3 t1_3 (actual rows=1 loops=1)
-               Filter: (b === 505)
+               Filter: (b === '505'::number)
                Rows Removed by Filter: 101
 (9 rows)
 
@@ -11453,12 +12668,12 @@ SELECT * FROM async_pt t1 WHERE t1.b === 505 LIMIT 1;
 (1 row)
 
 -- Check with foreign modify
-CREATE TABLE base_tbl3 (a int, b int, c text);
-CREATE FOREIGN TABLE remote_tbl (a int, b int, c text)
+CREATE TABLE base_tbl3 (a number(38,0), b number(38,0), c varchar2(1024));
+CREATE FOREIGN TABLE remote_tbl (a number(38,0), b number(38,0), c varchar2(1024))
   SERVER loopback OPTIONS (table_name 'base_tbl3');
 INSERT INTO remote_tbl VALUES (2505, 505, 'bar');
-CREATE TABLE base_tbl4 (a int, b int, c text);
-CREATE FOREIGN TABLE insert_tbl (a int, b int, c text)
+CREATE TABLE base_tbl4 (a number(38,0), b number(38,0), c varchar2(1024));
+CREATE FOREIGN TABLE insert_tbl (a number(38,0), b number(38,0), c varchar2(1024))
   SERVER loopback OPTIONS (table_name 'base_tbl4');
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO insert_tbl (SELECT * FROM local_tbl UNION ALL SELECT * FROM remote_tbl);
@@ -11487,32 +12702,34 @@ SELECT * FROM insert_tbl ORDER BY a;
 EXPLAIN (VERBOSE, COSTS OFF)
 WITH t AS (UPDATE remote_tbl SET c = c || c RETURNING *)
 INSERT INTO join_tbl SELECT * FROM async_pt LEFT JOIN t ON (async_pt.a = t.a AND async_pt.b = t.b) WHERE async_pt.b === 505;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Insert on public.join_tbl
    CTE t
      ->  Update on public.remote_tbl
            Output: remote_tbl.a, remote_tbl.b, remote_tbl.c
-           ->  Foreign Update on public.remote_tbl
-                 Remote SQL: UPDATE public.base_tbl3 SET c = (c || c) RETURNING a, b, c
+           Remote SQL: UPDATE public.base_tbl3 SET c = $2 WHERE ctid = $1 RETURNING a, b, c
+           ->  Foreign Scan on public.remote_tbl
+                 Output: ((remote_tbl.c)::text || (remote_tbl.c)::text), remote_tbl.ctid, remote_tbl.*
+                 Remote SQL: SELECT a, b, c, ctid FROM public.base_tbl3 FOR UPDATE
    ->  Nested Loop Left Join
          Output: async_pt.a, async_pt.b, async_pt.c, t.a, t.b, t.c
          Join Filter: ((async_pt.a = t.a) AND (async_pt.b = t.b))
          ->  Append
                ->  Async Foreign Scan on public.async_p1 async_pt_1
                      Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
-                     Filter: (async_pt_1.b === 505)
+                     Filter: (async_pt_1.b === '505'::number)
                      Remote SQL: SELECT a, b, c FROM public.base_tbl1
                ->  Async Foreign Scan on public.async_p2 async_pt_2
                      Output: async_pt_2.a, async_pt_2.b, async_pt_2.c
-                     Filter: (async_pt_2.b === 505)
+                     Filter: (async_pt_2.b === '505'::number)
                      Remote SQL: SELECT a, b, c FROM public.base_tbl2
                ->  Seq Scan on public.async_p3 async_pt_3
                      Output: async_pt_3.a, async_pt_3.b, async_pt_3.c
-                     Filter: (async_pt_3.b === 505)
+                     Filter: (async_pt_3.b === '505'::number)
          ->  CTE Scan on t
                Output: t.a, t.b, t.c
-(23 rows)
+(25 rows)
 
 WITH t AS (UPDATE remote_tbl SET c = c || c RETURNING *)
 INSERT INTO join_tbl SELECT * FROM async_pt LEFT JOIN t ON (async_pt.a = t.a AND async_pt.b = t.b) WHERE async_pt.b === 505;
@@ -11535,56 +12752,68 @@ RESET enable_hashjoin;
 -- Test that UPDATE/DELETE with inherited target works with async_capable enabled
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE async_pt SET c = c || c WHERE b = 0 RETURNING *;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Update on public.async_pt
    Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
    Foreign Update on public.async_p1 async_pt_1
+     Remote SQL: UPDATE public.base_tbl1 SET c = $2 WHERE ctid = $1 RETURNING a, b, c
    Foreign Update on public.async_p2 async_pt_2
+     Remote SQL: UPDATE public.base_tbl2 SET c = $2 WHERE ctid = $1 RETURNING a, b, c
    Update on public.async_p3 async_pt_3
    ->  Append
-         ->  Foreign Update on public.async_p1 async_pt_1
-               Remote SQL: UPDATE public.base_tbl1 SET c = (c || c) WHERE ((b = 0)) RETURNING a, b, c
-         ->  Foreign Update on public.async_p2 async_pt_2
-               Remote SQL: UPDATE public.base_tbl2 SET c = (c || c) WHERE ((b = 0)) RETURNING a, b, c
+         ->  Async Foreign Scan on public.async_p1 async_pt_1
+               Output: ((async_pt_1.c)::text || (async_pt_1.c)::text), async_pt_1.tableoid, async_pt_1.ctid, async_pt_1.*
+               Filter: (async_pt_1.b = '0'::number)
+               Remote SQL: SELECT a, b, c, ctid FROM public.base_tbl1 FOR UPDATE
+         ->  Async Foreign Scan on public.async_p2 async_pt_2
+               Output: ((async_pt_2.c)::text || (async_pt_2.c)::text), async_pt_2.tableoid, async_pt_2.ctid, async_pt_2.*
+               Filter: (async_pt_2.b = '0'::number)
+               Remote SQL: SELECT a, b, c, ctid FROM public.base_tbl2 FOR UPDATE
          ->  Seq Scan on public.async_p3 async_pt_3
-               Output: (async_pt_3.c || async_pt_3.c), async_pt_3.tableoid, async_pt_3.ctid, NULL::record
-               Filter: (async_pt_3.b = 0)
-(13 rows)
+               Output: ((async_pt_3.c)::text || (async_pt_3.c)::text), async_pt_3.tableoid, async_pt_3.ctid, NULL::record
+               Filter: (async_pt_3.b = '0'::number)
+(19 rows)
 
 UPDATE async_pt SET c = c || c WHERE b = 0 RETURNING *;
   a   | b |    c     
 ------+---+----------
+ 3000 | 0 | 00000000
  1000 | 0 | 00000000
  2000 | 0 | 00000000
- 3000 | 0 | 00000000
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM async_pt WHERE b = 0 RETURNING *;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Delete on public.async_pt
    Output: async_pt_1.a, async_pt_1.b, async_pt_1.c
    Foreign Delete on public.async_p1 async_pt_1
+     Remote SQL: DELETE FROM public.base_tbl1 WHERE ctid = $1 RETURNING a, b, c
    Foreign Delete on public.async_p2 async_pt_2
+     Remote SQL: DELETE FROM public.base_tbl2 WHERE ctid = $1 RETURNING a, b, c
    Delete on public.async_p3 async_pt_3
    ->  Append
-         ->  Foreign Delete on public.async_p1 async_pt_1
-               Remote SQL: DELETE FROM public.base_tbl1 WHERE ((b = 0)) RETURNING a, b, c
-         ->  Foreign Delete on public.async_p2 async_pt_2
-               Remote SQL: DELETE FROM public.base_tbl2 WHERE ((b = 0)) RETURNING a, b, c
+         ->  Async Foreign Scan on public.async_p1 async_pt_1
+               Output: async_pt_1.tableoid, async_pt_1.ctid
+               Filter: (async_pt_1.b = '0'::number)
+               Remote SQL: SELECT b, ctid FROM public.base_tbl1 FOR UPDATE
+         ->  Async Foreign Scan on public.async_p2 async_pt_2
+               Output: async_pt_2.tableoid, async_pt_2.ctid
+               Filter: (async_pt_2.b = '0'::number)
+               Remote SQL: SELECT b, ctid FROM public.base_tbl2 FOR UPDATE
          ->  Seq Scan on public.async_p3 async_pt_3
                Output: async_pt_3.tableoid, async_pt_3.ctid
-               Filter: (async_pt_3.b = 0)
-(13 rows)
+               Filter: (async_pt_3.b = '0'::number)
+(19 rows)
 
 DELETE FROM async_pt WHERE b = 0 RETURNING *;
   a   | b |    c     
 ------+---+----------
+ 3000 | 0 | 00000000
  1000 | 0 | 00000000
  2000 | 0 | 00000000
- 3000 | 0 | 00000000
 (3 rows)
 
 -- Check EXPLAIN ANALYZE for a query that scans empty partitions asynchronously
@@ -11609,9 +12838,9 @@ DROP TABLE result_tbl;
 DROP TABLE join_tbl;
 -- Test that an asynchronous fetch is processed before restarting the scan in
 -- ReScanForeignScan
-CREATE TABLE base_tbl (a int, b int);
+CREATE TABLE base_tbl (a number(38,0), b number(38,0));
 INSERT INTO base_tbl VALUES (1, 11), (2, 22), (3, 33);
-CREATE FOREIGN TABLE foreign_tbl (b int)
+CREATE FOREIGN TABLE foreign_tbl (b number(38,0))
   SERVER loopback OPTIONS (table_name 'base_tbl');
 CREATE FOREIGN TABLE foreign_tbl2 () INHERITS (foreign_tbl)
   SERVER loopback OPTIONS (table_name 'base_tbl');
@@ -11658,11 +12887,11 @@ CREATE SERVER inv_scst FOREIGN DATA WRAPPER postgres_fdw
 	OPTIONS(fdw_tuple_cost '100$%$#$#');
 ERROR:  invalid value for floating point option "fdw_tuple_cost": 100$%$#$#
 -- Invalid fetch_size option
-CREATE FOREIGN TABLE inv_fsz (c1 int )
+CREATE FOREIGN TABLE inv_fsz (c1 number(38,0) )
 	SERVER loopback OPTIONS (fetch_size '100$%$#$#');
 ERROR:  invalid value for integer option "fetch_size": 100$%$#$#
 -- Invalid batch_size option
-CREATE FOREIGN TABLE inv_bsz (c1 int )
+CREATE FOREIGN TABLE inv_bsz (c1 number(38,0) )
 	SERVER loopback OPTIONS (batch_size '100$%$#$#');
 ERROR:  invalid value for integer option "batch_size": 100$%$#$#
 -- No option is allowed to be specified at foreign data wrapper level
@@ -11676,7 +12905,7 @@ HINT:  There are no valid options in this context.
 -- use this view to make the remote session itself read its application_name.
 CREATE VIEW my_application_name AS
   SELECT application_name FROM pg_stat_activity WHERE pid = pg_backend_pid();
-CREATE FOREIGN TABLE remote_application_name (application_name text)
+CREATE FOREIGN TABLE remote_application_name (application_name varchar2(1024))
   SERVER loopback2
   OPTIONS (schema_name 'public', table_name 'my_application_name');
 SELECT count(*) FROM remote_application_name;
@@ -11698,7 +12927,7 @@ ALTER SERVER loopback2 OPTIONS (application_name 'fdw_%d%p');
 SELECT count(*) FROM remote_application_name
   WHERE application_name =
     substring('fdw_' || current_database() || pg_backend_pid() for
-      current_setting('max_identifier_length')::int);
+      current_setting('max_identifier_length')::number(38,0));
  count 
 -------
      1
@@ -11711,7 +12940,7 @@ SET postgres_fdw.application_name TO 'fdw_%a%u%%';
 SELECT count(*) FROM remote_application_name
   WHERE application_name =
     substring('fdw_' || current_setting('application_name') ||
-      CURRENT_USER || '%' for current_setting('max_identifier_length')::int);
+      CURRENT_USER || '%' for current_setting('max_identifier_length')::number(38,0));
  count 
 -------
      1
@@ -11742,11 +12971,11 @@ ALTER SERVER loopback OPTIONS (ADD parallel_commit 'true');
 ALTER SERVER loopback OPTIONS (ADD parallel_abort 'true');
 ALTER SERVER loopback2 OPTIONS (ADD parallel_commit 'true');
 ALTER SERVER loopback2 OPTIONS (ADD parallel_abort 'true');
-CREATE TABLE ploc1 (f1 int, f2 text);
-CREATE FOREIGN TABLE prem1 (f1 int, f2 text)
+CREATE TABLE ploc1 (f1 number(38,0), f2 varchar2(1024));
+CREATE FOREIGN TABLE prem1 (f1 number(38,0), f2 varchar2(1024))
   SERVER loopback OPTIONS (table_name 'ploc1');
-CREATE TABLE ploc2 (f1 int, f2 text);
-CREATE FOREIGN TABLE prem2 (f1 int, f2 text)
+CREATE TABLE ploc2 (f1 number(38,0), f2 varchar2(1024));
+CREATE FOREIGN TABLE prem2 (f1 number(38,0), f2 varchar2(1024))
   SERVER loopback2 OPTIONS (table_name 'ploc2');
 BEGIN;
 INSERT INTO prem1 VALUES (101, 'foo');
@@ -11865,8 +13094,8 @@ ALTER SERVER loopback2 OPTIONS (DROP parallel_abort);
 -- ===================================================================
 -- test for ANALYZE sampling
 -- ===================================================================
-CREATE TABLE analyze_table (id int, a text, b bigint);
-CREATE FOREIGN TABLE analyze_ftable (id int, a text, b bigint)
+CREATE TABLE analyze_table (id number(38,0), a varchar2(1024), b bigint);
+CREATE FOREIGN TABLE analyze_ftable (id number(38,0), a varchar2(1024), b bigint)
        SERVER loopback OPTIONS (table_name 'analyze_rtable1');
 INSERT INTO analyze_table (SELECT x FROM generate_series(1,1000) x);
 ANALYZE analyze_table;

--- a/contrib/xml2/expected/ivy_xml2_1.out
+++ b/contrib/xml2/expected/ivy_xml2_1.out
@@ -1,0 +1,170 @@
+CREATE EXTENSION xml2;
+set ivorysql.enable_emptystring_to_null to off;
+select query_to_xml('select 1 as x',true,false,'');
+                         query_to_xml                          
+---------------------------------------------------------------
+ <table xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">+
+                                                              +
+ <row>                                                        +
+   <x>1</x>                                                   +
+ </row>                                                       +
+                                                              +
+ </table>                                                     +
+ 
+(1 row)
+
+select xslt_process( query_to_xml('select x from generate_series(1,5) as
+x',true,false,'')::text,
+$$<xsl:stylesheet version="1.0"
+               xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml" indent="yes" />
+<xsl:template match="*">
+  <xsl:copy>
+     <xsl:copy-of select="@*" />
+     <xsl:apply-templates />
+  </xsl:copy>
+</xsl:template>
+<xsl:template match="comment()|processing-instruction()">
+  <xsl:copy />
+</xsl:template>
+</xsl:stylesheet>
+$$::text);
+ERROR:  xslt_process() is not available without libxslt
+CREATE TABLE xpath_test (id integer NOT NULL, t xml);
+INSERT INTO xpath_test VALUES (1, '<doc><int>1</int></doc>');
+SELECT * FROM xpath_table('id', 't', 'xpath_test', '/doc/int', 'true')
+as t(id int4);
+ id 
+----
+(0 rows)
+
+SELECT * FROM xpath_table('id', 't', 'xpath_test', '/doc/int', 'true')
+as t(id int4, doc int4);
+ id | doc 
+----+-----
+  1 |   1
+(1 row)
+
+DROP TABLE xpath_test;
+CREATE TABLE xpath_test (id integer NOT NULL, t text);
+INSERT INTO xpath_test VALUES (1, '<doc><int>1</int></doc>');
+SELECT * FROM xpath_table('id', 't', 'xpath_test', '/doc/int', 'true')
+as t(id int4);
+ id 
+----
+(0 rows)
+
+SELECT * FROM xpath_table('id', 't', 'xpath_test', '/doc/int', 'true')
+as t(id int4, doc int4);
+ id | doc 
+----+-----
+  1 |   1
+(1 row)
+
+create table articles (article_id integer, article_xml xml, date_entered pg_catalog.date);
+insert into articles (article_id, article_xml, date_entered)
+values (2, '<article><author>test</author><pages>37</pages></article>', now());
+SELECT * FROM
+xpath_table('article_id',
+            'article_xml',
+            'articles',
+            '/article/author|/article/pages|/article/title',
+            'date_entered > ''2003-01-01'' ')
+AS t(article_id integer, author text, page_count integer, title text);
+ article_id | author | page_count | title 
+------------+--------+------------+-------
+          2 | test   |         37 | 
+(1 row)
+
+-- this used to fail when invoked a second time
+select xslt_process('<aaa/>',$$<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:template match="@*|node()">
+      <xsl:copy>
+         <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+   </xsl:template>
+</xsl:stylesheet>$$)::xml;
+ERROR:  xslt_process() is not available without libxslt
+select xslt_process('<aaa/>',$$<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:template match="@*|node()">
+      <xsl:copy>
+         <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+   </xsl:template>
+</xsl:stylesheet>$$)::xml;
+ERROR:  xslt_process() is not available without libxslt
+create table t1 (id integer, xml_data xml);
+insert into t1 (id, xml_data)
+values
+(1, '<attributes><attribute name="attr_1">Some
+Value</attribute></attributes>');
+create index idx_xpath on t1 ( xpath_string
+('/attributes/attribute[@name="attr_1"]/text()', xml_data::text));
+SELECT xslt_process('<employee><name>cim</name><age>30</age><pay>400</pay></employee>'::text, $$<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="xml" omit-xml-declaration="yes" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+  <xsl:param name="n1"/>
+  <xsl:param name="n2"/>
+  <xsl:param name="n3"/>
+  <xsl:param name="n4"/>
+  <xsl:param name="n5" select="'me'"/>
+  <xsl:template match="*">
+    <xsl:element name="samples">
+      <xsl:element name="sample">
+        <xsl:value-of select="$n1"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n2"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n3"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n4"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n5"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n6"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n7"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n8"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n9"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n10"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n11"/>
+      </xsl:element>
+      <xsl:element name="sample">
+        <xsl:value-of select="$n12"/>
+      </xsl:element>
+    </xsl:element>
+  </xsl:template>
+</xsl:stylesheet>$$::text, 'n1="v1",n2="v2",n3="v3",n4="v4",n5="v5",n6="v6",n7="v7",n8="v8",n9="v9",n10="v10",n11="v11",n12="v12"'::text);
+ERROR:  xslt_process() is not available without libxslt
+-- possible security exploit
+SELECT xslt_process('<xml><foo>Hello from XML</foo></xml>',
+$$<xsl:stylesheet version="1.0"
+      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+      xmlns:sax="http://icl.com/saxon"
+      extension-element-prefixes="sax">
+
+  <xsl:template match="//foo">
+    <sax:output href="0wn3d.txt" method="text">
+      <xsl:value-of select="'0wn3d via xml2 extension and libxslt'"/>
+      <xsl:apply-templates/>
+    </sax:output>
+  </xsl:template>
+</xsl:stylesheet>$$);
+ERROR:  xslt_process() is not available without libxslt
+reset ivorysql.enable_emptystring_to_null;


### PR DESCRIPTION
add compatible test case in extension


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added two new functions `sys.ltree2varchar2` and `sys.varchar22ltree` for converting between `ltree` and `text` data types.
- Refactor: Updated the data types of columns in various foreign tables to `number(38,0)` and `binary_float`.
- Refactor: Modified the `ORA_REGRESS` variable in the Makefile for Oracle compatibility.
- Test: Added SQL statements for creating tables, inserting data, creating indexes, and performing various queries on the tables. Included tests for different scenarios and operations on BRIN (Block Range INdex) indexes.
- Test: Created a series of SQL statements related to testing an old extension version.
- Bug Fix: Improved error handling for unsupported relation types in the pg_visibility module.
- Chore: Updated configuration parameter `ivorysql.enable_emptystring_to_null` to `off`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->