### PR TITLE
Ivory rel 3 global unique index

### DIFF
--- a/contrib/pageinspect/btreefuncs.c
+++ b/contrib/pageinspect/btreefuncs.c
@@ -50,6 +50,7 @@ PG_FUNCTION_INFO_V1(bt_multi_page_stats);
 
 #define IS_INDEX(r) ((r)->rd_rel->relkind == RELKIND_INDEX)
 #define IS_BTREE(r) ((r)->rd_rel->relam == BTREE_AM_OID)
+#define IS_GLOBAL_INDEX(r) ((r)->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
 
 /* ------------------------------------------------
  * structure for single btree page statistics
@@ -226,7 +227,7 @@ check_relation_block_range(Relation rel, int64 blkno)
 static void
 bt_index_block_validate(Relation rel, int64 blkno)
 {
-	if (!IS_INDEX(rel) || !IS_BTREE(rel))
+	if ((!IS_INDEX(rel) && !IS_GLOBAL_INDEX(rel)) || !IS_BTREE(rel))
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a %s index",
@@ -859,7 +860,7 @@ bt_metap(PG_FUNCTION_ARGS)
 	relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
 	rel = relation_openrv(relrv, AccessShareLock);
 
-	if (!IS_INDEX(rel) || !IS_BTREE(rel))
+	if ((!IS_INDEX(rel) && !IS_GLOBAL_INDEX(rel)) || !IS_BTREE(rel))
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a %s index",

--- a/doc/src/sgml/ref/create_index.sgml
+++ b/doc/src/sgml/ref/create_index.sgml
@@ -28,6 +28,7 @@ CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ [ IF NOT EXISTS ] <replaceable class=
     [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) ]
     [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
     [ WHERE <replaceable class="parameter">predicate</replaceable> ]
+    [ GLOBAL ]
 </synopsis>
  </refsynopsisdiv>
 
@@ -376,6 +377,18 @@ CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ [ IF NOT EXISTS ] <replaceable class=
       <listitem>
        <para>
         The constraint expression for a partial index.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><literal>GLOBAL</literal></term>
+      <listitem>
+       <para>
+        Used with <literal>UNIQUE</literal> to enable cross-partition
+        uniqueness check on a partitioned table. Attempts to insert or
+        update data which would result in duplicate entries in other 
+        partitions as a whole will generate an error.
        </para>
       </listitem>
      </varlistentry>

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1410,6 +1410,7 @@ extractRelOptions(HeapTuple tuple, TupleDesc tupdesc,
 			options = view_reloptions(datum, false);
 			break;
 		case RELKIND_INDEX:
+		case RELKIND_GLOBAL_INDEX:
 		case RELKIND_PARTITIONED_INDEX:
 			options = index_reloptions(amoptions, datum, false);
 			break;

--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -136,6 +136,7 @@ index_open(Oid relationId, LOCKMODE lockmode)
 	r = relation_open(relationId, lockmode);
 
 	if (r->rd_rel->relkind != RELKIND_INDEX &&
+		r->rd_rel->relkind != RELKIND_GLOBAL_INDEX &&
 		r->rd_rel->relkind != RELKIND_PARTITIONED_INDEX)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),

--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -35,7 +35,7 @@ static BTStack _bt_search_insert(Relation rel, Relation heaprel,
 static TransactionId _bt_check_unique(Relation rel, BTInsertState insertstate,
 									  Relation heapRel,
 									  IndexUniqueCheck checkUnique, bool *is_unique,
-									  uint32 *speculativeToken);
+									  uint32 *speculativeToken, Relation origHeapRel);
 static OffsetNumber _bt_findinsertloc(Relation rel,
 									  BTInsertState insertstate,
 									  bool checkingunique,
@@ -74,6 +74,11 @@ static BlockNumber *_bt_deadblocks(Page page, OffsetNumber *deletable,
 								   int ndeletable, IndexTuple newitem,
 								   int *nblocks);
 static inline int _bt_blk_cmp(const void *arg1, const void *arg2);
+
+TransactionId _bt_check_unique_gi(Relation rel, BTInsertState insertstate,
+								  Relation heapRel,
+								  IndexUniqueCheck checkUnique, bool *is_unique,
+								  uint32 *speculativeToken, Relation origHeapRel);
 
 /*
  *	_bt_doinsert() -- Handle insertion of a single index tuple in the tree.
@@ -208,7 +213,7 @@ search:
 		uint32		speculativeToken;
 
 		xwait = _bt_check_unique(rel, &insertstate, heapRel, checkUnique,
-								 &is_unique, &speculativeToken);
+								 &is_unique, &speculativeToken, NULL);
 
 		if (unlikely(TransactionIdIsValid(xwait)))
 		{
@@ -381,6 +386,15 @@ _bt_search_insert(Relation rel, Relation heaprel, BTInsertState insertstate)
 					  BT_WRITE, NULL);
 }
 
+TransactionId
+_bt_check_unique_gi(Relation rel, BTInsertState insertstate, Relation heapRel,
+					IndexUniqueCheck checkUnique, bool *is_unique,
+					uint32 *speculativeToken, Relation origHeapRel)
+{
+	return _bt_check_unique(rel, insertstate, heapRel, checkUnique,
+							is_unique, speculativeToken, origHeapRel);
+}
+
 /*
  *	_bt_check_unique() -- Check for violation of unique index constraint
  *
@@ -407,7 +421,7 @@ _bt_search_insert(Relation rel, Relation heaprel, BTInsertState insertstate)
 static TransactionId
 _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 				 IndexUniqueCheck checkUnique, bool *is_unique,
-				 uint32 *speculativeToken)
+				 uint32 *speculativeToken, Relation origHeapRel)
 {
 	IndexTuple	itup = insertstate->itup;
 	IndexTuple	curitup = NULL;
@@ -562,6 +576,7 @@ _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 													   &all_dead))
 				{
 					TransactionId xwait;
+					bool		idx_fetch_result;
 
 					/*
 					 * It is a duplicate. If we are only doing a partial
@@ -615,8 +630,13 @@ _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 					 * entry.
 					 */
 					htid = itup->t_tid;
-					if (table_index_fetch_tuple_check(heapRel, &htid,
-													  SnapshotSelf, NULL))
+					if (origHeapRel)
+						idx_fetch_result = table_index_fetch_tuple_check(origHeapRel, &htid,
+																		 SnapshotSelf, NULL);
+					else
+						idx_fetch_result = table_index_fetch_tuple_check(heapRel, &htid,
+																		 SnapshotSelf, NULL);
+					if (idx_fetch_result)
 					{
 						/* Normal case --- it's still live */
 					}

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -23,6 +23,8 @@
 #include "access/relscan.h"
 #include "access/xlog.h"
 #include "access/xloginsert.h"
+#include "access/table.h"
+#include "catalog/partition.h"
 #include "commands/progress.h"
 #include "commands/vacuum.h"
 #include "miscadmin.h"
@@ -34,9 +36,11 @@
 #include "storage/ipc.h"
 #include "storage/lmgr.h"
 #include "storage/smgr.h"
+#include "storage/predicate.h"
 #include "utils/builtins.h"
 #include "utils/index_selfuncs.h"
 #include "utils/memutils.h"
