### PR TITLE
change the Modify file:*.po encoding format

### DIFF
--- a/src/pl/plisql/src/po/ja.po
+++ b/src/pl/plisql/src/po/ja.po
@@ -1,13 +1,13 @@
-# Japanese message translation file for plisql
+# Japanese message translation file for plpgsql
 # Copyright (C) 2022 PostgreSQL Global Development Group
 # This file is distributed under the same license as the pg_archivecleanup (PostgreSQL) package.
 # HOTTA Michihde <hotta@net-newbie.com>, 2013
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: plisql (PostgreSQL 15)\n"
+"Project-Id-Version: plpgsql (PostgreSQL 16)\n"
 "Report-Msgid-Bugs-To: pgsql-bugs@lists.postgresql.org\n"
-"POT-Creation-Date: 2022-05-11 14:17+0900\n"
+"POT-Creation-Date: 2022-07-14 10:48+0900\n"
 "PO-Revision-Date: 2022-05-11 13:52+0900\n"
 "Last-Translator: Kyotaro Horiguchi <horikyota.ntt@gmail.com>\n"
 "Language-Team: jpug-doc <jpug-doc@ml.postgresql.jp>\n"
@@ -21,7 +21,7 @@ msgstr ""
 #: pl_comp.c:438 pl_handler.c:496
 #, c-format
 msgid "PL/iSQL functions cannot accept type %s"
-msgstr "PL/iSQL 関数では %s 型は指定できませ�?
+msgstr "PL/iSQL 関数では %s 型は指定できません"
 
 #: pl_comp.c:530
 #, c-format
@@ -31,47 +31,47 @@ msgstr "多相関数\"%s\"の実際の戻り値の型を特定できませんで
 #: pl_comp.c:560
 #, c-format
 msgid "trigger functions can only be called as triggers"
-msgstr "トリガー関数はトリガーとしてのみコールできま�?
+msgstr "トリガー関数はトリガーとしてのみコールできます"
 
 #: pl_comp.c:564 pl_handler.c:480
 #, c-format
 msgid "PL/iSQL functions cannot return type %s"
-msgstr "PL/iSQL 関数�?%s 型を返せませ�?
+msgstr "PL/iSQL 関数は %s 型を返せません"
 
 #: pl_comp.c:604
 #, c-format
 msgid "trigger functions cannot have declared arguments"
-msgstr "トリガー関数には引数を宣言できませ�?
+msgstr "トリガー関数には引数を宣言できません"
 
 #: pl_comp.c:605
 #, c-format
 msgid "The arguments of the trigger can be accessed through TG_NARGS and TG_ARGV instead."
-msgstr "その代わり、トリガーの引数には TG_NARGS �?TG_ARGV を通してのみアクセスできま�?
+msgstr "その代わり、トリガーの引数には TG_NARGS と TG_ARGV を通してのみアクセスできます"
 
 #: pl_comp.c:738
 #, c-format
 msgid "event trigger functions cannot have declared arguments"
-msgstr "イベントトリガー関数では引数を宣言できませ�?
+msgstr "イベントトリガー関数では引数を宣言できません"
 
 #: pl_comp.c:1002
 #, c-format
 msgid "compilation of PL/iSQL function \"%s\" near line %d"
-msgstr "PL/iSQL 関数 \"%s\" �?%d 行目付近でのコンパイ�?
+msgstr "PL/iSQL関数\"%s\"の%d行目付近でのコンパイル"
 
 #: pl_comp.c:1025
 #, c-format
 msgid "parameter name \"%s\" used more than once"
-msgstr "パラメー�?\"%s\" が複数指定されました"
+msgstr "パラメータ \"%s\" が複数指定されました"
 
 #: pl_comp.c:1139
 #, c-format
 msgid "column reference \"%s\" is ambiguous"
-msgstr "列参�?\"%s\" が一意に特定できませ�?
+msgstr "列参照 \"%s\" が一意に特定できません"
 
 #: pl_comp.c:1141
 #, c-format
 msgid "It could refer to either a PL/iSQL variable or a table column."
-msgstr "PL/iSQL 変数もしくはテーブルのカラム名のどちらかを参照していた可能性があります�?
+msgstr "PL/iSQL 変数もしくはテーブルのカラム名のどちらかを参照していた可能性があります。"
 
 #: pl_comp.c:1324 pl_exec.c:5234 pl_exec.c:5407 pl_exec.c:5494 pl_exec.c:5585
 #: pl_exec.c:6606
@@ -97,12 +97,12 @@ msgstr "変数 \"%s\" の型は擬似タイプ %s です"
 #: pl_comp.c:2122
 #, c-format
 msgid "type \"%s\" is only a shell"
-msgstr "�?\"%s\" はシェルでのみ使えま�?
+msgstr "型 \"%s\" はシェルでのみ使えます"
 
 #: pl_comp.c:2204 pl_exec.c:6907
 #, c-format
 msgid "type %s is not composite"
-msgstr "�?sは複合型ではありませ�?
+msgstr "型%sは複合型ではありません"
 
 #: pl_comp.c:2252 pl_comp.c:2305
 #, c-format
@@ -112,7 +112,7 @@ msgstr "例外条件 \"%s\" が認識できません"
 #: pl_comp.c:2526
 #, c-format
 msgid "could not determine actual argument type for polymorphic function \"%s\""
-msgstr "多相関数\"%s\"の実際の引数の型を特定できませんでし�?
+msgstr "多相関数\"%s\"の実際の引数の型を特定できませんでした"
 
 #: pl_exec.c:501 pl_exec.c:940 pl_exec.c:1175
 msgid "during initialization of execution state"
@@ -120,7 +120,7 @@ msgstr "実行状態の初期化の際"
 
 #: pl_exec.c:507
 msgid "while storing call arguments into local variables"
-msgstr "引数をローカル変数に格納する�?
+msgstr "引数をローカル変数に格納する際"
 
 #: pl_exec.c:595 pl_exec.c:1013
 msgid "during function entry"
@@ -138,20 +138,20 @@ msgstr "戻り値を関数の戻り値の型へキャストする際に"
 #: pl_exec.c:636 pl_exec.c:3665
 #, c-format
 msgid "set-valued function called in context that cannot accept a set"
-msgstr "値の集合を受け付けないようなコンテキストで、集合値を返す関数が呼ばれまし�?
+msgstr "値の集合を受け付けないようなコンテキストで、集合値を返す関数が呼ばれました"
 
 #: pl_exec.c:641 pl_exec.c:3671
 #, c-format
 msgid "materialize mode required, but it is not allowed in this context"
-msgstr "マテリアライズモードが必要ですが、現在のコンテクストで禁止されていま�?
+msgstr "マテリアライズモードが必要ですが、現在のコンテクストで禁止されています"
 
 #: pl_exec.c:768 pl_exec.c:1039 pl_exec.c:1197
 msgid "during function exit"
-msgstr "関数を抜ける�?
+msgstr "関数を抜ける際"
 
 #: pl_exec.c:823 pl_exec.c:887 pl_exec.c:3464
 msgid "returned record type does not match expected record type"
-msgstr "返されたレコードの型が期待するレコードの型と一致しませ�?
+msgstr "返されたレコードの型が期待するレコードの型と一致しません"
 
 #: pl_exec.c:1036 pl_exec.c:1194
 #, c-format
@@ -165,7 +165,7 @@ msgstr "トリガー手続きは集合値を返すことができません"
 
 #: pl_exec.c:1083 pl_exec.c:1111
 msgid "returned row structure does not match the structure of the triggering table"
-msgstr "返された行の構造が、トリガーしているテーブルの構造とマッチしませ�?
+msgstr "返された行の構造が、トリガーしているテーブルの構造とマッチしません"
 
 #. translator: last %s is a phrase such as "during statement block
 #. local variable initialization"
@@ -173,7 +173,7 @@ msgstr "返された行の構造が、トリガーしているテーブルの構
 #: pl_exec.c:1252
 #, c-format
 msgid "PL/iSQL function %s line %d %s"
-msgstr "PL/iSQL関数%s�?d行目 %s"
+msgstr "PL/iSQL関数%sの%d行目 %s"
 
 #. translator: last %s is a phrase such as "while storing call
 #. arguments into local variables"
@@ -183,20 +183,20 @@ msgstr "PL/iSQL関数%s�?d行目 %s"
 msgid "PL/iSQL function %s %s"
 msgstr "PL/iSQL関数%s - %s"
 
-#. translator: last %s is a plisql statement type name
+#. translator: last %s is a plpgsql statement type name
 #: pl_exec.c:1271
 #, c-format
 msgid "PL/iSQL function %s line %d at %s"
-msgstr "PL/iSQL関数%s�?d行目 - %s"
+msgstr "PL/iSQL関数%sの%d行目 - %s"
 
 #: pl_exec.c:1277
 #, c-format
-msgid "PL/iSQL function %s"
-msgstr "PL/iSQL関数 %s"
+msgid "PL/pgSQL function %s"
+msgstr "PL/pgSQL関数 %s"
 
 #: pl_exec.c:1648
 msgid "during statement block local variable initialization"
-msgstr "ステートメントブロックでローカル変数を初期化�?
+msgstr "ステートメントブロックでローカル変数を初期化中"
 
 #: pl_exec.c:1753
 msgid "during statement block entry"
@@ -204,7 +204,7 @@ msgstr "ステートメントブロックに入る際に"
 
 #: pl_exec.c:1785
 msgid "during statement block exit"
-msgstr "ステートメントブロックを抜ける際�?
+msgstr "ステートメントブロックを抜ける際に"
 
 #: pl_exec.c:1823
 msgid "during exception cleanup"
@@ -238,27 +238,27 @@ msgstr "CASE ステートメントに ELSE 部分がありません"
 #: pl_exec.c:2693
 #, c-format
 msgid "lower bound of FOR loop cannot be null"
-msgstr "FOR ループの下限�?NULL にすることはできませ�?
+msgstr "FOR ループの下限を NULL にすることはできません"
 
 #: pl_exec.c:2709
 #, c-format
 msgid "upper bound of FOR loop cannot be null"
-msgstr "FOR ループの上限�?NULL にすることはできませ�?
+msgstr "FOR ループの上限を NULL にすることはできません"
 
 #: pl_exec.c:2727
 #, c-format
 msgid "BY value of FOR loop cannot be null"
-msgstr "FOR ループにおけ�?BY の値を NULL にすることはできませ�?
+msgstr "FOR ループにおける BY の値を NULL にすることはできません"
 
 #: pl_exec.c:2733
 #, c-format
 msgid "BY value of FOR loop must be greater than zero"
-msgstr "FOR ループにおけ�?BY の値はゼロより大きくなければなりません"
+msgstr "FOR ループにおける BY の値はゼロより大きくなければなりません"
 
 #: pl_exec.c:2867 pl_exec.c:4667
 #, c-format
 msgid "cursor \"%s\" already in use"
-msgstr "カーソル \"%s\" はすでに使われていま�?
+msgstr "カーソル \"%s\" はすでに使われています"
 
 #: pl_exec.c:2890 pl_exec.c:4737
 #, c-format
@@ -268,7 +268,7 @@ msgstr "引数なしのカーソルに引数が与えられました"
 #: pl_exec.c:2909 pl_exec.c:4756
 #, c-format
 msgid "arguments required for cursor"
-msgstr "カーソルには引数が必要で�?
+msgstr "カーソルには引数が必要です"
 
 #: pl_exec.c:3000
 #, c-format
@@ -283,56 +283,56 @@ msgstr "FOREACH 式は %s 型ではなく配列を生成しなければなりま
 #: pl_exec.c:3032
 #, c-format
 msgid "slice dimension (%d) is out of the valid range 0..%d"
-msgstr "配列の要素数 (%d) が有効範�?から%dまでの間にありません"
+msgstr "配列の要素数 (%d) が有効範囲0から%dまでの間にありません"
 
 #: pl_exec.c:3059
 #, c-format
 msgid "FOREACH ... SLICE loop variable must be of an array type"
-msgstr "FOREACH ... SLICE ループ変数は配列型でなければなりませ�?
+msgstr "FOREACH ... SLICE ループ変数は配列型でなければなりません"
 
 #: pl_exec.c:3063
 #, c-format
 msgid "FOREACH loop variable must not be of an array type"
-msgstr "FOREACH ループ変数は配列型であってはなりませ�?
+msgstr "FOREACH ループ変数は配列型であってはなりません"
 
 #: pl_exec.c:3225 pl_exec.c:3282 pl_exec.c:3457
 #, c-format
 msgid "cannot return non-composite value from function returning composite type"
 msgstr "複合型を返す関数から複合型以外の値を返すことはできません"
 
-#: pl_exec.c:3321 pl_gram.y:3318
+#: pl_exec.c:3321 pl_gram.y:3319
 #, c-format
 msgid "cannot use RETURN NEXT in a non-SETOF function"
-msgstr "SETOF でない関数で�?RETURN NEXT は使えません"
+msgstr "SETOF でない関数では RETURN NEXT は使えません"
 
 #: pl_exec.c:3362 pl_exec.c:3494
 #, c-format
 msgid "wrong result type supplied in RETURN NEXT"
-msgstr "RETURN NEXT で指定されている結果の型が誤っていま�?
+msgstr "RETURN NEXT で指定されている結果の型が誤っています"
 
 #: pl_exec.c:3400 pl_exec.c:3421
 #, c-format
 msgid "wrong record type supplied in RETURN NEXT"
-msgstr "RETURN NEXT で指定されているレコードの型が誤っていま�?
+msgstr "RETURN NEXT で指定されているレコードの型が誤っています"
 
 #: pl_exec.c:3513
 #, c-format
 msgid "RETURN NEXT must have a parameter"
-msgstr "RETURN NEXT にはパラメーターが必要で�?
+msgstr "RETURN NEXT にはパラメーターが必要です"
 
-#: pl_exec.c:3541 pl_gram.y:3382
+#: pl_exec.c:3541 pl_gram.y:3383
 #, c-format
 msgid "cannot use RETURN QUERY in a non-SETOF function"
-msgstr "SETOF でない関数で�?RETURN QUERY は使えません"
+msgstr "SETOF でない関数では RETURN QUERY は使えません"
 
 #: pl_exec.c:3559
 msgid "structure of query does not match function result type"
-msgstr "問い合わせの構造が関数の結果の型と一致しませ�?
+msgstr "問い合わせの構造が関数の結果の型と一致しません"
 
 #: pl_exec.c:3614 pl_exec.c:4444 pl_exec.c:8685
 #, c-format
 msgid "query string argument of EXECUTE is null"
-msgstr "EXECUTE の問い合わせ文字列の引数�?NULL です"
+msgstr "EXECUTE の問い合わせ文字列の引数が NULL です"
 
 #: pl_exec.c:3699 pl_exec.c:3837
 #, c-format
@@ -342,12 +342,12 @@ msgstr "RAISE オプションは既に指定されています: %s"
 #: pl_exec.c:3733
 #, c-format
 msgid "RAISE without parameters cannot be used outside an exception handler"
-msgstr "引数の無�?RAISE は、例外ハンドラの外では使えません"
+msgstr "引数の無い RAISE は、例外ハンドラの外では使えません"
 
 #: pl_exec.c:3827
 #, c-format
 msgid "RAISE statement option cannot be null"
-msgstr "RAISE ステートメントのオプションに�?NULL は指定できません"
+msgstr "RAISE ステートメントのオプションには NULL は指定できません"
 
 #: pl_exec.c:3897
 #, c-format
@@ -357,22 +357,22 @@ msgstr "%s"
 #: pl_exec.c:3952
 #, c-format
 msgid "assertion failed"
-msgstr "アサーションに失�?
+msgstr "アサーションに失敗"
 
 #: pl_exec.c:4317 pl_exec.c:4506
 #, c-format
 msgid "cannot COPY to/from client in PL/iSQL"
-msgstr "PL/iSQL 内で�?COPY to/from クライアントは使えません"
+msgstr "PL/iSQL内では COPY to/from クライアントは使えません"
 
 #: pl_exec.c:4323
 #, c-format
 msgid "unsupported transaction command in PL/iSQL"
-msgstr "PL/iSQL 内ではサポートされないトランザクションコマン�?
+msgstr "PL/iSQL内ではサポートされないトランザクションコマンド"
 
 #: pl_exec.c:4346 pl_exec.c:4535
 #, c-format
 msgid "INTO used with a command that cannot return data"
-msgstr "データを返せないコマンド�?INTO が使われまし�?
+msgstr "データを返せないコマンドで INTO が使われました"
 
 #: pl_exec.c:4369 pl_exec.c:4558
 #, c-format
@@ -387,27 +387,27 @@ msgstr "問い合わせが複数の行を返しました"
 #: pl_exec.c:4393
 #, c-format
 msgid "Make sure the query returns a single row, or use LIMIT 1."
-msgstr "問い合わせを1行返却するようにするか、LIMIT 1 をつけてください�?
+msgstr "問い合わせを1行返却するようにするか、LIMIT 1 をつけてください。"
 
 #: pl_exec.c:4409
 #, c-format
 msgid "query has no destination for result data"
-msgstr "問い合わせに結果データの返却先が指定されていませ�?
+msgstr "問い合わせに結果データの返却先が指定されていません"
 
 #: pl_exec.c:4410
 #, c-format
 msgid "If you want to discard the results of a SELECT, use PERFORM instead."
-msgstr "SELECT の結果を破棄したい場合、代わり�?PERFORM を使ってください"
+msgstr "SELECT の結果を破棄したい場合、代わりに PERFORM を使ってください"
 
 #: pl_exec.c:4498
 #, c-format
 msgid "EXECUTE of SELECT ... INTO is not implemented"
-msgstr "SELECT ... INTO �?EXECUTE は実装されていません"
+msgstr "SELECT ... INTO の EXECUTE は実装されていません"
 
 #: pl_exec.c:4499
 #, c-format
 msgid "You might want to use EXECUTE ... INTO or EXECUTE CREATE TABLE ... AS instead."
-msgstr "代わりに EXECUTE ... INTO また�?EXECUTE CREATE TABLE ... AS が使えます�?
+msgstr "代わりに EXECUTE ... INTO または EXECUTE CREATE TABLE ... AS が使えます。"
 
 #: pl_exec.c:4512
 #, c-format
@@ -417,27 +417,27 @@ msgstr "トランザクションコマンドのEXECUTEは実装されていま�
 #: pl_exec.c:4822 pl_exec.c:4910
 #, c-format
 msgid "cursor variable \"%s\" is null"
-msgstr "カーソル変数 \"%s\" �?NULL です"
+msgstr "カーソル変数 \"%s\" が NULL です"
 
 #: pl_exec.c:4833 pl_exec.c:4921
 #, c-format
 msgid "cursor \"%s\" does not exist"
-msgstr "カーソル \"%s\" は存在しませ�?
+msgstr "カーソル \"%s\" は存在しません"
 
 #: pl_exec.c:4846
 #, c-format
 msgid "relative or absolute cursor position is null"
-msgstr "相対もしくは絶対カーソル位置�?NULL です"
+msgstr "相対もしくは絶対カーソル位置が NULL です"
 
 #: pl_exec.c:5084 pl_exec.c:5179
 #, c-format
 msgid "null value cannot be assigned to variable \"%s\" declared NOT NULL"
-msgstr "NOT NULL として宣言された変�?\"%s\" には NULL を代入できません"
+msgstr "NOT NULL として宣言された変数 \"%s\" には NULL を代入できません"
 
 #: pl_exec.c:5160
 #, c-format
 msgid "cannot assign non-composite value to a row variable"
-msgstr "複合型でない値を行変数に代入できませ�?
+msgstr "複合型でない値を行変数に代入できません"
 
 #: pl_exec.c:5192
 #, c-format
@@ -457,13 +457,13 @@ msgstr "問い合わせがデータを返しませんでした"
 #: pl_exec.c:5693 pl_exec.c:5705 pl_exec.c:5730 pl_exec.c:5806 pl_exec.c:5811
 #, c-format
 msgid "query: %s"
-msgstr "問い合わ�? %s"
+msgstr "問い合わせ: %s"
 
 #: pl_exec.c:5701
 #, c-format
 msgid "query returned %d column"
 msgid_plural "query returned %d columns"
-msgstr[0] "問い合わせが%d個の列を返しまし�?
+msgstr[0] "問い合わせが%d個の列を返しました"
 
 #: pl_exec.c:5805
 #, c-format
@@ -473,47 +473,47 @@ msgstr "問い合わせはSELECT INTOですが、単純なSELECTでなければ�
 #: pl_exec.c:5810
 #, c-format
 msgid "query is not a SELECT"
-msgstr "問い合わせがSELECTではありませ�?
+msgstr "問い合わせがSELECTではありません"
 
 #: pl_exec.c:6620 pl_exec.c:6660 pl_exec.c:6700
 #, c-format
 msgid "type of parameter %d (%s) does not match that when preparing the plan (%s)"
-msgstr "パラメータの�?d(%s)が実行計�?%s)を準備する時点と一致しませ�?
+msgstr "パラメータの型%d(%s)が実行計画(%s)を準備する時点と一致しません"
 
 #: pl_exec.c:7111 pl_exec.c:7145 pl_exec.c:7219 pl_exec.c:7245
 #, c-format
 msgid "number of source and target fields in assignment does not match"
-msgstr "代入のソースとターゲットのフィールド数が一致していませ�?
+msgstr "代入のソースとターゲットのフィールド数が一致していません"
 
 #. translator: %s represents a name of an extra check
 #: pl_exec.c:7113 pl_exec.c:7147 pl_exec.c:7221 pl_exec.c:7247
 #, c-format
 msgid "%s check of %s is active."
-msgstr "%2$s�?1$sチェックが有効です�?
+msgstr "%2$sの%1$sチェックが有効です。"
 
 #: pl_exec.c:7117 pl_exec.c:7151 pl_exec.c:7225 pl_exec.c:7251
 #, c-format
 msgid "Make sure the query returns the exact list of columns."
-msgstr "問い合わせはカラムの正確なリストを返却するようにしてください�?
+msgstr "問い合わせはカラムの正確なリストを返却するようにしてください。"
 
 #: pl_exec.c:7638
 #, c-format
 msgid "record \"%s\" is not assigned yet"
-msgstr "レコード \"%s\" にはまだ値が代入されていませ�?
+msgstr "レコード \"%s\" にはまだ値が代入されていません"
 
 #: pl_exec.c:7639
 #, c-format
 msgid "The tuple structure of a not-yet-assigned record is indeterminate."
 msgstr "まだ代入されていないレコードのタプル構造は不定です"
 
-#: pl_exec.c:8283 pl_gram.y:3441
+#: pl_exec.c:8283 pl_gram.y:3442
 #, c-format
 msgid "variable \"%s\" is declared CONSTANT"
-msgstr "変数\"%s\" はCONSTANTとして定義されていま�?
+msgstr "変数\"%s\" はCONSTANTとして定義されています"
 
 #: pl_funcs.c:237
 msgid "statement block"
-msgstr "ステートメントブロッ�?
+msgstr "ステートメントブロック"
 
 #: pl_funcs.c:239
 msgid "assignment"
@@ -525,7 +525,7 @@ msgstr "整数のループ変数を使った FOR"
 
 #: pl_funcs.c:251
 msgid "FOR over SELECT rows"
-msgstr "SELECT 行を使っ�?FOR"
+msgstr "SELECT 行を使った FOR"
 
 #: pl_funcs.c:253
 msgid "FOR over cursor"
@@ -533,308 +533,308 @@ msgstr "カーソルを使った FOR"
 
 #: pl_funcs.c:255
 msgid "FOREACH over array"
-msgstr "配列を巡回す�?FOREACH"
+msgstr "配列を巡回する FOREACH"
 
 #: pl_funcs.c:269
 msgid "SQL statement"
