### PR TITLE
Calling a PROCEDURE in "CREATE FUNCTION/PROCEDURE" does not require an explicit "CALL" #537

### DIFF
--- a/src/oracle_test/regress/expected/ora_plisql.out
+++ b/src/oracle_test/regress/expected/ora_plisql.out
@@ -1076,8 +1076,8 @@ TRUNCATE TABLE test1;
 CREATE or replace PROCEDURE test_proc4(y int)
 AS
 BEGIN
-    CALL test_proc3(y);
-    CALL test_proc3($1);
+     test_proc3(y);
+     test_proc3($1);
 END;
 /
 EXEC test_proc4(66);
@@ -1148,7 +1148,7 @@ BEGIN
 IF x > 1 THEN
     a := x / 10;
     b := x / 2;
-    CALL test_proc7(b::int, a, b);
+     test_proc7(b::int, a, b);
 END IF;
 END;
 /
@@ -1220,3 +1220,82 @@ NOTICE:  1000 510
 EXEC test_proc8c(b => 500, a => 100);
 NOTICE:  1000 510
 DROP PROCEDURE test_proc8c;
+-- add test 
+CREATE OR REPLACE PROCEDURE protest 
+AS 
+BEGIN 
+raise notice 'protest';
+END;
+/
+-- function
+CREATE OR REPLACE FUNCTION functest()
+RETURN INT4
+AS 
+BEGIN
+protest();  -- No need to write "CALL" anymore.
+raise notice 'functest';
+RETURN 25;
+END;
+/
+SELECT functest();
+NOTICE:  protest
+NOTICE:  functest
+ functest 
+----------
+       25
+(1 row)
+
+DROP FUNCTION functest;
+-- procedure
+CREATE OR REPLACE PROCEDURE protest2
+AS
+BEGIN 
+protest();          -- No need to write "CALL" anymore.
+raise notice 'protest2';
+END;
+/
+CALL protest2();
+NOTICE:  protest
+NOTICE:  protest2
+DROP PROCEDURE  protest2;
+DROP PROCEDURE  protest;
+-- schema.procedure
+CREATE SCHEMA stest;
+CREATE OR REPLACE PROCEDURE stest.protest 
+AS 
+BEGIN 
+raise notice 'stest.protest';
+END;
+/
+-- function
+CREATE OR REPLACE FUNCTION functest2()
+RETURN INT4
+AS 
+BEGIN
+stest.protest();  -- No need to write "CALL" anymore.
+raise notice 'functest2';
+RETURN 25;
+END;
+/
+SELECT functest2();
+NOTICE:  stest.protest
+NOTICE:  functest2
+ functest2 
+-----------
+        25
+(1 row)
+
+DROP FUNCTION functest2;
+-- procedure
+CREATE OR REPLACE PROCEDURE protest2
+AS
+BEGIN 
+stest.protest();          -- No need to write "CALL" anymore.
+raise notice 'protest2';
+END;
+/
+CALL protest2();
+NOTICE:  stest.protest
+NOTICE:  protest2
+DROP PROCEDURE  protest2;
+DROP PROCEDURE  stest.protest;

--- a/src/oracle_test/regress/sql/ora_plisql.sql
+++ b/src/oracle_test/regress/sql/ora_plisql.sql
@@ -1018,8 +1018,8 @@ TRUNCATE TABLE test1;
 CREATE or replace PROCEDURE test_proc4(y int)
 AS
 BEGIN
-    CALL test_proc3(y);
-    CALL test_proc3($1);
+     test_proc3(y);
+     test_proc3($1);
 END;
 /
 
@@ -1063,7 +1063,7 @@ BEGIN
 IF x > 1 THEN
     a := x / 10;
     b := x / 2;
-    CALL test_proc7(b::int, a, b);
+     test_proc7(b::int, a, b);
 END IF;
 END;
 /
@@ -1114,3 +1114,77 @@ EXEC test_proc8c(10);
 EXEC test_proc8c(100, 500);
 EXEC test_proc8c(b => 500, a => 100);
 DROP PROCEDURE test_proc8c;
+
+
+-- add test 
+CREATE OR REPLACE PROCEDURE protest 
+AS 
+BEGIN 
+raise notice 'protest';
+END;
+/
+
+-- function
+CREATE OR REPLACE FUNCTION functest()
+RETURN INT4
+AS 
+BEGIN
+protest();  -- No need to write "CALL" anymore.
+raise notice 'functest';
+RETURN 25;
+END;
+/
+
+SELECT functest();
+DROP FUNCTION functest;
+
+-- procedure
+CREATE OR REPLACE PROCEDURE protest2
+AS
+BEGIN 
+protest();          -- No need to write "CALL" anymore.
+raise notice 'protest2';
+END;
+/
+
+CALL protest2();
+
+DROP PROCEDURE  protest2;
+DROP PROCEDURE  protest;
+
+-- schema.procedure
+CREATE SCHEMA stest;
+CREATE OR REPLACE PROCEDURE stest.protest 
+AS 
+BEGIN 
+raise notice 'stest.protest';
+END;
+/
+
+-- function
+CREATE OR REPLACE FUNCTION functest2()
+RETURN INT4
+AS 
+BEGIN
+stest.protest();  -- No need to write "CALL" anymore.
+raise notice 'functest2';
+RETURN 25;
+END;
+/
+
+SELECT functest2();
+DROP FUNCTION functest2;
+
+-- procedure
+CREATE OR REPLACE PROCEDURE protest2
+AS
+BEGIN 
+stest.protest();          -- No need to write "CALL" anymore.
+raise notice 'protest2';
+END;
+/
+
+CALL protest2();
+
+DROP PROCEDURE  protest2;
+DROP PROCEDURE  stest.protest;