+#include "partitioning/partdesc.h"
 
 
 /*
@@ -86,7 +90,9 @@ static BTVacuumPosting btreevacuumposting(BTVacState *vstate,
 										  IndexTuple posting,
 										  OffsetNumber updatedoffset,
 										  int *nremaining);
-
+static void
+			btinsert_check_unique_gi(IndexTuple itup, Relation idxRel,
+									 Relation heapRel, IndexUniqueCheck checkUnique);
 
 /*
  * Btree handler function: return IndexAmRoutine with access method parameters
@@ -181,6 +187,121 @@ btbuildempty(Relation index)
 }
 
 /*
+ *	btinsert_check_unique_gi() -- cross partitions uniqueness check.
+ *
+ *		loop all partitions with global index for uniqueness check.
+ */
+static void
+btinsert_check_unique_gi(IndexTuple itup, Relation idxRel,
+						 Relation heapRel, IndexUniqueCheck checkUnique)
+{
+	bool		is_unique = false;
+	BTScanInsert itup_key = _bt_mkscankey(idxRel, itup);
+
+	if (!itup_key->anynullkeys &&
+		idxRel->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
+	{
+		Oid			parentId;
+		Relation	parentTbl;
+		PartitionDesc partDesc;
+		int			i;
+		int			nparts;
+		Oid		   *partOids;
+
+		itup_key->scantid = NULL;
+		parentId = heapRel->rd_rel->relispartition ?
+			get_partition_parent(idxRel->rd_index->indrelid, false) : InvalidOid;
+		parentTbl = table_open(parentId, AccessShareLock);
+		partDesc = RelationGetPartitionDesc(parentTbl, true);
+		nparts = partDesc->nparts;
+		partOids = palloc(sizeof(Oid) * nparts);
+		memcpy(partOids, partDesc->oids, sizeof(Oid) * nparts);
+		for (i = 0; i < nparts; i++)
+		{
+			Oid			childRelid = partOids[i];
+			List	   *childidxs;
+			ListCell   *cell;
+
+			if (childRelid != heapRel->rd_rel->oid)
+			{
+				Relation	hRel = table_open(childRelid, AccessShareLock);
+
+				childidxs = RelationGetIndexList(hRel);
+				foreach(cell, childidxs)
+				{
+					Oid			cldidxid = lfirst_oid(cell);
+					Relation	iRel = index_open(cldidxid, AccessShareLock);
+
+					if (iRel->rd_rel->relkind == RELKIND_GLOBAL_INDEX
+						&& iRel->rd_rel->oid != idxRel->rd_rel->oid)
+					{
+						BTStack		stack;
+						uint32		speculativeToken;
+						BTInsertStateData insertstate;
+						TransactionId xwait = InvalidBuffer;
+
+						insertstate.itup = itup;
+						insertstate.itemsz = MAXALIGN(IndexTupleSize(itup));
+						insertstate.itup_key = itup_key;
+						insertstate.bounds_valid = false;
+						insertstate.buf = InvalidBuffer;
+						insertstate.postingoff = 0;
+
+				search_global:
+						stack = _bt_search(iRel, heapRel, insertstate.itup_key,
+										   &insertstate.buf, BT_READ, NULL);
+						if (insertstate.buf)
+						{
+							xwait = _bt_check_unique_gi(iRel, &insertstate,
+														hRel, checkUnique, &is_unique,
+														&speculativeToken, heapRel);
+							if (unlikely(TransactionIdIsValid(xwait)))
+							{
+								/* Have to wait for the other guy ... */
+								if (insertstate.buf)
+								{
+									_bt_relbuf(iRel, insertstate.buf);
+									insertstate.buf = InvalidBuffer;
+								}
+
+								/*
+								 * If it's a speculative insertion, wait for it to
+								 * finish (ie. to go ahead with the insertion, or
+								 * kill the tuple).  Otherwise wait for the
+								 * transaction to finish as usual.
+								 */
+								if (speculativeToken)
+									SpeculativeInsertionWait(xwait, speculativeToken);
+								else
+									XactLockTableWait(xwait, iRel, &itup->t_tid, XLTW_InsertIndex);
+
+								/* start over... */
+								if (stack)
+									_bt_freestack(stack);
+								goto search_global;
+							}
+						}
+						if (insertstate.buf)
+							_bt_relbuf(iRel, insertstate.buf);
+						if (stack)
+							_bt_freestack(stack);
+					}
+					index_close(iRel, AccessShareLock);
+				}
+				if (childidxs)
+					list_free(childidxs);
+				table_close(hRel, AccessShareLock);
+			}
+		}
+		if (partOids)
+			pfree(partOids);
+		table_close(parentTbl, AccessShareLock);
+	}
+	if (itup_key)
+		pfree(itup_key);
+}
+
+/*
  *	btinsert() -- insert an index tuple into a btree.
  *
  *		Descend the tree recursively, find the appropriate location for our
@@ -201,6 +322,9 @@ btinsert(Relation rel, Datum *values, bool *isnull,
 	itup->t_tid = *ht_ctid;
 
 	result = _bt_doinsert(rel, itup, checkUnique, indexUnchanged, heapRel);
+
+	if (checkUnique != UNIQUE_CHECK_NO)
+		btinsert_check_unique_gi(itup, rel, heapRel, checkUnique);
 
 	pfree(itup);
 

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -71,6 +71,7 @@
 #define PARALLEL_KEY_QUERY_TEXT			UINT64CONST(0xA000000000000004)
 #define PARALLEL_KEY_WAL_USAGE			UINT64CONST(0xA000000000000005)
 #define PARALLEL_KEY_BUFFER_USAGE		UINT64CONST(0xA000000000000006)
+#define PARALLEL_KEY_TUPLESORT_GLOBAL	UINT64CONST(0xA000000000000007)
 
 /*
  * DISABLE_LEADER_PARTICIPATION disables the leader's participation in
@@ -110,6 +111,7 @@ typedef struct BTShared
 	bool		nulls_not_distinct;
 	bool		isconcurrent;
 	int			scantuplesortstates;
+	bool		isglobal;
 
 	/*
 	 * workersdonecv is used to monitor the progress of workers.  All parallel
@@ -197,6 +199,7 @@ typedef struct BTLeader
 	Snapshot	snapshot;
 	WalUsage   *walusage;
 	BufferUsage *bufferusage;
+	Sharedsort *sharedsortglobal;
 } BTLeader;
 
 /*
@@ -226,6 +229,16 @@ typedef struct BTBuildState
 	 * BTBuildState.  Workers have their own spool and spool2, though.)
 	 */
 	BTLeader   *btleader;
+
+	/*
+	 * global unique index related parameters
+	 */
+	BTSpool    *spoolglobal;	/* spoolglobal is used on global unique index
+								 * build in parallel */
+	bool		global_index;	/* true if index is global */
+	int			globalIndexPart;	/* partition number indication */
+	int			nparts;			/* number of partitions involved in global
+								 * unique index build in parallel */
 } BTBuildState;
 
 /*
@@ -291,8 +304,29 @@ static void _bt_leader_participate_as_worker(BTBuildState *buildstate);
 static void _bt_parallel_scan_and_sort(BTSpool *btspool, BTSpool *btspool2,
 									   BTShared *btshared, Sharedsort *sharedsort,
 									   Sharedsort *sharedsort2, int sortmem,
-									   bool progress);
+									   bool progress, Sharedsort *sharedsortglobal,
+									   bool isworker);
 
+static BTSpool *global_btspool;
+Sharedsort *global_sharedsort;
+
+static void
+btinit_global_spool(Relation heap, Relation index, BTBuildState *buildstate)
+{
+	elog(DEBUG2, "%s: init global index spool", __FUNCTION__);
+	global_btspool = (BTSpool *) palloc0(sizeof(BTSpool));
+	global_btspool->heap = heap;
+	global_btspool->index = index;
+	global_btspool->isunique = buildstate->isunique;
+
+	global_btspool->sortstate =
+		tuplesort_begin_index_btree(heap, index, buildstate->isunique,
+									buildstate->nulls_not_distinct,
+									maintenance_work_mem, NULL,
+									false);
+
+	tuplesort_mark_global_sort(global_btspool->sortstate);
+}
 
 /*
  *	btbuild() -- build a new btree index.
@@ -318,22 +352,149 @@ btbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	buildstate.indtuples = 0;
 	buildstate.btleader = NULL;
 
+	if (indexInfo->ii_Global_index && indexInfo->ii_Unique)
+	{
+		/* copy global unique index related parameters to buildstate */
+		buildstate.global_index = indexInfo->ii_Global_index;
+		buildstate.globalIndexPart = indexInfo->ii_GlobalIndexPart;
+		buildstate.nparts = indexInfo->ii_Nparts;
+	}
+	else
+	{
+		/* disable global unique check */
+		buildstate.global_index = false;
+		buildstate.globalIndexPart = 0;
+		buildstate.nparts = 0;
+	}
+
 	/*
 	 * We expect to be called exactly once for any index relation. If that's
-	 * not the case, big trouble's what we have.
+	 * not the case, big trouble's what we have unless you set
+	 * buildGlobalSpool to true, which only builds the global spool for global
+	 * uniqueness check and not physical index tuples
 	 */
-	if (RelationGetNumberOfBlocks(index) != 0)
+	if (indexInfo->ii_BuildGlobalSpool == false && RelationGetNumberOfBlocks(index) != 0)
 		elog(ERROR, "index \"%s\" already contains data",
 			 RelationGetRelationName(index));
 
 	reltuples = _bt_spools_heapscan(heap, index, &buildstate, indexInfo);
 
+	if (indexInfo->ii_ParallelWorkers > 0)
+	{
+		/*
+		 * global uniqueness check in parallel build case
+		 */
+		if (indexInfo->ii_Global_index && indexInfo->ii_Unique && global_btspool)
+		{
+			/*
+			 * indexInfo->ii_GlobalIndexPart <= 0 indicates the first and
+			 * intermediate partition to build index on. For parallel global
+			 * unique index build, we need to clean up global_btspool
+			 * structure to prevent resource leak
+			 */
+			if (indexInfo->ii_GlobalIndexPart <= 0)
+			{
+				_bt_spooldestroy(global_btspool);
+				global_btspool = NULL;
+			}
+
+			/*
+			 * indexInfo->ii_GlobalIndexPart > 0 indicates the last partition
+			 * to build index on. For parallel global unique index build, we
+			 * need to call tuplesort_performsort to merge all the tapes
+			 * created from previous partition build runs and do a final
+			 * sorting to determine global uniqueness
+			 */
+			if (indexInfo->ii_GlobalIndexPart > 0)
+			{
+				IndexTuple	itup;
+
+				elog(DEBUG2, "last partitioned to build global index in parallel. Perform merge run and "
+					 "uniqueness check now...");
+				tuplesort_performsort(buildstate.spoolglobal->sortstate);
+
+				/*
+				 * this loop checks for uniqueness after all tapes have been
+				 * merged. If a duplicate is found, we will error out.
+				 */
+				while ((itup = tuplesort_getindextuple(buildstate.spoolglobal->sortstate,
+													   true)) != NULL)
+				{
+					/*
+					 * simply checking for global uniqueness, nothing to do
+					 * here
+					 */
+				}
+
+				/*
+				 * no global uniqueness violation is found at this point,
+				 * remove all the tapes (temp files) and destroy resources and
+				 * continue to build the actual index.
+				 */
+				_bt_spooldestroy(buildstate.spoolglobal);
+				_bt_spooldestroy(global_btspool);
+				global_btspool = NULL;
+				if (global_sharedsort)
+				{
+					pfree(global_sharedsort);
+					global_sharedsort = NULL;
+				}
+			}
+		}
+	}
+	else
+	{
+		/*
+		 * global uniqueness check in serial build case
+		 */
+		if (indexInfo->ii_GlobalIndexPart > 0 && indexInfo->ii_Global_index &&
+			indexInfo->ii_Unique && global_btspool)
+		{
+			/*
+			 * indexInfo->ii_GlobalIndexPart > 0 indicates the last partition
+			 * to build index on. For serial global unique index build, we
+			 * call tuplesort_performsort on global_btspool->sortstate which
+			 * should contain index tuples from all partitions. If a duplicate
+			 * is found, we will error out.
+			 */
+			elog(DEBUG2, "last partitioned to build global index serially. Sorting global_btspool for "
+				 "uniqueness check now...");
+			tuplesort_performsort(global_btspool->sortstate);
+
+			/*
+			 * no global uniqueness violation is found at this point, destroy
+			 * global_btspool structure and continue to build the actual
+			 * index.
+			 */
+			_bt_spooldestroy(global_btspool);
+			global_btspool = NULL;
+		}
+	}
+
 	/*
-	 * Finish the build by (1) completing the sort of the spool file, (2)
-	 * inserting the sorted tuples into btree pages and (3) building the upper
-	 * levels.  Finally, it may also be necessary to end use of parallelism.
+	 * if indexInfo->ii_BuildGlobalSpool is set, we will not continue to build
+	 * the actual index. This is used during a new partition attach, where we
+	 * just want to populate the global_btspool from current partitions
+	 * without building the actual indexes (because they exist already). Then,
+	 * we take that global_btspool and sort it with the tuples in newly
+	 * attached partition to determine if attach would violate global
+	 * uniquenes check
 	 */
-	_bt_leafbuild(buildstate.spool, buildstate.spool2);
+	if (indexInfo->ii_BuildGlobalSpool)
+	{
+		elog(DEBUG2, "ii_BuildGlobalSpool is set. Skip building actual index content");
+	}
+	else
+	{
+		/*
+		 * Finish the build by (1) completing the sort of the spool file, (2)
+		 * inserting the sorted tuples into btree pages and (3) building the
+		 * upper levels.  Finally, it may also be necessary to end use of
+		 * parallelism.
+		 */
+		_bt_leafbuild(buildstate.spool, buildstate.spool2);
+	}
+
 	_bt_spooldestroy(buildstate.spool);
 	if (buildstate.spool2)
 		_bt_spooldestroy(buildstate.spool2);
