### PR TITLE
enum value `config_group` and it's string name do not match

### DIFF
--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -772,11 +772,13 @@ const char *const config_group_names[] =
 	gettext_noop("Customized Options"),
 	/* DEVELOPER_OPTIONS */
 	gettext_noop("Developer Options"),
+	/* COMPAT_ORACLE_OPTIONS */
+	gettext_noop("Compat Oracle Options"),
 	/* help_config wants this array to be null-terminated */
 	NULL
 };
 
-StaticAssertDecl(lengthof(config_group_names) == (DEVELOPER_OPTIONS + 2),
+StaticAssertDecl(lengthof(config_group_names) == (COMPAT_ORACLE_OPTIONS + 2),
 				 "array length mismatch");
 
 /*


### PR DESCRIPTION
enum variable  **_config_group_** and string array **_config_group_names_** are in one-to-one correspondence，
so we need to add **_gettext_noop("Compat Oracle Options")_**  after adding _**COMPAT_ORACLE_OPTIONS**_,
further more, _**config_group_names**_ must end with **_NULL_**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration group "Compat Oracle Options" for enhanced database compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->