-msgstr "SQL ステートメン�?
+msgstr "SQL ステートメント"
 
 #: pl_funcs.c:273
 msgid "FOR over EXECUTE statement"
-msgstr "EXECUTE ステートメントを使っ�?FOR"
+msgstr "EXECUTE ステートメントを使った FOR"
 
-#: pl_gram.y:486
+#: pl_gram.y:487
 #, c-format
 msgid "block label must be placed before DECLARE, not after"
-msgstr "ブロックラベルは DECLARE の後ではなく前に置かなければなりませ�?
+msgstr "ブロックラベルは DECLARE の後ではなく前に置かなければなりません"
 
-#: pl_gram.y:506
+#: pl_gram.y:507
 #, c-format
 msgid "collations are not supported by type %s"
-msgstr "%s 型では照合順序はサポートされていませ�?
+msgstr "%s 型では照合順序はサポートされていません"
 
-#: pl_gram.y:525
+#: pl_gram.y:526
 #, c-format
 msgid "variable \"%s\" must have a default value, since it's declared NOT NULL"
-msgstr "NOT NULL宣言されているため、変数\"%s\"はデフォルト値を持つ必要がありま�?
+msgstr "NOT NULL宣言されているため、変数\"%s\"はデフォルト値を持つ必要があります"
 
-#: pl_gram.y:673 pl_gram.y:688 pl_gram.y:714
+#: pl_gram.y:674 pl_gram.y:689 pl_gram.y:715
 #, c-format
 msgid "variable \"%s\" does not exist"
-msgstr "変数 \"%s\" は存在しませ�?
+msgstr "変数 \"%s\" は存在しません"
 
-#: pl_gram.y:732 pl_gram.y:760
+#: pl_gram.y:733 pl_gram.y:761
 msgid "duplicate declaration"
-msgstr "重複した宣言です�?
+msgstr "重複した宣言です。"
 
-#: pl_gram.y:743 pl_gram.y:771
+#: pl_gram.y:744 pl_gram.y:772
 #, c-format
 msgid "variable \"%s\" shadows a previously defined variable"
-msgstr "変数 \"%s\" が事前に定義された変数を不可視にしていま�?
+msgstr "変数 \"%s\" が事前に定義された変数を不可視にしています"
 
-#: pl_gram.y:1043
+#: pl_gram.y:1044
 #, c-format
 msgid "diagnostics item %s is not allowed in GET STACKED DIAGNOSTICS"
 msgstr "GET STACKED DIAGNOSTICS では診断項目 %s は許可されていません"
 
-#: pl_gram.y:1061
+#: pl_gram.y:1062
 #, c-format
 msgid "diagnostics item %s is not allowed in GET CURRENT DIAGNOSTICS"
 msgstr "GET CURRENT DIAGNOSTICS では診断項目 %s は許可されていません"
 
-#: pl_gram.y:1156
+#: pl_gram.y:1157
 msgid "unrecognized GET DIAGNOSTICS item"
 msgstr "GET DIAGNOSTICS 項目が認識できません"
 
-#: pl_gram.y:1172 pl_gram.y:3557
+#: pl_gram.y:1173 pl_gram.y:3558
 #, c-format
 msgid "\"%s\" is not a scalar variable"
 msgstr "\"%s\" はスカラー変数ではありません"
 
-#: pl_gram.y:1402 pl_gram.y:1596
+#: pl_gram.y:1403 pl_gram.y:1597
 #, c-format
 msgid "loop variable of loop over rows must be a record variable or list of scalar variables"
 msgstr "行に対するループでのループ変数は、レコード変数またはスカラー変数のリストでなければなりません"
 
-#: pl_gram.y:1437
+#: pl_gram.y:1438
 #, c-format
 msgid "cursor FOR loop must have only one target variable"
-msgstr "カーソルを使った FOR ループには、ターゲット変数が１個だけ必要で�?
+msgstr "カーソルを使った FOR ループには、ターゲット変数が１個だけ必要です"
 
-#: pl_gram.y:1444
+#: pl_gram.y:1445
 #, c-format
 msgid "cursor FOR loop must use a bound cursor variable"
-msgstr "カーソルを使った FOR ループでは、それに関連付けられたカーソル変数を使用しなければなりませ�?
+msgstr "カーソルを使った FOR ループでは、それに関連付けられたカーソル変数を使用しなければなりません"
 
-#: pl_gram.y:1535
+#: pl_gram.y:1536
 #, c-format
 msgid "integer FOR loop must have only one target variable"
-msgstr "整数を使った FOR ループには、ターゲット変数が１個だけ必要で�?
+msgstr "整数を使った FOR ループには、ターゲット変数が１個だけ必要です"
 
-#: pl_gram.y:1569
+#: pl_gram.y:1570
 #, c-format
 msgid "cannot specify REVERSE in query FOR loop"
-msgstr "問い合わせを使っ�?FOR ループの中で�?REVERSE は指定できません"
+msgstr "問い合わせを使った FOR ループの中では REVERSE は指定できません"
 
-#: pl_gram.y:1699
+#: pl_gram.y:1700
 #, c-format
 msgid "loop variable of FOREACH must be a known variable or list of variables"
-msgstr "FOREACH のループ変数は、既知の変数または変数のリストでなければなりませ�?
+msgstr "FOREACH のループ変数は、既知の変数または変数のリストでなければなりません"
 
-#: pl_gram.y:1741
+#: pl_gram.y:1742
 #, c-format
 msgid "there is no label \"%s\" attached to any block or loop enclosing this statement"
-msgstr "このステートメントを囲むブロックやループに割り当てられた \"%s\" というラベルはありません�?
+msgstr "このステートメントを囲むブロックやループに割り当てられた \"%s\" というラベルはありません。"
 
-#: pl_gram.y:1749
+#: pl_gram.y:1750
 #, c-format
 msgid "block label \"%s\" cannot be used in CONTINUE"
-msgstr "ブロックラベ�?\"%s\" �?CONTINUE の中では使えません�?
-
-#: pl_gram.y:1764
-#, c-format
-msgid "EXIT cannot be used outside a loop, unless it has a label"
-msgstr "ラベルのない EXIT は、ループの外では使えませ�?
+msgstr "ブロックラベル \"%s\" は CONTINUE の中では使えません。"
 
 #: pl_gram.y:1765
 #, c-format
-msgid "CONTINUE cannot be used outside a loop"
-msgstr "CONTINUE はループの外では使えませ�?
+msgid "EXIT cannot be used outside a loop, unless it has a label"
+msgstr "ラベルのない EXIT は、ループの外では使えません"
 
-#: pl_gram.y:1789 pl_gram.y:1827 pl_gram.y:1875 pl_gram.y:3004 pl_gram.y:3092
-#: pl_gram.y:3203 pl_gram.y:3956
+#: pl_gram.y:1766
+#, c-format
+msgid "CONTINUE cannot be used outside a loop"
+msgstr "CONTINUE はループの外では使えません"
+
+#: pl_gram.y:1790 pl_gram.y:1828 pl_gram.y:1876 pl_gram.y:3005 pl_gram.y:3093
+#: pl_gram.y:3204 pl_gram.y:3957
 msgid "unexpected end of function definition"
 msgstr "予期しない関数定義の終端に達しました"
 
-#: pl_gram.y:1895 pl_gram.y:1919 pl_gram.y:1935 pl_gram.y:1941 pl_gram.y:2066
-#: pl_gram.y:2074 pl_gram.y:2088 pl_gram.y:2183 pl_gram.y:2407 pl_gram.y:2497
-#: pl_gram.y:2655 pl_gram.y:3799 pl_gram.y:3860 pl_gram.y:3937
+#: pl_gram.y:1896 pl_gram.y:1920 pl_gram.y:1936 pl_gram.y:1942 pl_gram.y:2067
+#: pl_gram.y:2075 pl_gram.y:2089 pl_gram.y:2184 pl_gram.y:2408 pl_gram.y:2498
+#: pl_gram.y:2656 pl_gram.y:3800 pl_gram.y:3861 pl_gram.y:3938
 msgid "syntax error"
-msgstr "構文エラ�?
+msgstr "構文エラー"
 
-#: pl_gram.y:1923 pl_gram.y:1925 pl_gram.y:2411 pl_gram.y:2413
+#: pl_gram.y:1924 pl_gram.y:1926 pl_gram.y:2412 pl_gram.y:2414
 msgid "invalid SQLSTATE code"
-msgstr "無効�?SQLSTATE コードで�?
+msgstr "無効な SQLSTATE コードです"
 
-#: pl_gram.y:2131
+#: pl_gram.y:2132
 msgid "syntax error, expected \"FOR\""
-msgstr "構文エラー。\"FOR\" が現れるべきでした�?
+msgstr "構文エラー。\"FOR\" が現れるべきでした。"
 
-#: pl_gram.y:2192
+#: pl_gram.y:2193
 #, c-format
 msgid "FETCH statement cannot return multiple rows"
-msgstr "FETCH ステートメントは複数行を返せませ�?
+msgstr "FETCH ステートメントは複数行を返せません"
 
-#: pl_gram.y:2289
+#: pl_gram.y:2290
 #, c-format
 msgid "cursor variable must be a simple variable"
-msgstr "カーソル変数は単純変数でなければなりませ�?
+msgstr "カーソル変数は単純変数でなければなりません"
 
-#: pl_gram.y:2295
+#: pl_gram.y:2296
 #, c-format
 msgid "variable \"%s\" must be of type cursor or refcursor"
-msgstr "変数 \"%s\" �?cursor 型または refcursor 型でなければなりませ�?
+msgstr "変数 \"%s\" は cursor 型または refcursor 型でなければなりません"
 
-#: pl_gram.y:2626 pl_gram.y:2637
+#: pl_gram.y:2627 pl_gram.y:2638
 #, c-format
 msgid "\"%s\" is not a known variable"
-msgstr "\"%s\" は既知の変数ではありませ�?
+msgstr "\"%s\" は既知の変数ではありません"
 
-#: pl_gram.y:2743 pl_gram.y:2753 pl_gram.y:2909
+#: pl_gram.y:2744 pl_gram.y:2754 pl_gram.y:2910
 msgid "mismatched parentheses"
-msgstr "括弧が対応していませ�?
+msgstr "括弧が対応していません"
 
-#: pl_gram.y:2757
+#: pl_gram.y:2758
 #, c-format
 msgid "missing \"%s\" at end of SQL expression"
 msgstr "SQL 表現式の終わりに \"%s\" がありません"
 
-#: pl_gram.y:2763
+#: pl_gram.y:2764
 #, c-format
 msgid "missing \"%s\" at end of SQL statement"
 msgstr "SQL ステートメントの終わりに \"%s\" がありません"
 
-#: pl_gram.y:2780
+#: pl_gram.y:2781
 msgid "missing expression"
-msgstr "表現式がありませ�?
+msgstr "表現式がありません"
 
-#: pl_gram.y:2782
+#: pl_gram.y:2783
 msgid "missing SQL statement"
-msgstr "SQL ステートメントがありませ�?
+msgstr "SQL ステートメントがありません"
 
-#: pl_gram.y:2911
+#: pl_gram.y:2912
 msgid "incomplete data type declaration"
-msgstr "データ型の定義が不完全で�?
+msgstr "データ型の定義が不完全です"
 
-#: pl_gram.y:2934
+#: pl_gram.y:2935
 msgid "missing data type declaration"
-msgstr "データ型の定義がありませ�?
+msgstr "データ型の定義がありません"
 
-#: pl_gram.y:3014
+#: pl_gram.y:3015
 msgid "INTO specified more than once"
 msgstr "INTO が複数回指定されています"
 
-#: pl_gram.y:3184
+#: pl_gram.y:3185
 msgid "expected FROM or IN"
 msgstr "FROM もしくは IN が来るべきでした"
 
-#: pl_gram.y:3245
+#: pl_gram.y:3246
 #, c-format
 msgid "RETURN cannot have a parameter in function returning set"
 msgstr "集合を返す関数では、RETURN にパラメータを指定できません"
 
-#: pl_gram.y:3246
+#: pl_gram.y:3247
 #, c-format
 msgid "Use RETURN NEXT or RETURN QUERY."
-msgstr "RETURN NEXT もしくは RETURN QUERY を使用してくださ�?
+msgstr "RETURN NEXT もしくは RETURN QUERY を使用してください"
 
-#: pl_gram.y:3256
+#: pl_gram.y:3257
 #, c-format
 msgid "RETURN cannot have a parameter in a procedure"
-msgstr "プロシージャないのRETURNはパラメータを取ることができませ�?
+msgstr "プロシージャないのRETURNはパラメータを取ることができません"
 
-#: pl_gram.y:3261
+#: pl_gram.y:3262
 #, c-format
 msgid "RETURN cannot have a parameter in function returning void"
 msgstr "void を返す関数では、RETURN にパラメータを指定できません"
 
-#: pl_gram.y:3270
+#: pl_gram.y:3271
 #, c-format
 msgid "RETURN cannot have a parameter in function with OUT parameters"
 msgstr "OUT パラメータのない関数では、RETURN にパラメータを指定できません"
 
-#: pl_gram.y:3333
+#: pl_gram.y:3334
 #, c-format
 msgid "RETURN NEXT cannot have a parameter in function with OUT parameters"
 msgstr "OUT パラメータ付きの関数では、RETURN NEXT にパラメータを指定できません"
 
-#: pl_gram.y:3499
+#: pl_gram.y:3500
 #, c-format
 msgid "record variable cannot be part of multiple-item INTO list"
 msgstr "レコード変数は、複数項目を持つ INTO リストでは使えません"
 
-#: pl_gram.y:3545
+#: pl_gram.y:3546
 #, c-format
 msgid "too many INTO variables specified"
-msgstr "INTO 変数の指定が多すぎま�?
+msgstr "INTO 変数の指定が多すぎます"
 
-#: pl_gram.y:3753
+#: pl_gram.y:3754
 #, c-format
 msgid "end label \"%s\" specified for unlabeled block"
 msgstr "終端ラベル\"%s\"がラベルなしのブロックに対して指定されました"
 
-#: pl_gram.y:3760
+#: pl_gram.y:3761
 #, c-format
 msgid "end label \"%s\" differs from block's label \"%s\""
-msgstr "終端ラベ�?\"%s\" がブロックのラベ�?\"%s\" と異なります"
+msgstr "終端ラベル \"%s\" がブロックのラベル \"%s\" と異なります"
 
-#: pl_gram.y:3794
+#: pl_gram.y:3795
 #, c-format
 msgid "cursor \"%s\" has no arguments"
-msgstr "カーソル \"%s\" に引数がありませ�?
+msgstr "カーソル \"%s\" に引数がありません"
 
-#: pl_gram.y:3808
+#: pl_gram.y:3809
 #, c-format
 msgid "cursor \"%s\" has arguments"
 msgstr "カーソル \"%s\" に引数がついています"
 
-#: pl_gram.y:3850
+#: pl_gram.y:3851
 #, c-format
 msgid "cursor \"%s\" has no argument named \"%s\""
-msgstr "カーソル \"%s\" �?\"%s\" という名前の引数がありません"
+msgstr "カーソル \"%s\" に \"%s\" という名前の引数がありません"
 
-#: pl_gram.y:3870
+#: pl_gram.y:3871
 #, c-format
 msgid "value for parameter \"%s\" of cursor \"%s\" specified more than once"
 msgstr "カーソル \"%2$s\" のパラメータ \"%1$s\" の値が複数個指定されました"
 
-#: pl_gram.y:3895
+#: pl_gram.y:3896
 #, c-format
 msgid "not enough arguments for cursor \"%s\""
-msgstr "カーソル \"%s\" の引数が不足していま�?
+msgstr "カーソル \"%s\" の引数が不足しています"
 
-#: pl_gram.y:3902
+#: pl_gram.y:3903
 #, c-format
 msgid "too many arguments for cursor \"%s\""
 msgstr "カーソル \"%s\" に対する引数が多すぎます"
 
-#: pl_gram.y:3988
+#: pl_gram.y:3989
 msgid "unrecognized RAISE statement option"
-msgstr "RAISE ステートメントのオプションを認識できませ�?
+msgstr "RAISE ステートメントのオプションを認識できません"
 
-#: pl_gram.y:3992
+#: pl_gram.y:3993
 msgid "syntax error, expected \"=\""
-msgstr "構文エラー。\"=\" を期待していまし�?
+msgstr "構文エラー。\"=\" を期待していました"
 
-#: pl_gram.y:4033
+#: pl_gram.y:4034
 #, c-format
 msgid "too many parameters specified for RAISE"
 msgstr "RAISE に指定されたパラメーターの数が多すぎます"
 
-#: pl_gram.y:4037
+#: pl_gram.y:4038
 #, c-format
 msgid "too few parameters specified for RAISE"
 msgstr "RAISE に指定されたパラメーターの数が足りません"
 
 #: pl_handler.c:156
-msgid "Sets handling of conflicts between PL/iSQL variable names and table column names."
-msgstr "PL/iSQL 変数名とテーブルのカラム名の間の衝突時処理を設定します�?
+msgid "Sets handling of conflicts between PL/pgSQL variable names and table column names."
+msgstr "PL/pgSQL 変数名とテーブルのカラム名の間の衝突時処理を設定します。"
 
 #: pl_handler.c:165
 msgid "Print information about parameters in the DETAIL part of the error messages generated on INTO ... STRICT failures."
-msgstr "INTO ... STRICT 失敗時に生成されたエラーメッセージの DETAIL 部分のパラメーター情報を表示します�?
+msgstr "INTO ... STRICT 失敗時に生成されたエラーメッセージの DETAIL 部分のパラメーター情報を表示します。"
 
 #: pl_handler.c:173
 msgid "Perform checks given in ASSERT statements."
-msgstr "ASSERT ステートメントで指定されたチェックを実行します�?
+msgstr "ASSERT ステートメントで指定されたチェックを実行します。"
 
 #: pl_handler.c:181
 msgid "List of programming constructs that should produce a warning."
-msgstr "生成されたプログラムの中で、警告を発生すべき部分の一覧です�?
+msgstr "生成されたプログラムの中で、警告を発生すべき部分の一覧です。"
 
 #: pl_handler.c:191
 msgid "List of programming constructs that should produce an error."
-msgstr "生成されたプログラムの中で、エラーを発生すべき部分の一覧です�?
+msgstr "生成されたプログラムの中で、エラーを発生すべき部分の一覧です。"
 
 #. translator: %s is typically the translation of "syntax error"
 #: pl_scanner.c:508
@@ -846,10 +846,10 @@ msgstr "入力の最後で %s"
 #: pl_scanner.c:524
 #, c-format
 msgid "%s at or near \"%s\""
-msgstr "\"%2$s\" もしくはその近辺�?%1$s"
+msgstr "\"%2$s\" もしくはその近辺で %1$s"
 
 #~ msgid "number of array dimensions (%d) exceeds the maximum allowed (%d)"
-#~ msgstr "配列の次元数(%d)が制限�?%d)を超えていま�?
+#~ msgstr "配列の次元数(%d)が制限値(%d)を超えています"
 
 #~ msgid "subscripted object is not an array"
 #~ msgstr "添字つきオブジェクトは配列ではありません"
@@ -858,22 +858,22 @@ msgstr "\"%2$s\" もしくはその近辺�?%1$s"
 #~ msgstr "代入における配列の添字が NULL であってはなりません"
 
 #~ msgid "query \"%s\" returned more than one row"
-#~ msgstr "問い合わ�?\"%s\" が複数の行を返しまし�?
+#~ msgstr "問い合わせ \"%s\" が複数の行を返しました"
 
 #~ msgid "relation \"%s\" is not a table"
 #~ msgstr "リレーション \"%s\" はテーブルではありません"
 
 #~ msgid "variable \"%s\" declared NOT NULL cannot default to NULL"
-#~ msgstr "変数 \"%s\" �?NOT NULL として宣言されているため、デフォルト値を NULL にすることはできませ�?
+#~ msgstr "変数 \"%s\" は NOT NULL として宣言されているため、デフォルト値を NULL にすることはできません"
 
 #~ msgid "Use a BEGIN block with an EXCEPTION clause instead."
-#~ msgstr "代わりに EXCEPTION 句を伴う BEGIN ブロックを使用してくださ�?
+#~ msgstr "代わりに EXCEPTION 句を伴う BEGIN ブロックを使用してください"
 
 #~ msgid "row or record variable cannot be CONSTANT"
-#~ msgstr "行またはレコード変数�?CONSTANT にはできませ�?
+#~ msgstr "行またはレコード変数は CONSTANT にはできません"
 
 #~ msgid "row or record variable cannot be NOT NULL"
-#~ msgstr "行またはレコード変数�?NOT NULL にはできませ�?
+#~ msgstr "行またはレコード変数を NOT NULL にはできません"
 
 #~ msgid "default value for row or record variable is not supported"
-#~ msgstr "行またはレコード変数のデフォルト値指定はサポートされていませ�?
+#~ msgstr "行またはレコード変数のデフォルト値指定はサポートされていません"

--- a/src/pl/plisql/src/po/ko.po
+++ b/src/pl/plisql/src/po/ko.po
@@ -19,59 +19,59 @@ msgstr ""
 #: pl_comp.c:436 pl_handler.c:471
 #, c-format
 msgid "PL/iSQL functions cannot accept type %s"
-msgstr "PL/iSQL 함수�?%s 형식�?사용�?�?없음"
+msgstr "PL/iSQL 함수에 %s 형식을 사용할 수 없음"
 
 #: pl_comp.c:526
 #, c-format
 msgid "could not determine actual return type for polymorphic function \"%s\""
-msgstr "다형�?함수 \"%s\"�?실제 반환 형식�?확인�?�?없음"
+msgstr "다형적 함수 \"%s\"의 실제 반환 형식을 확인할 수 없음"
 
 #: pl_comp.c:556
 #, c-format
 msgid "trigger functions can only be called as triggers"
-msgstr "트리�?함수�?트리거로�?호출�?�?있음"
+msgstr "트리거 함수는 트리거로만 호출될 수 있음"
 
 #: pl_comp.c:560 pl_handler.c:455
 #, c-format
 msgid "PL/iSQL functions cannot return type %s"
-msgstr "PL/iSQL 함수�?%s 형식�?반환�?�?없음"
+msgstr "PL/iSQL 함수는 %s 형식을 반환할 수 없음"
 
 #: pl_comp.c:600
 #, c-format
 msgid "trigger functions cannot have declared arguments"
-msgstr "트리�?함수�?선언�?인수�?포함�?�?없음"
+msgstr "트리거 함수는 선언된 인수를 포함할 수 없음"
 
 #: pl_comp.c:601
 #, c-format
 msgid ""
 "The arguments of the trigger can be accessed through TG_NARGS and TG_ARGV "
 "instead."
-msgstr "대�?TG_NARGS �?TG_ARGV�?통해 트리거의 인수�?액세스할 �?있습니다."
+msgstr "대신 TG_NARGS 및 TG_ARGV를 통해 트리거의 인수에 액세스할 수 있습니다."
 
 #: pl_comp.c:734
 #, c-format
 msgid "event trigger functions cannot have declared arguments"
-msgstr "이벤�?트리�?함수�?선언�?인자(declare argument)�?사용�?�?없음"
+msgstr "이벤트 트리거 함수는 선언된 인자(declare argument)를 사용할 수 없음"
 
 #: pl_comp.c:997
 #, c-format
 msgid "compilation of PL/iSQL function \"%s\" near line %d"
-msgstr "PL/iSQL 함수 \"%s\" 컴파�?%d번째 �?근처)"
+msgstr "PL/iSQL 함수 \"%s\" 컴파일(%d번째 줄 근처)"
 
 #: pl_comp.c:1020
 #, c-format
 msgid "parameter name \"%s\" used more than once"