@@ -374,6 +535,7 @@ _bt_spools_heapscan(Relation heap, Relation index, BTBuildState *buildstate,
 	BTSpool    *btspool = (BTSpool *) palloc0(sizeof(BTSpool));
 	SortCoordinate coordinate = NULL;
 	double		reltuples = 0;
+	SortCoordinate coordinateglobal = NULL;
 
 	/*
 	 * We size the sort area as maintenance_work_mem rather than work_mem to
@@ -395,8 +557,40 @@ _bt_spools_heapscan(Relation heap, Relation index, BTBuildState *buildstate,
 
 	/* Attempt to launch parallel worker scan when required */
 	if (indexInfo->ii_ParallelWorkers > 0)
+	{
+		/*
+		 * while building the last partition table in parallel global unique
+		 * index build, we need to allocate a primary spoolglobal, which will
+		 * be used in the leader process later to "take over" all tapes
+		 * created by previous partition runs
+		 */
+		if (buildstate->isunique && buildstate->global_index &&
+			buildstate->globalIndexPart > 0)
+		{
+			elog(DEBUG2, "init primary spoolglobal in last partition for parallel index build");
+			buildstate->spoolglobal = (BTSpool *) palloc0(sizeof(BTSpool));
+			buildstate->spoolglobal->heap = heap;
+			buildstate->spoolglobal->index = index;
+			buildstate->spoolglobal->isunique = indexInfo->ii_Unique;
+		}
 		_bt_begin_parallel(buildstate, indexInfo->ii_Concurrent,
 						   indexInfo->ii_ParallelWorkers);
+	}
+	else
+	{
+		/*
+		 * in serial global unique index build, we just need to allocate a
+		 * single global_btspool structure at the first partition build. The
+		 * rest of the partitions will add their index tuples to this single
+		 * global spool structure
+		 */
+		if (buildstate->isunique && buildstate->global_index &&
+			buildstate->globalIndexPart < 0)
+		{
+			elog(DEBUG2, "init new global_btspool for serial index build");
+			btinit_global_spool(heap, index, buildstate);
+		}
+	}
 
 	/*
 	 * If parallel build requested and at least one worker process was
@@ -409,6 +603,22 @@ _bt_spools_heapscan(Relation heap, Relation index, BTBuildState *buildstate,
 		coordinate->nParticipants =
 			buildstate->btleader->nparticipanttuplesorts;
 		coordinate->sharedsort = buildstate->btleader->sharedsort;
+
+		/*
+		 * set up a coordinator state for primary spoolglobal if we are doing
+		 * global unique index build in parallel. We do this at the last
+		 * partition create in parallel mode
+		 */
+		if (buildstate->isunique && buildstate->global_index && buildstate->globalIndexPart > 0)
+		{
+			elog(DEBUG2, "set up coordinate state for primary spoolglobal for "
+				 "parallel index build case");
+			coordinateglobal = (SortCoordinate) palloc0(sizeof(SortCoordinateData));
+			coordinateglobal->isWorker = false;
+			coordinateglobal->nParticipants =
+				tuplesort_get_curr_workers(buildstate->btleader->sharedsortglobal);
+			coordinateglobal->sharedsort = buildstate->btleader->sharedsortglobal;
+		}
 	}
 
 	/*
@@ -437,6 +647,23 @@ _bt_spools_heapscan(Relation heap, Relation index, BTBuildState *buildstate,
 									buildstate->nulls_not_distinct,
 									maintenance_work_mem, coordinate,
 									TUPLESORT_NONE);
+
+	/*
+	 * initialize primary spoolglobal if we are doing global unique index
+	 * build in parallel. We do this at the last partition create in parallel
+	 * mode
+	 */
+	if (buildstate->btleader && buildstate->isunique &&
+		buildstate->global_index && buildstate->globalIndexPart > 0)
+	{
+		elog(DEBUG2, "tuplesort_begin_index_btree for primary spoolglobal for "
+			 "parallel index build case");
+		buildstate->spoolglobal->sortstate =
+			tuplesort_begin_index_btree(heap, index, buildstate->isunique,
+										buildstate->nulls_not_distinct,
+										maintenance_work_mem, coordinateglobal,
+										false);
+	}
 
 	/*
 	 * If building a unique index, put dead tuples in a second spool to keep
@@ -486,6 +713,19 @@ _bt_spools_heapscan(Relation heap, Relation index, BTBuildState *buildstate,
 	else
 		reltuples = _bt_parallel_heapscan(buildstate,
 										  &indexInfo->ii_BrokenHotChain);
+
+	/*
+	 * all parallel workers should finish at this point, make backup of
+	 * sharedsortglobal, which is needed to persist the logical tape and temp
+	 * file information for next partition build when building global unique
+	 * index in parallel
+	 */
+	if (buildstate->btleader && buildstate->global_index &&
+		buildstate->isunique)
+	{
+		elog(DEBUG2, "all workers finished, backup sharedsortglobal");
+		tuplesort_copy_sharedsort2(global_sharedsort, global_btspool->sortstate);
+	}
 
 	/*
 	 * Set the progress target for the next phase.  Reset the block number
@@ -599,7 +839,11 @@ _bt_build_callback(Relation index,
 	 * processing
 	 */
 	if (tupleIsAlive || buildstate->spool2 == NULL)
+	{
 		_bt_spool(buildstate->spool, tid, values, isnull);
+		if (buildstate->global_index && buildstate->isunique && global_btspool)
+			_bt_spool(global_btspool, tid, values, isnull);
+	}
 	else
 	{
 		/* dead tuples are put into spool2 */
@@ -1460,9 +1704,11 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	Snapshot	snapshot;
 	Size		estbtshared;
 	Size		estsort;
+	Size		estsortglobal = 0;
 	BTShared   *btshared;
 	Sharedsort *sharedsort;
 	Sharedsort *sharedsort2;
+	Sharedsort *sharedsortglobal;
 	BTSpool    *btspool = buildstate->spool;
 	BTLeader   *btleader = (BTLeader *) palloc0(sizeof(BTLeader));
 	WalUsage   *walusage;
@@ -1505,6 +1751,13 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	shm_toc_estimate_chunk(&pcxt->estimator, estbtshared);
 	estsort = tuplesort_estimate_shared(scantuplesortstates);
 	shm_toc_estimate_chunk(&pcxt->estimator, estsort);
+
+	if (buildstate->isunique && buildstate->global_index)
+	{
+		/* global unique index case will estimate 1 more sharesort struct */
+		estsortglobal = tuplesort_estimate_shared(scantuplesortstates * buildstate->nparts);
+		shm_toc_estimate_chunk(&pcxt->estimator, estsortglobal);
+	}
 
 	/*
 	 * Unique case requires a second spool, and so we may have to account for
@@ -1573,6 +1826,7 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	btshared->havedead = false;
 	btshared->indtuples = 0.0;
 	btshared->brokenhotchain = false;
+	btshared->isglobal = buildstate->global_index;
 	table_parallelscan_initialize(btspool->heap,
 								  ParallelTableScanFromBTShared(btshared),
 								  snapshot);
@@ -1604,6 +1858,43 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 
 		shm_toc_insert(pcxt->toc, PARALLEL_KEY_TUPLESORT_SPOOL2, sharedsort2);
 	}
+
+	if (buildstate->isunique && buildstate->global_index)
+	{
+		/* global unique index case will allocate 1 more sharesort struct */
+		sharedsortglobal = (Sharedsort *) shm_toc_allocate(pcxt->toc, estsortglobal);
+		if (!sharedsortglobal)
+			elog(ERROR, "failed to allocate shared memory space");
+
+		if (buildstate->globalIndexPart == -1)
+		{
+			elog(DEBUG2, "initialize and make a copy of sharedsortglobal for first time");
+			tuplesort_initialize_shared(sharedsortglobal, scantuplesortstates * buildstate->nparts, NULL);
+
+			/* save a copy of sharedsortglobal */
+			global_sharedsort = (Sharedsort *) palloc(estsortglobal);
+			tuplesort_copy_sharedsort(global_sharedsort, sharedsortglobal);
+		}
+		else if (buildstate->globalIndexPart == 0 || buildstate->globalIndexPart == 1)
+		{
+			elog(DEBUG2, "restore the copy of sharedsortglobal for subsequent processing");
+			tuplesort_copy_sharedsort(sharedsortglobal, global_sharedsort);
+
+			/* register for cleanup at the last partition index build */
+			if (buildstate->globalIndexPart == 1)
+			{
+				tuplesort_register_cleanup_callback(sharedsortglobal, pcxt->seg);
+			}
+		}
+		else
+		{
+			elog(ERROR, "invalid global inedx partition value %d", buildstate->globalIndexPart);
+		}
+
+		shm_toc_insert(pcxt->toc, PARALLEL_KEY_TUPLESORT_GLOBAL, sharedsortglobal);
+	}
+	else
+		sharedsortglobal = NULL;
 
 	/* Store query string for workers */
 	if (debug_query_string)
@@ -1638,6 +1929,7 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	btleader->snapshot = snapshot;
 	btleader->walusage = walusage;
 	btleader->bufferusage = bufferusage;
+	btleader->sharedsortglobal = sharedsortglobal;
 
 	/* If no workers were successfully launched, back out (do serial build) */
 	if (pcxt->nworkers_launched == 0)
@@ -1782,7 +2074,8 @@ _bt_leader_participate_as_worker(BTBuildState *buildstate)
 	/* Perform work common to all participants */
 	_bt_parallel_scan_and_sort(leaderworker, leaderworker2, btleader->btshared,
 							   btleader->sharedsort, btleader->sharedsort2,
-							   sortmem, true);
+							   sortmem, true, btleader->sharedsortglobal,
+							   false);
 
 #ifdef BTREE_BUILD_STATS
 	if (log_btree_build_stats)
@@ -1805,6 +2098,7 @@ _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 	BTShared   *btshared;
 	Sharedsort *sharedsort;
 	Sharedsort *sharedsort2;
+	Sharedsort *sharedsortglobal;
 	Relation	heapRel;
 	Relation	indexRel;
 	LOCKMODE	heapLockmode;
@@ -1880,13 +2174,26 @@ _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 		tuplesort_attach_shared(sharedsort2, seg);
 	}
 
+	if (btshared->isunique && btshared->isglobal)
+	{
+		sharedsortglobal = shm_toc_lookup(toc, PARALLEL_KEY_TUPLESORT_GLOBAL, false);
+		tuplesort_attach_shared(sharedsortglobal, seg);
+		elog(DEBUG2, "worker %d processing global unique index", MyProcPid);
+	}
+	else
+	{
+		sharedsortglobal = NULL;
+		elog(DEBUG2, "worker %d processing regular index", MyProcPid);
+	}
+
 	/* Prepare to track buffer usage during parallel execution */
 	InstrStartParallelQuery();
 
 	/* Perform sorting of spool, and possibly a spool2 */
 	sortmem = maintenance_work_mem / btshared->scantuplesortstates;
 	_bt_parallel_scan_and_sort(btspool, btspool2, btshared, sharedsort,
-							   sharedsort2, sortmem, false);
+							   sharedsort2, sortmem, false,
+							   sharedsortglobal, true);
 
 	/* Report WAL/buffer usage during parallel execution */
 	bufferusage = shm_toc_lookup(toc, PARALLEL_KEY_BUFFER_USAGE, false);
@@ -1921,7 +2228,8 @@ _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 static void
 _bt_parallel_scan_and_sort(BTSpool *btspool, BTSpool *btspool2,
 						   BTShared *btshared, Sharedsort *sharedsort,
-						   Sharedsort *sharedsort2, int sortmem, bool progress)
+						   Sharedsort *sharedsort2, int sortmem, bool progress,
+						   Sharedsort *sharedsortglobal, bool isworker)
 {
 	SortCoordinate coordinate;
 	BTBuildState buildstate;
@@ -1967,6 +2275,28 @@ _bt_parallel_scan_and_sort(BTSpool *btspool, BTSpool *btspool2,
 										false);
 	}
 
