### PR TITLE
IvorySQL: failed to execute make oracle-pg-check directly

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -93,7 +93,7 @@ GNUmakefile: GNUmakefile.in $(top_builddir)/config.status
 	./config.status $@
 
 
-$(call recurse,oracle-pg-check-world,src/test/regress,oracle-pg-check)
+$(call recurse,oracle-pg-check-world,src/test,oracle-pg-check)
 #add oracle regression
 $(call recurse,oracle-check-world,src/oracle_test src/pl src/interfaces/ecpg contrib/ivorysql_ora contrib/ora_btree_gist contrib/ora_btree_gin src/bin,oracle-check)
 $(call recurse,oracle-checkprep,  src/oracle_test src/pl src/interfaces/ecpg contrib src/bin)

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -21,7 +21,8 @@
 
 #standard_targets = all install installdirs uninstall distprep clean distclean maintainer-clean coverage check checkprep installcheck init-po update-po
 # IvorySQL:BEGIN - SQL oracle_test
-standard_targets = all install installdirs uninstall distprep clean distclean maintainer-clean coverage check oracle-check checkprep oracle-checkprep installcheck oracle-installcheck init-po update-po
+standard_targets = all install installdirs uninstall distprep clean distclean maintainer-clean coverage check oracle-check checkprep oracle-checkprep installcheck oracle-installcheck init-po update-po \
+                    oracle-pg-check oracle-pg-checkprep
 # IvorySQL:END - SQL oracle_test
 # these targets should recurse even into subdirectories not being built:
 standard_always_targets = distprep clean distclean maintainer-clean
@@ -403,6 +404,7 @@ endif
 check: temp-install
 #IvorySQL:BEGIN - SQL oracle_test
 oracle-check: temp-install
+oracle-pg-check: temp-install
 #IvorySQL:END - SQL oracle_test
 
 .PHONY: temp-install
@@ -775,6 +777,17 @@ ora_pg_regress_check = \
     --bindir= \
     $(TEMP_CONF) \
     $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
+
+oracle_pg_isolation_regress_check = \
+    echo "\# +++ ora pg isolation regress check in $(subdir) +++" && \
+    $(with_temp_install) \
+    $(top_builddir)/src/test/isolation/pg_isolation_regress \
+    --temp-instance=./tmp_check_iso \
+    --inputdir=$(srcdir) --outputdir=output_iso \
+    --bindir= \
+    $(TEMP_CONF) \
+    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
+
 oracle_regress_check = \
     echo "\# +++ ora regress check in $(subdir) +++" && \
     $(with_temp_install) \
@@ -1004,7 +1017,7 @@ define _create_recursive_target
 $(1): $(1)-$(2)-recurse
 #$(1)-$(2)-recurse: $(if $(filter all install check installcheck, $(3)), submake-generated-headers) $(if $(filter check, $(3)), temp-install)
 #IvorySQL:BEGIN - SQL oracle_test
-$(1)-$(2)-recurse: $(if $(filter all install check oracle-check installcheck oracle-installcheck, $(3)), submake-generated-headers) $(if $(filter check oracle-check, $(3)), temp-install)
+$(1)-$(2)-recurse: $(if $(filter all install check oracle-check installcheck oracle-installcheck oracle-pg-check, $(3)), submake-generated-headers) $(if $(filter check oracle-check oracle-pg-check, $(3)), temp-install)
 #IvorySQL:END - SQL oracle_test
 	$$(MAKE) -C $(2) $(3)
 endef

--- a/src/makefiles/pgxs.mk
+++ b/src/makefiles/pgxs.mk
@@ -521,6 +521,16 @@ endif
 ifdef TAP_TESTS
 	$(prove_check)
 endif
+oracle-pg-check: submake $(REGRESS_PREP)
+ifdef REGRESS
+	$(ora_pg_regress_check) $(REGRESS_OPTS) $(REGRESS)
+endif
+ifdef ISOLATION
+	$(oracle_pg_isolation_regress_check) $(ISOLATION_OPTS) $(ISOLATION)
+endif
+ifdef TAP_TESTS
+	$(prove_check)
+endif
 #IvorySQL:BEGIN - SQL oracle_test
 oracle-check: oracle-submake $(REGRESS_PREP)
 ifdef ORA_REGRESS
@@ -540,6 +550,7 @@ checkprep: EXTRA_INSTALL+=$(subdir)
 #IvorySQL:BEGIN - SQL oracle_test
 oracle-checkprep: EXTRA_INSTALL+=$(subdir)
 #IvorySQL:END - SQL oracle_test
+oracle-pg-checkprep: EXTRA_INSTALL+=$(subdir)
 endif
 
 


### PR DESCRIPTION
#534 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced new targets `oracle-pg-check` and `oracle-pg-checkprep` in the makefiles to facilitate regression and isolation tests for Oracle and PostgreSQL databases.
- Refactor: Updated the directory path in the `GNUmakefile` to improve the build process.
- Test: Enhanced the `oracle-check` and `oracle-checkprep` targets to include the new `oracle-pg-check` and `oracle-pg-checkprep` targets, providing more comprehensive database testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->