-msgstr "\"%s\" 매개 변수가 여러 �?사용 �?
+msgstr "\"%s\" 매개 변수가 여러 번 사용 됨"
 
 #: pl_comp.c:1132
 #, c-format
 msgid "column reference \"%s\" is ambiguous"
-msgstr "�?참조 \"%s\" 가 명확하지 않습니다."
+msgstr "열 참조 \"%s\" 가 명확하지 않습니다."
 
 #: pl_comp.c:1134
 #, c-format
 msgid "It could refer to either a PL/iSQL variable or a table column."
-msgstr "PL/iSQL 변수명�? 테이�?칼럼 이름�?아니여야 �?
+msgstr "PL/iSQL 변수명도, 테이블 칼럼 이름도 아니여야 함"
 
 #: pl_comp.c:1317 pl_exec.c:5218 pl_exec.c:5583 pl_exec.c:5670 pl_exec.c:5761
 #: pl_exec.c:6749
@@ -82,17 +82,17 @@ msgstr "\"%s\" 레코드에 \"%s\" 필드가 없음"
 #: pl_comp.c:1793
 #, c-format
 msgid "relation \"%s\" does not exist"
-msgstr "\"%s\" 이름�?릴레이션(relation)�?없습니다"
+msgstr "\"%s\" 이름의 릴레이션(relation)이 없습니다"
 
 #: pl_comp.c:1891
 #, c-format
 msgid "variable \"%s\" has pseudo-type %s"
-msgstr "\"%s\" 변수에 의사 형식 %s�?가) 있음"
+msgstr "\"%s\" 변수에 의사 형식 %s이(가) 있음"
 
 #: pl_comp.c:2080
 #, c-format
 msgid "type \"%s\" is only a shell"
-msgstr "자료�?\"%s\" �?오로지 shell 에만 있습니다. "
+msgstr "자료형 \"%s\" 는 오로지 shell 에만 있습니다. "
 
 #: pl_comp.c:2162 pl_exec.c:7050
 #, c-format
@@ -102,64 +102,64 @@ msgstr "%s 자료형은 복합 자료형이 아님"
 #: pl_comp.c:2210 pl_comp.c:2263
 #, c-format
 msgid "unrecognized exception condition \"%s\""
-msgstr "인식�?�?없는 예외 조건 \"%s\""
+msgstr "인식할 수 없는 예외 조건 \"%s\""
 
 #: pl_comp.c:2484
 #, c-format
 msgid ""
 "could not determine actual argument type for polymorphic function \"%s\""
-msgstr "다형�?함수 \"%s\"�?실제 인수 형식�?확인�?�?없음"
+msgstr "다형적 함수 \"%s\"의 실제 인수 형식을 확인할 수 없음"
 
 #: pl_exec.c:498 pl_exec.c:935 pl_exec.c:1173
 msgid "during initialization of execution state"
-msgstr "실행 상태�?초기화하�?동안"
+msgstr "실행 상태를 초기화하는 동안"
 
 #: pl_exec.c:504
 msgid "while storing call arguments into local variables"
-msgstr "호출 인수�?로컬 변수에 저장하�?동안"
+msgstr "호출 인수를 로컬 변수에 저장하는 동안"
 
 #: pl_exec.c:592 pl_exec.c:1008
 msgid "during function entry"
-msgstr "함수�?시작하는 동안"
+msgstr "함수를 시작하는 동안"
 
 #: pl_exec.c:617
 #, c-format
 msgid "control reached end of function without RETURN"
-msgstr "컨트롤이 RETURN 없이 함수 끝에 도달�?
+msgstr "컨트롤이 RETURN 없이 함수 끝에 도달함"
 
 #: pl_exec.c:624
 msgid "while casting return value to function's return type"
-msgstr "함수�?반환 형식으로 반환 값을 형변환하�?동안"
+msgstr "함수의 반환 형식으로 반환 값을 형변환하는 동안"
 
 #: pl_exec.c:637 pl_exec.c:3653
 #, c-format
 msgid "set-valued function called in context that cannot accept a set"
 msgstr ""
-"set-values 함수(테이�?리턴 함수)가 set 정의 없이 사용되었습니�?(테이블과 �?
-"�?�?alias 지정하세요)"
+"set-values 함수(테이블 리턴 함수)가 set 정의 없이 사용되었습니다 (테이블과 해"
+"당 열 alias 지정하세요)"
 
 #: pl_exec.c:763 pl_exec.c:1037 pl_exec.c:1198
 msgid "during function exit"
-msgstr "함수�?종료하는 동안"
+msgstr "함수를 종료하는 동안"
 
 #: pl_exec.c:818 pl_exec.c:882 pl_exec.c:3498
 msgid "returned record type does not match expected record type"
-msgstr "반환�?레코�?형식�?필요�?레코�?형식�?일치하지 않음"
+msgstr "반환된 레코드 형식이 필요한 레코드 형식과 일치하지 않음"
 
 #: pl_exec.c:1033 pl_exec.c:1194
 #, c-format
 msgid "control reached end of trigger procedure without RETURN"
-msgstr "컨트롤이 RETURN 없이 트리�?프로시저 끝에 도달�?
+msgstr "컨트롤이 RETURN 없이 트리거 프로시저 끝에 도달함"
 
 #: pl_exec.c:1042
 #, c-format
 msgid "trigger procedure cannot return a set"
-msgstr "트리�?프로시저�?집합�?반환�?�?없음"
+msgstr "트리거 프로시저는 집합을 반환할 수 없음"
 
 #: pl_exec.c:1081 pl_exec.c:1109
 msgid ""
 "returned row structure does not match the structure of the triggering table"
-msgstr "반환�?�?구조가 트리거하�?테이블의 구조와 일치하지 않음"
+msgstr "반환된 행 구조가 트리거하는 테이블의 구조와 일치하지 않음"
 
 #. translator: last %s is a phrase such as "during statement block
 #. local variable initialization"
@@ -167,7 +167,7 @@ msgstr "반환�?�?구조가 트리거하�?테이블의 구조와 일치하지
 #: pl_exec.c:1244
 #, c-format
 msgid "PL/iSQL function %s line %d %s"
-msgstr "PL/iSQL 함수 \"%s\" �?%d번째 �?%s"
+msgstr "PL/iSQL 함수 \"%s\" 의 %d번째 줄 %s"
 
 #. translator: last %s is a phrase such as "while storing call
 #. arguments into local variables"
@@ -181,7 +181,7 @@ msgstr "PL/iSQL 함수 %s %s"
 #: pl_exec.c:1263
 #, c-format
 msgid "PL/iSQL function %s line %d at %s"
-msgstr "PL/iSQL 함수 \"%s\" �?%d번째 %s"
+msgstr "PL/iSQL 함수 \"%s\" 의 %d번째 %s"
 
 #: pl_exec.c:1269
 #, c-format
@@ -190,68 +190,68 @@ msgstr "PL/iSQL 함수 %s"
 
 #: pl_exec.c:1607
 msgid "during statement block local variable initialization"
-msgstr "�?블록 로컬 변수를 초기화하�?동안"
+msgstr "문 블록 로컬 변수를 초기화하는 동안"
 
 #: pl_exec.c:1705
 msgid "during statement block entry"
-msgstr "�?블록�?시작하는 동안"
+msgstr "문 블록을 시작하는 동안"
 
 #: pl_exec.c:1737
 msgid "during statement block exit"
-msgstr "�?블록�?종료하는 동안"
+msgstr "문 블록을 종료하는 동안"
 
 #: pl_exec.c:1775
 msgid "during exception cleanup"
-msgstr "예외�?정리하는 동안"
+msgstr "예외를 정리하는 동안"
 
 #: pl_exec.c:2304
 #, c-format
 msgid ""
 "procedure parameter \"%s\" is an output parameter but corresponding argument "
 "is not writable"
-msgstr "\"%s\" 프로시져 인자�?출력 인자인데, �?변경이 불가�?�?
+msgstr "\"%s\" 프로시져 인자는 출력 인자인데, 값 변경이 불가능 함"
 
 #: pl_exec.c:2309
 #, c-format
 msgid ""
 "procedure parameter %d is an output parameter but corresponding argument is "
 "not writable"
-msgstr "%d 프로시져 인자�?출력 인자인데, �?변경이 불가�?�?
+msgstr "%d 프로시져 인자는 출력 인자인데, 값 변경이 불가능 함"
 
 #: pl_exec.c:2437
 #, c-format
 msgid "GET STACKED DIAGNOSTICS cannot be used outside an exception handler"
-msgstr "GET STACKED DIAGNOSTICS 구문은 예외처리 헨들�?밖에�?사용�?�?없음"
+msgstr "GET STACKED DIAGNOSTICS 구문은 예외처리 헨들러 밖에서 사용할 수 없음"
 
 #: pl_exec.c:2637
 #, c-format
 msgid "case not found"
-msgstr "사례�?찾지 못함"
+msgstr "사례를 찾지 못함"
 
 #: pl_exec.c:2638
 #, c-format
 msgid "CASE statement is missing ELSE part."
-msgstr "CASE 문에 ELSE 부분이 누락되었습니�?"
+msgstr "CASE 문에 ELSE 부분이 누락되었습니다."
 
 #: pl_exec.c:2731
 #, c-format
 msgid "lower bound of FOR loop cannot be null"
-msgstr "FOR 루프�?하한은 null�?�?없음"
+msgstr "FOR 루프의 하한은 null일 수 없음"
 
 #: pl_exec.c:2747
 #, c-format
 msgid "upper bound of FOR loop cannot be null"
-msgstr "FOR 루프�?상한은 null�?�?없음"
+msgstr "FOR 루프의 상한은 null일 수 없음"
 
 #: pl_exec.c:2765
 #, c-format
 msgid "BY value of FOR loop cannot be null"
-msgstr "FOR 루프�?BY 값은 null�?�?없음"
+msgstr "FOR 루프의 BY 값은 null일 수 없음"
 
 #: pl_exec.c:2771
 #, c-format
 msgid "BY value of FOR loop must be greater than zero"
-msgstr "FOR 루프�?BY 값은 0보다 커야 �?
+msgstr "FOR 루프의 BY 값은 0보다 커야 함"
 
 #: pl_exec.c:2905 pl_exec.c:4632
 #, c-format
@@ -261,88 +261,88 @@ msgstr "\"%s\" 커서가 이미 사용 중임"
 #: pl_exec.c:2928 pl_exec.c:4697
 #, c-format
 msgid "arguments given for cursor without arguments"
-msgstr "인수가 없는 커서�?인수가 제공�?
+msgstr "인수가 없는 커서에 인수가 제공됨"
 
 #: pl_exec.c:2947 pl_exec.c:4716
 #, c-format
 msgid "arguments required for cursor"
-msgstr "커서�?인수 필요"
+msgstr "커서에 인수 필요"
 
 #: pl_exec.c:3034
 #, c-format
 msgid "FOREACH expression must not be null"
-msgstr "FOREACH 구문은 null �?아니여야 �?
+msgstr "FOREACH 구문은 null 이 아니여야 함"
 
 #: pl_exec.c:3049
 #, c-format
 msgid "FOREACH expression must yield an array, not type %s"
-msgstr "FOREACH 구문에서�?배열�?사용됩니�? 사용�?자료�?%s"
+msgstr "FOREACH 구문에서는 배열이 사용됩니다. 사용된 자료형 %s"
 
 #: pl_exec.c:3066
 #, c-format
 msgid "slice dimension (%d) is out of the valid range 0..%d"
-msgstr "slice dimension (%d) 값이 범위�?벗어�? 0..%d"
+msgstr "slice dimension (%d) 값이 범위를 벗어남, 0..%d"
 
 #: pl_exec.c:3093
 #, c-format
 msgid "FOREACH ... SLICE loop variable must be of an array type"
-msgstr "FOREACH ... SLICE 루프 변수는 배열 자료형이어야 �?
+msgstr "FOREACH ... SLICE 루프 변수는 배열 자료형이어야 함"
 
 #: pl_exec.c:3097
 #, c-format
 msgid "FOREACH loop variable must not be of an array type"
-msgstr "FOREACH 반복 변수는 배열형이 아니여야 �?
+msgstr "FOREACH 반복 변수는 배열형이 아니여야 함"
 
 #: pl_exec.c:3259 pl_exec.c:3316 pl_exec.c:3491
 #, c-format
 msgid ""
 "cannot return non-composite value from function returning composite type"
 msgstr ""
-"함수�?반환값이 복합 자료형인�? 복합 자료형아�?자료형을 반환하려�?�?
+"함수의 반환값이 복합 자료형인데, 복합 자료형아닌 자료형을 반환하려고 함"
 
 #: pl_exec.c:3355 pl_gram.y:3309
 #, c-format
 msgid "cannot use RETURN NEXT in a non-SETOF function"
-msgstr "SETOF 함수가 아닌 함수에서 RETURN NEXT�?사용�?�?없음"
+msgstr "SETOF 함수가 아닌 함수에서 RETURN NEXT를 사용할 수 없음"
 
 #: pl_exec.c:3396 pl_exec.c:3528
 #, c-format
 msgid "wrong result type supplied in RETURN NEXT"
-msgstr "RETURN NEXT�?잘못�?결과 형식�?제공�?
+msgstr "RETURN NEXT에 잘못된 결과 형식이 제공됨"
 
 #: pl_exec.c:3434 pl_exec.c:3455
 #, c-format
 msgid "wrong record type supplied in RETURN NEXT"
-msgstr "RETURN NEXT�?잘못�?레코�?형식�?제공�?
+msgstr "RETURN NEXT에 잘못된 레코드 형식이 제공됨"
 
 #: pl_exec.c:3547
 #, c-format
 msgid "RETURN NEXT must have a parameter"
-msgstr "RETURN NEXT�?매개 변�?필요"
+msgstr "RETURN NEXT에 매개 변수 필요"
 
 #: pl_exec.c:3573 pl_gram.y:3373
 #, c-format
 msgid "cannot use RETURN QUERY in a non-SETOF function"
-msgstr "SETOF 함수가 아닌 함수에서 RETURN QUERY�?사용�?�?없음"
+msgstr "SETOF 함수가 아닌 함수에서 RETURN QUERY를 사용할 수 없음"
 
 #: pl_exec.c:3597
 msgid "structure of query does not match function result type"
-msgstr "쿼리 구조가 함수 결과 형식�?일치하지 않음"
+msgstr "쿼리 구조가 함수 결과 형식과 일치하지 않음"
 
 #: pl_exec.c:3681 pl_exec.c:3819
 #, c-format
 msgid "RAISE option already specified: %s"
-msgstr "RAISE 옵션�?이미 지정됨: %s"
+msgstr "RAISE 옵션이 이미 지정됨: %s"
 
 #: pl_exec.c:3715
 #, c-format
 msgid "RAISE without parameters cannot be used outside an exception handler"
-msgstr "매개 변�?없는 RAISE�?예외 처리�?외부�?사용�?�?없음"
+msgstr "매개 변수 없는 RAISE를 예외 처리기 외부에 사용할 수 없음"
 
 #: pl_exec.c:3809
 #, c-format
 msgid "RAISE statement option cannot be null"
-msgstr "RAISE �?옵션�?null�?�?없음"
+msgstr "RAISE 문 옵션이 null일 수 없음"
 
 #: pl_exec.c:3879
 #, c-format
@@ -357,7 +357,7 @@ msgstr "assertion 실패"
 #: pl_exec.c:4281 pl_exec.c:4471
 #, c-format
 msgid "cannot COPY to/from client in PL/iSQL"
-msgstr "PL/iSQL�?클라이언트와 상호 복사�?�?없음"
+msgstr "PL/iSQL의 클라이언트와 상호 복사할 수 없음"
 
 #: pl_exec.c:4287
 #, c-format
@@ -367,7 +367,7 @@ msgstr "PL/iSQL 안에서는 지원하지 않는 트랜잭션 명령"
 #: pl_exec.c:4310 pl_exec.c:4500
 #, c-format
 msgid "INTO used with a command that cannot return data"
-msgstr "데이터를 반환�?�?없는 명령�?함께 INTO가 사용�?
+msgstr "데이터를 반환할 수 없는 명령과 함께 INTO가 사용됨"
 
 #: pl_exec.c:4333 pl_exec.c:4523
 #, c-format
@@ -377,94 +377,94 @@ msgstr "쿼리에서 행을 반환하지 않음"
 #: pl_exec.c:4355 pl_exec.c:4542
 #, c-format
 msgid "query returned more than one row"
-msgstr "쿼리에서 �?�?이상�?행을 반환"
+msgstr "쿼리에서 두 개 이상의 행을 반환"
 
 #: pl_exec.c:4357
 #, c-format
 msgid "Make sure the query returns a single row, or use LIMIT 1."
-msgstr "하나�?로우�?반환하도�?쿼리�?바꾸거나 LIMIT 1 옵션�?추가하세�?"
+msgstr "하나의 로우만 반환하도록 쿼리를 바꾸거나 LIMIT 1 옵션을 추가하세요."
 
 #: pl_exec.c:4373
 #, c-format
 msgid "query has no destination for result data"
-msgstr "쿼리�?결과 데이터의 대상이 없음"
+msgstr "쿼리에 결과 데이터의 대상이 없음"
 
 #: pl_exec.c:4374
 #, c-format
 msgid "If you want to discard the results of a SELECT, use PERFORM instead."
-msgstr "SELECT�?결과�?취소하려�?대�?PERFORM�?사용하십시오."
+msgstr "SELECT의 결과를 취소하려면 대신 PERFORM을 사용하십시오."
 
 #: pl_exec.c:4407 pl_exec.c:8729
 #, c-format
 msgid "query string argument of EXECUTE is null"
-msgstr "EXECUTE�?쿼리 문자�?인수가 null�?
+msgstr "EXECUTE의 쿼리 문자열 인수가 null임"
 
 #: pl_exec.c:4463
 #, c-format
 msgid "EXECUTE of SELECT ... INTO is not implemented"
-msgstr "SELECT�?EXECUTE... INTO가 구현되지 않음"
+msgstr "SELECT의 EXECUTE... INTO가 구현되지 않음"
 
 #: pl_exec.c:4464
 #, c-format
 msgid ""
 "You might want to use EXECUTE ... INTO or EXECUTE CREATE TABLE ... AS "
 "instead."
-msgstr "EXECUTE ... INTO 또는 EXECUTE CREATE TABLE ... AS 구문�?사용하세�?"
+msgstr "EXECUTE ... INTO 또는 EXECUTE CREATE TABLE ... AS 구문을 사용하세요."
 
 #: pl_exec.c:4477
 #, c-format
 msgid "EXECUTE of transaction commands is not implemented"
-msgstr "트랜잭션 명령들의 EXECUTE 기능은 구현되지 않았�?
+msgstr "트랜잭션 명령들의 EXECUTE 기능은 구현되지 않았음"
 
 #: pl_exec.c:4778 pl_exec.c:4866
 #, c-format
 msgid "cursor variable \"%s\" is null"
-msgstr "커서 변�?\"%s\"�?가) null�?
+msgstr "커서 변수 \"%s\"이(가) null임"
 
 #: pl_exec.c:4789 pl_exec.c:4877
 #, c-format
 msgid "cursor \"%s\" does not exist"
-msgstr "\"%s\" 이름�?커서가 없음"
+msgstr "\"%s\" 이름의 커서가 없음"
 
 #: pl_exec.c:4802
 #, c-format
 msgid "relative or absolute cursor position is null"
-msgstr "상대 또는 절대 커서 위치가 null�?
+msgstr "상대 또는 절대 커서 위치가 null임"
 
 #: pl_exec.c:5068 pl_exec.c:5163
 #, c-format
 msgid "null value cannot be assigned to variable \"%s\" declared NOT NULL"
-msgstr "NOT NULL�?선언�?\"%s\" 변수에 null 값을 할당�?�?없음"
+msgstr "NOT NULL이 선언된 \"%s\" 변수에 null 값을 할당할 수 없음"
 
 #: pl_exec.c:5144
 #, c-format
 msgid "cannot assign non-composite value to a row variable"
-msgstr "�?변수에 비복�?값을 할당�?�?없음"
+msgstr "행 변수에 비복합 값을 할당할 수 없음"
 
 #: pl_exec.c:5176
 #, c-format
 msgid "cannot assign non-composite value to a record variable"
-msgstr "레코�?변수에 비복�?값을 할당�?�?없음"
+msgstr "레코드 변수에 비복합 값을 할당할 수 없음"
 
 #: pl_exec.c:5227
 #, c-format
 msgid "cannot assign to system column \"%s\""
-msgstr "시스�?�?\"%s\"�?할당�?�?없습니다."
+msgstr "시스템 열 \"%s\"에 할당할 수 없습니다."
 
 #: pl_exec.c:5291
 #, c-format
 msgid "number of array dimensions (%d) exceeds the maximum allowed (%d)"
-msgstr "지정한 배열 크기(%d)가 최대�?%d)�?초과했습니다"
+msgstr "지정한 배열 크기(%d)가 최대치(%d)를 초과했습니다"
 
 #: pl_exec.c:5323
 #, c-format
 msgid "subscripted object is not an array"
-msgstr "하위 스크립트 개체�?배열�?아님"
+msgstr "하위 스크립트 개체는 배열이 아님"
 
 #: pl_exec.c:5361
 #, c-format
 msgid "array subscript in assignment must not be null"
-msgstr "배열 하위 스크립트�?지정하�?값으�?null 값을 사용�?�?없습니다"
+msgstr "배열 하위 스크립트로 지정하는 값으로 null 값을 사용할 수 없습니다"
 
 #: pl_exec.c:5868
 #, c-format
@@ -475,12 +475,12 @@ msgstr "\"%s\" 쿼리에서 데이터를 반환하지 않음"
 #, c-format
 msgid "query \"%s\" returned %d column"
 msgid_plural "query \"%s\" returned %d columns"
-msgstr[0] "\"%s\" 쿼리가 %d 개의 칼럼�?반환�?
+msgstr[0] "\"%s\" 쿼리가 %d 개의 칼럼을 반환함"
 
 #: pl_exec.c:5904
 #, c-format
 msgid "query \"%s\" returned more than one row"
-msgstr "\"%s\" 쿼리에서 �?�?이상�?행을 반환�?
+msgstr "\"%s\" 쿼리에서 두 개 이상의 행을 반환함"
 
 #: pl_exec.c:5967
 #, c-format
@@ -492,23 +492,23 @@ msgstr "\"%s\" 쿼리가 SELECT가 아님"
 msgid ""
 "type of parameter %d (%s) does not match that when preparing the plan (%s)"
 msgstr ""
-"%d번째 매개 변수의 자료�?%s)�?미리 준비된 실행계획�?자료�?%s)�?다릅니다"
+"%d번째 매개 변수의 자료형(%s)이 미리 준비된 실행계획의 자료형(%s)과 다릅니다"
 
 #: pl_exec.c:7254 pl_exec.c:7288 pl_exec.c:7362 pl_exec.c:7388
 #, c-format
 msgid "number of source and target fields in assignment does not match"
-msgstr "원본�?대�?필드 수가 같지 않습니다."
+msgstr "원본과 대상 필드 수가 같지 않습니다."
 
 #. translator: %s represents a name of an extra check
 #: pl_exec.c:7256 pl_exec.c:7290 pl_exec.c:7364 pl_exec.c:7390
 #, c-format
 msgid "%s check of %s is active."
-msgstr "%s 검�?해당 변수이�? %s)가 활성�?되어있습니다."
+msgstr "%s 검사(해당 변수이름: %s)가 활성화 되어있습니다."
 
 #: pl_exec.c:7260 pl_exec.c:7294 pl_exec.c:7368 pl_exec.c:7394
 #, c-format
 msgid "Make sure the query returns the exact list of columns."