+
+	/* global index */
+	if (sharedsortglobal)
+	{
+		SortCoordinate coordinate3;
+
+		global_btspool = (BTSpool *) palloc0(sizeof(BTSpool));
+		global_btspool->heap = btspool->heap;
+		global_btspool->index = btspool->index;
+		global_btspool->isunique = btspool->isunique;
+
+		coordinate3 = palloc0(sizeof(SortCoordinateData));
+		coordinate3->isWorker = true;
+		coordinate3->nParticipants = -1;
+		coordinate3->sharedsort = sharedsortglobal;
+		global_btspool->sortstate =
+			tuplesort_begin_index_btree(global_btspool->heap, global_btspool->index, global_btspool->isunique,
+										btspool->nulls_not_distinct, sortmem, coordinate3,
+										false);
+	}
+
+
 	/* Fill in buildstate for _bt_build_callback() */
 	buildstate.isunique = btshared->isunique;
 	buildstate.nulls_not_distinct = btshared->nulls_not_distinct;
@@ -1976,6 +2306,12 @@ _bt_parallel_scan_and_sort(BTSpool *btspool, BTSpool *btspool2,
 	buildstate.spool2 = btspool2;
 	buildstate.indtuples = 0;
 	buildstate.btleader = NULL;
+
+	if (btshared->isglobal && btshared->isunique)
+	{
+		/* fill global unique index related parameters in buildstate */
+		buildstate.global_index = btshared->isglobal;
+	}
 
 	/* Join parallel scan */
 	indexInfo = BuildIndexInfo(btspool->index);
@@ -1999,6 +2335,11 @@ _bt_parallel_scan_and_sort(BTSpool *btspool, BTSpool *btspool2,
 		tuplesort_performsort(btspool2->sortstate);
 	}
 
+	if (global_btspool)
+	{
+		tuplesort_performsort(global_btspool->sortstate);
+	}
+
 	/*
 	 * Done.  Record ambuild statistics, and whether we encountered a broken
 	 * HOT chain.
@@ -2020,4 +2361,7 @@ _bt_parallel_scan_and_sort(BTSpool *btspool, BTSpool *btspool2,
 	tuplesort_end(btspool->sortstate);
 	if (btspool2)
 		tuplesort_end(btspool2->sortstate);
+
+	if (global_btspool && isworker)
+		tuplesort_end(global_btspool->sortstate);
 }

--- a/src/backend/access/table/table.c
+++ b/src/backend/access/table/table.c
@@ -138,6 +138,7 @@ static inline void
 validate_relation_kind(Relation r)
 {
 	if (r->rd_rel->relkind == RELKIND_INDEX ||
+		r->rd_rel->relkind == RELKIND_GLOBAL_INDEX ||
 		r->rd_rel->relkind == RELKIND_PARTITIONED_INDEX ||
 		r->rd_rel->relkind == RELKIND_COMPOSITE_TYPE)
 		ereport(ERROR,

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -1834,6 +1834,7 @@ ExecGrant_Relation(InternalGrant *istmt)
 
 		/* Not sensible to grant on an index */
 		if (pg_class_tuple->relkind == RELKIND_INDEX ||
+			pg_class_tuple->relkind == RELKIND_GLOBAL_INDEX ||
 			pg_class_tuple->relkind == RELKIND_PARTITIONED_INDEX)
 			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
@@ -4243,6 +4244,7 @@ recordExtObjInitPriv(Oid objoid, Oid classoid)
 		 * restrictions in ALTER EXTENSION ADD, but let's check anyway.)
 		 */
 		if (pg_class_tuple->relkind == RELKIND_INDEX ||
+			pg_class_tuple->relkind == RELKIND_GLOBAL_INDEX ||
 			pg_class_tuple->relkind == RELKIND_PARTITIONED_INDEX ||
 			pg_class_tuple->relkind == RELKIND_COMPOSITE_TYPE)
 		{
@@ -4402,6 +4404,7 @@ removeExtObjInitPriv(Oid objoid, Oid classoid)
 		 * restrictions in ALTER EXTENSION DROP, but let's check anyway.)
 		 */
 		if (pg_class_tuple->relkind == RELKIND_INDEX ||
+			pg_class_tuple->relkind == RELKIND_GLOBAL_INDEX ||
 			pg_class_tuple->relkind == RELKIND_PARTITIONED_INDEX ||
 			pg_class_tuple->relkind == RELKIND_COMPOSITE_TYPE)
 		{

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1405,6 +1405,7 @@ doDeletion(const ObjectAddress *object, int flags)
 				char		relKind = get_rel_relkind(object->objectId);
 
 				if (relKind == RELKIND_INDEX ||
+					relKind == RELKIND_GLOBAL_INDEX ||
 					relKind == RELKIND_PARTITIONED_INDEX)
 				{
 					bool		concurrent = ((flags & PERFORM_DELETION_CONCURRENTLY) != 0);

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -316,7 +316,8 @@ heap_create(const char *relname,
 	 * user defined relation, not a system one.
 	 */
 	if (!allow_system_table_mods &&
-		((IsCatalogNamespace(relnamespace) && relkind != RELKIND_INDEX) ||
+		((IsCatalogNamespace(relnamespace) &&
+		  (relkind != RELKIND_INDEX && relkind != RELKIND_GLOBAL_INDEX)) ||
 		 IsToastNamespace(relnamespace)) &&
 		IsNormalProcessingMode())
 		ereport(ERROR,
@@ -1300,6 +1301,7 @@ heap_create_with_catalog(const char *relname,
 	if (!(relkind == RELKIND_SEQUENCE ||
 		  relkind == RELKIND_TOASTVALUE ||
 		  relkind == RELKIND_INDEX ||
+		  relkind == RELKIND_GLOBAL_INDEX ||
 		  relkind == RELKIND_PARTITIONED_INDEX))
 	{
 		Oid			new_array_oid;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -745,6 +745,7 @@ index_create(Relation heapRelation,
 	bool		invalid = (flags & INDEX_CREATE_INVALID) != 0;
 	bool		concurrent = (flags & INDEX_CREATE_CONCURRENT) != 0;
 	bool		partitioned = (flags & INDEX_CREATE_PARTITIONED) != 0;
+	bool		globalindex = (flags & INDEX_CREATE_GLOBAL) != 0;
 	char		relkind;
 	TransactionId relfrozenxid;
 	MultiXactId relminmxid;
@@ -756,7 +757,10 @@ index_create(Relation heapRelation,
 	/* partitioned indexes must never be "built" by themselves */
 	Assert(!partitioned || (flags & INDEX_CREATE_SKIP_BUILD));
 
-	relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_INDEX;
+	if (globalindex)
+		relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_GLOBAL_INDEX;
+	else
+		relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_INDEX;
 	is_exclusion = (indexInfo->ii_ExclusionOps != NULL);
 
 	pg_class = table_open(RelationRelationId, RowExclusiveLock);
@@ -932,7 +936,7 @@ index_create(Relation heapRelation,
 			binary_upgrade_next_index_pg_class_oid = InvalidOid;
 
 			/* Override the index relfilenumber */
-			if ((relkind == RELKIND_INDEX) &&
+			if ((relkind == RELKIND_INDEX || relkind == RELKIND_GLOBAL_INDEX) &&
 				(!RelFileNumberIsValid(binary_upgrade_next_index_pg_class_relfilenumber)))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -2896,7 +2900,8 @@ index_update_stats(Relation rel,
 		BlockNumber relpages = RelationGetNumberOfBlocks(rel);
 		BlockNumber relallvisible;
 
-		if (rd_rel->relkind != RELKIND_INDEX)
+		if (rd_rel->relkind != RELKIND_INDEX &&
+			rd_rel->relkind != RELKIND_GLOBAL_INDEX)
 			visibilitymap_count(rel, &relallvisible, NULL);
 		else					/* don't bother for indexes */
 			relallvisible = 0;

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -1388,6 +1388,7 @@ get_relation_by_qualified_name(ObjectType objtype, List *object,
 	{
 		case OBJECT_INDEX:
 			if (relation->rd_rel->relkind != RELKIND_INDEX &&
+				relation->rd_rel->relkind != RELKIND_GLOBAL_INDEX &&
 				relation->rd_rel->relkind != RELKIND_PARTITIONED_INDEX)
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
@@ -4117,6 +4118,7 @@ getRelationDescription(StringInfo buffer, Oid relid, bool missing_ok)
 							 relname);
 			break;
 		case RELKIND_INDEX:
+		case RELKIND_GLOBAL_INDEX:
 		case RELKIND_PARTITIONED_INDEX:
 			appendStringInfo(buffer, _("index %s"),
 							 relname);
@@ -4627,6 +4629,7 @@ getRelationTypeDescription(StringInfo buffer, Oid relid, int32 objectSubId,
 			appendStringInfoString(buffer, "table");
 			break;
 		case RELKIND_INDEX:
+		case RELKIND_GLOBAL_INDEX:
 		case RELKIND_PARTITIONED_INDEX:
 			appendStringInfoString(buffer, "index");
 			break;
@@ -6105,6 +6108,7 @@ get_relkind_objtype(char relkind)
 		case RELKIND_PARTITIONED_TABLE:
 			return OBJECT_TABLE;
 		case RELKIND_INDEX:
+		case RELKIND_GLOBAL_INDEX:
 		case RELKIND_PARTITIONED_INDEX:
 			return OBJECT_INDEX;
 		case RELKIND_SEQUENCE:

--- a/src/backend/catalog/pg_class.c
+++ b/src/backend/catalog/pg_class.c
@@ -45,6 +45,8 @@ errdetail_relkind_not_supported(char relkind)
 			return errdetail("This operation is not supported for partitioned tables.");
 		case RELKIND_PARTITIONED_INDEX:
 			return errdetail("This operation is not supported for partitioned indexes.");
+		case RELKIND_GLOBAL_INDEX:
+			return errdetail("This operation is not supported for global indexes.");
 		default:
 			elog(ERROR, "unrecognized relkind: '%c'", relkind);
 			return 0;

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -1205,7 +1205,8 @@ swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class,
 	 */
 
 	/* set rel1's frozen Xid and minimum MultiXid */
-	if (relform1->relkind != RELKIND_INDEX)
+	if (relform1->relkind != RELKIND_INDEX &&
+		relform1->relkind != RELKIND_GLOBAL_INDEX)
 	{
 		Assert(!TransactionIdIsValid(frozenXid) ||
 			   TransactionIdIsNormal(frozenXid));
@@ -1717,7 +1718,8 @@ get_tables_to_cluster_partitioned(MemoryContext cluster_context, Oid indexOid)
 		RelToCluster *rtc;
 
 		/* consider only leaf indexes */
-		if (get_rel_relkind(indexrelid) != RELKIND_INDEX)
+		if (get_rel_relkind(indexrelid) != RELKIND_INDEX &&
+			get_rel_relkind(indexrelid) != RELKIND_GLOBAL_INDEX)
 			continue;
 
 		/* Silently skip partitions which the user has no access to. */

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1153,6 +1153,13 @@ DefineIndex(Oid relationId,
 		flags |= INDEX_CREATE_PARTITIONED;
 	if (stmt->primary)
 		flags |= INDEX_CREATE_IS_PRIMARY;
+	/* copy the partition indication -1 = first, 0 = N/A, 1 = last */
+	if (stmt->global_index)
+	{
+		indexInfo->ii_Global_index = stmt->global_index;
+		indexInfo->ii_GlobalIndexPart = stmt->globalIndexPart;
+		indexInfo->ii_Nparts = stmt->nparts;
+	}
 
 	/*
 	 * If the table is partitioned, and recursion was declined but partitions
@@ -1430,6 +1437,24 @@ DefineIndex(Oid relationId,
 					bool		found_whole_row;
 					ListCell   *lc;
 					ObjectAddress childAddr;
+
+					if (i == nparts - 1 && stmt->global_index)
+					{
+						elog(DEBUG2, "mark as last partitioned to scan");
+						childStmt->globalIndexPart = 1;
+					}
+
+					if (i == 0 && stmt->global_index)
+					{
+						elog(DEBUG2, "mark as first partitioned to scan");
+						childStmt->globalIndexPart = -1;
+					}
+
+					if (stmt->global_index)
+					{
+						childStmt->nparts = nparts;
+						elog(DEBUG2, "total partitions to build global index %d", childStmt->nparts);
+					}
 
 					/*
 					 * We can't use the same index name for the child index,
@@ -4443,4 +4468,139 @@ set_indexsafe_procflags(void)
 	MyProc->statusFlags |= PROC_IN_SAFE_IC;
 	ProcGlobal->statusFlags[MyProc->pgxactoff] = MyProc->statusFlags;
 	LWLockRelease(ProcArrayLock);
+}
+
+bool
+PopulateGlobalSpool(Relation idxRel, Relation heapRel, IndexStmt *stmt)
+{
+	IndexInfo  *idxinfo;
+	int			numberOfKeyAttributes;
+	int			numberOfAttributes;
+	List	   *allIndexParams;
+	Oid			accessMethodId;
+	Form_pg_am	accessMethodForm;
+	char	   *accessMethodName;
+	HeapTuple	tuple;
+	bool		concurrent;
+	bool		amissummarizing;
+	Oid		   *typeObjectId;
+	Oid		   *collationObjectId;
+	Oid		   *classObjectId;
+	int16	   *coloptions;
+	IndexAmRoutine *amRoutine;
+	bool		amcanorder;
+	Oid			root_save_userid;
+	int			root_save_sec_context;
+	int			root_save_nestlevel;
+
+	root_save_nestlevel = NewGUCNestLevel();
+
+	if (stmt->concurrent && get_rel_persistence(RelationGetRelid(heapRel)) != RELPERSISTENCE_TEMP)
+		concurrent = true;
+	else
+		concurrent = false;
+
+	allIndexParams = list_concat_copy(stmt->indexParams,
+									  stmt->indexIncludingParams);
+
+	numberOfKeyAttributes = list_length(stmt->indexParams);
+	numberOfAttributes = list_length(allIndexParams);
+
+	accessMethodName = stmt->accessMethod;
+	tuple = SearchSysCache1(AMNAME, PointerGetDatum(accessMethodName));
+	if (!HeapTupleIsValid(tuple))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("access method \"%s\" does not exist",
+						accessMethodName)));
+	}
+
+	accessMethodForm = (Form_pg_am) GETSTRUCT(tuple);
+	accessMethodId = accessMethodForm->oid;
+	amRoutine = GetIndexAmRoutine(accessMethodForm->amhandler);
+	amissummarizing = amRoutine->amsummarizing;
+
+	GetUserIdAndSecContext(&root_save_userid, &root_save_sec_context);
+	SetUserIdAndSecContext(heapRel->rd_rel->relowner, root_save_sec_context);
+
+	idxinfo = makeIndexInfo(numberOfAttributes,
+							numberOfKeyAttributes,
+							accessMethodId,
+							NIL,	/* expressions, NIL for now */
+							make_ands_implicit((Expr *) stmt->whereClause),
+							stmt->unique,
+							stmt->nulls_not_distinct,
+							!concurrent,
+							concurrent, 
+							amissummarizing);
+
+	typeObjectId = (Oid *) palloc(numberOfAttributes * sizeof(Oid));
+	collationObjectId = (Oid *) palloc(numberOfAttributes * sizeof(Oid));
+	classObjectId = (Oid *) palloc(numberOfAttributes * sizeof(Oid));
+	coloptions = (int16 *) palloc(numberOfAttributes * sizeof(int16));
+	amcanorder = amRoutine->amcanorder;
+
+	pfree(amRoutine);
+	ReleaseSysCache(tuple);
+
+	ComputeIndexAttrs(idxinfo,
+					  typeObjectId, collationObjectId, classObjectId,
+					  coloptions, allIndexParams,
+					  stmt->excludeOpNames, RelationGetRelid(heapRel),
+					  accessMethodName, accessMethodId,
+					  amcanorder, stmt->isconstraint, root_save_userid,
+					  root_save_sec_context, &root_save_nestlevel);
+
+	/* Fill global unique index related parameters */
+	idxinfo->ii_GlobalIndexPart = stmt->globalIndexPart;
+	idxinfo->ii_BuildGlobalSpool = true;
+	idxinfo->ii_Nparts = stmt->nparts;
+	idxinfo->ii_Global_index = stmt->global_index;
+
+	/*
+	 * Determine worker process details for parallel CREATE INDEX.  Currently,
+	 * only btree has support for parallel builds.
+	 */
+	if (IsNormalProcessingMode() && idxRel->rd_rel->relam == BTREE_AM_OID)
+	{
+		idxinfo->ii_ParallelWorkers =
+			plan_create_index_workers(RelationGetRelid(heapRel),
+									  RelationGetRelid(idxRel));
+	}
+
+	idxRel->rd_indam->ambuild(heapRel, idxRel,
+							  idxinfo);
+
+	return true;
+}
+
+void
+ChangeRelKind(Relation idxRel, char kind)
+{
+	Relation	pg_class;
+	HeapTuple	tuple;
+	Form_pg_class classform;
+
+	/*
+	 * Get a writable copy of the pg_class tuple for the given relation.
+	 */
+	pg_class = table_open(RelationRelationId, RowExclusiveLock);
+
+	tuple = SearchSysCacheCopy1(RELOID,
+								ObjectIdGetDatum(RelationGetRelid(idxRel)));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "could not find tuple for relation %u",
+			 RelationGetRelid(idxRel));
+
+	classform = (Form_pg_class) GETSTRUCT(tuple);
+
+	classform->relkind = kind;
+	idxRel->rd_rel->relkind = kind;
+
+	CatalogTupleUpdate(pg_class, &tuple->t_self, tuple);
+
+	heap_freetuple(tuple);
+
+	table_close(pg_class, RowExclusiveLock);
 }

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -646,6 +646,7 @@ static void ATDetachCheckNoForeignKeyRefs(Relation partition);
 static char GetAttributeCompression(Oid atttypid, char *compression);
 static char GetAttributeStorage(Oid atttypid, const char *storagemode);
 
+static bool HasGlobalChildIndex(Relation idxRel);
 
 /* ----------------------------------------------------------------
  *		DefineRelation
@@ -1219,6 +1220,11 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 			idxstmt =
 				generateClonedIndexStmt(NULL, idxRel,
 										attmap, &constraintOid);
+			if (HasGlobalChildIndex(idxRel))
+			{
+				elog(DEBUG2, "create global index for the new child partition table");
+				idxstmt->global_index = true;
+			}
 			DefineIndex(RelationGetRelid(rel),
 						idxstmt,
 						InvalidOid,
@@ -18054,6 +18060,7 @@ AttachPartitionEnsureIndexes(Relation rel, Relation attachrel)
 	IndexInfo **attachInfos;
 	int			i;
 	ListCell   *cell;
+	ListCell   *cell2;
 	MemoryContext cxt;
 	MemoryContext oldcxt;
 
@@ -18197,15 +18204,184 @@ AttachPartitionEnsureIndexes(Relation rel, Relation attachrel)
 		{
 			IndexStmt  *stmt;
 			Oid			conOid;
+			bool 		isGlobal = false;
 
+			isGlobal = HasGlobalChildIndex(idxRel);
 			stmt = generateClonedIndexStmt(NULL,
 										   idxRel, attmap,
 										   &conOid);
+			/*
+			 * Perform cross partition uniqueness check if it is a global
+			 * unique index
+			 */
+			if (isGlobal && idxRel->rd_index->indisunique)
+			{
+				PartitionDesc partdesc;
+				Relation		hRel;
+				Relation 		iRel;
+				int 			j = 0;
+				int 			nparts;
+				Oid 			*part_oids;
+
+				List       *childIndexList = find_inheritance_children(idx, ShareLock);
+
+				partdesc = RelationGetPartitionDesc(rel, true);
+				nparts = partdesc->nparts;
+				part_oids = palloc(sizeof(Oid) * nparts);
+
+				memcpy(part_oids, partdesc->oids, sizeof(Oid) * nparts);
+				for (j = 0; j < nparts; j++)
+				{
+					Oid 		childRelid = part_oids[j];
+					List		*childidxs;
+
+					if (childRelid == RelationGetRelid(attachrel))
+					{
+						elog(DEBUG2, "skip the partition-to-be from building global spool: %d", childRelid);
+						continue;
+					}
+					hRel = table_open(childRelid, AccessShareLock);
+
+					childidxs = RelationGetIndexList(hRel);
+					foreach(cell2, childidxs)
+					{
+						Oid 	cldidxid = lfirst_oid(cell2);
+
+						/*
+						 * only take a child index that is directly inherited
+						 * to parent index oid
+						 */
+						if (list_member_oid(childIndexList, cldidxid))
+						{
+							iRel = index_open(cldidxid, AccessShareLock);
+							elog(DEBUG2, "found a matching child index OID to build global spool %d", cldidxid);
+
+							/*
+							 * We need to construct a global spool structure
+							 * in nbtsort.c in order to determine global
+							 * uniqueness. Marking partitions now
+							 */
+							if (j == 0)
+							{
+								elog(DEBUG2, "mark as first partitioned to build global spool");
+								stmt->globalIndexPart = -1;
+							}
+							else
+								stmt->globalIndexPart = 0;
+
+							stmt->global_index = true;
+							stmt->nparts = nparts;
+
+							PopulateGlobalSpool(iRel, hRel, stmt);
+							index_close(iRel, AccessShareLock);
+							break;
+						}
+					}
+					table_close(hRel, AccessShareLock);
+				}
+				elog(DEBUG2, "mark as the last partitioned to utilize global spool");
+				stmt->globalIndexPart = 1;
+			}
+			else
+			{
+				elog(DEBUG2, "partitioned index %d is not a unique index, build it now...",
+						 RelationGetRelid(idxRel));
+			}
+
 			DefineIndex(RelationGetRelid(attachrel), stmt, InvalidOid,
 						RelationGetRelid(idxRel),
 						conOid,
 						-1,
 						true, false, false, false, false);
+		}
+		else
+		{
+			IndexStmt  *stmt;
+			Oid 		constraintOid;
+			bool 		isGlobal = false;
+
+			stmt = generateClonedIndexStmt(NULL,
+										   idxRel, attmap,
+										   &constraintOid);
+			isGlobal = HasGlobalChildIndex(idxRel);
+			if (isGlobal && idxRel->rd_index->indisunique)
+			{
+				PartitionDesc partdesc;
+				Relation        hRel;
+				Relation        iRel;
+				int 			j = 0;
+				int 			nparts;
+				Oid 			*part_oids;
+
+				List 			*childIndexList = find_inheritance_children(idx, ShareLock);
+
+				partdesc = RelationGetPartitionDesc(rel, true);
+				nparts = partdesc->nparts;
+				part_oids = palloc(sizeof(Oid) * nparts);
+
+				memcpy(part_oids, partdesc->oids, sizeof(Oid) * nparts);
+				for (j = 0; j < nparts; j++)
+				{
+					Oid 		childRelid = part_oids[j];
+					List 		*childidxs;
+
+					hRel = table_open(childRelid, AccessShareLock);
+
+					childidxs = RelationGetIndexList(hRel);
+					foreach(cell2, childidxs)
+					{
+						Oid 	cldidxid = lfirst_oid(cell2);
+
+						/*
+						 * only take a child index that is directly inherited
+						 * to parent index oid
+						 */
+						if (list_member_oid(childIndexList, cldidxid))
+						{
+							iRel = index_open(cldidxid, AccessShareLock);
+							elog(DEBUG2, "found a matching child index OID type %c to build global spool %d",
+									 iRel->rd_rel->relkind, cldidxid);
+
+							/*
+							 * change partition-to-be's duplicate unique index
+							 * relkind to RELKIND_GLOBAL_INDEX
+							 */
+							if (iRel->rd_rel->relkind != RELKIND_GLOBAL_INDEX)
+							{
+								elog(DEBUG2, "Update index relation %d to have relkind = RELKIND_GLOBAL_INDEX",
+										 RelationGetRelid(iRel));
+								ChangeRelKind(iRel, RELKIND_GLOBAL_INDEX);
+							}
+
+							/*
+							 * We need to construct a global spool structure
+							 * in nbtsort.c in order to determine global
+							 * uniqueness. Marking partitions now
+							 */
+							if (j == 0)
+							{
+								elog(DEBUG2, "mark as first partition to build global spool");
+								stmt->globalIndexPart = -1;
+							}
+							else if (j == nparts - 1)
+							{
+								elog(DEBUG2, "mark as last partition to build global spool");
+								stmt->globalIndexPart = 1;
+							}
+							else
+								stmt->globalIndexPart = 0;
+
+							stmt->global_index = true;
+							stmt->nparts = nparts;
+
+							PopulateGlobalSpool(iRel, hRel, stmt);
+							index_close(iRel, AccessShareLock);
+							break;
+						}
+					}
+					table_close(hRel, AccessShareLock);
+				}
+			}
 		}
 
 		index_close(idxRel, AccessShareLock);
@@ -18704,6 +18880,15 @@ DetachPartitionFinalize(Relation rel, Relation partRel, bool concurrent,
 		if (OidIsValid(constrOid))
 			ConstraintSetParentConstraint(constrOid, InvalidOid, InvalidOid);
 
+		/*
+		 * if it has any global index, make it a regular index relkind after
+		 * detach
+		 */
+		if (idx->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
+		{
+			elog(DEBUG2, "found a global index, transform it to RELKIND_INDEX at detach...");
+			ChangeRelKind(idx, RELKIND_INDEX);
+		}
 		index_close(idx, NoLock);
 	}
 
@@ -19434,4 +19619,32 @@ GetAttributeStorage(Oid atttypid, const char *storagemode)
 						format_type_be(atttypid))));
 
 	return cstorage;
+}
+
+static bool
+HasGlobalChildIndex(Relation idxRel)
+{
+	/* find out if current index contains child indexes that are global */
+	List	   *childIndexOidList;
+	ListCell   *cell;
+	bool		isGlobal = false;;
+
+	childIndexOidList = find_all_inheritors(RelationGetRelid(idxRel),
+											AccessExclusiveLock, NULL);
+
+	foreach(cell, childIndexOidList)
+	{
+		Oid			childIndexOid = lfirst_oid(cell);
+		Relation	idxChildRel;
+
+		idxChildRel = index_open(childIndexOid, AccessShareLock);
+		if (idxChildRel->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
+		{
+			isGlobal = true;
+			index_close(idxChildRel, NoLock);
+			break;
+		}
+		index_close(idxChildRel, NoLock);
+	}
+	return isGlobal;
 }

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -1024,7 +1024,8 @@ estimate_rel_size(Relation rel, int32 *attr_widths,
 		table_relation_estimate_size(rel, attr_widths, pages, tuples,
 									 allvisfrac);
 	}
-	else if (rel->rd_rel->relkind == RELKIND_INDEX)
+	else if (rel->rd_rel->relkind == RELKIND_INDEX ||
+			 rel->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
 	{
 		/*
 		 * XXX: It'd probably be good to move this into a callback, individual

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -491,7 +491,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 %type <str>		unicode_normal_form
 
 %type <boolean> opt_instead
-%type <boolean> opt_unique opt_verbose opt_full
+%type <boolean> opt_unique opt_verbose opt_full opt_global
 %type <boolean> opt_freeze opt_analyze opt_default opt_recheck
 %type <defelt>	opt_binary copy_delimiter
 
@@ -7941,7 +7941,7 @@ defacl_privilege_target:
 
 IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 			ON relation_expr access_method_clause '(' index_params ')'
-			opt_include opt_unique_null_treatment opt_reloptions OptTableSpace where_clause
+			opt_include opt_unique_null_treatment opt_reloptions OptTableSpace where_clause opt_global
 				{
 					IndexStmt *n = makeNode(IndexStmt);
 
@@ -7956,6 +7956,7 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 					n->options = $14;
 					n->tableSpace = $15;
 					n->whereClause = $16;
+					n->global_index = $17;
 					n->excludeOpNames = NIL;
 					n->idxcomment = NULL;
 					n->indexOid = InvalidOid;
@@ -7973,7 +7974,7 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 				}
 			| CREATE opt_unique INDEX opt_concurrently IF_P NOT EXISTS name
 			ON relation_expr access_method_clause '(' index_params ')'
-			opt_include opt_unique_null_treatment opt_reloptions OptTableSpace where_clause
+			opt_include opt_unique_null_treatment opt_reloptions OptTableSpace where_clause opt_global
 				{
 					IndexStmt *n = makeNode(IndexStmt);
 
@@ -7988,6 +7989,7 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 					n->options = $17;
 					n->tableSpace = $18;
 					n->whereClause = $19;
+					n->global_index = $20;
 					n->excludeOpNames = NIL;
 					n->idxcomment = NULL;
 					n->indexOid = InvalidOid;
@@ -8003,6 +8005,11 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 					n->reset_default_tblspc = false;
 					$$ = (Node *) n;
 				}
+		;
+
+opt_global:
+			GLOBAL									{ $$ = true; }
+			| /*EMPTY*/								{ $$ = false; }
 		;
 
 opt_unique:

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -3999,6 +3999,7 @@ transformPartitionCmd(CreateStmtContext *cxt, PartitionCmd *cmd)
 							RelationGetRelationName(parentRel))));
 			break;
 		case RELKIND_INDEX:
+		case RELKIND_GLOBAL_INDEX:
 			/* the index must be partitioned */
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),

--- a/src/backend/storage/file/sharedfileset.c
+++ b/src/backend/storage/file/sharedfileset.c
@@ -92,6 +92,16 @@ SharedFileSetDeleteAll(SharedFileSet *fileset)
 }
 
 /*
+ * Register cleanup callback of an already initialized fileset.
+ */
+void
+SharedFileSetRegisterCleanupCallback(SharedFileSet *fileset, dsm_segment *seg)
+{
+	/* Register our cleanup callback. */
+	if (seg)
+		on_dsm_detach(seg, SharedFileSetOnDetach, PointerGetDatum(fileset));
+}
+/*
  * Callback function that will be invoked when this backend detaches from a
  * DSM segment holding a SharedFileSet that it has created or attached to.  If
  * we are the last to detach, then try to remove the directories and

--- a/src/backend/utils/adt/amutils.c
+++ b/src/backend/utils/adt/amutils.c
@@ -173,6 +173,7 @@ indexam_property(FunctionCallInfo fcinfo,
 			PG_RETURN_NULL();
 		rd_rel = (Form_pg_class) GETSTRUCT(tuple);
 		if (rd_rel->relkind != RELKIND_INDEX &&
+			rd_rel->relkind != RELKIND_GLOBAL_INDEX &&
 			rd_rel->relkind != RELKIND_PARTITIONED_INDEX)
 		{
 			ReleaseSysCache(tuple);

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -480,6 +480,7 @@ RelationParseRelOptions(Relation relation, HeapTuple tuple)
 			amoptsfn = NULL;
 			break;
 		case RELKIND_INDEX:
+		case RELKIND_GLOBAL_INDEX:
 		case RELKIND_PARTITIONED_INDEX:
 			amoptsfn = relation->rd_indam->amoptions;
 			break;
@@ -1202,6 +1203,7 @@ retry:
 	 * initialize access method information
 	 */
 	if (relation->rd_rel->relkind == RELKIND_INDEX ||
+		relation->rd_rel->relkind == RELKIND_GLOBAL_INDEX ||
 		relation->rd_rel->relkind == RELKIND_PARTITIONED_INDEX)
 		RelationInitIndexAccessInfo(relation);
 	else if (RELKIND_HAS_TABLE_AM(relation->rd_rel->relkind) ||
@@ -2082,6 +2084,7 @@ RelationIdGetRelation(Oid relationId)
 			 * a headache for indexes that reload itself depends on.
 			 */
 			if (rd->rd_rel->relkind == RELKIND_INDEX ||
+				rd->rd_rel->relkind == RELKIND_GLOBAL_INDEX ||
 				rd->rd_rel->relkind == RELKIND_PARTITIONED_INDEX)
 				RelationReloadIndexInfo(rd);
 			else
@@ -2222,6 +2225,7 @@ RelationReloadIndexInfo(Relation relation)
 
 	/* Should be called only for invalidated, live indexes */
 	Assert((relation->rd_rel->relkind == RELKIND_INDEX ||
+			relation->rd_rel->relkind == RELKIND_GLOBAL_INDEX ||
 			relation->rd_rel->relkind == RELKIND_PARTITIONED_INDEX) &&
 		   !relation->rd_isvalid &&
 		   relation->rd_droppedSubid == InvalidSubTransactionId);
@@ -2350,7 +2354,8 @@ RelationReloadNailed(Relation relation)
 	if (!IsTransactionState() || relation->rd_refcnt <= 1)
 		return;
 
-	if (relation->rd_rel->relkind == RELKIND_INDEX)
+	if (relation->rd_rel->relkind == RELKIND_INDEX ||
+		relation->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
 	{
 		/*
 		 * If it's a nailed-but-not-mapped index, then we need to re-read the
@@ -2544,6 +2549,7 @@ RelationClearRelation(Relation relation, bool rebuild)
 	 * index, and we check for pg_index updates too.
 	 */
 	if ((relation->rd_rel->relkind == RELKIND_INDEX ||
+		 relation->rd_rel->relkind == RELKIND_GLOBAL_INDEX ||
 		 relation->rd_rel->relkind == RELKIND_PARTITIONED_INDEX) &&
 		relation->rd_refcnt > 0 &&
 		relation->rd_indexcxt != NULL)
@@ -3723,7 +3729,8 @@ RelationSetNewRelfilenumber(Relation relation, char persistence)
 		newrelfilenumber = GetNewRelFileNumber(relation->rd_rel->reltablespace,
 											   NULL, persistence);
 	}
-	else if (relation->rd_rel->relkind == RELKIND_INDEX)
+	else if (relation->rd_rel->relkind == RELKIND_INDEX ||
+			 relation->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
 	{
 		if (!OidIsValid(binary_upgrade_next_index_pg_class_relfilenumber))
 			ereport(ERROR,
@@ -6164,7 +6171,8 @@ load_relcache_init_file(bool shared)
 		 * If it's an index, there's more to do.  Note we explicitly ignore
 		 * partitioned indexes here.
 		 */
-		if (rel->rd_rel->relkind == RELKIND_INDEX)
+		if (rel->rd_rel->relkind == RELKIND_INDEX ||
+			rel->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
 		{
 			MemoryContext indexcxt;
 			Oid		   *opfamily;
@@ -6559,7 +6567,8 @@ write_relcache_init_file(bool shared)
 		 * If it's an index, there's more to do. Note we explicitly ignore
 		 * partitioned indexes here.
 		 */
-		if (rel->rd_rel->relkind == RELKIND_INDEX)
+		if (rel->rd_rel->relkind == RELKIND_INDEX ||
+			rel->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
 		{
 			/* write the pg_index tuple */
 			/* we assume this was created by heap_copytuple! */

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -328,6 +328,7 @@ struct Tuplesortstate
 	 */
 	int64		abbrevNext;		/* Tuple # at which to next check
 								 * applicability */
+	bool        isglobalsort;
 
 	/*
 	 * Resource snapshot for time of sort start.
@@ -2190,7 +2191,14 @@ mergeruns(Tuplesortstate *state)
 				/* Tell logtape.c we won't be writing anymore */
 				LogicalTapeSetForgetFreeSpace(state->tapeset);
 				/* Initialize for the final merge pass */
-				beginmerge(state);
+				if (state->isglobalsort)
+				{
+					elog(DEBUG2, "global unique index final merge run...");
+					mergeonerun(state);
+				}
+				else
+					beginmerge(state);
+
 				state->status = TSS_FINALMERGE;
 				return;
 			}
@@ -3000,6 +3008,51 @@ tuplesort_attach_shared(Sharedsort *shared, dsm_segment *seg)
 {
 	/* Attach to SharedFileSet */
 	SharedFileSetAttach(&shared->fileset, seg);
+}
+
+void
+tuplesort_mark_global_sort(Tuplesortstate *state)
+{
+	state->isglobalsort = true;
+}
+
+void
+tuplesort_copy_sharedsort(Sharedsort *shared1, Sharedsort *shared2)
+{
+	if (!shared1 || !shared2)
+		elog(ERROR, "%s: cannot do sharedsort copy due to bad input", __FUNCTION__);
+
+	shared1->currentWorker = shared2->currentWorker;
+	shared1->mutex = shared2->mutex;
+	shared1->nTapes = shared2->nTapes;
+	shared1->fileset = shared2->fileset;
+	shared1->workersFinished = shared2->workersFinished;
+	memcpy(shared1->tapes, shared2->tapes, sizeof(TapeShare) * shared2->nTapes);
+}
+
+void
+tuplesort_copy_sharedsort2(Sharedsort *shared1, Tuplesortstate *state)
+{
+	if (!shared1 || !state)
+		elog(ERROR, "%s: cannot do sharedsort copy due to bad input", __FUNCTION__);
+
+	shared1->currentWorker = state->shared->currentWorker;
+	shared1->mutex = state->shared->mutex;
+	shared1->nTapes = state->shared->nTapes;
+	shared1->fileset = state->shared->fileset;
+	shared1->workersFinished = state->shared->workersFinished;
+	memcpy(shared1->tapes, state->shared->tapes, sizeof(TapeShare) * state->shared->nTapes);
+}
+
+int
+tuplesort_get_curr_workers(Sharedsort *shared)
+{
+	return shared->currentWorker;
+}
+
+void tuplesort_register_cleanup_callback(Sharedsort *shared, dsm_segment *seg)
+{
+	SharedFileSetRegisterCleanupCallback(&shared->fileset, seg);
 }
 
 /*

--- a/src/bin/pg_upgrade/version.c
+++ b/src/bin/pg_upgrade/version.c
@@ -95,6 +95,7 @@ check_for_data_types_usage(ClusterInfo *cluster,
 						  "		c.relkind IN ("
 						  CppAsString2(RELKIND_RELATION) ", "
 						  CppAsString2(RELKIND_MATVIEW) ", "
+						  CppAsString2(RELKIND_GLOBAL_INDEX) ", "
 						  CppAsString2(RELKIND_INDEX) ") AND "
 						  "		c.relnamespace = n.oid AND "
 		/* exclude possible orphaned temp tables */

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -1098,7 +1098,8 @@ typedef struct BTOptions
 } BTOptions;
 
 #define BTGetFillFactor(relation) \
-	(AssertMacro(relation->rd_rel->relkind == RELKIND_INDEX && \
+	(AssertMacro((relation->rd_rel->relkind == RELKIND_INDEX || \
+			relation->rd_rel->relkind == RELKIND_GLOBAL_INDEX) && \
 				 relation->rd_rel->relam == BTREE_AM_OID), \
 	 (relation)->rd_options ? \
 	 ((BTOptions *) (relation)->rd_options)->fillfactor : \

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -1294,4 +1294,9 @@ extern IndexBuildResult *btbuild(Relation heap, Relation index,
 								 struct IndexInfo *indexInfo);
 extern void _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc);
 
+extern TransactionId _bt_check_unique_gi(Relation rel, BTInsertState insertstate,
+										 Relation heapRel,
+										 IndexUniqueCheck checkUnique, bool *is_unique,
+										 uint32 *speculativeToken, Relation origHeapRel);
+
 #endif							/* NBTREE_H */

--- a/src/include/catalog/index.h
+++ b/src/include/catalog/index.h
@@ -65,6 +65,7 @@ extern void index_check_primary_key(Relation heapRel,
 #define	INDEX_CREATE_IF_NOT_EXISTS			(1 << 4)
 #define	INDEX_CREATE_PARTITIONED			(1 << 5)
 #define INDEX_CREATE_INVALID				(1 << 6)
+#define INDEX_CREATE_GLOBAL					(1 << 7)
 
 extern Oid	index_create(Relation heapRelation,
 						 const char *indexRelationName,

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -168,6 +168,7 @@ DECLARE_INDEX(pg_class_tblspc_relfilenode_index, 3455, ClassTblspcRelfilenodeInd
 #define		  RELKIND_FOREIGN_TABLE   'f'	/* foreign table */
 #define		  RELKIND_PARTITIONED_TABLE 'p' /* partitioned table */
 #define		  RELKIND_PARTITIONED_INDEX 'I' /* partitioned index */
+#define		  RELKIND_GLOBAL_INDEX 		'g' /* global index */
 
 #define		  RELPERSISTENCE_PERMANENT	'p' /* regular table */
 #define		  RELPERSISTENCE_UNLOGGED	'u' /* unlogged permanent table */
@@ -194,6 +195,7 @@ DECLARE_INDEX(pg_class_tblspc_relfilenode_index, 3455, ClassTblspcRelfilenodeInd
 #define RELKIND_HAS_STORAGE(relkind) \
 	((relkind) == RELKIND_RELATION || \
 	 (relkind) == RELKIND_INDEX || \
+	 (relkind) == RELKIND_GLOBAL_INDEX || \
 	 (relkind) == RELKIND_SEQUENCE || \
 	 (relkind) == RELKIND_TOASTVALUE || \
 	 (relkind) == RELKIND_MATVIEW)

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -48,6 +48,8 @@ extern bool CheckIndexCompatible(Oid oldId,
 extern Oid	GetDefaultOpClass(Oid type_id, Oid am_id);
 extern Oid	ResolveOpClass(List *opclass, Oid attrType,
 						   const char *accessMethodName, Oid accessMethodId);
+extern bool PopulateGlobalSpool(Relation ixsRel, Relation heapRel, IndexStmt *stmt);
+extern void ChangeRelKind(Relation idxRel, char kind);
 
 /* commands/functioncmds.c */
 extern ObjectAddress CreateFunction(ParseState *pstate, CreateFunctionStmt *stmt);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -199,6 +199,11 @@ typedef struct IndexInfo
 	int			ii_ParallelWorkers;
 	Oid			ii_Am;
 	void	   *ii_AmCache;
+	bool		ii_Global_index;	/* true if index is global */
+	int			ii_GlobalIndexPart; /* partition number indication */
+	bool		ii_BuildGlobalSpool;	/* indicate to build global spool only */
+	int			ii_Nparts;		/* num partitions for global index build in
+								 * parallel */
 	MemoryContext ii_Context;
 } IndexInfo;
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3208,6 +3208,7 @@ typedef struct IndexStmt
 	bool		if_not_exists;	/* just do nothing if index already exists? */
 	bool		reset_default_tblspc;	/* reset default_tablespace prior to
 										 * executing */
+	bool		global_index;	/* true if index is global */
 } IndexStmt;
 
 /* ----------------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3209,6 +3209,10 @@ typedef struct IndexStmt
 	bool		reset_default_tblspc;	/* reset default_tablespace prior to
 										 * executing */
 	bool		global_index;	/* true if index is global */
+	int			globalIndexPart;	/* partition number indication */
+	int			nparts;			/* num partitions for global index build in
+								 * parallel */
+
 } IndexStmt;
 
 /* ----------------------

--- a/src/include/storage/sharedfileset.h
+++ b/src/include/storage/sharedfileset.h
@@ -33,5 +33,6 @@ typedef struct SharedFileSet
 extern void SharedFileSetInit(SharedFileSet *fileset, dsm_segment *seg);
 extern void SharedFileSetAttach(SharedFileSet *fileset, dsm_segment *seg);
 extern void SharedFileSetDeleteAll(SharedFileSet *fileset);
+extern void SharedFileSetRegisterCleanupCallback(SharedFileSet *fileset, dsm_segment *seg);
 
 #endif

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -442,4 +442,13 @@ extern bool tuplesort_getdatum(Tuplesortstate *state, bool forward, bool copy,
 							   Datum *val, bool *isNull, Datum *abbrev);
 
 
+extern void tuplesort_mark_global_sort(Tuplesortstate *state);
+
+extern void tuplesort_copy_sharedsort(Sharedsort *shared1, Sharedsort *shared2);
+
+extern void tuplesort_copy_sharedsort2(Sharedsort *shared1, Tuplesortstate *state);
+
+extern int	tuplesort_get_curr_workers(Sharedsort *shared);
+
+extern void tuplesort_register_cleanup_callback(Sharedsort *shared, dsm_segment *seg);
 #endif							/* TUPLESORT_H */

--- a/src/test/regress/expected/indexing.out
+++ b/src/test/regress/expected/indexing.out
@@ -1589,3 +1589,15 @@ Partitions: gidxpart1_b_idx,
 
 drop index gidx_u;
 drop table gidxpart;
+-- Test the cross-partition uniqueness with non-partition key with global unique index
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+create table gidxpart2 partition of gidxpart for values from (100000) to (199999);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+insert into gidxpart (a, b, c) values (150000, 572814, 'inserted second on gidxpart2');
+create unique index on gidxpart (b) global; -- should fail
+ERROR:  could not create unique index "gidxpart1_b_idx"
+DETAIL:  Key (b)=(572814) is duplicated.
+delete from gidxpart where a = 150000 and b = 572814;
+create unique index on gidxpart (b) global;
+drop table gidxpart;

--- a/src/test/regress/expected/indexing.out
+++ b/src/test/regress/expected/indexing.out
@@ -1601,3 +1601,58 @@ DETAIL:  Key (b)=(572814) is duplicated.
 delete from gidxpart where a = 150000 and b = 572814;
 create unique index on gidxpart (b) global;
 drop table gidxpart;
+-- Test partition attach and detach with global unique index (no existing index)
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+create unique index on gidxpart (b) global;
+create table gidxpart2 (a int, b int, c text);
+insert into gidxpart2 (a, b, c) values (150000, 572814, 'dup inserted on gidxpart2');
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999); -- should fail
+ERROR:  could not create unique index "gidxpart1_b_idx"
+DETAIL:  Key (b)=(572814) is duplicated.
+update gidxpart2 set b = 5000;
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999);
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be g
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | g
+(1 row)
+
+alter table gidxpart detach partition gidxpart2;
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be i
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | i
+(1 row)
+
+drop table gidxpart;
+drop table gidxpart2;
+-- Test partition attach and detach with global unique index (with duplicate index)
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+create unique index on gidxpart (b) global;
+create table gidxpart2 (a int, b int, c text);
+create unique index on gidxpart2 (b);
+insert into gidxpart2 (a, b, c) values (150000, 572814, 'dup inserted on gidxpart2');
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be i
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | i
+(1 row)
+
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999); -- should fail
+ERROR:  could not create unique index "gidxpart1_b_idx"
+DETAIL:  Key (b)=(572814) is duplicated.
+update gidxpart2 set b = 5000;
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999);
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be g
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | g
+(1 row)
+
+alter table gidxpart detach partition gidxpart2;
+drop table gidxpart;
+drop table gidxpart2;

--- a/src/test/regress/expected/indexing.out
+++ b/src/test/regress/expected/indexing.out
@@ -1549,3 +1549,43 @@ select indexrelid::regclass, indisvalid, indisreplident,
 (3 rows)
 
 drop table parted_replica_tab;
+-- create global index using non-partition key
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (10);
+create table gidxpart2 partition of gidxpart for values from (10) to (100);
+create unique index gidx_u on gidxpart using btree(b) global;
+select relname, relhasindex, relkind from pg_class where relname like '%gidx%' order by oid;
+     relname     | relhasindex | relkind 
+-----------------+-------------+---------
+ gidxpart        | t           | p
+ gidxpart1       | t           | r
+ gidxpart2       | t           | r
+ gidx_u          | f           | I
+ gidxpart1_b_idx | f           | g
+ gidxpart2_b_idx | f           | g
+(6 rows)
+
+\d+ gidxpart
+                            Partitioned table "public.gidxpart"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+--------------+-------------
+ a      | integer |           |          |         | plain    |              | 
+ b      | integer |           |          |         | plain    |              | 
+ c      | text    |           |          |         | extended |              | 
+Partition key: RANGE (a)
+Indexes:
+    "gidx_u" UNIQUE, btree (b)
+Partitions: gidxpart1 FOR VALUES FROM (0) TO (10),
+            gidxpart2 FOR VALUES FROM (10) TO (100)
+
+\d+ gidx_u
+               Partitioned index "public.gidx_u"
+ Column |  Type   | Key? | Definition | Storage | Stats target 
+--------+---------+------+------------+---------+--------------
+ b      | integer | yes  | b          | plain   | 
+unique, btree, for table "public.gidxpart"
+Partitions: gidxpart1_b_idx,
+            gidxpart2_b_idx
+
+drop index gidx_u;
+drop table gidxpart;

--- a/src/test/regress/expected/indexing.out
+++ b/src/test/regress/expected/indexing.out
@@ -1587,6 +1587,47 @@ unique, btree, for table "public.gidxpart"
 Partitions: gidxpart1_b_idx,
             gidxpart2_b_idx
 
+-- cross-partition uniqueness check for insert and update
+insert into gidxpart values (1, 1, 'first');
+insert into gidxpart values (11, 11, 'eleventh');
+insert into gidxpart values (2, 11, 'duplicated (b)=(11) on other partition');
+ERROR:  duplicate key value violates unique constraint "gidxpart2_b_idx"
+DETAIL:  Key (b)=(11) already exists.
+insert into gidxpart values (12, 1, 'duplicated (b)=(1) on other partition');
+ERROR:  duplicate key value violates unique constraint "gidxpart1_b_idx"
+DETAIL:  Key (b)=(1) already exists.
+insert into gidxpart values (2, 120, 'second');
+insert into gidxpart values (12, 2, 'twelfth');
+update gidxpart set b=2 where a=2;
+ERROR:  duplicate key value violates unique constraint "gidxpart2_b_idx"
+DETAIL:  Key (b)=(2) already exists.
+update gidxpart set b=1 where a=12;
+ERROR:  duplicate key value violates unique constraint "gidxpart1_b_idx"
+DETAIL:  Key (b)=(1) already exists.
+update gidxpart set b=12 where a=12;
+update gidxpart set b=2 where a=2;
+select * from gidxpart;
+ a  | b  |    c     
+----+----+----------
+  1 |  1 | first
+  2 |  2 | second
+ 11 | 11 | eleventh
+ 12 | 12 | twelfth
+(4 rows)
+
+-- cross-partition uniqueness check applys to newly created partition
+create table gidxpart3 partition of gidxpart for values from (100) to (200);
+select relname, relkind from pg_class where relname = 'gidxpart3_b_idx';
+     relname     | relkind 
+-----------------+---------
+ gidxpart3_b_idx | g
+(1 row)
+
+insert into gidxpart values (150, 11, 'duplicated (b)=(11) on other partition');
+ERROR:  duplicate key value violates unique constraint "gidxpart2_b_idx"
+DETAIL:  Key (b)=(11) already exists.
+insert into gidxpart values (150, 13, 'no duplicate b');
+-- clean up global index tests
 drop index gidx_u;
 drop table gidxpart;
 -- Test the cross-partition uniqueness with non-partition key with global unique index

--- a/src/test/regress/sql/indexing.sql
+++ b/src/test/regress/sql/indexing.sql
@@ -863,3 +863,14 @@ select relname, relhasindex, relkind from pg_class where relname like '%gidx%' o
 drop index gidx_u;
 drop table gidxpart;
 
+-- Test the cross-partition uniqueness with non-partition key with global unique index
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+create table gidxpart2 partition of gidxpart for values from (100000) to (199999);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+insert into gidxpart (a, b, c) values (150000, 572814, 'inserted second on gidxpart2');
+create unique index on gidxpart (b) global; -- should fail
+delete from gidxpart where a = 150000 and b = 572814;
+create unique index on gidxpart (b) global;
+drop table gidxpart;
+

--- a/src/test/regress/sql/indexing.sql
+++ b/src/test/regress/sql/indexing.sql
@@ -851,3 +851,15 @@ select indexrelid::regclass, indisvalid, indisreplident,
   where indexrelid::regclass::text like 'parted_replica%'
   order by indexrelid::regclass::text collate "C";
 drop table parted_replica_tab;
+
+-- create global index using non-partition key
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (10);
+create table gidxpart2 partition of gidxpart for values from (10) to (100);
+create unique index gidx_u on gidxpart using btree(b) global;
+select relname, relhasindex, relkind from pg_class where relname like '%gidx%' order by oid;
+\d+ gidxpart
+\d+ gidx_u
+drop index gidx_u;
+drop table gidxpart;
+

--- a/src/test/regress/sql/indexing.sql
+++ b/src/test/regress/sql/indexing.sql
@@ -860,6 +860,26 @@ create unique index gidx_u on gidxpart using btree(b) global;
 select relname, relhasindex, relkind from pg_class where relname like '%gidx%' order by oid;
 \d+ gidxpart
 \d+ gidx_u
+-- cross-partition uniqueness check for insert and update
+insert into gidxpart values (1, 1, 'first');
+insert into gidxpart values (11, 11, 'eleventh');
+insert into gidxpart values (2, 11, 'duplicated (b)=(11) on other partition');
+insert into gidxpart values (12, 1, 'duplicated (b)=(1) on other partition');
+insert into gidxpart values (2, 120, 'second');
+insert into gidxpart values (12, 2, 'twelfth');
+update gidxpart set b=2 where a=2;
+update gidxpart set b=1 where a=12;
+update gidxpart set b=12 where a=12;
+update gidxpart set b=2 where a=2;
+select * from gidxpart;
+
+-- cross-partition uniqueness check applys to newly created partition
+create table gidxpart3 partition of gidxpart for values from (100) to (200);
+select relname, relkind from pg_class where relname = 'gidxpart3_b_idx';
+insert into gidxpart values (150, 11, 'duplicated (b)=(11) on other partition');
+insert into gidxpart values (150, 13, 'no duplicate b');
+
+-- clean up global index tests
 drop index gidx_u;
 drop table gidxpart;
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced the concept of "Global Indexes" to PostgreSQL. This feature allows for cross-partition uniqueness checks on partitioned tables, ensuring that attempts to insert or update data that would result in duplicate entries across partitions will generate an error.
- New Feature: Added support for parallel building of B-tree indexes, including global unique indexes. This enhances the performance of index creation on large partitioned tables.
- Refactor: Updated various functions and structures throughout the codebase to handle the new `RELKIND_GLOBAL_INDEX` relation kind, improving the maintainability and consistency of the code.
- Chore: Modified grammar rules and AST structures related to index creation statements to include a new option indicating whether the index is a global index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->