--- a/src/pl/plisql/src/expected/plisql_call.out
+++ b/src/pl/plisql/src/expected/plisql_call.out
@@ -44,8 +44,8 @@ CREATE PROCEDURE test_proc4(y int)
 LANGUAGE plisql
 AS $$
 BEGIN
-    CALL test_proc3(y);
-    CALL test_proc3($1);
+     test_proc3(y);
+     test_proc3($1);
 END;
 $$;
 /
@@ -104,9 +104,9 @@ DECLARE
     x int := 3;
     y int := 4;
 BEGIN
-    CALL test_proc6(2, x, y);
+     test_proc6(2, x, y);
     RAISE INFO 'x = %, y = %', x, y;
-    CALL test_proc6(2, c => y, b => x);
+     test_proc6(2, c => y, b => x);
     RAISE INFO 'x = %, y = %', x, y;
 END;
 $$;
@@ -119,7 +119,7 @@ DECLARE
     x int := 3;
     y int := 4;
 BEGIN
-    CALL test_proc6(2, x + 1, y);  -- error
+     test_proc6(2, x + 1, y);  -- error
     RAISE INFO 'x = %, y = %', x, y;
 END;
 $$;
@@ -132,7 +132,7 @@ DECLARE
     x constant int := 3;
     y int := 4;
 BEGIN
-    CALL test_proc6(2, x, y);  -- error because x is constant
+     test_proc6(2, x, y);  -- error because x is constant
 END;
 $$;
 ERROR:  variable "x" is declared CONSTANT
@@ -163,7 +163,7 @@ BEGIN
 IF x > 1 THEN
     a := x / 10;
     b := x / 2;
-    CALL test_proc7(b::int, a, b);
+     test_proc7(b::int, a, b);
 END IF;
 END;
 $$;
@@ -190,7 +190,7 @@ LANGUAGE plisql
 AS $$
 DECLARE _a int; _b numeric;
 BEGIN
-  CALL test_proc7c(_x, _a, _b);
+   test_proc7c(_x, _a, _b);
   RAISE NOTICE '_x: %,_a: %, _b: %', _x, _a, _b;
 END
 $$;
@@ -229,9 +229,9 @@ DO $$
 DECLARE _a int; _b int;
 BEGIN
   _a := 10; _b := 30;
-  CALL test_proc8a(_a, _b);
+   test_proc8a(_a, _b);
   RAISE NOTICE '_a: %, _b: %', _a, _b;
-  CALL test_proc8a(b => _b, a => _a);
+   test_proc8a(b => _b, a => _a);
   RAISE NOTICE '_a: %, _b: %', _a, _b;
 END
 $$;
@@ -254,9 +254,9 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8b(_a, _b, _c);
+   test_proc8b(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
-  CALL test_proc8b(_a, c => _c, b => _b);
+   test_proc8b(_a, c => _c, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -279,13 +279,13 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, _b, _c);
+   test_proc8c(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, c => _c, b => _b);
+   test_proc8c(_a, c => _c, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(c => _c, b => _b, a => _a);
+   test_proc8c(c => _c, b => _b, a => _a);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -299,7 +299,7 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, _b);  -- fail, no output argument for c
+   test_proc8c(_a, _b);  -- fail, no output argument for c
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -309,7 +309,7 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, b => _b);  -- fail, no output argument for c
+   test_proc8c(_a, b => _b);  -- fail, no output argument for c
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -329,7 +329,7 @@ DO $$
 DECLARE _a int; _b int;
 BEGIN
   _a := 10; _b := 30;
-  CALL test_proc9(_a, _b);
+   test_proc9(_a, _b);
   RAISE NOTICE '_a: %, _b: %', _a, _b;
 END
 $$;