-msgstr "쿼리 결과가 정확�?칼럼 목록�?반환하도�?수정하세�?"
+msgstr "쿼리 결과가 정확한 칼럼 목록을 반환하도록 수정하세요."
 
 #: pl_exec.c:7781
 #, c-format
@@ -518,11 +518,11 @@ msgstr "\"%s\" 레코드가 아직 할당되지 않음"
 #: pl_exec.c:7782
 #, c-format
 msgid "The tuple structure of a not-yet-assigned record is indeterminate."
-msgstr "아직 할당되지 않은 레코드의 튜플 구조�?미정입니�?"
+msgstr "아직 할당되지 않은 레코드의 튜플 구조는 미정입니다."
 
 #: pl_funcs.c:237
 msgid "statement block"
-msgstr "�?블록"
+msgstr "문 블록"
 
 #: pl_funcs.c:239
 msgid "assignment"
@@ -538,15 +538,15 @@ msgstr "SELECT 행을 제어하는 FOR"
 
 #: pl_funcs.c:253
 msgid "FOR over cursor"
-msgstr "커서�?제어하는 FOR"
+msgstr "커서를 제어하는 FOR"
 
 #: pl_funcs.c:255
 msgid "FOREACH over array"
-msgstr "배열 초과�?FOREACH"
+msgstr "배열 초과된 FOREACH"
 
 #: pl_funcs.c:269
 msgid "SQL statement"
-msgstr "SQL �?
+msgstr "SQL 문"
 
 #: pl_funcs.c:273
 msgid "FOR over EXECUTE statement"
@@ -555,17 +555,17 @@ msgstr "EXECUTE 문을 제어하는 FOR"
 #: pl_gram.y:489
 #, c-format
 msgid "block label must be placed before DECLARE, not after"
-msgstr "블록 라벨은 DECLARE 영역 앞에 있어�?�?
+msgstr "블록 라벨은 DECLARE 영역 앞에 있어야 함"
 
 #: pl_gram.y:509
 #, c-format
 msgid "collations are not supported by type %s"
-msgstr "%s 자료형은 collation 지�?안함"
+msgstr "%s 자료형은 collation 지원 안함"
 
 #: pl_gram.y:528
 #, c-format
 msgid "variable \"%s\" must have a default value, since it's declared NOT NULL"
-msgstr "\"%s\" 변수는 NOT NULL 설정�?있어 기본값을 가져야 합니�?
+msgstr "\"%s\" 변수는 NOT NULL 설정이 있어 기본값을 가져야 합니다"
 
 #: pl_gram.y:675 pl_gram.y:690 pl_gram.y:716
 #, c-format
@@ -584,21 +584,21 @@ msgstr "variable \"%s\" shadows a previously defined variable"
 #: pl_gram.y:993
 #, c-format
 msgid "diagnostics item %s is not allowed in GET STACKED DIAGNOSTICS"
-msgstr "GET STACKED DIAGNOSTICS 에서 %s 항목�?사용�?�?없음"
+msgstr "GET STACKED DIAGNOSTICS 에서 %s 항목을 사용할 수 없음"
 
 #: pl_gram.y:1011
 #, c-format
 msgid "diagnostics item %s is not allowed in GET CURRENT DIAGNOSTICS"
-msgstr "GET CURRENT DIAGNOSTICS 에서 %s 항목�?사용�?�?없음"
+msgstr "GET CURRENT DIAGNOSTICS 에서 %s 항목을 사용할 수 없음"
 
 #: pl_gram.y:1106
 msgid "unrecognized GET DIAGNOSTICS item"
-msgstr "�?�?없는 GET DIAGNOSTICS 항목"
+msgstr "알 수 없는 GET DIAGNOSTICS 항목"
 
 #: pl_gram.y:1116 pl_gram.y:3553
 #, c-format
 msgid "\"%s\" is not a scalar variable"
-msgstr "\"%s\"은(�? 스칼�?변수가 아님"
+msgstr "\"%s\"은(는) 스칼라 변수가 아님"
 
 #: pl_gram.y:1370 pl_gram.y:1567
 #, c-format
@@ -606,59 +606,59 @@ msgid ""
 "loop variable of loop over rows must be a record variable or list of scalar "
 "variables"
 msgstr ""
-"행에 있는 루프�?루프 변수는 레코�?변수이거나 스칼�?변수의 목록이어�?�?
+"행에 있는 루프의 루프 변수는 레코드 변수이거나 스칼라 변수의 목록이어야 함"
 
 #: pl_gram.y:1405
 #, c-format
 msgid "cursor FOR loop must have only one target variable"
-msgstr "커서 FOR 루프�?대�?변수가 �?개만 있어�?�?
+msgstr "커서 FOR 루프에 대상 변수가 한 개만 있어야 함"
 
 #: pl_gram.y:1412
 #, c-format
 msgid "cursor FOR loop must use a bound cursor variable"
-msgstr "커서 FOR 루프�?바인딩된 커서 변수를 �?개만 사용해야 �?
+msgstr "커서 FOR 루프는 바인딩된 커서 변수를 한 개만 사용해야 함"
 
 #: pl_gram.y:1499
 #, c-format
 msgid "integer FOR loop must have only one target variable"
-msgstr "정수 FOR 루프�?대�?변수가 �?개만 있어�?�?
+msgstr "정수 FOR 루프에 대상 변수가 한 개만 있어야 함"
 
 #: pl_gram.y:1537
 #, c-format
 msgid "cannot specify REVERSE in query FOR loop"
-msgstr "쿼리 FOR 루프�?REVERSE�?지정할 �?없음"
+msgstr "쿼리 FOR 루프에 REVERSE를 지정할 수 없음"
 
 #: pl_gram.y:1670
 #, c-format
 msgid "loop variable of FOREACH must be a known variable or list of variables"
-msgstr "FOREACH�?반복 변수는 알려�?변수이거나 변수의 목록이어�?�?
+msgstr "FOREACH의 반복 변수는 알려진 변수이거나 변수의 목록이어야 함"
 
 #: pl_gram.y:1712
 #, c-format
 msgid ""
 "there is no label \"%s\" attached to any block or loop enclosing this "
 "statement"
-msgstr "임의 블록이나 루프 구문�?할당�?\"%s\" 라벨�?없음"
+msgstr "임의 블록이나 루프 구문에 할당된 \"%s\" 라벨이 없음"
 
 #: pl_gram.y:1720
 #, c-format
 msgid "block label \"%s\" cannot be used in CONTINUE"
-msgstr "CONTINUE 안에�?\"%s\" 블록 라벨�?사용�?�?없음"
+msgstr "CONTINUE 안에서 \"%s\" 블록 라벨을 사용할 수 없음"
 
 #: pl_gram.y:1735
 #, c-format
 msgid "EXIT cannot be used outside a loop, unless it has a label"
-msgstr "루프 외부�?라벨 지�?없이 EXIT 사용�?�?없음"
+msgstr "루프 외부에 라벨 지정 없이 EXIT 사용할 수 없음"
 
 #: pl_gram.y:1736
 #, c-format
 msgid "CONTINUE cannot be used outside a loop"
-msgstr "CONTINUE�?루프 외부�?사용�?�?없음"
+msgstr "CONTINUE를 루프 외부에 사용할 수 없음"
 
 #: pl_gram.y:1760 pl_gram.y:1798 pl_gram.y:1846 pl_gram.y:2998 pl_gram.y:3083
 #: pl_gram.y:3194 pl_gram.y:3957
 msgid "unexpected end of function definition"
-msgstr "예기�?않은 함수 정의�?�?
+msgstr "예기치 않은 함수 정의의 끝"
 
 #: pl_gram.y:1866 pl_gram.y:1890 pl_gram.y:1906 pl_gram.y:1912 pl_gram.y:2031
 #: pl_gram.y:2039 pl_gram.y:2053 pl_gram.y:2148 pl_gram.y:2399 pl_gram.y:2493
@@ -668,7 +668,7 @@ msgstr "구문 오류"
 
 #: pl_gram.y:1894 pl_gram.y:1896 pl_gram.y:2403 pl_gram.y:2405
 msgid "invalid SQLSTATE code"
-msgstr "잘못�?SQLSTATE 코드"
+msgstr "잘못된 SQLSTATE 코드"
 
 #: pl_gram.y:2096
 msgid "syntax error, expected \"FOR\""
@@ -677,56 +677,56 @@ msgstr "구문 오류, \"FOR\" 필요"
 #: pl_gram.y:2157
 #, c-format
 msgid "FETCH statement cannot return multiple rows"
-msgstr "FETCH 구문은 다중 로우�?반환�?�?없음"
+msgstr "FETCH 구문은 다중 로우를 반환할 수 없음"
 
 #: pl_gram.y:2281
 #, c-format
 msgid "cursor variable must be a simple variable"
-msgstr "커서 변수는 단순 변수여�?�?
+msgstr "커서 변수는 단순 변수여야 함"
 
 #: pl_gram.y:2287
 #, c-format
 msgid "variable \"%s\" must be of type cursor or refcursor"
-msgstr "\"%s\" 변수는 커서 또는 ref 커서 형식이어�?�?
+msgstr "\"%s\" 변수는 커서 또는 ref 커서 형식이어야 함"
 
 #: pl_gram.y:2623 pl_gram.y:2634
 #, c-format
 msgid "\"%s\" is not a known variable"
-msgstr "\"%s\" (은)�?알려�?변수가 아님"
+msgstr "\"%s\" (은)는 알려진 변수가 아님"
 
 #: pl_gram.y:2738 pl_gram.y:2748 pl_gram.y:2903
 msgid "mismatched parentheses"
-msgstr "괄호�?짝이 맞지 않음"
+msgstr "괄호의 짝이 맞지 않음"
 
 #: pl_gram.y:2752
 #, c-format
 msgid "missing \"%s\" at end of SQL expression"
-msgstr "SQL �?끝에 \"%s\" 누락"
+msgstr "SQL 식 끝에 \"%s\" 누락"
 
 #: pl_gram.y:2758
 #, c-format
 msgid "missing \"%s\" at end of SQL statement"
-msgstr "SQL �?끝에 \"%s\" 누락"
+msgstr "SQL 문 끝에 \"%s\" 누락"
 
 #: pl_gram.y:2775
 msgid "missing expression"
-msgstr "표현�?빠졌�?
+msgstr "표현식 빠졌음"
 
 #: pl_gram.y:2777
 msgid "missing SQL statement"
-msgstr "SQL 문이 빠졌�?
+msgstr "SQL 문이 빠졌음"
 
 #: pl_gram.y:2905
 msgid "incomplete data type declaration"
-msgstr "불완전한 데이�?형식 선언"
+msgstr "불완전한 데이터 형식 선언"
 
 #: pl_gram.y:2928
 msgid "missing data type declaration"
-msgstr "데이�?형식 선언 누락"
+msgstr "데이터 형식 선언 누락"
 
 #: pl_gram.y:3006
 msgid "INTO specified more than once"
-msgstr "INTO가 여러 �?지정됨"
+msgstr "INTO가 여러 번 지정됨"
 
 #: pl_gram.y:3175
 msgid "expected FROM or IN"
@@ -735,42 +735,42 @@ msgstr "FROM 또는 IN 필요"
 #: pl_gram.y:3236
 #, c-format
 msgid "RETURN cannot have a parameter in function returning set"
-msgstr "집합�?반환하는 함수에서 RETURN 구문에는 인자가 없음"
+msgstr "집합을 반환하는 함수에서 RETURN 구문에는 인자가 없음"
 
 #: pl_gram.y:3237
 #, c-format
 msgid "Use RETURN NEXT or RETURN QUERY."
-msgstr "RETURN NEXT �?RETURN QUERY 구문�?사용하세�?"
+msgstr "RETURN NEXT 나 RETURN QUERY 구문을 사용하세요."
 
 #: pl_gram.y:3247
 #, c-format
 msgid "RETURN cannot have a parameter in a procedure"
-msgstr "프로시져에서�?RETURN 문의 매개 변수를 사용�?�?없음"
+msgstr "프로시져에서는 RETURN 문의 매개 변수를 사용할 수 없음"
 
 #: pl_gram.y:3252
 #, c-format
 msgid "RETURN cannot have a parameter in function returning void"
-msgstr "RETURN은 void�?반환하는 함수�?매개 변수를 포함�?�?없음"
+msgstr "RETURN은 void를 반환하는 함수에 매개 변수를 포함할 수 없음"
 
 #: pl_gram.y:3261
 #, c-format
 msgid "RETURN cannot have a parameter in function with OUT parameters"
-msgstr "RETURN은 OUT 매개 변수가 있는 함수�?매개 변수를 포함�?�?없음"
+msgstr "RETURN은 OUT 매개 변수가 있는 함수에 매개 변수를 포함할 수 없음"
 
 #: pl_gram.y:3324
 #, c-format
 msgid "RETURN NEXT cannot have a parameter in function with OUT parameters"
-msgstr "RETURN NEXT�?OUT 매개 변수가 있는 함수�?매개 변수를 포함�?�?없음"
+msgstr "RETURN NEXT는 OUT 매개 변수가 있는 함수에 매개 변수를 포함할 수 없음"
 
 #: pl_gram.y:3432
 #, c-format
 msgid "variable \"%s\" is declared CONSTANT"
-msgstr "\"%s\" 변수는 CONSTANT�?선언�?
+msgstr "\"%s\" 변수는 CONSTANT로 선언됨"
 
 #: pl_gram.y:3495
 #, c-format
 msgid "record variable cannot be part of multiple-item INTO list"
-msgstr "다중 아이�?INTO 목록�?부분으�?record 변수가 사용�?�?없음"
+msgstr "다중 아이템 INTO 목록의 부분으로 record 변수가 사용될 수 없음"
 
 #: pl_gram.y:3541
 #, c-format
@@ -780,46 +780,46 @@ msgstr "너무 많은 INTO 변수가 지정됨"
 #: pl_gram.y:3752
 #, c-format
 msgid "end label \"%s\" specified for unlabeled block"
-msgstr "레이블이 없는 블록�?�?레이�?\"%s\"�?가) 지정됨"
+msgstr "레이블이 없는 블록에 끝 레이블 \"%s\"이(가) 지정됨"
 
 #: pl_gram.y:3759
 #, c-format
 msgid "end label \"%s\" differs from block's label \"%s\""
-msgstr "�?레이�?\"%s\"�?가) 블록�?\"%s\" 레이블과 다름"
+msgstr "끝 레이블 \"%s\"이(가) 블록의 \"%s\" 레이블과 다름"
 
 #: pl_gram.y:3794
 #, c-format
 msgid "cursor \"%s\" has no arguments"
-msgstr "\"%s\" 커서�?인수가 없음"
+msgstr "\"%s\" 커서에 인수가 없음"
 
 #: pl_gram.y:3808
 #, c-format
 msgid "cursor \"%s\" has arguments"
-msgstr "\"%s\" 커서�?인수가 있음"
+msgstr "\"%s\" 커서에 인수가 있음"
 
 #: pl_gram.y:3850
 #, c-format
 msgid "cursor \"%s\" has no argument named \"%s\""
-msgstr "\"%s\" 커서�?\"%s\" 이름�?인자가 없음"
+msgstr "\"%s\" 커서는 \"%s\" 이름의 인자가 없음"
 
 #: pl_gram.y:3870
 #, c-format
 msgid "value for parameter \"%s\" of cursor \"%s\" specified more than once"
-msgstr "\"%s\" 이름�?인자가 \"%s\" 커서에서 중복�?
+msgstr "\"%s\" 이름의 인자가 \"%s\" 커서에서 중복됨"
 
 #: pl_gram.y:3895
 #, c-format
 msgid "not enough arguments for cursor \"%s\""
-msgstr "\"%s\" 커서�?위한 충분하지 않은 인자"
+msgstr "\"%s\" 커서를 위한 충분하지 않은 인자"
 
 #: pl_gram.y:3902
 #, c-format
 msgid "too many arguments for cursor \"%s\""
-msgstr "\"%s\" 커서�?위한 인자가 너무 많음"
+msgstr "\"%s\" 커서를 위한 인자가 너무 많음"
 
 #: pl_gram.y:3989
 msgid "unrecognized RAISE statement option"
-msgstr "인식�?�?없는 RAISE �?옵션"
+msgstr "인식할 수 없는 RAISE 문 옵션"
 
 #: pl_gram.y:3993
 msgid "syntax error, expected \"=\""
@@ -828,48 +828,48 @@ msgstr "구문 오류, \"=\" 필요"
 #: pl_gram.y:4034
 #, c-format
 msgid "too many parameters specified for RAISE"
-msgstr "RAISE�?지정된 매개 변수가 너무 많음"
+msgstr "RAISE에 지정된 매개 변수가 너무 많음"
 
 #: pl_gram.y:4038
 #, c-format
 msgid "too few parameters specified for RAISE"
-msgstr "RAISE�?지정된 매개 변수가 너무 적음"
+msgstr "RAISE에 지정된 매개 변수가 너무 적음"
 
 #: pl_handler.c:156
 msgid ""
 "Sets handling of conflicts between PL/iSQL variable names and table column "
 "names."
 msgstr ""
-"PL/iSQL 변수명�?테이�?칼럼�?사이 충돌�?일어�?경우�?대�?처리�?하세�?"
+"PL/iSQL 변수명과 테이블 칼럼명 사이 충돌이 일어날 경우에 대한 처리를 하세요."
 
 #: pl_handler.c:165
 msgid ""
 "Print information about parameters in the DETAIL part of the error messages "
 "generated on INTO ... STRICT failures."
 msgstr ""
-"INTO ... STRICT 실패에서 오류 메시지�?만들 �?�?DETAIL 부분에 들어�?내용"
-"�?출력 하세�?
+"INTO ... STRICT 실패에서 오류 메시지를 만들 때 그 DETAIL 부분에 들어갈 내용"
+"을 출력 하세요"
 
 #: pl_handler.c:173
 msgid "Perform checks given in ASSERT statements."
-msgstr "ASSERT 구문에서 주어�?검사를 수행하세�?"
+msgstr "ASSERT 구문에서 주어진 검사를 수행하세요."
 
 #: pl_handler.c:181
 msgid "List of programming constructs that should produce a warning."
-msgstr "경고�?처리�?프로그래�?컨스트럭�?목록"
+msgstr "경고로 처리할 프로그래밍 컨스트럭트 목록"
 
 #: pl_handler.c:191
 msgid "List of programming constructs that should produce an error."
-msgstr "오류�?처리�?프로그래�?컨스트럭�?목록"
+msgstr "오류로 처리할 프로그래밍 컨스트럭트 목록"
 
 #. translator: %s is typically the translation of "syntax error"
 #: pl_scanner.c:508
 #, c-format
 msgid "%s at end of input"
-msgstr "%s, 입력 끝부�?
+msgstr "%s, 입력 끝부분"
 
 #. translator: first %s is typically the translation of "syntax error"
 #: pl_scanner.c:524
 #, c-format
 msgid "%s at or near \"%s\""
-msgstr "%s, \"%s\" 부�?
+msgstr "%s, \"%s\" 부근"

--- a/src/pl/plisql/src/po/vi.po
+++ b/src/pl/plisql/src/po/vi.po
@@ -21,27 +21,27 @@ msgstr ""
 #: pl_comp.c:434 pl_handler.c:457
 #, c-format
 msgid "PL/iSQL functions cannot accept type %s"
-msgstr "Các hàm PL/iSQL không th�?chấp nhận kiểu %s"
+msgstr "Các hàm PL/iSQL không thể chấp nhận kiểu %s"
 
 #: pl_comp.c:522
 #, c-format
 msgid "could not determine actual return type for polymorphic function \"%s\""
-msgstr "không th�?xác định kiểu thực t�?tr�?v�?cho hàm đa hình \"%s\""
+msgstr "không thể xác định kiểu thực tế trả về cho hàm đa hình \"%s\""
 
 #: pl_comp.c:552
 #, c-format
 msgid "trigger functions can only be called as triggers"
-msgstr "hàm trigger ch�?có th�?được gọi như một trigger"
+msgstr "hàm trigger chỉ có thể được gọi như một trigger"
 
 #: pl_comp.c:556 pl_handler.c:441
 #, c-format
 msgid "PL/iSQL functions cannot return type %s"
-msgstr "Các hàm PL/iSQL không th�?tr�?v�?kiểu %s"
+msgstr "Các hàm PL/iSQL không thể trả về kiểu %s"
 
 #: pl_comp.c:595
 #, c-format
 msgid "trigger functions cannot have declared arguments"
-msgstr "không th�?khai báo đối s�?cho hàm trigger"
+msgstr "không thể khai báo đối số cho hàm trigger"
 
 #: pl_comp.c:596
 #, c-format
@@ -49,13 +49,13 @@ msgid ""
 "The arguments of the trigger can be accessed through TG_NARGS and TG_ARGV "
 "instead."
 msgstr ""
-"Thay vào đó các đối s�?của trigger có th�?được truy cập thông qua TG_NARGS "
+"Thay vào đó các đối số của trigger có thể được truy cập thông qua TG_NARGS "
 "và TG_ARGV."
 
 #: pl_comp.c:719
 #, c-format
 msgid "event trigger functions cannot have declared arguments"
-msgstr "không th�?khai báo đối s�?cho hàm s�?kiện trigger"
+msgstr "không thể khai báo đối số cho hàm sự kiện trigger"
 
 #: pl_comp.c:976
 #, c-format
@@ -65,7 +65,7 @@ msgstr "biên dịch hàm PL/iSQL \"%s\" gần dòng %d"
 #: pl_comp.c:999
 #, c-format
 msgid "parameter name \"%s\" used more than once"
-msgstr "tên thông s�?\"%s\" được s�?dụng nhiều lần"
+msgstr "tên thông số \"%s\" được sử dụng nhiều lần"
 
 #: pl_comp.c:1109
 #, c-format
@@ -75,7 +75,7 @@ msgstr "tham chiếu cột \"%s\" không rõ ràng"
 #: pl_comp.c:1111
 #, c-format
 msgid "It could refer to either a PL/iSQL variable or a table column."
-msgstr "Nó có th�?tham chiếu đến một biến PL/iSQL hoặc một cột bảng."
+msgstr "Nó có thể tham chiếu đến một biến PL/iSQL hoặc một cột bảng."
 
 #: pl_comp.c:1294 pl_exec.c:5031 pl_exec.c:5396 pl_exec.c:5483 pl_exec.c:5574
 #: pl_exec.c:6491
@@ -96,18 +96,18 @@ msgstr "biến \"%s\" có pseudo-type %s"
 #: pl_comp.c:2026
 #, c-format
 msgid "type \"%s\" is only a shell"
-msgstr "kiểu \"%s\" ch�?là một shell(chưa được định nghĩa nội dung)"
+msgstr "kiểu \"%s\" chỉ là một shell(chưa được định nghĩa nội dung)"
 
 #: pl_comp.c:2123 pl_comp.c:2176
 #, c-format
 msgid "unrecognized exception condition \"%s\""
-msgstr "không th�?nhận ra điều kiện của ngoại l�?\"%s\""
+msgstr "không thể nhận ra điều kiện của ngoại lệ \"%s\""
 
 #: pl_comp.c:2390
 #, c-format
 msgid ""
 "could not determine actual argument type for polymorphic function \"%s\""
-msgstr "không th�?xác định loại đối s�?thực t�?cho hàm đa hình \"%s\""
+msgstr "không thể xác định loại đối số thực tế cho hàm đa hình \"%s\""
 
 #: pl_exec.c:473 pl_exec.c:885 pl_exec.c:1098
 msgid "during initialization of execution state"
@@ -115,7 +115,7 @@ msgstr "trong khi khởi tạo trạng thái thực thi"
 
 #: pl_exec.c:479
 msgid "while storing call arguments into local variables"
-msgstr "trong khi lưu tr�?các đối s�?gọi vào trong các biến cục b�?
+msgstr "trong khi lưu trữ các đối số gọi vào trong các biến cục bộ"
 
 #: pl_exec.c:567 pl_exec.c:933
 msgid "during function entry"
