### PR TITLE
Display function SQL information in oracle syntax

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -522,6 +522,7 @@ static text *string_to_text(char *str);
 static char *flatten_reloptions(Oid relid);
 static void get_reloptions(StringInfo buf, Datum reloptions);
 static const char *standard_quote_identifier(const char *ident);
+Datum pg_get_functiondef_internal(PG_FUNCTION_ARGS);
 
 #define only_marker(rte)  ((rte)->inh ? "" : "ONLY ")
 
@@ -2857,6 +2858,36 @@ pg_get_serial_sequence(PG_FUNCTION_ARGS)
 	PG_RETURN_NULL();
 }
 
+/*
+ * pg_get_functiondef
+ *		Returns the complete "CREATE OR REPLACE FUNCTION ..." statement for
+ *		the specified function.
+ *
+ * Note: An wrap of native postgres pg_get_functiondef, creating syntax
+ * for different functions selected by language.
+ */
+Datum
+pg_get_functiondef(PG_FUNCTION_ARGS)
+{
+	Datum		funcid = PG_GETARG_DATUM(0);
+	Datum		result;
+	HeapTuple	proctup;
+	Form_pg_proc proc;
+
+	proctup = SearchSysCache1(PROCOID, funcid);
+	if (!HeapTupleIsValid(proctup))
+		PG_RETURN_NULL();
+
+	proc = (Form_pg_proc) GETSTRUCT(proctup);
+
+	if (strcmp("plisql", get_language_name(proc->prolang, false)) == 0)
+		result = DirectFunctionCall1(ivy_get_plisql_functiondef, funcid);
+	else
+		result = DirectFunctionCall1(pg_get_functiondef_internal, funcid);
+
+	ReleaseSysCache(proctup);
+	PG_RETURN_DATUM(result);
+}
 
 /*
  * pg_get_functiondef
@@ -2867,9 +2898,12 @@ pg_get_serial_sequence(PG_FUNCTION_ARGS)
  * to break psql's rules (in \ef and \sf) for identifying the start of the
  * function body.  To wit: the function body starts on a line that begins with
  * "AS ", "BEGIN ", or "RETURN ", and no preceding line will look like that.
+ *
+ * we rename pg_get_functiondef to pg_get_functiondef_internal for warp a
+ * new pg_get_functiondef function.
  */
 Datum
-pg_get_functiondef(PG_FUNCTION_ARGS)
+pg_get_functiondef_internal(PG_FUNCTION_ARGS)
 {
 	Oid			funcid = PG_GETARG_OID(0);
 	StringInfoData buf;
@@ -3108,6 +3142,270 @@ pg_get_functiondef(PG_FUNCTION_ARGS)
 	}
 
 	appendStringInfoChar(&buf, '\n');