@@ -348,31 +348,31 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, _b, _c);
+   test_proc10(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, _b, c => _c);
+   test_proc10(_a, _b, c => _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(a => _a, b => _b, c => _c);
+   test_proc10(a => _a, b => _b, c => _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, c => _c, b => _b);
+   test_proc10(_a, c => _c, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, _b);
+   test_proc10(_a, _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, b => _b);
+   test_proc10(_a, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(b => _b, a => _a);
+   test_proc10(b => _b, a => _a);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -404,7 +404,7 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc11(_a, _b, _c);
+   test_proc11(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -418,7 +418,7 @@ AS $$
 DECLARE
     z int := 0;
 BEGIN
-    CALL test_proc6(2, NEW.a, NEW.a);
+     test_proc6(2, NEW.a, NEW.a);
     RETURN NEW;
 END;
 $$;
@@ -451,7 +451,7 @@ DECLARE
   v_Text text;
   v_cnt  integer := 42;
 BEGIN
-  CALL p1(v_cnt := v_cnt);  -- error, must supply something for v_Text
+   p1(v_cnt := v_cnt);  -- error, must supply something for v_Text
   RAISE NOTICE '%', v_Text;
 END;
 $$;
@@ -462,7 +462,7 @@ DECLARE
   v_Text text;
   v_cnt  integer := 42;
 BEGIN
-  CALL p1(v_cnt := v_cnt, v_Text := v_Text);
+   p1(v_cnt := v_cnt, v_Text := v_Text);
   RAISE NOTICE '%', v_Text;
 END;
 $$;
@@ -471,7 +471,7 @@ DO $$
 DECLARE
   v_Text text;
 BEGIN
-  CALL p1(10, v_Text := v_Text);
+   p1(10, v_Text := v_Text);
   RAISE NOTICE '%', v_Text;
 END;
 $$;
@@ -481,7 +481,7 @@ DECLARE
   v_Text text;
   v_cnt  integer;
 BEGIN
-  CALL p1(v_Text := v_Text, v_cnt := v_cnt);
+   p1(v_Text := v_Text, v_cnt := v_cnt);
   RAISE NOTICE '%', v_Text;
 END;
 $$;

--- a/src/pl/plisql/src/expected/plisql_nested_subproc.out
+++ b/src/pl/plisql/src/expected/plisql_nested_subproc.out
@@ -443,8 +443,8 @@ declare
   end;
 begin
      name := 'xiexie';
-     call test(23);
-     call test(name);
+     test(23);
+     test(name);
 end;$$ language plisql;
 INFO:  23
 INFO:  xiexie
@@ -914,14 +914,14 @@ declare
    begin
         raise info 'test out name=%', name;
         name1 := 'must be assign to null';
-	call test_out(id, name1);
+	test_out(id, name1);
 	raise info 'name1=%', name1;
 	name := 'return to declare';
    end;
 begin
     name := 'must be assign to null';
     id := 1;
-    call test_out(id, name);
+    test_out(id, name);
     raise info 'declare name=%', name;
  end; $$ language plisql;
 INFO:  test out name=must be assign to null
@@ -1618,7 +1618,7 @@ do $$
 declare
   id integer;
 begin
-  call test_mds(23);
+  test_mds(23);
 end; $$ language plisql;
 INFO:  23
 drop procedure test_mds(integer);
@@ -1643,7 +1643,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 INFO:  test_subprocproc
@@ -1670,7 +1670,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end; $$ language plisql;
@@ -1700,7 +1700,7 @@ do $$
 	end;
 BEGIN
   var1 := 23;
-  call test_f(var1);
+  test_f(var1);
 END; $$ language plisql;
 ERROR:  Only schema-level programs allow ACCESSIBLE BY at or near ")"
 LINE 6:  TYPE PACKAGE,PACAGE);
@@ -1727,7 +1727,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 /
@@ -1736,7 +1736,7 @@ do $$
 declare
   id integer;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end; $$ language plisql;
 INFO:  test_subprocproc
 INFO:  test_subprocfunc
@@ -1778,7 +1778,7 @@ begin
 --print 45 55 10000
 do $$
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end; $$ language plisql;
 INFO:  45
 INFO:  55
@@ -1886,7 +1886,7 @@ declare
 begin
     ret := SQUARE();
     raise info 'ret=%', ret;
-    call test_nopar();
+    test_nopar();
 end; $$ language plisql;
 INFO:  function no par
 INFO:  ret=100
@@ -2058,13 +2058,13 @@ DECLARE
   -- Declare and define proc2:
   PROCEDURE proc2(number2 NUMBER) IS
   BEGIN
-    call proc1(number2);
+    proc1(number2);
   END;
 
   -- Define proc 1:
   PROCEDURE proc1(number1 NUMBER) IS
   BEGIN
-    call proc2 (number1);
+    proc2 (number1);
   END;
 BEGIN
   NULL;
@@ -2077,7 +2077,7 @@ DECLARE
 
 	PROCEDURE proc2(number2 NUMBER) IS
 	BEGIN
-		call proc1(number2);
+		proc1(number2);
 		raise info '%', number2;
 		raise info '%','proc2';
 	END;
@@ -2085,7 +2085,7 @@ DECLARE
 	PROCEDURE proc4(number2 NUMBER) IS
 	BEGIN
 		raise info '%','proc4';
-		call proc3(number2);
+		proc3(number2);
 		raise info 'proc3 out %', number2;
 	END;
 
@@ -2102,8 +2102,8 @@ DECLARE
 	END;
 
 BEGIN
-	call proc2(1);
-	call proc4(2);
+	proc2(1);
+	proc4(2);
 END; $$ language plisql;
 INFO:  proc1
 INFO:  1
@@ -2833,7 +2833,7 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(23);
+  test_f(23);
 end; $$ language plisql;
 INFO:  function test_f
 INFO:  procedure test_f
@@ -2846,7 +2846,7 @@ declare
     raise info 'invoke test_f';
   end;
 begin
-  call test_f();
+  test_f();
 end; $$ language plisql;
 INFO:  invoke test_f
 --test pipelined failed
@@ -2887,7 +2887,7 @@ declare
     raise info '%',id;
   end;
 begin
-  call test_f(var1);
+  test_f(var1);
 end; $$ language plisql;
 ERROR:  Only schema-level programs allow ACCESSIBLE BY at or near ")"
 LINE 4: ...teger) accessible by ( package test_pkg,function test_func);
@@ -2902,7 +2902,7 @@ declare
     raise info '%', id;
   end;
 begin
-  call test_p(var1);
+  test_p(var1);
 end; $$ language plisql;
 ERROR:  Only schema-level programs allow AUTHID at or near "definer"
 LINE 4:   procedure test_p(id integer) authid definer;
@@ -2926,7 +2926,7 @@ declare
   end;
 begin
   var3 := 25;
-  call test_p(24);
+  test_p(24);
 end; $$ language plisql;
 INFO:  id = 24
 INFO:  welcome to beijing:25
@@ -2986,20 +2986,20 @@ declare
     return 23;
   end;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end; $$ language plisql;
 ERROR:  'test_func1' is not a procedure
-LINE 1: call test_func1(var1)
+LINE 1: CALL test_func1(var1)
              ^
 HINT:  To call a function, use SELECT.
-QUERY:  call test_func1(var1)
+QUERY:  CALL test_func1(var1)
 CONTEXT:  PL/iSQL function inline_code_block line 9 at CALL
 --sucess
 do $$
 declare
   var1 integer;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end; $$ language plisql;
 INFO:  id = <NULL>
 --raise error function keyword not as datum name
@@ -3262,7 +3262,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 INFO:  test_subprocproc
@@ -3289,7 +3289,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end; $$ language plisql;
@@ -3324,7 +3324,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 /
@@ -3333,7 +3333,7 @@ do $$
 declare
   id integer;
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end;$$ language plisql;
 INFO:  test_subprocproc
 INFO:  test_subprocfunc
@@ -3411,7 +3411,7 @@ end; $$ language plisql;
 --print 45 55 10000
 do $$
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end; $$ language plisql;
 INFO:  45
 INFO:  55
@@ -3912,9 +3912,9 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(24);
+  test_f(24);
   var1 := test_f(23,'xiexie');
-  call test_f(24,'xiexie');
+  test_f(24,'xiexie');
 end; $$ language plisql;
 INFO:  invoke func test_f(integer)
 INFO:  invoke proc test_f(integer)

--- a/src/pl/plisql/src/expected/plisql_nested_subproc2.out
+++ b/src/pl/plisql/src/expected/plisql_nested_subproc2.out
@@ -441,8 +441,8 @@ declare
   end;
 begin
      name := 'xiexie';
-     call test(23);
-     call test(name);
+     test(23);
+     test(name);
 end;
 /
 INFO:  23
@@ -887,14 +887,14 @@ declare
    begin
         raise info 'test out name=%', name;
         name1 := 'must be assign to null';
-	call test_out(id, name1);
+	test_out(id, name1);
 	raise info 'name1=%', name1;
 	name := 'return to declare';
    end;
 begin
     name := 'must be assign to null';
     id := 1;
-    call test_out(id, name);
+    test_out(id, name);
     raise info 'declare name=%', name;
  end;
  /
@@ -1540,7 +1540,7 @@ end;
 declare
   id integer;
 begin
-  call test_mds(23);
+  test_mds(23);
 end;
 /
 INFO:  23
@@ -1563,7 +1563,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -1587,7 +1587,7 @@ as
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end;
@@ -1616,7 +1616,7 @@ INFO:  test_subprocfunc
 	end;
 BEGIN
   var1 := 23;
-  call test_f(var1);
+  test_f(var1);
 END;
 /
 ERROR:  Only schema-level programs allow ACCESSIBLE BY at or near ")"
@@ -1635,7 +1635,7 @@ QUERY:  DECLARE
 	end;
 BEGIN
   var1 := 23;
-  call test_f(var1);
+  test_f(var1);
 END
 --test ok
 create or replace procedure test_subprocproc(id integer)
@@ -1655,7 +1655,7 @@ AS
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -1663,7 +1663,7 @@ end;
 declare
   id integer;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end;
 /
 INFO:  test_subprocproc
@@ -1701,7 +1701,7 @@ begin
 /
 --print 45 55 10000
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end;
 /
 INFO:  45
@@ -1806,7 +1806,7 @@ declare
 begin
     ret := SQUARE();
     raise info 'ret=%', ret;
-    call test_nopar();
+    test_nopar();
 end;
 /
 INFO:  function no par
@@ -2001,12 +2001,12 @@ DECLARE
   -- Declare and define proc2:
   PROCEDURE proc2(number2 NUMBER) IS
   BEGIN
-    call proc1(number2);
+    proc1(number2);
   END;
   -- Define proc 1:
   PROCEDURE proc1(number1 NUMBER) IS
   BEGIN
-    call proc2 (number1);
+    proc2 (number1);
   END;
 BEGIN
   NULL;
@@ -2018,14 +2018,14 @@ DECLARE
 	PROCEDURE proc3(number1 out NUMBER);
 	PROCEDURE proc2(number2 NUMBER) IS
 	BEGIN
-		call proc1(number2);
+		proc1(number2);
 		raise info '%', number2;
 		raise info '%','proc2';
 	END;
 	PROCEDURE proc4(number2 NUMBER) IS
 	BEGIN
 		raise info '%','proc4';
-		call proc3(number2);
+		proc3(number2);
 		raise info 'proc3 out %', number2;
 	END;
 	PROCEDURE proc1(number1 out NUMBER) IS
@@ -2039,8 +2039,8 @@ DECLARE
 		number1 := 1;
 	END;
 BEGIN
-	call proc2(1);
-	call proc4(2);
+	proc2(1);
+	proc4(2);
 END;
 /
 INFO:  proc1
@@ -2823,7 +2823,7 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(23);
+  test_f(23);
 end;
 /
 INFO:  function test_f
@@ -2836,7 +2836,7 @@ declare
     raise info 'invoke test_f';
   end;
 begin
-  call test_f();
+  test_f();
 end;
 /
 INFO:  invoke test_f
@@ -2877,7 +2877,7 @@ declare
     raise info '%',id;
   end;
 begin
-  call test_f(var1);
+  test_f(var1);
 end;
 /
 ERROR:  Only schema-level programs allow ACCESSIBLE BY at or near ")"
@@ -2891,7 +2891,7 @@ QUERY:  declare
     raise info '%',id;
   end;
 begin
-  call test_f(var1);
+  test_f(var1);
 end
 --test invoker_rights_clause failed
 declare
@@ -2902,7 +2902,7 @@ declare
     raise info '%', id;
   end;
 begin
-  call test_p(var1);
+  test_p(var1);
 end;
 /
 ERROR:  Only schema-level programs allow AUTHID at or near "definer"
@@ -2916,7 +2916,7 @@ QUERY:  declare
     raise info '%', id;
   end;
 begin
-  call test_p(var1);
+  test_p(var1);
 end
 --oracle failed, but we sucess
 declare
@@ -2936,7 +2936,7 @@ declare
   end;
 begin
   var3 := 25;
-  call test_p(24);
+  test_p(24);
 end;
 /
 INFO:  id = 24
@@ -2991,20 +2991,20 @@ declare
     return 23;
   end;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end;
 /
 ERROR:  'test_func1' is not a procedure
-LINE 1: call test_func1(var1)
+LINE 1: CALL test_func1(var1)
              ^
 HINT:  To call a function, use SELECT.
-QUERY:  call test_func1(var1)
+QUERY:  CALL test_func1(var1)
 CONTEXT:  PL/iSQL function inline_code_block line 8 at CALL
 --sucess
 declare
   var1 integer;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end;
 /
 INFO:  id = <NULL>
@@ -3294,7 +3294,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -3318,7 +3318,7 @@ as
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end;
@@ -3350,7 +3350,7 @@ AS
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -3358,7 +3358,7 @@ end;
 declare
   id integer;
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end;
 /
 INFO:  test_subprocproc
@@ -3430,7 +3430,7 @@ end;
 /
 --print 45 55 10000
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end;
 /
 INFO:  45
@@ -3918,9 +3918,9 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(24);
+  test_f(24);
   var1 := test_f(23,'xiexie');
-  call test_f(24,'xiexie');
+  test_f(24,'xiexie');
 end;
 /
 INFO:  invoke func test_f(integer)
@@ -3973,15 +3973,12 @@ begin
   dbms_output.put_line('xiexie');
 end;
 /
-ERROR:  syntax error at or near "dbms_output"
-LINE 5:   dbms_output.put_line('xiexie');
-          ^
-QUERY:  declare
-  var1 integer;
-begin
-  var1 := test.test_f(23);
-  dbms_output.put_line('xiexie');
-end
+INFO:  var1 = 2
+ERROR:  schema "dbms_output" does not exist
+LINE 1: CALL dbms_output.put_line('xiexie')
+             ^
+QUERY:  CALL dbms_output.put_line('xiexie')
+CONTEXT:  PL/iSQL function inline_code_block line 5 at CALL
 create or replace function test.test_f(id integer) return integer is
   var1 integer;
   function test_f(id integer) return integer;

--- a/src/pl/plisql/src/expected/plisql_transaction.out
+++ b/src/pl/plisql/src/expected/plisql_transaction.out
@@ -89,7 +89,7 @@ CREATE FUNCTION transaction_test3() RETURNS int
 LANGUAGE plisql
 AS $$
 BEGIN
-    CALL transaction_test1(9, 'error');
+    transaction_test1(9, 'error');
     RETURN 1;
 END;
 $$;
@@ -151,7 +151,7 @@ CREATE PROCEDURE transaction_test6(c text)
 LANGUAGE plisql
 AS $$
 BEGIN
-    CALL transaction_test1(9, c);
+    transaction_test1(9, c);
 END;
 $$;
 /
@@ -170,7 +170,7 @@ CREATE PROCEDURE transaction_test7()
 LANGUAGE plisql
 AS $$
 BEGIN
-    DO 'BEGIN CALL transaction_test1(9, $x$baz$x$); END;';
+    DO 'BEGIN transaction_test1(9, $x$baz$x$); END;';
 END;
 $$;
 /
@@ -179,7 +179,7 @@ ERROR:  invalid transaction termination
 CONTEXT:  PL/iSQL function transaction_test1(pg_catalog.int4,text) line 6 at COMMIT
 SQL statement "CALL transaction_test1(9, $x$baz$x$)"
 PL/iSQL function inline_code_block line 1 at CALL
-SQL statement "DO 'BEGIN CALL transaction_test1(9, $x$baz$x$); END;'"
+SQL statement "DO 'BEGIN transaction_test1(9, $x$baz$x$); END;'"
 PL/iSQL function transaction_test7() line 3 at DO
 SELECT * FROM test1;
  a | b 
@@ -629,7 +629,7 @@ $$;
 DO LANGUAGE plisql $$
 BEGIN
   ROLLBACK;
-  CALL transaction_test9();
+  transaction_test9();
 END
 $$;
 SELECT * FROM test2;
@@ -654,9 +654,9 @@ $$;
 /
 DO $$
 BEGIN
-    CALL transaction_test9b(report_count());
+    transaction_test9b(report_count());
     INSERT INTO test2 VALUES(43);
-    CALL transaction_test9b(report_count());
+    transaction_test9b(report_count());
 END
 $$;
 NOTICE:  count = 1

--- a/src/pl/plisql/src/sql/plisql_call.sql
+++ b/src/pl/plisql/src/sql/plisql_call.sql
@@ -48,8 +48,8 @@ CREATE PROCEDURE test_proc4(y int)
 LANGUAGE plisql
 AS $$
 BEGIN
-    CALL test_proc3(y);
-    CALL test_proc3($1);
+     test_proc3(y);
+     test_proc3($1);
 END;
 $$;
 /
@@ -97,9 +97,9 @@ DECLARE
     x int := 3;
     y int := 4;
 BEGIN
-    CALL test_proc6(2, x, y);
+     test_proc6(2, x, y);
     RAISE INFO 'x = %, y = %', x, y;
-    CALL test_proc6(2, c => y, b => x);
+     test_proc6(2, c => y, b => x);
     RAISE INFO 'x = %, y = %', x, y;
 END;
 $$;
@@ -112,7 +112,7 @@ DECLARE
     x int := 3;
     y int := 4;
 BEGIN
-    CALL test_proc6(2, x + 1, y);  -- error
+     test_proc6(2, x + 1, y);  -- error
     RAISE INFO 'x = %, y = %', x, y;
 END;
 $$;
@@ -125,7 +125,7 @@ DECLARE
     x constant int := 3;
     y int := 4;
 BEGIN
-    CALL test_proc6(2, x, y);  -- error because x is constant
+     test_proc6(2, x, y);  -- error because x is constant
 END;
 $$;
 
@@ -154,7 +154,7 @@ BEGIN
 IF x > 1 THEN
     a := x / 10;
     b := x / 2;
-    CALL test_proc7(b::int, a, b);
+     test_proc7(b::int, a, b);
 END IF;
 END;
 $$;
@@ -180,7 +180,7 @@ LANGUAGE plisql
 AS $$
 DECLARE _a int; _b numeric;
 BEGIN
-  CALL test_proc7c(_x, _a, _b);
+   test_proc7c(_x, _a, _b);
   RAISE NOTICE '_x: %,_a: %, _b: %', _x, _a, _b;
 END
 $$;
@@ -209,9 +209,9 @@ DO $$
 DECLARE _a int; _b int;
 BEGIN
   _a := 10; _b := 30;
-  CALL test_proc8a(_a, _b);
+   test_proc8a(_a, _b);
   RAISE NOTICE '_a: %, _b: %', _a, _b;
-  CALL test_proc8a(b => _b, a => _a);
+   test_proc8a(b => _b, a => _a);
   RAISE NOTICE '_a: %, _b: %', _a, _b;
 END
 $$;
@@ -233,9 +233,9 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8b(_a, _b, _c);
+   test_proc8b(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
-  CALL test_proc8b(_a, c => _c, b => _b);
+   test_proc8b(_a, c => _c, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -257,22 +257,13 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, _b, _c);
+   test_proc8c(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, c => _c, b => _b);
+   test_proc8c(_a, c => _c, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(c => _c, b => _b, a => _a);
-  RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
-END
-$$;
-
-DO $$
-DECLARE _a int; _b int; _c int;
-BEGIN
-  _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, _b);  -- fail, no output argument for c
+   test_proc8c(c => _c, b => _b, a => _a);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -281,7 +272,16 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 50;
-  CALL test_proc8c(_a, b => _b);  -- fail, no output argument for c
+   test_proc8c(_a, _b);  -- fail, no output argument for c
+  RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
+END
+$$;
+
+DO $$
+DECLARE _a int; _b int; _c int;
+BEGIN
+  _a := 10; _b := 30; _c := 50;
+   test_proc8c(_a, b => _b);  -- fail, no output argument for c
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -303,7 +303,7 @@ DO $$
 DECLARE _a int; _b int;
 BEGIN
   _a := 10; _b := 30;
-  CALL test_proc9(_a, _b);
+   test_proc9(_a, _b);
   RAISE NOTICE '_a: %, _b: %', _a, _b;
 END
 $$;
@@ -322,31 +322,31 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, _b, _c);
+   test_proc10(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, _b, c => _c);
+   test_proc10(_a, _b, c => _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(a => _a, b => _b, c => _c);
+   test_proc10(a => _a, b => _b, c => _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, c => _c, b => _b);
+   test_proc10(_a, c => _c, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, _b);
+   test_proc10(_a, _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(_a, b => _b);
+   test_proc10(_a, b => _b);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc10(b => _b, a => _a);
+   test_proc10(b => _b, a => _a);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -367,7 +367,7 @@ DO $$
 DECLARE _a int; _b int; _c int;
 BEGIN
   _a := 10; _b := 30; _c := 7;
-  CALL test_proc11(_a, _b, _c);
+   test_proc11(_a, _b, _c);
   RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;
 END
 $$;
@@ -383,7 +383,7 @@ AS $$
 DECLARE
     z int := 0;
 BEGIN
-    CALL test_proc6(2, NEW.a, NEW.a);
+     test_proc6(2, NEW.a, NEW.a);
     RETURN NEW;
 END;
 $$;
@@ -420,7 +420,7 @@ DECLARE
   v_Text text;
   v_cnt  integer := 42;
 BEGIN
-  CALL p1(v_cnt := v_cnt);  -- error, must supply something for v_Text
+   p1(v_cnt := v_cnt);  -- error, must supply something for v_Text
   RAISE NOTICE '%', v_Text;
 END;
 $$;
@@ -430,7 +430,7 @@ DECLARE
   v_Text text;
   v_cnt  integer := 42;
 BEGIN
-  CALL p1(v_cnt := v_cnt, v_Text := v_Text);
+   p1(v_cnt := v_cnt, v_Text := v_Text);
   RAISE NOTICE '%', v_Text;
 END;
 $$;
@@ -439,7 +439,7 @@ DO $$
 DECLARE
   v_Text text;
 BEGIN
-  CALL p1(10, v_Text := v_Text);
+   p1(10, v_Text := v_Text);
   RAISE NOTICE '%', v_Text;
 END;
 $$;
@@ -449,7 +449,7 @@ DECLARE
   v_Text text;
   v_cnt  integer;
 BEGIN
-  CALL p1(v_Text := v_Text, v_cnt := v_cnt);
+   p1(v_Text := v_Text, v_cnt := v_cnt);
   RAISE NOTICE '%', v_Text;
 END;
 $$;

--- a/src/pl/plisql/src/sql/plisql_nested_subproc.sql
+++ b/src/pl/plisql/src/sql/plisql_nested_subproc.sql
@@ -410,8 +410,8 @@ declare
   end;
 begin
      name := 'xiexie';
-     call test(23);
-     call test(name);
+     test(23);
+     test(name);
 end;$$ language plisql;
 
 -- test subproc function'argument has default value
@@ -851,14 +851,14 @@ declare
    begin
         raise info 'test out name=%', name;
         name1 := 'must be assign to null';
-	call test_out(id, name1);
+	test_out(id, name1);
 	raise info 'name1=%', name1;
 	name := 'return to declare';
    end;
 begin
     name := 'must be assign to null';
     id := 1;
-    call test_out(id, name);
+    test_out(id, name);
     raise info 'declare name=%', name;
  end; $$ language plisql;
 
@@ -1549,7 +1549,7 @@ do $$
 declare
   id integer;
 begin
-  call test_mds(23);
+  test_mds(23);
 end; $$ language plisql;
 
 drop procedure test_mds(integer);
@@ -1576,7 +1576,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 
@@ -1602,7 +1602,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end; $$ language plisql;
@@ -1632,7 +1632,7 @@ do $$
 	end;
 BEGIN
   var1 := 23;
-  call test_f(var1);
+  test_f(var1);
 END; $$ language plisql;
 
 --test ok
@@ -1657,7 +1657,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 /
@@ -1667,7 +1667,7 @@ do $$
 declare
   id integer;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end; $$ language plisql;
 
 
@@ -1710,7 +1710,7 @@ begin
 --print 45 55 10000
 do $$
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end; $$ language plisql;
 
 drop procedure test_subprocproc(integer);
@@ -1812,7 +1812,7 @@ declare
 begin
     ret := SQUARE();
     raise info 'ret=%', ret;
-    call test_nopar();
+    test_nopar();
 end; $$ language plisql;
 
 --check nocopy proper
@@ -1970,13 +1970,13 @@ DECLARE
   -- Declare and define proc2:
   PROCEDURE proc2(number2 NUMBER) IS
   BEGIN
-    call proc1(number2);
+    proc1(number2);
   END;
 
   -- Define proc 1:
   PROCEDURE proc1(number1 NUMBER) IS
   BEGIN
-    call proc2 (number1);
+    proc2 (number1);
   END;
 BEGIN
   NULL;
@@ -1990,7 +1990,7 @@ DECLARE
 
 	PROCEDURE proc2(number2 NUMBER) IS
 	BEGIN
-		call proc1(number2);
+		proc1(number2);
 		raise info '%', number2;
 		raise info '%','proc2';
 	END;
@@ -1998,7 +1998,7 @@ DECLARE
 	PROCEDURE proc4(number2 NUMBER) IS
 	BEGIN
 		raise info '%','proc4';
-		call proc3(number2);
+		proc3(number2);
 		raise info 'proc3 out %', number2;
 	END;
 
@@ -2015,8 +2015,8 @@ DECLARE
 	END;
 
 BEGIN
-	call proc2(1);
-	call proc4(2);
+	proc2(1);
+	proc4(2);
 END; $$ language plisql;
 
 --
@@ -2702,7 +2702,7 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(23);
+  test_f(23);
 end; $$ language plisql;
 
 --ok
@@ -2714,7 +2714,7 @@ declare
     raise info 'invoke test_f';
   end;
 begin
-  call test_f();
+  test_f();
 end; $$ language plisql;
 
 
@@ -2754,7 +2754,7 @@ declare
     raise info '%',id;
   end;
 begin
-  call test_f(var1);
+  test_f(var1);
 end; $$ language plisql;
 
 --test invoker_rights_clause failed
@@ -2767,7 +2767,7 @@ declare
     raise info '%', id;
   end;
 begin
-  call test_p(var1);
+  test_p(var1);
 end; $$ language plisql;
 
 --oracle failed, but we sucess
@@ -2789,7 +2789,7 @@ declare
   end;
 begin
   var3 := 25;
-  call test_p(24);
+  test_p(24);
 end; $$ language plisql;
 
 
@@ -2848,7 +2848,7 @@ declare
     return 23;
   end;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end; $$ language plisql;
 
 --sucess
@@ -2856,7 +2856,7 @@ do $$
 declare
   var1 integer;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end; $$ language plisql;
 
 --raise error function keyword not as datum name
@@ -3117,7 +3117,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 
@@ -3143,7 +3143,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end; $$ language plisql;
@@ -3178,7 +3178,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end; $$ language plisql;
 /
@@ -3188,7 +3188,7 @@ do $$
 declare
   id integer;
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end;$$ language plisql;
 
 DROP PROCEDURE test_subprocproc(integer);
@@ -3265,7 +3265,7 @@ end; $$ language plisql;
 --print 45 55 10000
 do $$
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end; $$ language plisql;
 
 DROP PROCEDURE test_subprocproc(integer);
@@ -3739,9 +3739,9 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(24);
+  test_f(24);
   var1 := test_f(23,'xiexie');
-  call test_f(24,'xiexie');
+  test_f(24,'xiexie');
 end; $$ language plisql;
 
 --test memory

--- a/src/pl/plisql/src/sql/plisql_nested_subproc2.sql
+++ b/src/pl/plisql/src/sql/plisql_nested_subproc2.sql
@@ -392,8 +392,8 @@ declare
   end;
 begin
      name := 'xiexie';
-     call test(23);
-     call test(name);
+     test(23);
+     test(name);
 end;
 /
 
@@ -808,14 +808,14 @@ declare
    begin
         raise info 'test out name=%', name;
         name1 := 'must be assign to null';
-	call test_out(id, name1);
+	test_out(id, name1);
 	raise info 'name1=%', name1;
 	name := 'return to declare';
    end;
 begin
     name := 'must be assign to null';
     id := 1;
-    call test_out(id, name);
+    test_out(id, name);
     raise info 'declare name=%', name;
  end;
  /
@@ -1441,7 +1441,7 @@ end;
 declare
   id integer;
 begin
-  call test_mds(23);
+  test_mds(23);
 end;
 /
 
@@ -1466,7 +1466,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -1489,7 +1489,7 @@ as
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end;
@@ -1518,7 +1518,7 @@ end;
 	end;
 BEGIN
   var1 := 23;
-  call test_f(var1);
+  test_f(var1);
 END;
 /
 
@@ -1540,7 +1540,7 @@ AS
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -1549,7 +1549,7 @@ end;
 declare
   id integer;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end;
 /
 
@@ -1588,7 +1588,7 @@ begin
 
 --print 45 55 10000
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end;
 /
 
@@ -1687,7 +1687,7 @@ declare
 begin
     ret := SQUARE();
     raise info 'ret=%', ret;
-    call test_nopar();
+    test_nopar();
 end;
 /
 
@@ -1838,13 +1838,13 @@ DECLARE
   -- Declare and define proc2:
   PROCEDURE proc2(number2 NUMBER) IS
   BEGIN
-    call proc1(number2);
+    proc1(number2);
   END;
 
   -- Define proc 1:
   PROCEDURE proc1(number1 NUMBER) IS
   BEGIN
-    call proc2 (number1);
+    proc2 (number1);
   END;
 BEGIN
   NULL;
@@ -1858,7 +1858,7 @@ DECLARE
 
 	PROCEDURE proc2(number2 NUMBER) IS
 	BEGIN
-		call proc1(number2);
+		proc1(number2);
 		raise info '%', number2;
 		raise info '%','proc2';
 	END;
@@ -1866,7 +1866,7 @@ DECLARE
 	PROCEDURE proc4(number2 NUMBER) IS
 	BEGIN
 		raise info '%','proc4';
-		call proc3(number2);
+		proc3(number2);
 		raise info 'proc3 out %', number2;
 	END;
 
@@ -1883,8 +1883,8 @@ DECLARE
 	END;
 
 BEGIN
-	call proc2(1);
-	call proc4(2);
+	proc2(1);
+	proc4(2);
 END;
 /
 
@@ -2558,7 +2558,7 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(23);
+  test_f(23);
 end;
 /
 
@@ -2570,7 +2570,7 @@ declare
     raise info 'invoke test_f';
   end;
 begin
-  call test_f();
+  test_f();
 end;
 /
 
@@ -2610,7 +2610,7 @@ declare
     raise info '%',id;
   end;
 begin
-  call test_f(var1);
+  test_f(var1);
 end;
 /
 
@@ -2623,7 +2623,7 @@ declare
     raise info '%', id;
   end;
 begin
-  call test_p(var1);
+  test_p(var1);
 end;
 /
 
@@ -2645,7 +2645,7 @@ declare
   end;
 begin
   var3 := 25;
-  call test_p(24);
+  test_p(24);
 end;
 /
 
@@ -2699,7 +2699,7 @@ declare
     return 23;
   end;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end;
 /
 
@@ -2707,7 +2707,7 @@ end;
 declare
   var1 integer;
 begin
-   call test_func1(var1);
+   test_func1(var1);
 end;
 /
 
@@ -2966,7 +2966,7 @@ declare
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -2989,7 +2989,7 @@ as
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
   return mds;
 end;
@@ -3021,7 +3021,7 @@ AS
      return id;
    end;
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
   mds := test_subprocfunc(23);
 end;
 /
@@ -3030,7 +3030,7 @@ end;
 declare
   id integer;
 begin
-   call test_subprocproc(23);
+   test_subprocproc(23);
 end;
 /
 
@@ -3101,7 +3101,7 @@ end;
 
 --print 45 55 10000
 begin
-  call test_subprocproc(23);
+  test_subprocproc(23);
 end;
 /
 
@@ -3562,9 +3562,9 @@ declare
   end;
 begin
   var1 := test_f(23);
-  call test_f(24);
+  test_f(24);
   var1 := test_f(23,'xiexie');
-  call test_f(24,'xiexie');
+  test_f(24,'xiexie');
 end;
 /
 

--- a/src/pl/plisql/src/sql/plisql_transaction.sql
+++ b/src/pl/plisql/src/sql/plisql_transaction.sql
@@ -82,7 +82,7 @@ CREATE FUNCTION transaction_test3() RETURNS int
 LANGUAGE plisql
 AS $$
 BEGIN
-    CALL transaction_test1(9, 'error');
+    transaction_test1(9, 'error');
     RETURN 1;
 END;
 $$;
@@ -142,7 +142,7 @@ CREATE PROCEDURE transaction_test6(c text)
 LANGUAGE plisql
 AS $$
 BEGIN
-    CALL transaction_test1(9, c);
+    transaction_test1(9, c);
 END;
 $$;
 /
@@ -157,7 +157,7 @@ CREATE PROCEDURE transaction_test7()
 LANGUAGE plisql
 AS $$
 BEGIN
-    DO 'BEGIN CALL transaction_test1(9, $x$baz$x$); END;';
+    DO 'BEGIN transaction_test1(9, $x$baz$x$); END;';
 END;
 $$;
 /
@@ -533,7 +533,7 @@ $$;
 DO LANGUAGE plisql $$
 BEGIN
   ROLLBACK;
-  CALL transaction_test9();
+  transaction_test9();
 END
 $$;
 
@@ -558,9 +558,9 @@ $$;
 
 DO $$
 BEGIN
-    CALL transaction_test9b(report_count());
+    transaction_test9b(report_count());
     INSERT INTO test2 VALUES(43);
-    CALL transaction_test9b(report_count());
+    transaction_test9b(report_count());
 END
 $$;
 


### PR DESCRIPTION
#537 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Removed the `CALL` keyword from procedure and function calls across multiple files, improving code readability and simplifying function invocation.
- New Feature: Added new procedures and functions `protest`, `functest`, `protest2`, `functest2`, and `stest.protest` in `ora_plisql.sql`.
- Refactor: Enhanced the PL/pgSQL parser's handling of `CALL` statements, introducing a new function `build_call_expr()` and modifying existing parsing rules and functions.
- Chore: Added `DROP` statements for procedures and functions in `ora_plisql.sql` to ensure clean removal when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->