@@ -124,17 +124,17 @@ msgstr "trong lúc đi vào hàm"
 #: pl_exec.c:592
 #, c-format
 msgid "control reached end of function without RETURN"
-msgstr "Hàm đã kết thúc trước khi tr�?v�?RETURN"
+msgstr "Hàm đã kết thúc trước khi trả về RETURN"
 
 #: pl_exec.c:599
 msgid "while casting return value to function's return type"
-msgstr "trong khi ép kiểu giá tr�?tr�?v�?cho kiểu tr�?v�?của hàm"
+msgstr "trong khi ép kiểu giá trị trả về cho kiểu trả về của hàm"
 
 #: pl_exec.c:612 pl_exec.c:3484
 #, c-format
 msgid "set-valued function called in context that cannot accept a set"
 msgstr ""
-"hàm thiết lập giá tr�?được gọi trong ng�?cảnh không th�?chấp nhận một tập hợp"
+"hàm thiết lập giá trị được gọi trong ngữ cảnh không thể chấp nhận một tập hợp"
 
 #: pl_exec.c:738 pl_exec.c:962 pl_exec.c:1123
 msgid "during function exit"
@@ -142,22 +142,22 @@ msgstr "trong lúc kết thúc hàm"
 
 #: pl_exec.c:793 pl_exec.c:832 pl_exec.c:3329
 msgid "returned record type does not match expected record type"
-msgstr "loại bản ghi đã tr�?v�?không khớp với kiểu được ghi k�?vọng"
+msgstr "loại bản ghi đã trả về không khớp với kiểu được ghi kỳ vọng"
 
 #: pl_exec.c:958 pl_exec.c:1119
 #, c-format
 msgid "control reached end of trigger procedure without RETURN"
-msgstr "th�?tục trigger kết thúc trước khi tra v�?RETURN"
+msgstr "thủ tục trigger kết thúc trước khi tra về RETURN"
 
 #: pl_exec.c:967
 #, c-format
 msgid "trigger procedure cannot return a set"
-msgstr "th�?tục trigger không th�?tr�?v�?một tập hợp"
+msgstr "thủ tục trigger không thể trả về một tập hợp"
 
 #: pl_exec.c:1006 pl_exec.c:1034
 msgid ""
 "returned row structure does not match the structure of the triggering table"
-msgstr "cấu trúc hàng tr�?v�?không khớp với cấu trúc của trigger bảng"
+msgstr "cấu trúc hàng trả về không khớp với cấu trúc của trigger bảng"
 
 #. translator: last %s is a phrase such as "during statement block
 #. local variable initialization"
@@ -188,7 +188,7 @@ msgstr "Hàm PL/iSQL %s"
 
 #: pl_exec.c:1534
 msgid "during statement block local variable initialization"
-msgstr "trong khi khởi tạo biến cục b�?trong khối lệnh"
+msgstr "trong khi khởi tạo biến cục bộ trong khối lệnh"
 
 #: pl_exec.c:1632
 msgid "during statement block entry"
@@ -200,19 +200,19 @@ msgstr "trong khi kết thúc khối lệnh"
 
 #: pl_exec.c:1702
 msgid "during exception cleanup"
-msgstr "trong khi dọn dẹp ngoại l�?
+msgstr "trong khi dọn dẹp ngoại lệ"
 
 #: pl_exec.c:2207 pl_exec.c:2221
 #, c-format
 msgid "argument %d is an output argument but is not writable"
-msgstr "đối s�?%d là đối s�?đầu ra nhưng không th�?ghi"
+msgstr "đối số %d là đối số đầu ra nhưng không thể ghi"
 
 #: pl_exec.c:2263
 #, c-format
 msgid "GET STACKED DIAGNOSTICS cannot be used outside an exception handler"
 msgstr ""
-"GET STACKED DIAGNOSTICS không th�?được s�?dụng bên ngoài bên ngoài một trình "
-"x�?lý ngoại l�?
+"GET STACKED DIAGNOSTICS không thể được sử dụng bên ngoài bên ngoài một trình "
+"xử lý ngoại lệ"
 
 #: pl_exec.c:2468
 #, c-format
@@ -227,37 +227,37 @@ msgstr "Câu lệnh CASE thiếu phần ELSE."
 #: pl_exec.c:2562
 #, c-format
 msgid "lower bound of FOR loop cannot be null"
-msgstr "giới hạn dưới của vòng lặp FOR không th�?là null"
+msgstr "giới hạn dưới của vòng lặp FOR không thể là null"
 
 #: pl_exec.c:2578
 #, c-format
 msgid "upper bound of FOR loop cannot be null"
-msgstr "giới hạn trên của vòng lặp FOR không th�?là null"
+msgstr "giới hạn trên của vòng lặp FOR không thể là null"
 
 #: pl_exec.c:2596
 #, c-format
 msgid "BY value of FOR loop cannot be null"
-msgstr "Giá tr�?BY của vòng lặp FOR không th�?là null"
+msgstr "Giá trị BY của vòng lặp FOR không thể là null"
 
 #: pl_exec.c:2602
 #, c-format
 msgid "BY value of FOR loop must be greater than zero"
-msgstr "Giá tr�?BY của vòng lặp FOR phải lớn hơn 0"
+msgstr "Giá trị BY của vòng lặp FOR phải lớn hơn 0"
 
 #: pl_exec.c:2736 pl_exec.c:4461
 #, c-format
 msgid "cursor \"%s\" already in use"
-msgstr "con tr�?\"%s\" đã đang được s�?dụng"
+msgstr "con trỏ \"%s\" đã đang được sử dụng"
 
 #: pl_exec.c:2759 pl_exec.c:4526
 #, c-format
 msgid "arguments given for cursor without arguments"
-msgstr "đối s�?được đưa ra cho con tr�?không có đối s�?
+msgstr "đối số được đưa ra cho con trỏ không có đối số"
 
 #: pl_exec.c:2778 pl_exec.c:4545
 #, c-format
 msgid "arguments required for cursor"
-msgstr "đối s�?cần thiết cho con tr�?
+msgstr "đối số cần thiết cho con trỏ"
 
 #: pl_exec.c:2865
 #, c-format
@@ -272,7 +272,7 @@ msgstr "Biểu thức FOREACH phải tạo ra một mảng, không phải kiểu
 #: pl_exec.c:2897
 #, c-format
 msgid "slice dimension (%d) is out of the valid range 0..%d"
-msgstr "kích thước slice (%d) nằm ngoài phạm vi hợp l�?0..%d"
+msgstr "kích thước slice (%d) nằm ngoài phạm vi hợp lệ 0..%d"
 
 #: pl_exec.c:2924
 #, c-format
@@ -288,53 +288,53 @@ msgstr "Biến vòng lặp FOREACH không được thuộc loại mảng"
 #, c-format
 msgid ""
 "cannot return non-composite value from function returning composite type"
-msgstr "không th�?tr�?v�?giá tr�?không-phức hợp t�?hàm tr�?v�?kiểu phức hợp"
+msgstr "không thể trả về giá trị không-phức hợp từ hàm trả về kiểu phức hợp"
 
 #: pl_exec.c:3186 pl_gram.y:3266
 #, c-format
 msgid "cannot use RETURN NEXT in a non-SETOF function"
-msgstr "không th�?s�?dụng RETURN NEXT trong một hàm không phải-SETOF"
+msgstr "không thể sử dụng RETURN NEXT trong một hàm không phải-SETOF"
 
 #: pl_exec.c:3227 pl_exec.c:3359
 #, c-format
 msgid "wrong result type supplied in RETURN NEXT"
-msgstr "kiểu kết qu�?tr�?v�?không đúng trong RETURN NEXT"
+msgstr "kiểu kết quả trả về không đúng trong RETURN NEXT"
 
 #: pl_exec.c:3265 pl_exec.c:3286
 #, c-format
 msgid "wrong record type supplied in RETURN NEXT"
-msgstr "kiểu bản ghi tr�?v�?không đúng trong RETURN NEXT"
+msgstr "kiểu bản ghi trả về không đúng trong RETURN NEXT"
 
 #: pl_exec.c:3378
 #, c-format
 msgid "RETURN NEXT must have a parameter"
-msgstr "RETURN NEXT phải có một tham s�?
+msgstr "RETURN NEXT phải có một tham số"
 
 #: pl_exec.c:3404 pl_gram.y:3329
 #, c-format
 msgid "cannot use RETURN QUERY in a non-SETOF function"
-msgstr "không th�?s�?dụng RETURN QUERY trong một hàm không phải-SETOF"
+msgstr "không thể sử dụng RETURN QUERY trong một hàm không phải-SETOF"
 
 #: pl_exec.c:3428
 msgid "structure of query does not match function result type"
-msgstr "cấu trúc của truy vấn không khớp với kiểu kết qu�?hàm"
+msgstr "cấu trúc của truy vấn không khớp với kiểu kết quả hàm"
 
 #: pl_exec.c:3512 pl_exec.c:3650
 #, c-format
 msgid "RAISE option already specified: %s"
-msgstr "Tùy chọn RAISE đã được ch�?định: %s"
+msgstr "Tùy chọn RAISE đã được chỉ định: %s"
 
 #: pl_exec.c:3546
 #, c-format
 msgid "RAISE without parameters cannot be used outside an exception handler"
 msgstr ""
-"RAISE không có tham s�?không th�?được s�?dụng bên ngoài một trình x�?lý "
-"ngoại l�?
+"RAISE không có tham số không thể được sử dụng bên ngoài một trình xử lý "
+"ngoại lệ"
 
 #: pl_exec.c:3640
 #, c-format
 msgid "RAISE statement option cannot be null"
-msgstr "Tùy chọn lệnh RAISE không th�?là null"
+msgstr "Tùy chọn lệnh RAISE không thể là null"
 
 #: pl_exec.c:3710
 #, c-format
@@ -349,47 +349,47 @@ msgstr "lỗi assertion"
 #: pl_exec.c:3970 pl_exec.c:4117 pl_exec.c:4301
 #, c-format
 msgid "cannot COPY to/from client in PL/iSQL"
-msgstr "không th�?COPY tới/t�?client trong PL/iSQL"
+msgstr "không thể COPY tới/từ client trong PL/iSQL"
 
 #: pl_exec.c:3974 pl_exec.c:4121 pl_exec.c:4305
 #, c-format
 msgid "cannot begin/end transactions in PL/iSQL"
-msgstr "không th�?begin/end transactions trong PL/iSQL"
+msgstr "không thể begin/end transactions trong PL/iSQL"
 
 #: pl_exec.c:3975 pl_exec.c:4122 pl_exec.c:4306
 #, c-format
 msgid "Use a BEGIN block with an EXCEPTION clause instead."
-msgstr "S�?dụng một khối BEGIN với một cấu trúc EXCEPTION đ�?thay th�?"
+msgstr "Sử dụng một khối BEGIN với một cấu trúc EXCEPTION để thay thế."
 
 #: pl_exec.c:4144 pl_exec.c:4329
 #, c-format
 msgid "INTO used with a command that cannot return data"
-msgstr "INTO được s�?dụng với lệnh không th�?tr�?v�?d�?liệu"
+msgstr "INTO được sử dụng với lệnh không thể trả về dữ liệu"
 
 #: pl_exec.c:4167 pl_exec.c:4352
 #, c-format
 msgid "query returned no rows"
-msgstr "truy vấn không tr�?lại dòng nào"
+msgstr "truy vấn không trả lại dòng nào"
 
 #: pl_exec.c:4186 pl_exec.c:4371
 #, c-format
 msgid "query returned more than one row"
-msgstr "truy vấn tr�?v�?nhiều dòng"
+msgstr "truy vấn trả về nhiều dòng"
 
 #: pl_exec.c:4203
 #, c-format
 msgid "query has no destination for result data"
-msgstr "truy vấn không có đích cho d�?liệu kết qu�?
+msgstr "truy vấn không có đích cho dữ liệu kết quả"
 
 #: pl_exec.c:4204
 #, c-format
 msgid "If you want to discard the results of a SELECT, use PERFORM instead."
-msgstr "Nếu bạn không muốn s�?dụng kết qu�?của SELECT, hãy s�?dụng PERFORM."
+msgstr "Nếu bạn không muốn sử dụng kết quả của SELECT, hãy sử dụng PERFORM."
 
 #: pl_exec.c:4237 pl_exec.c:8212
 #, c-format
 msgid "query string argument of EXECUTE is null"
-msgstr "đối s�?chuỗi truy vấn của EXECUTE là null"
+msgstr "đối số chuỗi truy vấn của EXECUTE là null"
 
 #: pl_exec.c:4293
 #, c-format
@@ -402,74 +402,74 @@ msgid ""
 "You might want to use EXECUTE ... INTO or EXECUTE CREATE TABLE ... AS "
 "instead."
 msgstr ""
-"Thay vào đó có th�?bạn muốn s�?dụng EXECUTE ... INTO hoặc EXECUTE CREATE "
+"Thay vào đó có thể bạn muốn sử dụng EXECUTE ... INTO hoặc EXECUTE CREATE "
 "TABLE ... AS."
 
 #: pl_exec.c:4607 pl_exec.c:4695
 #, c-format
 msgid "cursor variable \"%s\" is null"
-msgstr "biến con tr�?\"%s\" là null"
+msgstr "biến con trỏ \"%s\" là null"
 
 #: pl_exec.c:4618 pl_exec.c:4706
 #, c-format
 msgid "cursor \"%s\" does not exist"
-msgstr "con tr�?\"%s\" không tồn tại"
+msgstr "con trỏ \"%s\" không tồn tại"
 
 #: pl_exec.c:4631
 #, c-format
 msgid "relative or absolute cursor position is null"
-msgstr "v�?trí con tr�?tương đối hoặc tuyệt đối là null"
+msgstr "vị trí con trỏ tương đối hoặc tuyệt đối là null"
 
 #: pl_exec.c:4881 pl_exec.c:4976
 #, c-format
 msgid "null value cannot be assigned to variable \"%s\" declared NOT NULL"
-msgstr "giá tr�?null không th�?được gán cho biến \"%s\" được khai báo NOT NULL"
+msgstr "giá trị null không thể được gán cho biến \"%s\" được khai báo NOT NULL"
 
 #: pl_exec.c:4957
 #, c-format
 msgid "cannot assign non-composite value to a row variable"
-msgstr "không th�?gán giá tr�?không-phức hợp cho biến dòng"
+msgstr "không thể gán giá trị không-phức hợp cho biến dòng"
 
 #: pl_exec.c:4989
 #, c-format
 msgid "cannot assign non-composite value to a record variable"
-msgstr "không th�?gán giá tr�?không phải-phức hợp cho biến bản ghi"
+msgstr "không thể gán giá trị không phải-phức hợp cho biến bản ghi"
 
 #: pl_exec.c:5040
 #, c-format
 msgid "cannot assign to system column \"%s\""
-msgstr "không th�?gán cho cột h�?thống \"%s\""
+msgstr "không thể gán cho cột hệ thống \"%s\""
 
 #: pl_exec.c:5104
 #, c-format
 msgid "number of array dimensions (%d) exceeds the maximum allowed (%d)"
-msgstr "s�?lượng chiều của mảng (%d) vượt quá s�?lượng tối đa cho phép (%d)"
+msgstr "số lượng chiều của mảng (%d) vượt quá số lượng tối đa cho phép (%d)"
 
 #: pl_exec.c:5136
 #, c-format
 msgid "subscripted object is not an array"
-msgstr "đối tượng ch�?s�?không phải là một mảng"
+msgstr "đối tượng chỉ số không phải là một mảng"
 
 #: pl_exec.c:5174
 #, c-format
 msgid "array subscript in assignment must not be null"
-msgstr "ch�?s�?mảng s�?dụng trong gán không th�?là null"
+msgstr "chỉ số mảng sử dụng trong gán không thể là null"
 
 #: pl_exec.c:5681
 #, c-format
 msgid "query \"%s\" did not return data"
-msgstr "truy vấn \"%s\" không tr�?v�?d�?liệu"
+msgstr "truy vấn \"%s\" không trả về dữ liệu"
 
 #: pl_exec.c:5689
 #, c-format
 msgid "query \"%s\" returned %d column"
 msgid_plural "query \"%s\" returned %d columns"
-msgstr[0] "truy vấn \"%s\" tr�?lại %d cột"
+msgstr[0] "truy vấn \"%s\" trả lại %d cột"
 
 #: pl_exec.c:5717
 #, c-format
 msgid "query \"%s\" returned more than one row"
-msgstr "truy vấn \"%s\" đã tr�?lại nhiều hàng"
+msgstr "truy vấn \"%s\" đã trả lại nhiều hàng"
 
 #: pl_exec.c:5780
 #, c-format
@@ -480,7 +480,7 @@ msgstr "truy vấn \"%s\" không phải là một SELECT"
 #, c-format
 msgid ""
 "type of parameter %d (%s) does not match that when preparing the plan (%s)"
-msgstr "kiểu tham s�?%d (%s) không khớp với thông s�?khi chuẩn b�?plan (%s)"
+msgstr "kiểu tham số %d (%s) không khớp với thông số khi chuẩn bị plan (%s)"
 
 #: pl_exec.c:7356
 #, c-format
@@ -502,7 +502,7 @@ msgstr "gán"
 
 #: pl_funcs.c:251
 msgid "FOR with integer loop variable"
-msgstr "FOR với biến s�?nguyên vòng lặp"
+msgstr "FOR với biến số nguyên vòng lặp"
 
 #: pl_funcs.c:253
 msgid "FOR over SELECT rows"
@@ -510,7 +510,7 @@ msgstr "FOR trên các dòng SELECT"
 
 #: pl_funcs.c:255
 msgid "FOR over cursor"
-msgstr "FOR trên con tr�?
+msgstr "FOR trên con trỏ"
 
 #: pl_funcs.c:257
 msgid "FOREACH over array"
@@ -532,12 +532,12 @@ msgstr "nhãn khối phải được đặt trước DECLARE, không phải sau"
 #: pl_gram.y:505
 #, c-format
 msgid "collations are not supported by type %s"
-msgstr "collation không được h�?tr�?bởi kiểu %s"
+msgstr "collation không được hỗ trợ bởi kiểu %s"
 
 #: pl_gram.y:524
 #, c-format
 msgid "variable \"%s\" must have a default value, since it's declared NOT NULL"
-msgstr "biến \"%s\" phải có giá tr�?mặc định, vì nó được khai báo là NOT NULL"
+msgstr "biến \"%s\" phải có giá trị mặc định, vì nó được khai báo là NOT NULL"
 
 #: pl_gram.y:669 pl_gram.y:684 pl_gram.y:710
 #, c-format
@@ -551,7 +551,7 @@ msgstr "khai báo trùng lặp"
 #: pl_gram.y:739 pl_gram.y:767
 #, c-format
 msgid "variable \"%s\" shadows a previously defined variable"
-msgstr "biến \"%s\" làm cho một biến được định nghĩa trước đó không kh�?th�?
+msgstr "biến \"%s\" làm cho một biến được định nghĩa trước đó không khả thị"
 
 #: pl_gram.y:983
 #, c-format
@@ -584,22 +584,22 @@ msgstr ""
 #: pl_gram.y:1391
 #, c-format
 msgid "cursor FOR loop must have only one target variable"
-msgstr "vòng lặp FOR s�?dụng con tr�?ch�?có một biến đích"
+msgstr "vòng lặp FOR sử dụng con trỏ chỉ có một biến đích"
 
 #: pl_gram.y:1398
 #, c-format
 msgid "cursor FOR loop must use a bound cursor variable"
-msgstr "vòng lặp FOR s�?dụng con tr�?phải s�?dụng một biến con tr�?
+msgstr "vòng lặp FOR sử dụng con trỏ phải sử dụng một biến con trỏ"
 
 #: pl_gram.y:1485
 #, c-format
 msgid "integer FOR loop must have only one target variable"
-msgstr "vòng lặp FOR s�?dụng s�?nguyên ch�?được phép có một biến đích"
+msgstr "vòng lặp FOR sử dụng số nguyên chỉ được phép có một biến đích"
 
 #: pl_gram.y:1521
 #, c-format
 msgid "cannot specify REVERSE in query FOR loop"
-msgstr "không th�?ch�?định REVERSE trong vòng lặp truy vấn FOR"
+msgstr "không thể chỉ định REVERSE trong vòng lặp truy vấn FOR"
 
 #: pl_gram.y:1652
 #, c-format
@@ -612,24 +612,24 @@ msgid ""
 "there is no label \"%s\" attached to any block or loop enclosing this "
 "statement"
 msgstr ""
-"không có nhãn \"%s\" được đính kèm với bất k�?khối hoặc vòng lặp nào kèm "
+"không có nhãn \"%s\" được đính kèm với bất kỳ khối hoặc vòng lặp nào kèm "
 "theo câu lệnh này"
 
 #: pl_gram.y:1701
 #, c-format
 msgid "block label \"%s\" cannot be used in CONTINUE"
-msgstr "không th�?s�?dụng nhãn khối \"%s\" trong CONTINUE"
+msgstr "không thể sử dụng nhãn khối \"%s\" trong CONTINUE"
 
 #: pl_gram.y:1716
 #, c-format
 msgid "EXIT cannot be used outside a loop, unless it has a label"
 msgstr ""
-"EXIT không th�?được s�?dụng bên ngoài một vòng lặp, tr�?khi nó có một nhãn"
+"EXIT không thể được sử dụng bên ngoài một vòng lặp, trừ khi nó có một nhãn"
 
 #: pl_gram.y:1717
 #, c-format
 msgid "CONTINUE cannot be used outside a loop"
-msgstr "Không th�?s�?dụng CONTINUE bên ngoài vòng lặp"
+msgstr "Không thể sử dụng CONTINUE bên ngoài vòng lặp"
 
 #: pl_gram.y:1741 pl_gram.y:1778 pl_gram.y:1826 pl_gram.y:2958 pl_gram.y:3041
 #: pl_gram.y:3152 pl_gram.y:3907
@@ -644,26 +644,26 @@ msgstr "lỗi cú pháp"
 
 #: pl_gram.y:1874 pl_gram.y:1876 pl_gram.y:2364 pl_gram.y:2366
 msgid "invalid SQLSTATE code"
-msgstr "mã SQLSTATE không hợp l�?
+msgstr "mã SQLSTATE không hợp lệ"
 
 #: pl_gram.y:2073
 msgid "syntax error, expected \"FOR\""
-msgstr "lỗi cú pháp, k�?vọng \"FOR\""
+msgstr "lỗi cú pháp, kỳ vọng \"FOR\""
 
 #: pl_gram.y:2134
 #, c-format
 msgid "FETCH statement cannot return multiple rows"
-msgstr "Câu lệnh FETCH không th�?tr�?v�?nhiều hàng"
+msgstr "Câu lệnh FETCH không thể trả về nhiều hàng"
 
 #: pl_gram.y:2244
 #, c-format
 msgid "cursor variable must be a simple variable"
-msgstr "biến con tr�?phải là một biến đơn giản"
+msgstr "biến con trỏ phải là một biến đơn giản"
 
 #: pl_gram.y:2250
 #, c-format
 msgid "variable \"%s\" must be of type cursor or refcursor"
-msgstr "biến \"%s\" phải là kiểu con tr�?hoặc refcursor"
+msgstr "biến \"%s\" phải là kiểu con trỏ hoặc refcursor"
 
 #: pl_gram.y:2583 pl_gram.y:2594
 #, c-format
@@ -677,12 +677,12 @@ msgstr "dấu ngoặc đơn không khớp"
 #: pl_gram.y:2712
 #, c-format
 msgid "missing \"%s\" at end of SQL expression"
