### PR TITLE
IvorySQL: adjust sample file format

### DIFF
--- a/src/backend/utils/misc/ivorysql.conf.sample
+++ b/src/backend/utils/misc/ivorysql.conf.sample
@@ -10,4 +10,4 @@
 
 ivorysql.enable_emptystring_to_NULL = 'on'
 shared_preload_libraries = 'liboracle_parser, ivorysql_ora'		# (change requires restart)
-ivorysql.identifier_case_switch = interchange   				#set the case conversion mode.  range [normal,interchange,lowercase]
+ivorysql.identifier_case_switch = interchange				# set the case conversion mode. range [normal,interchange,lowercase]


### PR DESCRIPTION
adjust format, delete extra spaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Chores:
- Updated the `ivorysql.identifier_case_switch` parameter in the configuration file from its previous value to `interchange`. This change will affect the case conversion mode for identifiers. Please note that this change requires a system restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->