+
+	ReleaseSysCache(proctup);
+
+	PG_RETURN_TEXT_P(string_to_text(buf.data));
+}
+
+/*
+ * ivy_get_plisql_functiondef
+ *		Returns the complete "CREATE OR REPLACE FUNCTION ..." statement for
+ *		the specified plisql function.
+ *
+ * Note: if you change the output format of this function, be careful not
+ * to break psql's rules (in \ef and \sf) for identifying the start of the
+ * function body.  To wit: the function body starts on a line that begins
+ * with "AS ", and no preceding line will look like that.
+ */
+Datum
+ivy_get_plisql_functiondef(PG_FUNCTION_ARGS)
+{
+	Oid 		funcid = PG_GETARG_OID(0);
+	StringInfoData buf;
+	HeapTuple proctup;
+	Form_pg_proc proc;
+	bool		isfunction;
+	Datum 	tmp;
+	bool		isnull;
+	const char *prosrc;
+	const char *name;
+	const char *nsp;
+	float4		procost;
+	int 		oldlen;
+
+	initStringInfo(&buf);
+
+	/* Look up the function */
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	if (!HeapTupleIsValid(proctup))
+		PG_RETURN_NULL();
+
+	proc = (Form_pg_proc) GETSTRUCT(proctup);
+	name = NameStr(proc->proname);
+
+	/*
+	 * sanity check, only functions created by plisql language is ok.
+	 */
+	if (strcmp("plisql", get_language_name(proc->prolang, false)))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not an plisql function", name)));
+
+	if (proc->prokind == PROKIND_AGGREGATE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is an aggregate function", name)));
+
+	isfunction = (proc->prokind != PROKIND_PROCEDURE);
+
+	/*
+	 * We always qualify the function name, to ensure the right function gets
+	 * replaced.
+	 */
+	nsp = get_namespace_name(proc->pronamespace);
+	appendStringInfo(&buf, "CREATE OR REPLACE %s %s(",
+					 isfunction ? "FUNCTION" : "PROCEDURE",
+					 quote_qualified_identifier(nsp, name));
+	(void) print_function_arguments(&buf, proctup, false, true);
+	appendStringInfoString(&buf, ")\n");
+
+	/* Oracle uses the RETURN keyword on the return sytax of function */
+	if (isfunction)
+	{
+		appendStringInfoString(&buf, " RETURN ");
+		print_function_rettype(&buf, proctup);
+		appendStringInfoChar(&buf, '\n');
+	}
+
+	/*
+	 * Deal with the opt_ora_function_source_clause_list of ora_gram.y.
+	 * DETERMINISTIC, PARALLEL_ENABLE and AUTHID parsed in here and doesn't
+	 * need to be parsed later.
+	 */
+	if (proc->provolatile == PROVOLATILE_IMMUTABLE)
+		appendStringInfoString(&buf, " DETERMINISTIC"); /* IMMUTABLE => DETERMINISTIC */
+
+	if (proc->proparallel == PROPARALLEL_SAFE)
+		appendStringInfoString(&buf, " PARALLEL_ENABLE"); /* PARALLEL SAFE => PARALLEL_ENABLE */
+
+	/*
+	 * SECURITY DEFINER => AUTHID DEFINER
+	 * SECURITY INVOKER => AUTHID CURRENT_USER
+	 */
+	if (proc->prosecdef)
+		appendStringInfoString(&buf, " AUTHID DEFINER");
+	else
+		appendStringInfoString(&buf, " AUTHID CURRENT_USER");
+
+	appendStringInfoChar(&buf, '\n');
+	print_function_trftypes(&buf, proctup);
+
+	/*
+	 * No need LANGUAGE clause for plisql, we will automatically determine the language
+	 * in ora_gram.y, this make the function definition looks more like Oracle.
+	 */
+	//appendStringInfo(&buf, " LANGUAGE %s\n", "plisql");
+
+	/* Emit some miscellaneous options on one line */
+	oldlen = buf.len;
+
+	if (proc->prokind == PROKIND_WINDOW)
+		appendStringInfoString(&buf, " WINDOW");
+	switch (proc->provolatile)
+	{
+		case PROVOLATILE_IMMUTABLE:
+			/* This has been parsed before */
+			break;
+		case PROVOLATILE_STABLE:
+			appendStringInfoString(&buf, " STABLE");
+			break;
+		case PROVOLATILE_VOLATILE:
+			break;
+	}
+
+	switch (proc->proparallel)
+	{
+		case PROPARALLEL_SAFE:
+			/* This has been parsed before */
+			break;
+		case PROPARALLEL_RESTRICTED:
+			appendStringInfoString(&buf, " PARALLEL RESTRICTED");
+			break;
+		case PROPARALLEL_UNSAFE:
+			break;
+	}
+
+	if (proc->proisstrict)
+		appendStringInfoString(&buf, " STRICT");
+
+	if (proc->proleakproof)
+		appendStringInfoString(&buf, " LEAKPROOF");
+
+	/* This code for the default cost and rows should match functioncmds.c */
+	if (proc->prolang == INTERNALlanguageId ||
+		proc->prolang == ClanguageId)
+		procost = 1;
+	else
+		procost = 100;
+	if (proc->procost != procost)
+		appendStringInfo(&buf, " COST %g", proc->procost);
+
+	if (proc->prorows > 0 && proc->prorows != 1000)
+		appendStringInfo(&buf, " ROWS %g", proc->prorows);
+
+	if (proc->prosupport)
+	{
+		Oid 		argtypes[1];
+
+		/*
+		 * We should qualify the support function's name if it wouldn't be
+		 * resolved by lookup in the current search path.
+		 */
+		argtypes[0] = INTERNALOID;
+		appendStringInfo(&buf, " SUPPORT %s",
+						 generate_function_name(proc->prosupport, 1,
+												NIL, argtypes,
+												false, NULL, EXPR_KIND_NONE));
+	}
+
+	if (oldlen != buf.len)
+		appendStringInfoChar(&buf, '\n');
+
+	/* Emit any proconfig options, one per line */
+	tmp = SysCacheGetAttr(PROCOID, proctup, Anum_pg_proc_proconfig, &isnull);
+	if (!isnull)
+	{
+		ArrayType  *a = DatumGetArrayTypeP(tmp);
+		int 		i;
+
+		Assert(ARR_ELEMTYPE(a) == TEXTOID);
+		Assert(ARR_NDIM(a) == 1);
+		Assert(ARR_LBOUND(a)[0] == 1);
+
+		for (i = 1; i <= ARR_DIMS(a)[0]; i++)
+		{
+			Datum 	d;
+
+			d = array_ref(a, 1, &i,
+							-1 /* varlenarray */ ,
+							-1 /* TEXT's typlen */ ,
+							false /* TEXT's typbyval */ ,
+							TYPALIGN_INT /* TEXT's typalign */ ,
+							&isnull);
+			if (!isnull)
+			{
+				char		 *configitem = TextDatumGetCString(d);
+				char		 *pos;
+
+				pos = strchr(configitem, '=');
+				if (pos == NULL)
+					continue;
+				*pos++ = '\0';
+
+				appendStringInfo(&buf, " SET %s TO ",
+								 quote_identifier(configitem));
+
+				/*
+				 * Variables that are marked GUC_LIST_QUOTE were already fully
+				 * quoted by flatten_set_variable_args() before they were put
+				 * into the proconfig array.	However, because the quoting
+				 * rules used there aren't exactly like SQL's, we have to
+				 * break the list value apart and then quote the elements as
+				 * string literals.  (The elements may be double-quoted as-is,
+				 * but we can't just feed them to the SQL parser; it would do
+				 * the wrong thing with elements that are zero-length or
+				 * longer than NAMEDATALEN.)
+				 *
+				 * Variables that are not so marked should just be emitted as
+				 * simple string literals.	If the variable is not known to
+				 * guc.c, we'll do that; this makes it unsafe to use
+				 * GUC_LIST_QUOTE for extension variables.
+				 */
+				if (GetConfigOptionFlags(configitem, true) & GUC_LIST_QUOTE)
+				{
+					List		 *namelist;
+					ListCell	 *lc;
+
+					/* Parse string into list of identifiers */
+					if (!SplitGUCList(pos, ',', &namelist))
+					{
+						/* this shouldn't fail really */
+						elog(ERROR, "invalid list syntax in proconfig item");
+					}
+					foreach(lc, namelist)
+					{
+						char		 *curname = (char *) lfirst(lc);
+
+						simple_quote_literal(&buf, curname);
+						if (lnext(namelist, lc))
+							appendStringInfoString(&buf, ", ");
+					}
+				}
+				else
+					simple_quote_literal(&buf, pos);
+				appendStringInfoChar(&buf, '\n');
+			}
+		}
+	}
+
+	/* And finally the function definition ... */
+	/* AS => IS */
+	appendStringInfoString(&buf, "IS ");
+	appendStringInfoChar(&buf, '\n');
+
+	tmp = SysCacheGetAttr(PROCOID, proctup, Anum_pg_proc_prosrc, &isnull);
+	if (isnull)
+		elog(ERROR, "null prosrc");
+	prosrc = TextDatumGetCString(tmp);
+
+	/*
+	 * Plisql body no need dollar quoting, append directly.
+	 */
+	appendStringInfoString(&buf, prosrc);
+
+	if (buf.data[buf.len - 1] != ';')
+		appendStringInfoChar(&buf, ';');
 
 	ReleaseSysCache(proctup);
 

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -12048,4 +12048,8 @@
   proname => 'pg_get_connection_mode', provolatile => 's', prorettype => 'text',
   proargtypes => '', prosrc => 'pg_get_connection_mode' },
 
+{ oid => '4643', descr => 'definition of a plisql function',
+  proname => 'ivy_get_plisql_functiondef', provolatile => 's', prorettype => 'text',
+  proargtypes => 'oid', prosrc => 'ivy_get_plisql_functiondef' },
+
 ]

