### PR TITLE
IvorySQL,backend: fix typo in error msg.

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5159,7 +5159,7 @@ InitIvorysql(void)
 			SetConfigOption("ivorysql.compatible_mode", "oracle", PGC_USERSET, PGC_S_OVERRIDE);
 			if (NULL == ora_raw_parser)
 				ereport(ERROR,
-						(errmsg("Invalid Oracle compatibility mdoe syntax library.")));
+						(errmsg("Invalid Oracle compatibility mode syntax library.")));
 		}
 	}
 


### PR DESCRIPTION
fix typo in error msg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in an error message related to Oracle compatibility mode syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->