-msgstr "thiếu \"%s\" �?cuối biểu thức SQL"
+msgstr "thiếu \"%s\" ở cuối biểu thức SQL"
 
 #: pl_gram.y:2718
 #, c-format
 msgid "missing \"%s\" at end of SQL statement"
-msgstr "thiếu \"%s\" �?cuối câu lệnh SQL"
+msgstr "thiếu \"%s\" ở cuối câu lệnh SQL"
 
 #: pl_gram.y:2735
 msgid "missing expression"
@@ -694,49 +694,49 @@ msgstr "thiếu câu lệnh SQL"
 
 #: pl_gram.y:2865
 msgid "incomplete data type declaration"
-msgstr "khai báo kiểu d�?liệu không đầy đ�?
+msgstr "khai báo kiểu dữ liệu không đầy đủ"
 
 #: pl_gram.y:2888
 msgid "missing data type declaration"
-msgstr "thiếu khai báo kiểu d�?liệu"
+msgstr "thiếu khai báo kiểu dữ liệu"
 
 #: pl_gram.y:2966
 msgid "INTO specified more than once"
-msgstr "INTO được ch�?định nhiều lần"
+msgstr "INTO được chỉ định nhiều lần"
 
 #: pl_gram.y:3133
 msgid "expected FROM or IN"
-msgstr "k�?vọng FROM hoặc IN"
+msgstr "kỳ vọng FROM hoặc IN"
 
 #: pl_gram.y:3193
 #, c-format
 msgid "RETURN cannot have a parameter in function returning set"
-msgstr "RETURN không th�?có tham s�?trong tập hợp giá tr�?tr�?v�?của hàm"
+msgstr "RETURN không thể có tham số trong tập hợp giá trị trả về của hàm"
 
 #: pl_gram.y:3194
 #, c-format
 msgid "Use RETURN NEXT or RETURN QUERY."
-msgstr "s�?dụng RETURN NEXT hay RETURN QUERY."
+msgstr "sử dụng RETURN NEXT hay RETURN QUERY."
 
 #: pl_gram.y:3204
 #, c-format
 msgid "RETURN cannot have a parameter in a procedure"
-msgstr "RETURN không th�?có tham s�?trong một th�?tục"
+msgstr "RETURN không thể có tham số trong một thủ tục"
 
 #: pl_gram.y:3209
 #, c-format
 msgid "RETURN cannot have a parameter in function returning void"
-msgstr "RETURN không th�?có tham s�?trong hàm tr�?v�?void"
+msgstr "RETURN không thể có tham số trong hàm trả về void"
 
 #: pl_gram.y:3218
 #, c-format
 msgid "RETURN cannot have a parameter in function with OUT parameters"
-msgstr "RETURN không th�?có tham s�?trong hàm với tham s�?OUT"
+msgstr "RETURN không thể có tham số trong hàm với tham số OUT"
 
 #: pl_gram.y:3280
 #, c-format
 msgid "RETURN NEXT cannot have a parameter in function with OUT parameters"
-msgstr "RETURN NEXT không th�?có tham s�?trong hàm với tham s�?OUT"
+msgstr "RETURN NEXT không thể có tham số trong hàm với tham số OUT"
 
 #: pl_gram.y:3387
 #, c-format
@@ -746,17 +746,17 @@ msgstr "biến \"%s\" được khai báo CONSTANT"
 #: pl_gram.y:3450
 #, c-format
 msgid "record variable cannot be part of multiple-item INTO list"
-msgstr "biến bản ghi không th�?là một phần của danh sách INTO nhiều mục"
+msgstr "biến bản ghi không thể là một phần của danh sách INTO nhiều mục"
 
 #: pl_gram.y:3496
 #, c-format
 msgid "too many INTO variables specified"
-msgstr "quá nhiều biến INTO được ch�?định"
+msgstr "quá nhiều biến INTO được chỉ định"
 
 #: pl_gram.y:3702
 #, c-format
 msgid "end label \"%s\" specified for unlabelled block"
-msgstr "nhãn kết thúc \"%s\" được ch�?định cho khối không được gắn nhãn"
+msgstr "nhãn kết thúc \"%s\" được chỉ định cho khối không được gắn nhãn"
 
 #: pl_gram.y:3709
 #, c-format
@@ -766,63 +766,63 @@ msgstr "nhãn kết thúc \"%s\" khác với nhãn của block \"%s\""
 #: pl_gram.y:3744
 #, c-format
 msgid "cursor \"%s\" has no arguments"
-msgstr "con tr�?\"%s\" không có đối s�?
+msgstr "con trỏ \"%s\" không có đối số"
 
 #: pl_gram.y:3758
 #, c-format
 msgid "cursor \"%s\" has arguments"
-msgstr "con tr�?\"%s\" có đối s�?
+msgstr "con trỏ \"%s\" có đối số"
 
 #: pl_gram.y:3800
 #, c-format
 msgid "cursor \"%s\" has no argument named \"%s\""
-msgstr "con tr�?\"%s\" không có đối s�?tên là \"%s\""
+msgstr "con trỏ \"%s\" không có đối số tên là \"%s\""
 
 #: pl_gram.y:3820
 #, c-format
 msgid "value for parameter \"%s\" of cursor \"%s\" specified more than once"
-msgstr "giá tr�?cho tham s�?\"%s\" của con tr�?\"%s\" được ch�?định nhiều lần"
+msgstr "giá trị cho tham số \"%s\" của con trỏ \"%s\" được chỉ định nhiều lần"
 
 #: pl_gram.y:3845
 #, c-format
 msgid "not enough arguments for cursor \"%s\""
-msgstr "không đ�?đối s�?cho con tr�?\"%s\""
+msgstr "không đủ đối số cho con trỏ \"%s\""
 
 #: pl_gram.y:3852
 #, c-format
 msgid "too many arguments for cursor \"%s\""
-msgstr "quá nhiều đối s�?cho con tr�?\"%s\""
+msgstr "quá nhiều đối số cho con trỏ \"%s\""
 
 #: pl_gram.y:3939
 msgid "unrecognized RAISE statement option"
-msgstr "không th�?xác định tùy chọn cho lệnh RAISE"
+msgstr "không thể xác định tùy chọn cho lệnh RAISE"
 
 #: pl_gram.y:3943
 msgid "syntax error, expected \"=\""
-msgstr "lỗi cú pháp, k�?vọng \"=\""
+msgstr "lỗi cú pháp, kỳ vọng \"=\""
 
 #: pl_gram.y:3984
 #, c-format
 msgid "too many parameters specified for RAISE"
-msgstr "quá nhiều thông s�?được ch�?định cho RAISE"
+msgstr "quá nhiều thông số được chỉ định cho RAISE"
 
 #: pl_gram.y:3988
 #, c-format
 msgid "too few parameters specified for RAISE"
-msgstr "quá ít thông s�?được ch�?định cho RAISE"
+msgstr "quá ít thông số được chỉ định cho RAISE"
 
 #: pl_handler.c:154
 msgid ""
 "Sets handling of conflicts between PL/iSQL variable names and table column "
 "names."
-msgstr "Đặt x�?lý xung đột giữa tên biến PL/iSQL và tên cột bảng."
+msgstr "Đặt xử lý xung đột giữa tên biến PL/iSQL và tên cột bảng."
 
 #: pl_handler.c:163
 msgid ""
 "Print information about parameters in the DETAIL part of the error messages "
 "generated on INTO ... STRICT failures."
 msgstr ""
-"Hiển th�?thông tin v�?các tham s�?trong phần DETAIL của các thông báo lỗi "
+"Hiển thị thông tin về các tham số trong phần DETAIL của các thông báo lỗi "
 "được tạo ra khi INTO ... STRICT lỗi."
 
 #: pl_handler.c:171
@@ -831,11 +831,11 @@ msgstr "Thực hiện các kiểm tra được đưa ra trong các câu lệnh A
 
 #: pl_handler.c:179
 msgid "List of programming constructs that should produce a warning."
-msgstr "Danh sách các cấu trúc lập trình s�?tạo ra một cảnh báo."
+msgstr "Danh sách các cấu trúc lập trình sẽ tạo ra một cảnh báo."
 
 #: pl_handler.c:189
 msgid "List of programming constructs that should produce an error."
-msgstr "Danh sách các cấu trúc lập trình s�?tạo ra lỗi."
+msgstr "Danh sách các cấu trúc lập trình sẽ tạo ra lỗi."
 
 #. translator: %s is typically the translation of "syntax error"
 #: pl_scanner.c:630

--- a/src/pl/plisql/src/po/zh_CN.po
+++ b/src/pl/plisql/src/po/zh_CN.po
@@ -20,13 +20,13 @@ msgstr ""
 
 #: pl_comp.c:438 pl_handler.c:496
 #, c-format
-msgid "PL/iSQL functions cannot accept type %s"
-msgstr "PL/iSQL函数不使用类�?s"
+msgid "PL/iSQL  functions cannot accept type %s"
+msgstr "PL/iSQL 函数不使用类型%s"
 
 #: pl_comp.c:530
 #, c-format
 msgid "could not determine actual return type for polymorphic function \"%s\""
-msgstr "无法确定多态函数\"%s\"的实际返回类�?
+msgstr "无法确定多态函数\"%s\"的实际返回类型"
 
 #: pl_comp.c:560
 #, c-format
@@ -35,8 +35,8 @@ msgstr "触发器函数只能以触发器的形式调用"
 
 #: pl_comp.c:564 pl_handler.c:480
 #, c-format
-msgid "PL/iSQL functions cannot return type %s"
-msgstr "PL/iSQL函数不能返回类型%s"
+msgid "PL/iSQL  functions cannot return type %s"
+msgstr "PL/iSQL 函数不能返回类型%s"
 
 #: pl_comp.c:604
 #, c-format
@@ -55,8 +55,8 @@ msgstr "事件触发器函数不能有已声明的参数"
 
 #: pl_comp.c:1002
 #, c-format
-msgid "compilation of PL/iSQL function \"%s\" near line %d"
-msgstr "在第%2$d行附件编译PL/pgSQL函数\"%1$s\""
+msgid "compilation of PL/iSQL  function \"%s\" near line %d"
+msgstr "在第%2$d行附件编译PL/iSQL 函数\"%1$s\""
 
 #: pl_comp.c:1025
 #, c-format
@@ -66,12 +66,12 @@ msgstr "多次使用参数名称 \"%s\""
 #: pl_comp.c:1137
 #, c-format
 msgid "column reference \"%s\" is ambiguous"
-msgstr "字段关联 \"%s\" 是不明确�?
+msgstr "字段关联 \"%s\" 是不明确的"
 
 #: pl_comp.c:1139
 #, c-format
-msgid "It could refer to either a PL/iSQL variable or a table column."
-msgstr "可以指向一个PL/pgSQL变量或表中的�?
+msgid "It could refer to either a PL/iSQL  variable or a table column."
+msgstr "可以指向一个PL/iSQL 变量或表中的列"
 
 #: pl_comp.c:1322 pl_exec.c:5189 pl_exec.c:5362 pl_exec.c:5449 pl_exec.c:5540
 #: pl_exec.c:6547
@@ -82,7 +82,7 @@ msgstr "记录\"%s\"没有字段\"%s\""
 #: pl_comp.c:1816
 #, c-format
 msgid "relation \"%s\" does not exist"
-msgstr "关系 \"%s\" 不存�?
+msgstr "关系 \"%s\" 不存在"
 
 #: pl_comp.c:1823 pl_comp.c:1865
 #, fuzzy, c-format
@@ -93,12 +93,12 @@ msgstr "\"%s\" 不是组合类型"
 #: pl_comp.c:1931
 #, c-format
 msgid "variable \"%s\" has pseudo-type %s"
-msgstr "变量\"%s\"具有伪类�?s"
+msgstr "变量\"%s\"具有伪类型%s"
 
 #: pl_comp.c:2120
 #, c-format
 msgid "type \"%s\" is only a shell"
-msgstr "类型 \"%s\" 只是一�?shell"
+msgstr "类型 \"%s\" 只是一个 shell"
 
 #: pl_comp.c:2202 pl_exec.c:6848
 #, c-format
@@ -113,19 +113,19 @@ msgstr "不可识别的异常条件\"%s\""
 #: pl_comp.c:2524
 #, c-format
 msgid "could not determine actual argument type for polymorphic function \"%s\""
-msgstr "无法确定多态函数\"%s\"的实际参数类�?
+msgstr "无法确定多态函数\"%s\"的实际参数类型"
 
 #: pl_exec.c:500 pl_exec.c:934 pl_exec.c:1169
 msgid "during initialization of execution state"
-msgstr "在执行状态的初始化期�?
+msgstr "在执行状态的初始化期间"
 
 #: pl_exec.c:506
 msgid "while storing call arguments into local variables"
-msgstr "在将调用的参数存储到本地变量�?
+msgstr "在将调用的参数存储到本地变量时"
 
 #: pl_exec.c:594 pl_exec.c:1007
 msgid "during function entry"
-msgstr "在进入函数期�?
+msgstr "在进入函数期间"
 
 #: pl_exec.c:617
 #, c-format
@@ -134,7 +134,7 @@ msgstr "控制流程到达函数的结束部分，但是没有看到RETURN"
 
 #: pl_exec.c:623
 msgid "while casting return value to function's return type"
-msgstr "正在将返回值强行指派为函数的返回类�?
+msgstr "正在将返回值强行指派为函数的返回类型"
 
 #: pl_exec.c:636 pl_exec.c:3636
 #, c-format
@@ -143,7 +143,7 @@ msgstr "在不能接受使用集合的环境中调用set-valued函数"
 
 #: pl_exec.c:762 pl_exec.c:1033 pl_exec.c:1191
 msgid "during function exit"
-msgstr "在函数退出期�?
+msgstr "在函数退出期间"
 
 #: pl_exec.c:817 pl_exec.c:881 pl_exec.c:3434
 msgid "returned record type does not match expected record type"
@@ -152,47 +152,47 @@ msgstr "所返回的记录类型与所期待的记录类型不匹配"
 #: pl_exec.c:1030 pl_exec.c:1188
 #, c-format
 msgid "control reached end of trigger procedure without RETURN"
-msgstr "控制流程到达触发�?存储过程的结束部分，但是没有看到RETURN"
+msgstr "控制流程到达触发器/存储过程的结束部分，但是没有看到RETURN"
 
 #: pl_exec.c:1038
 #, c-format
 msgid "trigger procedure cannot return a set"
-msgstr "触发器存储过程无法返回集�?
+msgstr "触发器存储过程无法返回集合"
 
 #: pl_exec.c:1077 pl_exec.c:1105
 msgid "returned row structure does not match the structure of the triggering table"
-msgstr "所返回的记录结构与触发表的结构不匹�?
+msgstr "所返回的记录结构与触发表的结构不匹配"
 
 #. translator: last %s is a phrase such as "during statement block
 #. local variable initialization"
 #.
 #: pl_exec.c:1237
 #, c-format
-msgid "PL/iSQL function %s line %d %s"
-msgstr "PL/iSQL 函数%s在第%d�?s"
+msgid "PL/iSQL  function %s line %d %s"
+msgstr "PL/iSQL  函数%s在第%d行%s"
 
 #. translator: last %s is a phrase such as "while storing call
 #. arguments into local variables"
 #.
 #: pl_exec.c:1248
 #, c-format
-msgid "PL/iSQL function %s %s"
-msgstr "PL/iSQL 函数%s %s"
+msgid "PL/iSQL  function %s %s"
+msgstr "PL/iSQL  函数%s %s"
 
 #. translator: last %s is a plisql statement type name
 #: pl_exec.c:1256
 #, c-format
-msgid "PL/iSQL function %s line %d at %s"
-msgstr "�?3$s的第%2$d行的PL/iSQL函数%1$s"
+msgid "PL/iSQL  function %s line %d at %s"
+msgstr "在%3$s的第%2$d行的PL/iSQL 函数%1$s"
 
 #: pl_exec.c:1262
 #, c-format
-msgid "PL/iSQL function %s"
-msgstr "PL/iSQL函数 %s"
+msgid "PL/iSQL  function %s"
+msgstr "PL/iSQL 函数 %s"
 
 #: pl_exec.c:1633
 msgid "during statement block local variable initialization"
-msgstr "在初始化语句块的局部变量期�?
+msgstr "在初始化语句块的局部变量期间"
 
 #: pl_exec.c:1731
 msgid "during statement block entry"
@@ -204,17 +204,17 @@ msgstr "在退出语句块期间"
 
 #: pl_exec.c:1801
 msgid "during exception cleanup"
-msgstr "在清理异常期�?
+msgstr "在清理异常期间"
 
 #: pl_exec.c:2334
 #, c-format
 msgid "procedure parameter \"%s\" is an output parameter but corresponding argument is not writable"
-msgstr "过程参数\"%s\"是输出参数，但相应的参数不可�?
+msgstr "过程参数\"%s\"是输出参数，但相应的参数不可写"
 
 #: pl_exec.c:2339
 #, c-format
 msgid "procedure parameter %d is an output parameter but corresponding argument is not writable"
-msgstr "过程参数%d是输出参数，但相应的参数不可�?
+msgstr "过程参数%d是输出参数，但相应的参数不可写"
 
 #: pl_exec.c:2373
 #, c-format
@@ -234,47 +234,47 @@ msgstr "在CASE语句结构中丢失ELSE部分"
 #: pl_exec.c:2667
 #, c-format
 msgid "lower bound of FOR loop cannot be null"
-msgstr "FOR循环的低位边界不能为�?
+msgstr "FOR循环的低位边界不能为空"
 
 #: pl_exec.c:2683
 #, c-format
 msgid "upper bound of FOR loop cannot be null"
-msgstr "FOR循环的高位边界不能为�?
+msgstr "FOR循环的高位边界不能为空"
 
 #: pl_exec.c:2701
 #, c-format
 msgid "BY value of FOR loop cannot be null"
-msgstr "FOR循环的BY值不能为�?
+msgstr "FOR循环的BY值不能为空"
 
 #: pl_exec.c:2707
 #, c-format
 msgid "BY value of FOR loop must be greater than zero"
-msgstr "FOR循环的BY值必须大�?"
+msgstr "FOR循环的BY值必须大于0"
 
 #: pl_exec.c:2841 pl_exec.c:4625
 #, c-format
 msgid "cursor \"%s\" already in use"
-msgstr "游标\"%s\"已经在使�?
+msgstr "游标\"%s\"已经在使用"
 
 #: pl_exec.c:2864 pl_exec.c:4690
 #, c-format
 msgid "arguments given for cursor without arguments"
-msgstr "给不带有参数的游标指定参�?
+msgstr "给不带有参数的游标指定参数"
 
 #: pl_exec.c:2883 pl_exec.c:4709
 #, c-format
 msgid "arguments required for cursor"
-msgstr "游标需要参�?
+msgstr "游标需要参数"
 
 #: pl_exec.c:2970
 #, c-format
 msgid "FOREACH expression must not be null"
-msgstr "FOREACH表达式不能为�?
+msgstr "FOREACH表达式不能为空"
 
 #: pl_exec.c:2985
 #, c-format
 msgid "FOREACH expression must yield an array, not type %s"
-msgstr "FOREACH表达式的结果必须是数�? 而不是类�?%s"
+msgstr "FOREACH表达式的结果必须是数组, 而不是类型 %s"
 
 #: pl_exec.c:3002
 #, c-format
@@ -289,12 +289,12 @@ msgstr "FOREACH ... SLICE循环变量必须属于数组类型"
 #: pl_exec.c:3033
 #, c-format
 msgid "FOREACH loop variable must not be of an array type"
-msgstr "FOREACH循环变量不能为数组类�?
+msgstr "FOREACH循环变量不能为数组类型"
 
 #: pl_exec.c:3195 pl_exec.c:3252 pl_exec.c:3427
 #, c-format
 msgid "cannot return non-composite value from function returning composite type"
-msgstr "返回值为组合类型的函数不能返回非组合型的�?
+msgstr "返回值为组合类型的函数不能返回非组合型的值"
 
 #: pl_exec.c:3291 pl_gram.y:3310
 #, c-format
@@ -304,17 +304,17 @@ msgstr "无法在非SETOF函数中使用RETURN NEXT"
 #: pl_exec.c:3332 pl_exec.c:3464
 #, c-format
 msgid "wrong result type supplied in RETURN NEXT"
-msgstr "在RETURN NEXT中提供了错误的结果类�?
+msgstr "在RETURN NEXT中提供了错误的结果类型"
 
 #: pl_exec.c:3370 pl_exec.c:3391
 #, c-format
 msgid "wrong record type supplied in RETURN NEXT"
-msgstr "在RETURN NEXT中提供了错误的记录类�?
+msgstr "在RETURN NEXT中提供了错误的记录类型"
 
 #: pl_exec.c:3483
 #, c-format
 msgid "RETURN NEXT must have a parameter"
-msgstr "RETURN NEXT必须有一个参�?
+msgstr "RETURN NEXT必须有一个参数"
 
 #: pl_exec.c:3511 pl_gram.y:3374
 #, c-format
@@ -333,12 +333,12 @@ msgstr "查询 \"%s\"不是SELECT语句"
 #: pl_exec.c:3584 pl_exec.c:4403 pl_exec.c:8589
 #, c-format
 msgid "query string argument of EXECUTE is null"
-msgstr "EXECUTE的查询字符串参数是空�?
+msgstr "EXECUTE的查询字符串参数是空值"
 
 #: pl_exec.c:3664 pl_exec.c:3802
 #, c-format
 msgid "RAISE option already specified: %s"
-msgstr "已经指定了RAISE选项�?s"
+msgstr "已经指定了RAISE选项：%s"
 
 #: pl_exec.c:3698
 #, c-format
@@ -362,13 +362,13 @@ msgstr "断言失败"
 
 #: pl_exec.c:4276 pl_exec.c:4464
 #, c-format
-msgid "cannot COPY to/from client in PL/iSQL"
-msgstr "无法在PL/pgSQL中从客户端或向客户端使用COPY命令"
+msgid "cannot COPY to/from client in PL/iSQL "
+msgstr "无法在PL/iSQL 中从客户端或向客户端使用COPY命令"
 
 #: pl_exec.c:4282
 #, c-format
-msgid "unsupported transaction command in PL/iSQL"
-msgstr "PL/iSQL中不支持的事务命�?
+msgid "unsupported transaction command in PL/iSQL "
+msgstr "PL/iSQL 中不支持的事务命令"
 
 #: pl_exec.c:4305 pl_exec.c:4493
 #, c-format
@@ -393,7 +393,7 @@ msgstr "确保查询返回单行，或使用 LIMIT 1."
 #: pl_exec.c:4368
 #, c-format
 msgid "query has no destination for result data"
-msgstr "对于结果数据，查询没有目�?
+msgstr "对于结果数据，查询没有目标"
 
 #: pl_exec.c:4369
 #, c-format
@@ -408,32 +408,32 @@ msgstr "没有执行EXECUTE of SELECT ... INTO "
 #: pl_exec.c:4457
 #, c-format
 msgid "You might want to use EXECUTE ... INTO or EXECUTE CREATE TABLE ... AS instead."
-msgstr "您可以使用EXECUTE ... INTO或者EXECUTE CREATE TABLE ... AS语句来替�?
+msgstr "您可以使用EXECUTE ... INTO或者EXECUTE CREATE TABLE ... AS语句来替代"
 
 #: pl_exec.c:4470
 #, c-format
 msgid "EXECUTE of transaction commands is not implemented"
-msgstr "未执行事务命�?
+msgstr "未执行事务命令"
 
 #: pl_exec.c:4771 pl_exec.c:4859
 #, c-format
 msgid "cursor variable \"%s\" is null"
-msgstr "游标变量\"%s\"是空�?
+msgstr "游标变量\"%s\"是空的"
 
 #: pl_exec.c:4782 pl_exec.c:4870
 #, c-format
 msgid "cursor \"%s\" does not exist"