--- a/src/oracle_test/regress/expected/ora_plisql.out
+++ b/src/oracle_test/regress/expected/ora_plisql.out
@@ -839,6 +839,160 @@ select f_noparentheses from t_noparentheses;
              123
 (1 row)
 
+CREATE OR REPLACE FUNCTION test_func RETURN integer
+AUTHID DEFINER
+DETERMINISTIC
+PARALLEL_ENABLE ( PARTITION A BY RANGE ( B, C ) CLUSTER A BY ( E,F ) )
+IS
+BEGIN    
+    RETURN 1;
+END;
+/
+CREATE OR REPLACE PROCEDURE test_proc
+AUTHID CURRENT_USER
+IS
+	p integer := 20;   
+begin
+	raise notice '%', p;
+end;
+/
+-- nested subproc of plisql
+create or replace function test_subproc_func(a in integer) returns integer as
+$$
+declare
+  mds integer;
+  original integer;
+  function square(original in integer) return integer;
+  function square(original in integer) return integer
+  AS
+  declare
+       original_squared integer;
+  begin
+       original_squared := original * original;
+       original := original_squared + 1;
+       return original_squared;
+   end;
+begin
+    mds := 10;
+    original := square(mds);
+    raise info '%',original;
+    a := original + 1;
+    return mds;
+end;$$ language plisql;
+/
+-- pg_get_functiondef
+SELECT pg_get_functiondef('test_func'::regproc) from dual;
+              pg_get_functiondef               
+-----------------------------------------------
+ CREATE OR REPLACE FUNCTION public.test_func()+
+  RETURN pg_catalog.int4                      +
+  DETERMINISTIC PARALLEL_ENABLE AUTHID DEFINER+
+ IS                                           +
+ BEGIN                                        +
+     RETURN 1;                                +
+ END;
+(1 row)
+
+SELECT pg_get_functiondef('test_proc'::regproc) from dual;
+               pg_get_functiondef               
+------------------------------------------------
+ CREATE OR REPLACE PROCEDURE public.test_proc()+
+  AUTHID CURRENT_USER                          +
+ IS                                            +
+ p integer := 20;                              +
+ begin                                         +
+         raise notice '%', p;                  +
+ end;
+(1 row)
+
+SELECT pg_get_functiondef('test_subproc_func'::regproc) from dual;
+                           pg_get_functiondef                           
+------------------------------------------------------------------------
+ CREATE OR REPLACE FUNCTION public.test_subproc_func(a pg_catalog.int4)+
+  RETURN pg_catalog.int4                                               +
+  AUTHID DEFINER                                                       +
+ IS                                                                    +
+                                                                       +
+ declare                                                               +
+   mds integer;                                                        +
+   original integer;                                                   +
+   function square(original in integer) return integer;                +
+   function square(original in integer) return integer                 +
+   AS                                                                  +
+   declare                                                             +
+        original_squared integer;                                      +
+   begin                                                               +
+        original_squared := original * original;                       +
+        original := original_squared + 1;                              +
+        return original_squared;                                       +
+    end;                                                               +
+ begin                                                                 +
+     mds := 10;                                                        +
+     original := square(mds);                                          +
+     raise info '%',original;                                          +
+     a := original + 1;                                                +
+     return mds;                                                       +
+ end;
+(1 row)
+
+-- ivy_get_plisql_functiondef is only using get plisql func/proc definition.
+SELECT ivy_get_plisql_functiondef('test_func'::regproc) from dual;
+          ivy_get_plisql_functiondef           
+-----------------------------------------------
+ CREATE OR REPLACE FUNCTION public.test_func()+
+  RETURN pg_catalog.int4                      +
+  DETERMINISTIC PARALLEL_ENABLE AUTHID DEFINER+
+ IS                                           +
+ BEGIN                                        +
+     RETURN 1;                                +
+ END;
+(1 row)
+
+SELECT ivy_get_plisql_functiondef('test_proc'::regproc) from dual;
+           ivy_get_plisql_functiondef           
+------------------------------------------------
+ CREATE OR REPLACE PROCEDURE public.test_proc()+
+  AUTHID CURRENT_USER                          +
+ IS                                            +
+ p integer := 20;                              +
+ begin                                         +
+         raise notice '%', p;                  +
+ end;
+(1 row)
+
+SELECT ivy_get_plisql_functiondef('test_subproc_func'::regproc) from dual;
+                       ivy_get_plisql_functiondef                       
+------------------------------------------------------------------------
+ CREATE OR REPLACE FUNCTION public.test_subproc_func(a pg_catalog.int4)+
+  RETURN pg_catalog.int4                                               +
+  AUTHID DEFINER                                                       +
+ IS                                                                    +
+                                                                       +
+ declare                                                               +
+   mds integer;                                                        +
+   original integer;                                                   +
+   function square(original in integer) return integer;                +
+   function square(original in integer) return integer                 +
+   AS                                                                  +
+   declare                                                             +
+        original_squared integer;                                      +
+   begin                                                               +
+        original_squared := original * original;                       +
+        original := original_squared + 1;                              +
+        return original_squared;                                       +
+    end;                                                               +
+ begin                                                                 +
+     mds := 10;                                                        +
+     original := square(mds);                                          +
+     raise info '%',original;                                          +
+     a := original + 1;                                                +
+     return mds;                                                       +
+ end;
+(1 row)
+
+DROP PROCEDURE test_proc();
+DROP FUNCTION test_func();
+DROP FUNCTION test_subproc_func(int);
 --
 -- Compatible with Oracle:
 -- The input parameter type is %rowtype


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added `pg_get_functiondef` and `ivy_get_plisql_functiondef` functions to retrieve the complete "CREATE OR REPLACE FUNCTION" statement for a specified function, enhancing support for different function languages.
- New Feature: Introduced new test functions and procedures in `ora_plisql.sql`, including `test_func`, `test_proc`, and `test_subproc_func`, improving the robustness of our testing suite.
- Refactor: Renamed existing `pg_get_functiondef` function to `pg_get_functiondef_internal` for better clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->