### PR TITLE
support global unique index insert and update

### DIFF
--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -35,7 +35,7 @@ static BTStack _bt_search_insert(Relation rel, Relation heaprel,
 static TransactionId _bt_check_unique(Relation rel, BTInsertState insertstate,
 									  Relation heapRel,
 									  IndexUniqueCheck checkUnique, bool *is_unique,
-									  uint32 *speculativeToken);
+									  uint32 *speculativeToken, Relation origHeapRel);
 static OffsetNumber _bt_findinsertloc(Relation rel,
 									  BTInsertState insertstate,
 									  bool checkingunique,
@@ -74,6 +74,11 @@ static BlockNumber *_bt_deadblocks(Page page, OffsetNumber *deletable,
 								   int ndeletable, IndexTuple newitem,
 								   int *nblocks);
 static inline int _bt_blk_cmp(const void *arg1, const void *arg2);
+
+TransactionId _bt_check_unique_gi(Relation rel, BTInsertState insertstate,
+								  Relation heapRel,
+								  IndexUniqueCheck checkUnique, bool *is_unique,
+								  uint32 *speculativeToken, Relation origHeapRel);
 
 /*
  *	_bt_doinsert() -- Handle insertion of a single index tuple in the tree.
@@ -208,7 +213,7 @@ search:
 		uint32		speculativeToken;
 
 		xwait = _bt_check_unique(rel, &insertstate, heapRel, checkUnique,
-								 &is_unique, &speculativeToken);
+								 &is_unique, &speculativeToken, NULL);
 
 		if (unlikely(TransactionIdIsValid(xwait)))
 		{
@@ -381,6 +386,15 @@ _bt_search_insert(Relation rel, Relation heaprel, BTInsertState insertstate)
 					  BT_WRITE, NULL);
 }
 
+TransactionId
+_bt_check_unique_gi(Relation rel, BTInsertState insertstate, Relation heapRel,
+					IndexUniqueCheck checkUnique, bool *is_unique,
+					uint32 *speculativeToken, Relation origHeapRel)
+{
+	return _bt_check_unique(rel, insertstate, heapRel, checkUnique,
+							is_unique, speculativeToken, origHeapRel);
+}
+
 /*
  *	_bt_check_unique() -- Check for violation of unique index constraint
  *
@@ -407,7 +421,7 @@ _bt_search_insert(Relation rel, Relation heaprel, BTInsertState insertstate)
 static TransactionId
 _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 				 IndexUniqueCheck checkUnique, bool *is_unique,
-				 uint32 *speculativeToken)
+				 uint32 *speculativeToken, Relation origHeapRel)
 {
 	IndexTuple	itup = insertstate->itup;
 	IndexTuple	curitup = NULL;
@@ -562,6 +576,7 @@ _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 													   &all_dead))
 				{
 					TransactionId xwait;
+					bool		idx_fetch_result;
 
 					/*
 					 * It is a duplicate. If we are only doing a partial
@@ -615,8 +630,13 @@ _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 					 * entry.
 					 */
 					htid = itup->t_tid;
-					if (table_index_fetch_tuple_check(heapRel, &htid,
-													  SnapshotSelf, NULL))
+					if (origHeapRel)
+						idx_fetch_result = table_index_fetch_tuple_check(origHeapRel, &htid,
+																		 SnapshotSelf, NULL);
+					else
+						idx_fetch_result = table_index_fetch_tuple_check(heapRel, &htid,
+																		 SnapshotSelf, NULL);
+					if (idx_fetch_result)
 					{
 						/* Normal case --- it's still live */
 					}

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -23,6 +23,8 @@
 #include "access/relscan.h"
 #include "access/xlog.h"
 #include "access/xloginsert.h"
+#include "access/table.h"
+#include "catalog/partition.h"
 #include "commands/progress.h"
 #include "commands/vacuum.h"
 #include "miscadmin.h"
@@ -34,9 +36,11 @@
 #include "storage/ipc.h"
 #include "storage/lmgr.h"
 #include "storage/smgr.h"
+#include "storage/predicate.h"
 #include "utils/builtins.h"
 #include "utils/index_selfuncs.h"
 #include "utils/memutils.h"
+#include "partitioning/partdesc.h"
 
 
 /*
@@ -86,7 +90,9 @@ static BTVacuumPosting btreevacuumposting(BTVacState *vstate,
 										  IndexTuple posting,
 										  OffsetNumber updatedoffset,
 										  int *nremaining);
-
+static void
+			btinsert_check_unique_gi(IndexTuple itup, Relation idxRel,
+									 Relation heapRel, IndexUniqueCheck checkUnique);
 
 /*
  * Btree handler function: return IndexAmRoutine with access method parameters
@@ -179,6 +185,121 @@ btbuildempty(Relation index)
 }
 
 /*
+ *	btinsert_check_unique_gi() -- cross partitions uniqueness check.
+ *
+ *		loop all partitions with global index for uniqueness check.
+ */
+static void
+btinsert_check_unique_gi(IndexTuple itup, Relation idxRel,
+						 Relation heapRel, IndexUniqueCheck checkUnique)
+{
+	bool		is_unique = false;
+	BTScanInsert itup_key = _bt_mkscankey(idxRel, itup);
+
+	if (!itup_key->anynullkeys &&
+		idxRel->rd_rel->relkind == RELKIND_GLOBAL_INDEX)
+	{
+		Oid			parentId;
+		Relation	parentTbl;
+		PartitionDesc partDesc;
+		int			i;
+		int			nparts;
+		Oid		   *partOids;
+
+		itup_key->scantid = NULL;
+		parentId = heapRel->rd_rel->relispartition ?
+			get_partition_parent(idxRel->rd_index->indrelid, false) : InvalidOid;
+		parentTbl = table_open(parentId, AccessShareLock);
+		partDesc = RelationGetPartitionDesc(parentTbl, true);
+		nparts = partDesc->nparts;
+		partOids = palloc(sizeof(Oid) * nparts);
+		memcpy(partOids, partDesc->oids, sizeof(Oid) * nparts);
+		for (i = 0; i < nparts; i++)
+		{
+			Oid			childRelid = partOids[i];
+			List	   *childidxs;
+			ListCell   *cell;
+
+			if (childRelid != heapRel->rd_rel->oid)
+			{
+				Relation	hRel = table_open(childRelid, AccessShareLock);
+
+				childidxs = RelationGetIndexList(hRel);
+				foreach(cell, childidxs)
+				{
+					Oid			cldidxid = lfirst_oid(cell);
+					Relation	iRel = index_open(cldidxid, AccessShareLock);
+
+					if (iRel->rd_rel->relkind == RELKIND_GLOBAL_INDEX
+						&& iRel->rd_rel->oid != idxRel->rd_rel->oid)
+					{
+						BTStack		stack;
+						uint32		speculativeToken;
+						BTInsertStateData insertstate;
+						TransactionId xwait = InvalidBuffer;
+
+						insertstate.itup = itup;
+						insertstate.itemsz = MAXALIGN(IndexTupleSize(itup));
+						insertstate.itup_key = itup_key;
+						insertstate.bounds_valid = false;
+						insertstate.buf = InvalidBuffer;
+						insertstate.postingoff = 0;
+
+				search_global:
+						stack = _bt_search(iRel, heapRel, insertstate.itup_key,
+										   &insertstate.buf, BT_READ, NULL);
+						if (insertstate.buf)
+						{
+							xwait = _bt_check_unique_gi(iRel, &insertstate,
+														hRel, checkUnique, &is_unique,
+														&speculativeToken, heapRel);
+							if (unlikely(TransactionIdIsValid(xwait)))
+							{
+								/* Have to wait for the other guy ... */
+								if (insertstate.buf)
+								{
+									_bt_relbuf(iRel, insertstate.buf);
+									insertstate.buf = InvalidBuffer;
+								}
+
+								/*
+								 * If it's a speculative insertion, wait for it to
+								 * finish (ie. to go ahead with the insertion, or
+								 * kill the tuple).  Otherwise wait for the
+								 * transaction to finish as usual.
+								 */
+								if (speculativeToken)
+									SpeculativeInsertionWait(xwait, speculativeToken);
+								else
+									XactLockTableWait(xwait, iRel, &itup->t_tid, XLTW_InsertIndex);
+
+								/* start over... */
+								if (stack)
+									_bt_freestack(stack);
+								goto search_global;
+							}
+						}
+						if (insertstate.buf)
+							_bt_relbuf(iRel, insertstate.buf);
+						if (stack)
+							_bt_freestack(stack);
+					}
+					index_close(iRel, AccessShareLock);
+				}
+				if (childidxs)
+					list_free(childidxs);
+				table_close(hRel, AccessShareLock);
+			}
+		}
+		if (partOids)
+			pfree(partOids);
+		table_close(parentTbl, AccessShareLock);
+	}
+	if (itup_key)
+		pfree(itup_key);
+}
+
+/*
  *	btinsert() -- insert an index tuple into a btree.
  *
  *		Descend the tree recursively, find the appropriate location for our
@@ -199,6 +320,9 @@ btinsert(Relation rel, Datum *values, bool *isnull,
 	itup->t_tid = *ht_ctid;
 
 	result = _bt_doinsert(rel, itup, checkUnique, indexUnchanged, heapRel);
+
+	if (checkUnique != UNIQUE_CHECK_NO)
+		btinsert_check_unique_gi(itup, rel, heapRel, checkUnique);
 
 	pfree(itup);
 

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -1293,4 +1293,9 @@ extern IndexBuildResult *btbuild(Relation heap, Relation index,
 								 struct IndexInfo *indexInfo);
 extern void _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc);
 
+extern TransactionId _bt_check_unique_gi(Relation rel, BTInsertState insertstate,
+										 Relation heapRel,
+										 IndexUniqueCheck checkUnique, bool *is_unique,
+										 uint32 *speculativeToken, Relation origHeapRel);
+
 #endif							/* NBTREE_H */

--- a/src/test/regress/expected/indexing.out
+++ b/src/test/regress/expected/indexing.out
@@ -1451,3 +1451,249 @@ select indexrelid::regclass, indisvalid,
 (5 rows)
 
 drop table parted_inval_tab;
+-- Check setup of indisvalid across a complex partition tree on index
+-- creation.  If one index in a partition index is invalid, so should its
+-- partitioned index.
+create table parted_isvalid_tab (a int, b int) partition by range (a);
+create table parted_isvalid_tab_1 partition of parted_isvalid_tab
+  for values from (1) to (10) partition by range (a);
+create table parted_isvalid_tab_2 partition of parted_isvalid_tab
+  for values from (10) to (20) partition by range (a);
+create table parted_isvalid_tab_11 partition of parted_isvalid_tab_1
+  for values from (1) to (5);
+create table parted_isvalid_tab_12 partition of parted_isvalid_tab_1
+  for values from (5) to (10);
+-- create an invalid index on one of the partitions.
+insert into parted_isvalid_tab_11 values (1, 0);
+create index concurrently parted_isvalid_idx_11 on parted_isvalid_tab_11 ((a/b));
+ERROR:  division by zero
+-- The previous invalid index is selected, invalidating all the indexes up to
+-- the top-most parent.
+create index parted_isvalid_idx on parted_isvalid_tab ((a/b));
+select indexrelid::regclass, indisvalid,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_isvalid%'
+  order by indexrelid::regclass::text collate "C";
+           indexrelid           | indisvalid |       indrelid        |           inhparent           
+--------------------------------+------------+-----------------------+-------------------------------
+ parted_isvalid_idx             | f          | parted_isvalid_tab    | 
+ parted_isvalid_idx_11          | f          | parted_isvalid_tab_11 | parted_isvalid_tab_1_expr_idx
+ parted_isvalid_tab_12_expr_idx | t          | parted_isvalid_tab_12 | parted_isvalid_tab_1_expr_idx
+ parted_isvalid_tab_1_expr_idx  | f          | parted_isvalid_tab_1  | parted_isvalid_idx
+ parted_isvalid_tab_2_expr_idx  | t          | parted_isvalid_tab_2  | parted_isvalid_idx
+(5 rows)
+
+drop table parted_isvalid_tab;
+-- Check state of replica indexes when attaching a partition.
+begin;
+create table parted_replica_tab (id int not null) partition by range (id);
+create table parted_replica_tab_1 partition of parted_replica_tab
+  for values from (1) to (10) partition by range (id);
+create table parted_replica_tab_11 partition of parted_replica_tab_1
+  for values from (1) to (5);
+create unique index parted_replica_idx
+  on only parted_replica_tab using btree (id);
+create unique index parted_replica_idx_1
+  on only parted_replica_tab_1 using btree (id);
+-- This triggers an update of pg_index.indisreplident for parted_replica_idx.
+alter table only parted_replica_tab_1 replica identity
+  using index parted_replica_idx_1;
+create unique index parted_replica_idx_11 on parted_replica_tab_11 USING btree (id);
+select indexrelid::regclass, indisvalid, indisreplident,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_replica%'
+  order by indexrelid::regclass::text collate "C";
+      indexrelid       | indisvalid | indisreplident |       indrelid        | inhparent 
+-----------------------+------------+----------------+-----------------------+-----------
+ parted_replica_idx    | f          | f              | parted_replica_tab    | 
+ parted_replica_idx_1  | f          | t              | parted_replica_tab_1  | 
+ parted_replica_idx_11 | t          | f              | parted_replica_tab_11 | 
+(3 rows)
+
+-- parted_replica_idx is not valid yet here, because parted_replica_idx_1
+-- is not valid.
+alter index parted_replica_idx ATTACH PARTITION parted_replica_idx_1;
+select indexrelid::regclass, indisvalid, indisreplident,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_replica%'
+  order by indexrelid::regclass::text collate "C";
+      indexrelid       | indisvalid | indisreplident |       indrelid        |     inhparent      
+-----------------------+------------+----------------+-----------------------+--------------------
+ parted_replica_idx    | f          | f              | parted_replica_tab    | 
+ parted_replica_idx_1  | f          | t              | parted_replica_tab_1  | parted_replica_idx
+ parted_replica_idx_11 | t          | f              | parted_replica_tab_11 | 
+(3 rows)
+
+-- parted_replica_idx becomes valid here.
+alter index parted_replica_idx_1 ATTACH PARTITION parted_replica_idx_11;
+alter table only parted_replica_tab_1 replica identity
+  using index parted_replica_idx_1;
+commit;
+select indexrelid::regclass, indisvalid, indisreplident,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_replica%'
+  order by indexrelid::regclass::text collate "C";
+      indexrelid       | indisvalid | indisreplident |       indrelid        |      inhparent       
+-----------------------+------------+----------------+-----------------------+----------------------
+ parted_replica_idx    | t          | f              | parted_replica_tab    | 
+ parted_replica_idx_1  | t          | t              | parted_replica_tab_1  | parted_replica_idx
+ parted_replica_idx_11 | t          | f              | parted_replica_tab_11 | parted_replica_idx_1
+(3 rows)
+
+drop table parted_replica_tab;
+-- create global index using non-partition key
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (10);
+create table gidxpart2 partition of gidxpart for values from (10) to (100);
+create unique index gidx_u on gidxpart using btree(b) global;
+select relname, relhasindex, relkind from pg_class where relname like '%gidx%' order by oid;
+     relname     | relhasindex | relkind 
+-----------------+-------------+---------
+ gidxpart        | t           | p
+ gidxpart1       | t           | r
+ gidxpart2       | t           | r
+ gidx_u          | f           | I
+ gidxpart1_b_idx | f           | g
+ gidxpart2_b_idx | f           | g
+(6 rows)
+
+\d+ gidxpart
+                            Partitioned table "public.gidxpart"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+--------------+-------------
+ a      | integer |           |          |         | plain    |              | 
+ b      | integer |           |          |         | plain    |              | 
+ c      | text    |           |          |         | extended |              | 
+Partition key: RANGE (a)
+Indexes:
+    "gidx_u" UNIQUE, btree (b)
+Partitions: gidxpart1 FOR VALUES FROM (0) TO (10),
+            gidxpart2 FOR VALUES FROM (10) TO (100)
+
+\d+ gidx_u
+               Partitioned index "public.gidx_u"
+ Column |  Type   | Key? | Definition | Storage | Stats target 
+--------+---------+------+------------+---------+--------------
+ b      | integer | yes  | b          | plain   | 
+unique, btree, for table "public.gidxpart"
+Partitions: gidxpart1_b_idx,
+            gidxpart2_b_idx
+
+-- cross-partition uniqueness check for insert and update
+insert into gidxpart values (1, 1, 'first');
+insert into gidxpart values (11, 11, 'eleventh');
+insert into gidxpart values (2, 11, 'duplicated (b)=(11) on other partition');
+ERROR:  duplicate key value violates unique constraint "gidxpart2_b_idx"
+DETAIL:  Key (b)=(11) already exists.
+insert into gidxpart values (12, 1, 'duplicated (b)=(1) on other partition');
+ERROR:  duplicate key value violates unique constraint "gidxpart1_b_idx"
+DETAIL:  Key (b)=(1) already exists.
+insert into gidxpart values (2, 120, 'second');
+insert into gidxpart values (12, 2, 'twelfth');
+update gidxpart set b=2 where a=2;
+ERROR:  duplicate key value violates unique constraint "gidxpart2_b_idx"
+DETAIL:  Key (b)=(2) already exists.
+update gidxpart set b=1 where a=12;
+ERROR:  duplicate key value violates unique constraint "gidxpart1_b_idx"
+DETAIL:  Key (b)=(1) already exists.
+update gidxpart set b=12 where a=12;
+update gidxpart set b=2 where a=2;
+select * from gidxpart;
+ a  | b  |    c     
+----+----+----------
+  1 |  1 | first
+  2 |  2 | second
+ 11 | 11 | eleventh
+ 12 | 12 | twelfth
+(4 rows)
+
+-- cross-partition uniqueness check applys to newly created partition
+create table gidxpart3 partition of gidxpart for values from (100) to (200);
+select relname, relkind from pg_class where relname = 'gidxpart3_b_idx';
+     relname     | relkind 
+-----------------+---------
+ gidxpart3_b_idx | g
+(1 row)
+
+insert into gidxpart values (150, 11, 'duplicated (b)=(11) on other partition');
+ERROR:  duplicate key value violates unique constraint "gidxpart2_b_idx"
+DETAIL:  Key (b)=(11) already exists.
+insert into gidxpart values (150, 13, 'no duplicate b');
+-- clean up global index tests
+drop index gidx_u;
+drop table gidxpart;
+-- Test the cross-partition uniqueness with non-partition key with global unique index
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+create table gidxpart2 partition of gidxpart for values from (100000) to (199999);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+insert into gidxpart (a, b, c) values (150000, 572814, 'inserted second on gidxpart2');
+create unique index on gidxpart (b) global; -- should fail
+ERROR:  could not create unique index "gidxpart1_b_idx"
+DETAIL:  Key (b)=(572814) is duplicated.
+delete from gidxpart where a = 150000 and b = 572814;
+create unique index on gidxpart (b) global;
+drop table gidxpart;
+-- Test partition attach and detach with global unique index (no existing index)
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+create unique index on gidxpart (b) global;
+create table gidxpart2 (a int, b int, c text);
+insert into gidxpart2 (a, b, c) values (150000, 572814, 'dup inserted on gidxpart2');
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999); -- should fail
+ERROR:  could not create unique index "gidxpart1_b_idx"
+DETAIL:  Key (b)=(572814) is duplicated.
+update gidxpart2 set b = 5000;
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999);
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be g
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | g
+(1 row)
+
+alter table gidxpart detach partition gidxpart2;
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be i
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | i
+(1 row)
+
+drop table gidxpart;
+drop table gidxpart2;
+-- Test partition attach and detach with global unique index (with duplicate index)
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+create unique index on gidxpart (b) global;
+create table gidxpart2 (a int, b int, c text);
+create unique index on gidxpart2 (b);
+insert into gidxpart2 (a, b, c) values (150000, 572814, 'dup inserted on gidxpart2');
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be i
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | i
+(1 row)
+
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999); -- should fail
+ERROR:  could not create unique index "gidxpart1_b_idx"
+DETAIL:  Key (b)=(572814) is duplicated.
+update gidxpart2 set b = 5000;
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999);
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be g
+     relname     | relkind 
+-----------------+---------
+ gidxpart2_b_idx | g
+(1 row)
+
+alter table gidxpart detach partition gidxpart2;
+drop table gidxpart;
+drop table gidxpart2;