-msgstr "游标 \"%s\" 不存�?
+msgstr "游标 \"%s\" 不存在"
 
 #: pl_exec.c:4795
 #, c-format
 msgid "relative or absolute cursor position is null"
-msgstr "游标的相对或绝对位置是空�?
+msgstr "游标的相对或绝对位置是空的"
 
 #: pl_exec.c:5039 pl_exec.c:5134
 #, c-format
 msgid "null value cannot be assigned to variable \"%s\" declared NOT NULL"
-msgstr "不能将声明为NOT NULL的变量\"%s\" 分配空�?
+msgstr "不能将声明为NOT NULL的变量\"%s\" 分配空值"
 
 #: pl_exec.c:5115
 #, c-format
@@ -448,7 +448,7 @@ msgstr "无法将非组合值分配给记录类型变量"
 #: pl_exec.c:5198
 #, c-format
 msgid "cannot assign to system column \"%s\""
-msgstr "不能指定系统字段�?\"%s\""
+msgstr "不能指定系统字段名 \"%s\""
 
 #: pl_exec.c:5647
 #, c-format
@@ -459,7 +459,7 @@ msgstr "查询\"%s\"没有返回数据"
 #, c-format
 msgid "query \"%s\" returned %d column"
 msgid_plural "query \"%s\" returned %d columns"
-msgstr[0] "查询\"%s\"返回%d�?
+msgstr[0] "查询\"%s\"返回%d列"
 
 #: pl_exec.c:5683
 #, c-format
@@ -469,7 +469,7 @@ msgstr "查询\"%s\"返回多条数据"
 #: pl_exec.c:6561 pl_exec.c:6601 pl_exec.c:6641
 #, c-format
 msgid "type of parameter %d (%s) does not match that when preparing the plan (%s)"
-msgstr "�?d个参�?%s)的类型与正在执行计划(%s)中的不匹�?
+msgstr "第%d个参数(%s)的类型与正在执行计划(%s)中的不匹配"
 
 #: pl_exec.c:7052 pl_exec.c:7086 pl_exec.c:7160 pl_exec.c:7186
 #, c-format
@@ -480,7 +480,7 @@ msgstr "分配中的源字段和目标字段数不匹配"
 #: pl_exec.c:7054 pl_exec.c:7088 pl_exec.c:7162 pl_exec.c:7188
 #, c-format
 msgid "%s check of %s is active."
-msgstr "%s检�?s是否激�?"
+msgstr "%s检查%s是否激活."
 
 #: pl_exec.c:7058 pl_exec.c:7092 pl_exec.c:7166 pl_exec.c:7192
 #, c-format
@@ -490,20 +490,20 @@ msgstr "确保查询返回准确的列列表."
 #: pl_exec.c:7579
 #, c-format
 msgid "record \"%s\" is not assigned yet"
-msgstr "记录 \"%s\"还没有分�?
+msgstr "记录 \"%s\"还没有分配"
 
 #: pl_exec.c:7580
 #, c-format
 msgid "The tuple structure of a not-yet-assigned record is indeterminate."
-msgstr "未分配记录的元组结构未确�?"
+msgstr "未分配记录的元组结构未确定."
 
 #: pl_funcs.c:237
 msgid "statement block"
-msgstr "语句�?
+msgstr "语句块"
 
 #: pl_funcs.c:239
 msgid "assignment"
-msgstr "赋�?
+msgstr "赋值"
 
 #: pl_funcs.c:249
 msgid "FOR with integer loop variable"
@@ -532,7 +532,7 @@ msgstr "在EXECUTE语句上的FOR语句"
 #: pl_gram.y:485
 #, c-format
 msgid "block label must be placed before DECLARE, not after"
-msgstr "代码块标签必须放在DECLARE的前面，而不是后�?
+msgstr "代码块标签必须放在DECLARE的前面，而不是后面"
 
 #: pl_gram.y:505
 #, c-format
@@ -547,7 +547,7 @@ msgstr "变量\"%s\"必须有默认值，因为它声明为非空"
 #: pl_gram.y:672 pl_gram.y:687 pl_gram.y:713
 #, c-format
 msgid "variable \"%s\" does not exist"
-msgstr "变量 \"%s\" 不存�?
+msgstr "变量 \"%s\" 不存在"
 
 #: pl_gram.y:731 pl_gram.y:759
 msgid "duplicate declaration"
@@ -556,17 +556,17 @@ msgstr "重复声明"
 #: pl_gram.y:742 pl_gram.y:770
 #, c-format
 msgid "variable \"%s\" shadows a previously defined variable"
-msgstr "变量\"%s\"隐藏了前一个已定义的变�?
+msgstr "变量\"%s\"隐藏了前一个已定义的变量"
 
 #: pl_gram.y:1042
 #, c-format
 msgid "diagnostics item %s is not allowed in GET STACKED DIAGNOSTICS"
-msgstr "诊断�?%s 不允许出现在GET STACKED DIAGNOSTICS的结果中"
+msgstr "诊断项 %s 不允许出现在GET STACKED DIAGNOSTICS的结果中"
 
 #: pl_gram.y:1060
 #, c-format
 msgid "diagnostics item %s is not allowed in GET CURRENT DIAGNOSTICS"
-msgstr "诊断�?%s 不允许出现在GET CURRENT DIAGNOSTICS的结果中"
+msgstr "诊断项 %s 不允许出现在GET CURRENT DIAGNOSTICS的结果中"
 
 #: pl_gram.y:1155
 msgid "unrecognized GET DIAGNOSTICS item"
@@ -575,7 +575,7 @@ msgstr "无法识别的项GET DIAGNOSTICS"
 #: pl_gram.y:1171 pl_gram.y:3549
 #, c-format
 msgid "\"%s\" is not a scalar variable"
-msgstr "\"%s\" 不是一个标量变�?
+msgstr "\"%s\" 不是一个标量变量"
 
 #: pl_gram.y:1401 pl_gram.y:1595
 #, c-format
@@ -585,7 +585,7 @@ msgstr "在记录集上进行循环的循环变量必须是记录变量或标量
 #: pl_gram.y:1436
 #, c-format
 msgid "cursor FOR loop must have only one target variable"
-msgstr "游标的FOR循环只能有一个目标变�?
+msgstr "游标的FOR循环只能有一个目标变量"
 
 #: pl_gram.y:1443
 #, c-format
@@ -595,7 +595,7 @@ msgstr "游标的FOR循环必须使用有界游标变量"
 #: pl_gram.y:1534
 #, c-format
 msgid "integer FOR loop must have only one target variable"
-msgstr "整数FOR循环必须只能有一个目标变�?
+msgstr "整数FOR循环必须只能有一个目标变量"
 
 #: pl_gram.y:1568
 #, c-format
@@ -615,12 +615,12 @@ msgstr "在任何包围这个语句的块或者循环上都没有附着标签\"%
 #: pl_gram.y:1748
 #, c-format
 msgid "block label \"%s\" cannot be used in CONTINUE"
-msgstr "块标�?\"%s\" 不能被用�?CONTINUE �?
+msgstr "块标签 \"%s\" 不能被用在 CONTINUE 中"
 
 #: pl_gram.y:1763
 #, c-format
 msgid "EXIT cannot be used outside a loop, unless it has a label"
-msgstr "不能在循环外部使用EXIT，除非该循环有一个标�?
+msgstr "不能在循环外部使用EXIT，除非该循环有一个标签"
 
 #: pl_gram.y:1764
 #, c-format
@@ -630,7 +630,7 @@ msgstr "在循环的外部不能使用CONTINUE"
 #: pl_gram.y:1788 pl_gram.y:1826 pl_gram.y:1874 pl_gram.y:2998 pl_gram.y:3084
 #: pl_gram.y:3195 pl_gram.y:3948
 msgid "unexpected end of function definition"
-msgstr "在函数定义中意外出现的结束标�?
+msgstr "在函数定义中意外出现的结束标志"
 
 #: pl_gram.y:1894 pl_gram.y:1918 pl_gram.y:1934 pl_gram.y:1940 pl_gram.y:2061
 #: pl_gram.y:2069 pl_gram.y:2083 pl_gram.y:2178 pl_gram.y:2402 pl_gram.y:2492
@@ -654,7 +654,7 @@ msgstr "FETCH语句无法返回多条记录"
 #: pl_gram.y:2284
 #, c-format
 msgid "cursor variable must be a simple variable"
-msgstr "游标变量必须是一个简单变�?
+msgstr "游标变量必须是一个简单变量"
 
 #: pl_gram.y:2290
 #, c-format
@@ -664,11 +664,11 @@ msgstr "变量\"%s\" 必须属于游标类型或refcursor类型"
 #: pl_gram.y:2620 pl_gram.y:2631
 #, c-format
 msgid "\"%s\" is not a known variable"
-msgstr "\"%s\" 不是一个已知变�?
+msgstr "\"%s\" 不是一个已知变量"
 
 #: pl_gram.y:2737 pl_gram.y:2747 pl_gram.y:2903
 msgid "mismatched parentheses"
-msgstr "括号不匹�?
+msgstr "括号不匹配"
 
 #: pl_gram.y:2751
 #, c-format
@@ -682,7 +682,7 @@ msgstr "在SQL语句的结尾处丢失\"%s\""
 
 #: pl_gram.y:2774
 msgid "missing expression"
-msgstr "缺少表达�?
+msgstr "缺少表达式"
 
 #: pl_gram.y:2776
 msgid "missing SQL statement"
@@ -722,17 +722,17 @@ msgstr "在过程中RETURN不能带有参数"
 #: pl_gram.y:3253
 #, c-format
 msgid "RETURN cannot have a parameter in function returning void"
-msgstr "在返回为空的函数中RETURN不能有参�?
+msgstr "在返回为空的函数中RETURN不能有参数"
 
 #: pl_gram.y:3262
 #, c-format
 msgid "RETURN cannot have a parameter in function with OUT parameters"
-msgstr "在带有输出参数的函数中RETURN不能有参�?
+msgstr "在带有输出参数的函数中RETURN不能有参数"
 
 #: pl_gram.y:3325
 #, c-format
 msgid "RETURN NEXT cannot have a parameter in function with OUT parameters"
-msgstr "在带有输出参数的函数中RETURN NEXT不能有参�?
+msgstr "在带有输出参数的函数中RETURN NEXT不能有参数"
 
 #: pl_gram.y:3433
 #, c-format
@@ -768,27 +768,27 @@ msgstr "游标\"%s\" 没有参数"
 #: pl_gram.y:3800
 #, c-format
 msgid "cursor \"%s\" has arguments"
-msgstr "游标\"%s\"有参�?
+msgstr "游标\"%s\"有参数"
 
 #: pl_gram.y:3842
 #, c-format
 msgid "cursor \"%s\" has no argument named \"%s\""
-msgstr "游标\"%s\" 没有名为 \"%s\"的参�?
+msgstr "游标\"%s\" 没有名为 \"%s\"的参数"
 
 #: pl_gram.y:3862
 #, c-format
 msgid "value for parameter \"%s\" of cursor \"%s\" specified more than once"
-msgstr "游标\"%2$s\"中的参数值\"%1$s\"指定了多�?
+msgstr "游标\"%2$s\"中的参数值\"%1$s\"指定了多次"
 
 #: pl_gram.y:3887
 #, c-format
 msgid "not enough arguments for cursor \"%s\""
-msgstr "游标 \"%s\"没有足够的参�?
+msgstr "游标 \"%s\"没有足够的参数"
 
 #: pl_gram.y:3894
 #, c-format
 msgid "too many arguments for cursor \"%s\""
-msgstr "游标 \"%s\"给定的参数太�?
+msgstr "游标 \"%s\"给定的参数太多"
 
 #: pl_gram.y:3980
 msgid "unrecognized RAISE statement option"
@@ -809,24 +809,24 @@ msgid "too few parameters specified for RAISE"
 msgstr "为RAISE子句指定参数过少"
 
 #: pl_handler.c:156
-msgid "Sets handling of conflicts between PL/iSQL variable names and table column names."
-msgstr "设置在PL/pgSQL变量名称和表中列名冲突时的处理原�?
+msgid "Sets handling of conflicts between PL/iSQL  variable names and table column names."
+msgstr "设置在PL/iSQL 变量名称和表中列名冲突时的处理原则"
 
 #: pl_handler.c:165
 msgid "Print information about parameters in the DETAIL part of the error messages generated on INTO ... STRICT failures."
-msgstr "打印产生于INTO...STRICT失败时的详细的错误消息里的参数信�?
+msgstr "打印产生于INTO...STRICT失败时的详细的错误消息里的参数信息"
 
 #: pl_handler.c:173
 msgid "Perform checks given in ASSERT statements."
-msgstr "执行在ASSERT语句中给定的检查�?
+msgstr "执行在ASSERT语句中给定的检查。"
 
 #: pl_handler.c:181
 msgid "List of programming constructs that should produce a warning."
-msgstr "程序构造列表必须输出警�?"
+msgstr "程序构造列表必须输出警告."
 
 #: pl_handler.c:191
 msgid "List of programming constructs that should produce an error."
-msgstr "程序构造列表必须输出一个错误信息提�?"
+msgstr "程序构造列表必须输出一个错误信息提示."
 
 #. translator: %s is typically the translation of "syntax error"
 #: pl_scanner.c:508
@@ -838,5 +838,5 @@ msgstr "%s 在输入的末尾"
 #: pl_scanner.c:524
 #, c-format
 msgid "%s at or near \"%s\""
-msgstr "%s �?\"%s\" 或附近的"
+msgstr "%s 在 \"%s\" 或附近的"
 

--- a/src/pl/plisql/src/po/zh_TW.po
+++ b/src/pl/plisql/src/po/zh_TW.po
@@ -1,4 +1,4 @@
-# Traditional Chinese message translation file for plisql
+# Traditional Chinese message translation file for plpgsql
 # Copyright (C) 2011 PostgreSQL Global Development Group
 # This file is distributed under the same license as the PostgreSQL package.
 #
@@ -37,13 +37,13 @@ msgstr "PL/iSQL 函式無法傳回型別 %s"
 
 #: pl_comp.c:582
 msgid "trigger functions cannot have declared arguments"
-msgstr "觸發函式不能有宣告過的參�?
+msgstr "觸發函式不能有宣告過的參數"
 
 #: pl_comp.c:583
 msgid ""
 "The arguments of the trigger can be accessed through TG_NARGS and TG_ARGV "
 "instead."
-msgstr "觸發程序的參數可以改透過 TG_NARGS �?TG_ARGV 存取�?
+msgstr "觸發程序的參數可以改透過 TG_NARGS 和 TG_ARGV 存取。"
 
 #: pl_comp.c:911
 #, c-format
@@ -54,29 +54,29 @@ msgstr "編譯 PL/iSQL 函式 \"%s\"，靠近行 %d"
 #: pl_comp.c:1019
 #, c-format
 msgid "column reference \"%s\" is ambiguous"
-msgstr "資料行參�?\"%s\" 模稜兩可"
+msgstr "資料行參考 \"%s\" 模稜兩可"
 
 #: pl_comp.c:1021
-msgid "It could refer to either a PL/iSQL variable or a table column."
-msgstr "可能參考到 PL/iSQL 變數或資料表欄位�?
+msgid "It could refer to either a PL/pgSQL variable or a table column."
+msgstr "可能參考到 PL/pgSQL 變數或資料表欄位。"
 
 #: pl_comp.c:1201 pl_comp.c:1229 pl_exec.c:3862 pl_exec.c:4208 pl_exec.c:4294
 #: pl_exec.c:4351
 #, c-format
 msgid "record \"%s\" has no field \"%s\""
-msgstr "紀�?\"%s\" 沒有欄位 \"%s\""
+msgstr "紀錄 \"%s\" 沒有欄位 \"%s\""
 
 # catalog/namespace.c:200 utils/adt/regproc.c:837
 #: pl_comp.c:1754
 #, c-format
 msgid "relation \"%s\" does not exist"
-msgstr "關聯 \"%s\"不存�?
+msgstr "關聯 \"%s\"不存在"
 
 # catalog/namespace.c:195
 #: pl_comp.c:1786
 #, c-format
 msgid "relation \"%s.%s\" does not exist"
-msgstr "關聯 \"%s.%s\"不存�?
+msgstr "關聯 \"%s.%s\"不存在"
 
 #: pl_comp.c:1868
 #, c-format
@@ -86,27 +86,27 @@ msgstr "變數 \"%s\" 具有處擬型別 %s"
 #: pl_comp.c:1929
 #, c-format
 msgid "relation \"%s\" is not a table"
-msgstr "關係 \"%s\" 不是資料�?
+msgstr "關係 \"%s\" 不是資料表"
 
 #: pl_comp.c:2089
 #, c-format
 msgid "type \"%s\" is only a shell"
-msgstr "型別 \"%s\" 只是�?
+msgstr "型別 \"%s\" 只是殼"
 
 #: pl_comp.c:2162 pl_comp.c:2215
 #, c-format
 msgid "unrecognized exception condition \"%s\""
-msgstr "無法辨識的例外條�?\"%s\""
+msgstr "無法辨識的例外條件 \"%s\""
 
 #: pl_comp.c:2373
 #, c-format
 msgid ""
 "could not determine actual argument type for polymorphic function \"%s\""
-msgstr "無法判斷同名異式函式 \"%s\" 的實際參數型�?
+msgstr "無法判斷同名異式函式 \"%s\" 的實際參數型別"
 
 #: pl_exec.c:239 pl_exec.c:510
 msgid "during initialization of execution state"
-msgstr "在初始化執行狀態期�?
+msgstr "在初始化執行狀態期間"
 
 #: pl_exec.c:246
 msgid "while storing call arguments into local variables"
@@ -118,11 +118,11 @@ msgstr "在函式進入期間"
 
 #: pl_exec.c:332 pl_exec.c:698
 msgid "CONTINUE cannot be used outside a loop"
-msgstr "CONTINUE 不能在迴圈之外使�?
+msgstr "CONTINUE 不能在迴圈之外使用"
 
 #: pl_exec.c:336
 msgid "control reached end of function without RETURN"
-msgstr "控制權已到達沒有 RETURN 的函式結�?
+msgstr "控制權已到達沒有 RETURN 的函式結尾"
 
 #: pl_exec.c:343
 msgid "while casting return value to function's return type"
@@ -134,15 +134,15 @@ msgstr "set-valued 函式於無法接受集合的內容中進行呼叫"
 
 #: pl_exec.c:394
 msgid "returned record type does not match expected record type"
-msgstr "傳回的記錄型別與預期的記錄型別不相符�?
+msgstr "傳回的記錄型別與預期的記錄型別不相符。"
 
 #: pl_exec.c:452 pl_exec.c:706
 msgid "during function exit"
-msgstr "在函式結束期�?
+msgstr "在函式結束期間"
 
 #: pl_exec.c:702
 msgid "control reached end of trigger procedure without RETURN"
-msgstr "控制權已到達沒有 RETURN 的觸發程序結�?
+msgstr "控制權已到達沒有 RETURN 的觸發程序結尾"
 
 #: pl_exec.c:711
 msgid "trigger procedure cannot return a set"
@@ -163,11 +163,11 @@ msgstr "PL/iSQL 函式 \"%s\"，位於行 %d %s"
 msgid "PL/iSQL function \"%s\" %s"
 msgstr "PL/iSQL 函式 \"%s\" %s"
 
-#. translator: last %s is a plisql statement type name
+#. translator: last %s is a plpgsql statement type name
 #: pl_exec.c:815
 #, c-format
 msgid "PL/iSQL function \"%s\" line %d at %s"
-msgstr "PL/iSQL 函式 \"%s\"，行 %d，位�?%s"
+msgstr "PL/iSQL 函式 \"%s\"，行 %d，位於 %s"
 
 #: pl_exec.c:821
 #, c-format
@@ -181,7 +181,7 @@ msgstr "在陳述式區塊區域變數初始化期間"
 #: pl_exec.c:971
 #, c-format
 msgid "variable \"%s\" declared NOT NULL cannot default to NULL"
-msgstr "宣告�?NOT NULL 的變�?\"%s\" 不能預設�?NULL"
+msgstr "宣告為 NOT NULL 的變數 \"%s\" 不能預設為 NULL"
 
 #: pl_exec.c:1021
 msgid "during statement block entry"
@@ -189,19 +189,19 @@ msgstr "在陳述式區塊進入期間"
 
 #: pl_exec.c:1042
 msgid "during statement block exit"
-msgstr "在陳述式區塊結束期�?
+msgstr "在陳述式區塊結束期間"
 
 #: pl_exec.c:1085
 msgid "during exception cleanup"
-msgstr "在例外清除期�?
+msgstr "在例外清除期間"
 
 #: pl_exec.c:1570
 msgid "case not found"
-msgstr "找不到案�?
+msgstr "找不到案例"
 
 #: pl_exec.c:1571
 msgid "CASE statement is missing ELSE part."
-msgstr "CASE 陳述式遺�?ELSE 部分�?
+msgstr "CASE 陳述式遺漏 ELSE 部分。"
 
 #: pl_exec.c:1725
 msgid "lower bound of FOR loop cannot be null"
@@ -213,24 +213,24 @@ msgstr "FOR 迴圈的上限不可為 null"
 
 #: pl_exec.c:1757
 msgid "BY value of FOR loop cannot be null"
-msgstr "FOR 迴圈�?BY 值不可為 null"
+msgstr "FOR 迴圈的 BY 值不可為 null"
 
 #: pl_exec.c:1763
 msgid "BY value of FOR loop must be greater than zero"
-msgstr "FOR 迴圈�?BY 值必須大於零"
+msgstr "FOR 迴圈的 BY 值必須大於零"
 
 #: pl_exec.c:1933 pl_exec.c:3395
 #, c-format
 msgid "cursor \"%s\" already in use"
-msgstr "指標 \"%s\" 已在使用�?
+msgstr "指標 \"%s\" 已在使用中"
 
 #: pl_exec.c:1956 pl_exec.c:3457
 msgid "arguments given for cursor without arguments"
-msgstr "指定給沒有參數之指標的參�?
+msgstr "指定給沒有參數之指標的參數"
 
 #: pl_exec.c:1975 pl_exec.c:3476
 msgid "arguments required for cursor"
-msgstr "指標所需的參�?
+msgstr "指標所需的參數"
 
 # catalog/heap.c:1797
 #: pl_exec.c:2063
@@ -251,15 +251,15 @@ msgstr "分割維度(%d)超出有效範圍 0..%d"
 
 #: pl_exec.c:2113
 msgid "FOREACH ... SLICE loop variable must be of an array type"
-msgstr "FOREACH ... SLICE 迴圈變數必須是陣列型�?
+msgstr "FOREACH ... SLICE 迴圈變數必須是陣列型別"
 
 #: pl_exec.c:2117
 msgid "FOREACH loop variable must not be of an array type"
-msgstr "FOREACH 迴圈變數不能是陣列型�?
+msgstr "FOREACH 迴圈變數不能是陣列型別"
 
 #: pl_exec.c:2375 gram.y:2844
 msgid "cannot use RETURN NEXT in a non-SETOF function"
-msgstr "無法在非 SETOF 函式中使�?RETURN NEXT"
+msgstr "無法在非 SETOF 函式中使用 RETURN NEXT"
 
 #: pl_exec.c:2399 pl_exec.c:2465
 msgid "wrong result type supplied in RETURN NEXT"
@@ -274,7 +274,7 @@ msgstr "尚未指派記錄 \"%s\""
 #: pl_exec.c:2423 pl_exec.c:3851 pl_exec.c:4168 pl_exec.c:4203 pl_exec.c:4270
 #: pl_exec.c:4289 pl_exec.c:4346
 msgid "The tuple structure of a not-yet-assigned record is indeterminate."
