### PR TITLE
IvorySQL:After compiling with meson, the execution of the 'initdb' command failed.

### DIFF
--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -16,6 +16,8 @@ ivorysql_ora_sources = files(
   'src/datatype/compatible_oracle_precedence.c',
   'src/datatype/common_datatypes.c',
   'src/datatype/raw_long.c',
+  'src/datatype/binary_float.c',
+  'src/datatype/binary_double.c',
   'src/builtin_functions/character_datatype_functions.c',
   'src/builtin_functions/datetime_datatype_functions.c',
   'src/builtin_functions/numeric_datatype_functions.c',


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for binary floating-point data types in IvorySQL Oracle. The update includes the addition of two new source files, `binary_float.c` and `binary_double.c`, enhancing the handling and processing of binary floating-point data. This feature will improve the precision and performance of numerical computations in your database operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->