--- a/src/test/regress/sql/indexing.sql
+++ b/src/test/regress/sql/indexing.sql
@@ -782,3 +782,148 @@ select indexrelid::regclass, indisvalid,
   where indexrelid::regclass::text like 'parted_inval%'
   order by indexrelid::regclass::text collate "C";
 drop table parted_inval_tab;
+
+-- Check setup of indisvalid across a complex partition tree on index
+-- creation.  If one index in a partition index is invalid, so should its
+-- partitioned index.
+create table parted_isvalid_tab (a int, b int) partition by range (a);
+create table parted_isvalid_tab_1 partition of parted_isvalid_tab
+  for values from (1) to (10) partition by range (a);
+create table parted_isvalid_tab_2 partition of parted_isvalid_tab
+  for values from (10) to (20) partition by range (a);
+create table parted_isvalid_tab_11 partition of parted_isvalid_tab_1
+  for values from (1) to (5);
+create table parted_isvalid_tab_12 partition of parted_isvalid_tab_1
+  for values from (5) to (10);
+-- create an invalid index on one of the partitions.
+insert into parted_isvalid_tab_11 values (1, 0);
+create index concurrently parted_isvalid_idx_11 on parted_isvalid_tab_11 ((a/b));
+-- The previous invalid index is selected, invalidating all the indexes up to
+-- the top-most parent.
+create index parted_isvalid_idx on parted_isvalid_tab ((a/b));
+select indexrelid::regclass, indisvalid,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_isvalid%'
+  order by indexrelid::regclass::text collate "C";
+drop table parted_isvalid_tab;
+
+-- Check state of replica indexes when attaching a partition.
+begin;
+create table parted_replica_tab (id int not null) partition by range (id);
+create table parted_replica_tab_1 partition of parted_replica_tab
+  for values from (1) to (10) partition by range (id);
+create table parted_replica_tab_11 partition of parted_replica_tab_1
+  for values from (1) to (5);
+create unique index parted_replica_idx
+  on only parted_replica_tab using btree (id);
+create unique index parted_replica_idx_1
+  on only parted_replica_tab_1 using btree (id);
+-- This triggers an update of pg_index.indisreplident for parted_replica_idx.
+alter table only parted_replica_tab_1 replica identity
+  using index parted_replica_idx_1;
+create unique index parted_replica_idx_11 on parted_replica_tab_11 USING btree (id);
+select indexrelid::regclass, indisvalid, indisreplident,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_replica%'
+  order by indexrelid::regclass::text collate "C";
+-- parted_replica_idx is not valid yet here, because parted_replica_idx_1
+-- is not valid.
+alter index parted_replica_idx ATTACH PARTITION parted_replica_idx_1;
+select indexrelid::regclass, indisvalid, indisreplident,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_replica%'
+  order by indexrelid::regclass::text collate "C";
+-- parted_replica_idx becomes valid here.
+alter index parted_replica_idx_1 ATTACH PARTITION parted_replica_idx_11;
+alter table only parted_replica_tab_1 replica identity
+  using index parted_replica_idx_1;
+commit;
+select indexrelid::regclass, indisvalid, indisreplident,
+       indrelid::regclass, inhparent::regclass
+  from pg_index idx left join
+       pg_inherits inh on (idx.indexrelid = inh.inhrelid)
+  where indexrelid::regclass::text like 'parted_replica%'
+  order by indexrelid::regclass::text collate "C";
+drop table parted_replica_tab;
+
+-- create global index using non-partition key
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (10);
+create table gidxpart2 partition of gidxpart for values from (10) to (100);
+create unique index gidx_u on gidxpart using btree(b) global;
+select relname, relhasindex, relkind from pg_class where relname like '%gidx%' order by oid;
+\d+ gidxpart
+\d+ gidx_u
+-- cross-partition uniqueness check for insert and update
+insert into gidxpart values (1, 1, 'first');
+insert into gidxpart values (11, 11, 'eleventh');
+insert into gidxpart values (2, 11, 'duplicated (b)=(11) on other partition');
+insert into gidxpart values (12, 1, 'duplicated (b)=(1) on other partition');
+insert into gidxpart values (2, 120, 'second');
+insert into gidxpart values (12, 2, 'twelfth');
+update gidxpart set b=2 where a=2;
+update gidxpart set b=1 where a=12;
+update gidxpart set b=12 where a=12;
+update gidxpart set b=2 where a=2;
+select * from gidxpart;
+
+-- cross-partition uniqueness check applys to newly created partition
+create table gidxpart3 partition of gidxpart for values from (100) to (200);
+select relname, relkind from pg_class where relname = 'gidxpart3_b_idx';
+insert into gidxpart values (150, 11, 'duplicated (b)=(11) on other partition');
+insert into gidxpart values (150, 13, 'no duplicate b');
+
+-- clean up global index tests
+drop index gidx_u;
+drop table gidxpart;
+
+-- Test the cross-partition uniqueness with non-partition key with global unique index
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+create table gidxpart2 partition of gidxpart for values from (100000) to (199999);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+insert into gidxpart (a, b, c) values (150000, 572814, 'inserted second on gidxpart2');
+create unique index on gidxpart (b) global; -- should fail
+delete from gidxpart where a = 150000 and b = 572814;
+create unique index on gidxpart (b) global;
+drop table gidxpart;
+
+-- Test partition attach and detach with global unique index (no existing index)
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+create unique index on gidxpart (b) global;
+create table gidxpart2 (a int, b int, c text);
+insert into gidxpart2 (a, b, c) values (150000, 572814, 'dup inserted on gidxpart2');
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999); -- should fail
+update gidxpart2 set b = 5000;
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999);
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be g
+alter table gidxpart detach partition gidxpart2;
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be i
+drop table gidxpart;
+drop table gidxpart2;
+
+-- Test partition attach and detach with global unique index (with duplicate index)
+create table gidxpart (a int, b int, c text) partition by range (a);
+create table gidxpart1 partition of gidxpart for values from (0) to (100000);
+insert into gidxpart (a, b, c) values (42, 572814, 'inserted first on gidxpart1');
+create unique index on gidxpart (b) global;
+create table gidxpart2 (a int, b int, c text);
+create unique index on gidxpart2 (b);
+insert into gidxpart2 (a, b, c) values (150000, 572814, 'dup inserted on gidxpart2');
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be i
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999); -- should fail
+update gidxpart2 set b = 5000;
+alter table gidxpart attach partition gidxpart2 for values from (100000) to (199999);
+select relname, relkind from pg_class where relname = 'gidxpart2_b_idx'; -- should be g
+alter table gidxpart detach partition gidxpart2;
+drop table gidxpart;
+drop table gidxpart2;
+


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a cross-partition uniqueness check during index insertion to improve handling of duplicate index entries. This feature enhances the robustness of index operations in partitioned tables.
- Refactor: Modified the `btinsert()` function and related methods for better tuple fetch operation from the original heap relation, improving the performance and reliability of these operations.
- Test: Extended test coverage with new scenarios in `indexing.sql` to validate the functionality and integrity of indexes, particularly in the context of table partitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->