-msgstr "尚未指派之記錄的欄組結構未定�?
+msgstr "尚未指派之記錄的欄組結構未定。"
 
 #: pl_exec.c:2427 pl_exec.c:2446
 msgid "wrong record type supplied in RETURN NEXT"
@@ -286,23 +286,23 @@ msgstr "RETURN NEXT 必須要有參數"
 
 #: pl_exec.c:2519 gram.y:2903
 msgid "cannot use RETURN QUERY in a non-SETOF function"
-msgstr "無法在非 SETOF 函式中使�?RETURN QUERY"
+msgstr "無法在非 SETOF 函式中使用 RETURN QUERY"
 
 #: pl_exec.c:2539
 msgid "structure of query does not match function result type"
-msgstr "查詢的結構與函式結果型別不相�?
+msgstr "查詢的結構與函式結果型別不相符"
 
 #: pl_exec.c:2637
 msgid "RAISE without parameters cannot be used outside an exception handler"
-msgstr "沒有參數�?RAISE 不能在例外處理常式之外使�?
+msgstr "沒有參數的 RAISE 不能在例外處理常式之外使用"
 
 #: pl_exec.c:2678
 msgid "too few parameters specified for RAISE"
-msgstr "�?RAISE 指定的參數太�?
+msgstr "為 RAISE 指定的參數太少"
 
 #: pl_exec.c:2704
 msgid "too many parameters specified for RAISE"
-msgstr "�?RAISE 指定的參數太�?
+msgstr "為 RAISE 指定的參數太多"
 
 #: pl_exec.c:2724
 msgid "RAISE statement option cannot be null"
@@ -311,7 +311,7 @@ msgstr "RAISE 陳述式選項不可為 null"
 #: pl_exec.c:2734 pl_exec.c:2743 pl_exec.c:2751 pl_exec.c:2759
 #, c-format
 msgid "RAISE option already specified: %s"
-msgstr "RAISE 選項已指�? %s"
+msgstr "RAISE 選項已指定: %s"
 
 # commands/vacuum.c:2258 commands/vacuumlazy.c:489 commands/vacuumlazy.c:770
 # nodes/print.c:86 storage/lmgr/deadlock.c:888 tcop/postgres.c:3285
@@ -321,24 +321,24 @@ msgid "%s"
 msgstr "%s"
 
 #: pl_exec.c:2945 pl_exec.c:3081 pl_exec.c:3260
-msgid "cannot COPY to/from client in PL/iSQL"
-msgstr "無法�?PL/iSQL 中與用戶端進行 COPY"
+msgid "cannot COPY to/from client in PL/pgSQL"
+msgstr "無法在 PL/pgSQL 中與用戶端進行 COPY"
 
 #: pl_exec.c:2949 pl_exec.c:3085 pl_exec.c:3264
-msgid "cannot begin/end transactions in PL/iSQL"
-msgstr "無法�?PL/iSQL 中開�?結束交易"
+msgid "cannot begin/end transactions in PL/pgSQL"
+msgstr "無法在 PL/pgSQL 中開始/結束交易"
 
 #: pl_exec.c:2950 pl_exec.c:3086 pl_exec.c:3265
 msgid "Use a BEGIN block with an EXCEPTION clause instead."
-msgstr "改用具有 EXCEPTION 子句�?BEGIN 區�?
+msgstr "改用具有 EXCEPTION 子句的 BEGIN 區塊"
 
 #: pl_exec.c:3109 pl_exec.c:3289
 msgid "INTO used with a command that cannot return data"
-msgstr "搭配指令使用�?INTO 無法傳回資料"
+msgstr "搭配指令使用的 INTO 無法傳回資料"
 
 #: pl_exec.c:3129 pl_exec.c:3309
 msgid "query returned no rows"
-msgstr "查詢沒有傳回任何資料�?
+msgstr "查詢沒有傳回任何資料列"
 
 #: pl_exec.c:3138 pl_exec.c:3318
 msgid "query returned more than one row"
@@ -350,7 +350,7 @@ msgstr "查詢沒有結果資料的目的地"
 
 #: pl_exec.c:3153
 msgid "If you want to discard the results of a SELECT, use PERFORM instead."
-msgstr "如果要捨�?SELECT 的結果，請改�?PERFORM�?
+msgstr "如果要捨棄 SELECT 的結果，請改用 PERFORM。"
 
 #: pl_exec.c:3186 pl_exec.c:5889
 msgid "query string argument of EXECUTE is null"
@@ -358,24 +358,24 @@ msgstr "EXECUTE 的查詢字串參數為 null"
 
 #: pl_exec.c:3251
 msgid "EXECUTE of SELECT ... INTO is not implemented"
-msgstr "SELECT ...INTO �?EXECUTE 尚未實作"
+msgstr "SELECT ...INTO 的 EXECUTE 尚未實作"
 
 #: pl_exec.c:3252
 msgid ""
 "You might want to use EXECUTE ... INTO or EXECUTE CREATE TABLE ... AS "
 "instead."
-msgstr "你可能想改用  EXECUTE ... INTO or EXECUTE CREATE TABLE ... AS�?
+msgstr "你可能想改用  EXECUTE ... INTO or EXECUTE CREATE TABLE ... AS。"
 
 #: pl_exec.c:3540 pl_exec.c:3631
 #, c-format
 msgid "cursor variable \"%s\" is null"
-msgstr "指標變數 \"%s\" �?null"
+msgstr "指標變數 \"%s\" 為 null"
 
 # commands/portalcmds.c:182 commands/portalcmds.c:229
 #: pl_exec.c:3547 pl_exec.c:3638
 #, c-format
 msgid "cursor \"%s\" does not exist"
-msgstr "cursor \"%s\"不存�?
+msgstr "cursor \"%s\"不存在"
 
 #: pl_exec.c:3561
 msgid "relative or absolute cursor position is null"
@@ -384,11 +384,11 @@ msgstr "相對或絕對指標位置為 null"
 #: pl_exec.c:3702
 #, c-format
 msgid "null value cannot be assigned to variable \"%s\" declared NOT NULL"
-msgstr "不可�?Null 值指派給宣告�?NOT NULL 的變�?\"%s\""
+msgstr "不可將 Null 值指派給宣告為 NOT NULL 的變數 \"%s\""
 
 #: pl_exec.c:3760
 msgid "cannot assign non-composite value to a row variable"
-msgstr "不可將非複合值指派給資料列變�?
+msgstr "不可將非複合值指派給資料列變數"
 
 #: pl_exec.c:3802
 msgid "cannot assign non-composite value to a record variable"
@@ -397,7 +397,7 @@ msgstr "不可將非複合值指派給記錄變數"
 #: pl_exec.c:3973
 #, c-format
 msgid "number of array dimensions (%d) exceeds the maximum allowed (%d)"
-msgstr "陣列維度數目 (%d) 超過允許的上�?(%d)"
+msgstr "陣列維度數目 (%d) 超過允許的上限 (%d)"
 
 #: pl_exec.c:3992
 msgid "subscripted object is not an array"
@@ -405,18 +405,18 @@ msgstr "下標物件不是陣列"
 
 #: pl_exec.c:4015
 msgid "array subscript in assignment must not be null"
-msgstr "指派中的陣列下標不可�?null"
+msgstr "指派中的陣列下標不可為 null"
 
 #: pl_exec.c:4453
 #, c-format
 msgid "query \"%s\" did not return data"
-msgstr "查詢 \"%s\" 未傳回資�?
+msgstr "查詢 \"%s\" 未傳回資料"
 
 #: pl_exec.c:4461
 #, c-format
 msgid "query \"%s\" returned %d column"
 msgid_plural "query \"%s\" returned %d columns"
-msgstr[0] "查詢 \"%s\" 傳回 %d 個欄�?
+msgstr[0] "查詢 \"%s\" 傳回 %d 個欄位"
 
 #: pl_exec.c:4487
 #, c-format
@@ -440,29 +440,29 @@ msgstr "定序不被型別 %s 支援"
 
 #: gram.y:465
 msgid "row or record variable cannot be CONSTANT"
-msgstr "資料列或記錄變數不可�?CONSTANT"
+msgstr "資料列或記錄變數不可為 CONSTANT"
 
 #: gram.y:475
 msgid "row or record variable cannot be NOT NULL"
-msgstr "資料列或記錄變數不可�?NOT NULL"
+msgstr "資料列或記錄變數不可為 NOT NULL"
 
 #: gram.y:486
 msgid "default value for row or record variable is not supported"
-msgstr "不支援資料列或記錄變數的預設�?
+msgstr "不支援資料列或記錄變數的預設值"
 
 # tcop/utility.c:77
 #: gram.y:631 gram.y:657
 #, c-format
 msgid "variable \"%s\" does not exist"
-msgstr "變數 \"%s\" 不存�?
+msgstr "變數 \"%s\" 不存在"
 
 #: gram.y:675 gram.y:688
 msgid "duplicate declaration"
-msgstr "重複的宣�?
+msgstr "重複的宣告"
 
 #: gram.y:881
 msgid "unrecognized GET DIAGNOSTICS item"
-msgstr "無法辨識�?GET DIAGNOSTICS 項目"
+msgstr "無法辨識的 GET DIAGNOSTICS 項目"
 
 #: gram.y:892 gram.y:3090
 #, c-format
@@ -477,7 +477,7 @@ msgstr "資料列迴圈的迴圈變數必須是記錄或資料列變數，或是
 
 #: gram.y:1188
 msgid "cursor FOR loop must have only one target variable"
-msgstr "指標 FOR 迴圈只能有一個目標變�?
+msgstr "指標 FOR 迴圈只能有一個目標變數"
 
 #: gram.y:1195
 msgid "cursor FOR loop must use a bound cursor variable"
@@ -485,15 +485,15 @@ msgstr "指標 FOR 迴圈必須使用繫結指標變數"
 
 #: gram.y:1278
 msgid "integer FOR loop must have only one target variable"
-msgstr "整數 FOR 迴圈只能有一個目標變�?
+msgstr "整數 FOR 迴圈只能有一個目標變數"
 
 #: gram.y:1314
 msgid "cannot specify REVERSE in query FOR loop"
-msgstr "無法在查�?FOR 迴圈中指�?REVERSE"
+msgstr "無法在查詢 FOR 迴圈中指定 REVERSE"
 
 #: gram.y:1461
 msgid "loop variable of FOREACH must be a known variable or list of variables"
-msgstr "FOREACH 的迴圈變數必須是已知變數或變數清�?
+msgstr "FOREACH 的迴圈變數必須是已知變數或變數清單"
 
 #: gram.y:1513 gram.y:1550 gram.y:1598 gram.y:2540 gram.y:2621 gram.y:2732
 #: gram.y:3365
@@ -509,19 +509,19 @@ msgstr "語法錯誤"
 
 #: gram.y:1646 gram.y:1648 gram.y:2052 gram.y:2054
 msgid "invalid SQLSTATE code"
-msgstr "SQLSTATE 程式碼無�?
+msgstr "SQLSTATE 程式碼無效"
 
 #: gram.y:1814
 msgid "syntax error, expected \"FOR\""
-msgstr "語法錯誤，預�?\"FOR\""
+msgstr "語法錯誤，預期 \"FOR\""
 
 #: gram.y:1876
 msgid "FETCH statement cannot return multiple rows"
-msgstr "FETCH 陳述式不能傳回多筆資�?
+msgstr "FETCH 陳述式不能傳回多筆資料"
 
 #: gram.y:1932
 msgid "cursor variable must be a simple variable"
-msgstr "指標變數必須是簡單變�?
+msgstr "指標變數必須是簡單變數"
 
 #: gram.y:1938
 #, c-format
@@ -530,7 +530,7 @@ msgstr "變數 \"%s\" 必須是指標型別或 refcursor 型別"
 
 #: gram.y:2106
 msgid "label does not exist"
-msgstr "標籤不存�?
+msgstr "標籤不存在"
 
 #: gram.y:2213 gram.y:2224
 #, c-format
@@ -539,7 +539,7 @@ msgstr "\"%s\" 不是已知變數"
 
 #: gram.y:2326 gram.y:2336 gram.y:2464
 msgid "mismatched parentheses"
-msgstr "括號不相�?
+msgstr "括號不相符"
 
 #: gram.y:2340
 #, c-format
@@ -553,11 +553,11 @@ msgstr "SQL 陳述式的結尾遺漏 \"%s\""
 
 #: gram.y:2363
 msgid "missing expression"
-msgstr "缺少運算�?
+msgstr "缺少運算式"
 
 #: gram.y:2365
 msgid "missing SQL statement"
-msgstr "缺少 SQL 陳述�?
+msgstr "缺少 SQL 陳述式"
 
 #: gram.y:2466
 msgid "incomplete data type declaration"
@@ -569,27 +569,27 @@ msgstr "遺漏資料型別宣告"
 
 #: gram.y:2545
 msgid "INTO specified more than once"
-msgstr "INTO 指定一次以�?
+msgstr "INTO 指定一次以上"
 
 #: gram.y:2713
 msgid "expected FROM or IN"
-msgstr "預期 FROM �?IN "
+msgstr "預期 FROM 或 IN "
 
 #: gram.y:2773
 msgid "RETURN cannot have a parameter in function returning set"
-msgstr "RETURN 在傳�?set 的函式中不能有參�?
+msgstr "RETURN 在傳回 set 的函式中不能有參數"
 
 #: gram.y:2774
 msgid "Use RETURN NEXT or RETURN QUERY."
-msgstr "�?RETURN NEXT �?RETURN QUERY�?
+msgstr "用 RETURN NEXT 或 RETURN QUERY。"
 
 #: gram.y:2782
 msgid "RETURN cannot have a parameter in function with OUT parameters"
-msgstr "RETURN 在具�?OUT 參數的函式中不能有參�?
+msgstr "RETURN 在具有 OUT 參數的函式中不能有參數"
 
 #: gram.y:2791
 msgid "RETURN cannot have a parameter in function returning void"
-msgstr "RETURN 在傳�?void 的函式中不能有參�?
+msgstr "RETURN 在傳回 void 的函式中不能有參數"
 
 #: gram.y:2809 gram.y:2816
 msgid "RETURN must specify a record or row variable in function returning row"
@@ -597,7 +597,7 @@ msgstr "RETURN 在傳回資料列的函式中必須指定記錄或資料列變�
 
 #: gram.y:2858
 msgid "RETURN NEXT cannot have a parameter in function with OUT parameters"
-msgstr "RETURN NEXT 在具�?OUT 參數的函式中不能有參�?
+msgstr "RETURN NEXT 在具有 OUT 參數的函式中不能有參數"
 
 #: gram.y:2873 gram.y:2880
 msgid ""
@@ -607,7 +607,7 @@ msgstr "RETURN NEXT 在傳回資料列的函式中必須指定記錄或資料列
 #: gram.y:2959
 #, c-format
 msgid "\"%s\" is declared CONSTANT"
-msgstr "\"%s\" 宣告�?CONSTANT"
+msgstr "\"%s\" 宣告為 CONSTANT"
 
 #: gram.y:3021 gram.y:3033
 msgid "record or row variable cannot be part of multiple-item INTO list"
@@ -615,17 +615,17 @@ msgstr "紀錄或資料行變數不能用在多項目 INTO 清單"
 
 #: gram.y:3078
 msgid "too many INTO variables specified"
-msgstr "指定太多�?INTO 變數"
+msgstr "指定太多的 INTO 變數"
 
 #: gram.y:3286
 #, c-format
 msgid "end label \"%s\" specified for unlabelled block"
-msgstr "為未標籤區塊指定結束標�?\"%s\""
+msgstr "為未標籤區塊指定結束標籤 \"%s\""
 
 #: gram.y:3293
 #, c-format
 msgid "end label \"%s\" differs from block's label \"%s\""
-msgstr "結束標籤 \"%s\" 不同於區塊標�?\"%s\""
+msgstr "結束標籤 \"%s\" 不同於區塊標籤 \"%s\""
 
 #: gram.y:3320
 #, c-format
@@ -635,19 +635,19 @@ msgstr "指標 \"%s\" 沒有參數"
 #: gram.y:3334
 #, c-format
 msgid "cursor \"%s\" has arguments"
-msgstr "指標 \"%s\" 有參�?
+msgstr "指標 \"%s\" 有參數"
 
 #: gram.y:3382
 msgid "unrecognized RAISE statement option"
-msgstr "無法辨識 RAISE 陳述式選�?
+msgstr "無法辨識 RAISE 陳述式選項"
 
 #: gram.y:3386
 msgid "syntax error, expected \"=\""
-msgstr "語法錯誤，預�?\"=\""
+msgstr "語法錯誤，預期 \"=\""
 
 #: pl_funcs.c:218
 msgid "statement block"
-msgstr "陳述式區�?
+msgstr "陳述式區塊"
 
 #: pl_funcs.c:220
 msgid "assignment"
@@ -655,11 +655,11 @@ msgstr "指派"
 
 #: pl_funcs.c:230
 msgid "FOR with integer loop variable"
-msgstr "具有整數迴圈變數�?FOR"
+msgstr "具有整數迴圈變數的 FOR"
 
 #: pl_funcs.c:232
 msgid "FOR over SELECT rows"
-msgstr "FOR 用於 SELECT 資料�?
+msgstr "FOR 用於 SELECT 資料行"
 
 #: pl_funcs.c:234
 msgid "FOR over cursor"
@@ -671,21 +671,21 @@ msgstr "FOREACH 用於陣列"
 
 #: pl_funcs.c:248
 msgid "SQL statement"
-msgstr "SQL 陳述�?
+msgstr "SQL 陳述式"
 
 #: pl_funcs.c:250
 msgid "EXECUTE statement"
-msgstr "EXECUTE 陳述�?
+msgstr "EXECUTE 陳述式"
 
 #: pl_funcs.c:252
 msgid "FOR over EXECUTE statement"
-msgstr "目標�?EXECUTE 陳述式的 FOR"
+msgstr "目標為 EXECUTE 陳述式的 FOR"
 
 #: pl_handler.c:60
 msgid ""
-"Sets handling of conflicts between PL/iSQL variable names and table column "
+"Sets handling of conflicts between PL/pgSQL variable names and table column "
 "names."
-msgstr "PL/iSQL 變數名稱和資料表欄位名稱衝突處理�?
+msgstr "PL/pgSQL 變數名稱和資料表欄位名稱衝突處理。"
 
 #  translator: %s is typically "syntax error"
 # scan.l:621
@@ -707,10 +707,10 @@ msgstr "\"%2$s\" 附近發生 %1$s"
 #~ msgstr "預期 \"[\""
 
 #~ msgid "row \"%s\" has no field \"%s\""
-#~ msgstr "資料�?\"%s\" 沒有欄位 \"%s\""
+#~ msgstr "資料列 \"%s\" 沒有欄位 \"%s\""
 
 #~ msgid "row \"%s.%s\" has no field \"%s\""
-#~ msgstr "資料�?\"%s.%s\" 沒有欄位 \"%s\""
+#~ msgstr "資料列 \"%s.%s\" 沒有欄位 \"%s\""
 
 #~ msgid "type of \"%s\" does not match that when preparing the plan"
 #~ msgstr "\"%s\" 型別與準備計畫時的型別不相符"
@@ -726,13 +726,13 @@ msgstr "\"%2$s\" 附近發生 %1$s"
 
 #~ msgid ""
 #~ "Number of returned columns (%d) does not match expected column count (%d)."
-#~ msgstr "傳回的資料行�?(%d) 與預期的資料行計�?(%d) 不相符�?
+#~ msgstr "傳回的資料行數 (%d) 與預期的資料行計數 (%d) 不相符。"
 
 #~ msgid "Returned type %s does not match expected type %s in column \"%s\"."
-#~ msgstr "傳回的型�?%s 不符合預期的型別 %s (在資料行 \"%s\" �?�?
+#~ msgstr "傳回的型別 %s 不符合預期的型別 %s (在資料行 \"%s\" 中)。"
 
 #~ msgid "only positional parameters can be aliased"
-#~ msgstr "只有位置參數可以有別�?
+#~ msgstr "只有位置參數可以有別名"
 
 #~ msgid "function has no parameter \"%s\""
 #~ msgstr "函式沒有參數 \"%s\""
@@ -744,10 +744,10 @@ msgstr "\"%2$s\" 附近發生 %1$s"
 #~ msgstr "\"%s\" 發生語法錯誤"
 
 #~ msgid "Expected \"FOR\", to open a cursor for an unbound cursor variable."
-#~ msgstr "預期 \"FOR\"，以開啟未繫結指標變數的指標�?
+#~ msgstr "預期 \"FOR\"，以開啟未繫結指標變數的指標。"
 
 #~ msgid "expected a cursor or refcursor variable"
-#~ msgstr "預期指標變數�?refcursor 變數"
+#~ msgstr "預期指標變數或 refcursor 變數"
 
 #~ msgid "too many variables specified in SQL statement"
 #~ msgstr "SQL 陳述式中指定太多變數"
@@ -756,21 +756,21 @@ msgstr "\"%2$s\" 附近發生 %1$s"
 #~ "RETURN cannot have a parameter in function returning set; use RETURN NEXT "
 #~ "or RETURN QUERY"
 #~ msgstr ""
-#~ "RETURN 在傳回集合的函式中不能有參數，請使用 RETURN NEXT �?RETURN QUERY"
+#~ "RETURN 在傳回集合的函式中不能有參數，請使用 RETURN NEXT 或 RETURN QUERY"
 
 #~ msgid "cannot assign to tg_argv"
-#~ msgstr "無法指派�?tg_argv"
+#~ msgstr "無法指派給 tg_argv"
 
 #~ msgid ""
 #~ "Expected record variable, row variable, or list of scalar variables "
 #~ "following INTO."
-#~ msgstr "預期是記錄變數、資料列變數或接�?INTO 之後的純量清單變數�?
+#~ msgstr "預期是記錄變數、資料列變數或接在 INTO 之後的純量清單變數。"
 
-#~ msgid "SQL statement in PL/iSQL function \"%s\" near line %d"
-#~ msgstr " PL/iSQL 函式 \"%s\" 中的 SQL 陳述式，靠近�?%d"
+#~ msgid "SQL statement in PL/PgSQL function \"%s\" near line %d"
+#~ msgstr " PL/PgSQL 函式 \"%s\" 中的 SQL 陳述式，靠近行 %d"
 
-#~ msgid "string literal in PL/iSQL function \"%s\" near line %d"
-#~ msgstr " PL/iSQL 函式 \"%s\" 中的字串實量，靠近行 %d"
+#~ msgid "string literal in PL/PgSQL function \"%s\" near line %d"
+#~ msgstr " PL/PgSQL 函式 \"%s\" 中的字串實量，靠近行 %d"
 
 #~ msgid "expected \")\""
 #~ msgstr "預期 \")\""
@@ -779,10 +779,10 @@ msgstr "\"%2$s\" 附近發生 %1$s"
 #~ msgstr "變數 \"%s\" 不在目前區塊中"
 
 #~ msgid "unterminated \" in identifier: %s"
-#~ msgstr "識別字中有未結束�?\":%s"
+#~ msgstr "識別字中有未結束的 \":%s"
 
 #~ msgid "qualified identifier cannot be used here: %s"
 #~ msgstr "此處不可使用完整的識別字:%s"
 
 #~ msgid "unterminated quoted identifier"
-#~ msgstr "未結束的引號識別�?
+#~ msgstr "未結束的引號識別字"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Localization Improvement":

- Improved the clarity and accuracy of error messages in PL/pgSQL for Japanese, Korean, Vietnamese, Simplified Chinese, and Traditional Chinese translations.
- Fixed typos and updated message formats across multiple languages to enhance readability.
- Updated project version and POT creation date in the Japanese translation file.

These changes aim to provide a better user experience for non-English speakers by improving the quality of translated error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->