### PR TITLE
Add support for TO_MULTI_BYTE(), TO_SINGLE_BYTE(), ASCIISTR(), COMPOSE(), DECOMPOSE()

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3307,43 +3307,43 @@ select compose('a'||chr(768)) from dual;
 (1 row)
 
 -- Nested Composition and Decomposition 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('é'))) FROM DUAL;
+select asciistr(compose(decompose('é'))) from dual;
  asciistr 
 ----------
  \00E9
 (1 row)
 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('áéíóú'))) FROM DUAL;
+select asciistr(compose(decompose('áéíóú'))) from dual;
          asciistr          
 ---------------------------
  \00E1\00E9\00ED\00F3\00FA
 (1 row)
 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('àèìòù'))) FROM DUAL;
+select asciistr(compose(decompose('àèìòù'))) from dual;
          asciistr          
 ---------------------------
  \00E0\00E8\00EC\00F2\00F9
 (1 row)
 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('áèíóú'))) FROM DUAL;
+select asciistr(compose(decompose('áèíóú'))) from dual;
          asciistr          
 ---------------------------
  \00E1\00E8\00ED\00F3\00FA
 (1 row)
 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('hello'))) FROM DUAL;
+select asciistr(compose(decompose('hello'))) from dual;
  asciistr 
 ----------
  hello
 (1 row)
 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E9')))) FROM DUAL;
+select asciistr(compose(decompose(unistr('\00E9')))) from dual;
  asciistr 
 ----------
  \00E9
 (1 row)
 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E1\00E9\00ED\00F3\00FA')))) FROM DUAL;
+select asciistr(compose(decompose(unistr('\00E1\00E9\00ED\00F3\00FA')))) from dual;
          asciistr          
 ---------------------------
  \00E1\00E9\00ED\00F3\00FA

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3128,3 +3128,94 @@ select decode(null, null, 2018, 2, 3) from test_decode; --expect:all
 (4 rows)
 
 drop table test_decode;
+/*
+ * asciistr
+ */
+  
+ -- string with only ascii chars
+ select asciistr('Hello, World!') from dual;
+   asciistr    
+---------------
+ Hello, World!
+(1 row)
+
+ select asciistr('Hello\nWorld') from dual;
+     asciistr     
+------------------
+ Hello\005CnWorld
+(1 row)
+
+ select asciistr('') from dual;
+ asciistr 
+----------
+ 
+(1 row)
+
+ -- string with non-ascii chars
+ select asciistr('こんにちは') from dual;
+         asciistr          
+---------------------------
+ \3053\3093\306B\3061\306F
+(1 row)
+
+ select asciistr('你好') from dual;
+  asciistr  
+------------
+ \4F60\597D
+(1 row)
+
+ select asciistr('😊👍') from dual;
+       asciistr       
+----------------------
+ \D83D\DE0A\D83D\DC4D
+(1 row)
+
+ -- string with mixed ascii and non-ascii
+ select asciistr('ABÄCDE') from dual;
+  asciistr  
+------------
+ AB\00C4CDE
+(1 row)
+
+ select asciistr('ABCÄÊ') from dual;
+   asciistr    
+---------------
+ ABC\00C4\00CA
+(1 row)
+
+ select asciistr('ABCÕØ') from dual;
+   asciistr    
+---------------
+ ABC\00D5\00D8
+(1 row)
+
+ select asciistr('ABCÄÊÍÕØ') from dual;
+           asciistr           
+------------------------------
+ ABC\00C4\00CA\00CD\00D5\00D8
+(1 row)
+
+ select asciistr('Hello, こんにちは!') from dual;
+             asciistr              
+-----------------------------------
+ Hello, \3053\3093\306B\3061\306F!
+(1 row)
+
+ select asciistr('Café') from dual;
+ asciistr 
+----------
+ Caf\00E9
+(1 row)
+
+ select asciistr('Αλφάβητο') from dual;
+                 asciistr                 
+------------------------------------------
+ \0391\03BB\03C6\03AC\03B2\03B7\03C4\03BF
+(1 row)
+
+ select asciistr('Привет') from dual;
+            asciistr            
+--------------------------------
+ \041F\0440\0438\0432\0435\0442
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3219,3 +3219,133 @@ drop table test_decode;
  \041F\0440\0438\0432\0435\0442
 (1 row)
 
+/*
+ * compose & decompose
+ */
+select asciistr(decompose('é')) from dual;
+ asciistr 
+----------
+ e\0301
+(1 row)
+
+select asciistr(compose('e'||chr(769))) from dual;
+ asciistr 
+----------
+ \00E9
+(1 row)
+
+select asciistr(decompose('áéíóú')) from dual;
+            asciistr            
+--------------------------------
+ a\0301e\0301i\0301o\0301u\0301
+(1 row)
+
+select asciistr(compose('a'||chr(769)||'e'||chr(769)||'i'||chr(769)||'o'||chr(769)||'u'||chr(769))) from dual;
+         asciistr          
+---------------------------
+ \00E1\00E9\00ED\00F3\00FA
+(1 row)
+
+select asciistr(decompose('àèìòù')) from dual;
+            asciistr            
+--------------------------------
+ a\0300e\0300i\0300o\0300u\0300
+(1 row)
+
+select asciistr(compose('a'||chr(768)||'e'||chr(768)||'i'||chr(768)||'o'||chr(768)||'u'||chr(768))) from dual;
+         asciistr          
+---------------------------
+ \00E0\00E8\00EC\00F2\00F9
+(1 row)
+
+select asciistr(decompose('áèíóú')) from dual;
+            asciistr            
+--------------------------------
+ a\0301e\0300i\0301o\0301u\0301
+(1 row)
+
+select asciistr(compose('a'||chr(769)||'e'||chr(768)||'i'||chr(769)||'o'||chr(769)||'u'||chr(769))) from dual;
+         asciistr          
+---------------------------
+ \00E1\00E8\00ED\00F3\00FA
+(1 row)
+
+select asciistr(decompose('hello')) from dual;
+ asciistr 
+----------
+ hello
+(1 row)
+
+select asciistr(compose('hello')) from dual;
+ asciistr 
+----------
+ hello
+(1 row)
+
+select asciistr(compose(chr(101)||chr(769))) from dual;
+ asciistr 
+----------
+ \00E9
+(1 row)
+
+select asciistr(decompose('é')) from dual;
+ asciistr 
+----------
+ e\0301
+(1 row)
+
+select unistr('\00e9') from dual;
+ unistr 
+--------
+ é
+(1 row)
+
+select compose('a'||chr(768)) from dual;
+ compose 
+---------
+ à
+(1 row)
+
+-- Nested Composition and Decomposition 
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('é'))) FROM DUAL;
+ asciistr 
+----------
+ \00E9
+(1 row)
+
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('áéíóú'))) FROM DUAL;
+         asciistr          
+---------------------------
+ \00E1\00E9\00ED\00F3\00FA
+(1 row)
+
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('àèìòù'))) FROM DUAL;
+         asciistr          
+---------------------------
+ \00E0\00E8\00EC\00F2\00F9
+(1 row)
+
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('áèíóú'))) FROM DUAL;
+         asciistr          
+---------------------------
+ \00E1\00E8\00ED\00F3\00FA
+(1 row)
+
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('hello'))) FROM DUAL;
+ asciistr 
+----------
+ hello
+(1 row)
+
+SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E9')))) FROM DUAL;
+ asciistr 
+----------
+ \00E9
+(1 row)
+
+SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E1\00E9\00ED\00F3\00FA')))) FROM DUAL;
+         asciistr          
+---------------------------
+ \00E1\00E9\00ED\00F3\00FA
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3349,3 +3349,120 @@ SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E1\00E9\00ED\00F3\00FA')))) FROM DU
  \00E1\00E9\00ED\00F3\00FA
 (1 row)
 
+-- Tests for to_multi_byte
+select to_multi_byte('123$test');
+  to_multi_byte   
+------------------
+ １２３＄ｔｅｓｔ
+(1 row)
+
+-- Check internal representation difference
+select octet_length('abc');
+ octet_length 
+--------------
+            3
+(1 row)
+
+select octet_length(to_multi_byte('abc'));
+ octet_length 
+--------------
+            9
+(1 row)
+
+select to_multi_byte('abc'::text);
+ to_multi_byte 
+---------------
+ ａｂｃ
+(1 row)
+
+select to_multi_byte('1.2'::text) ;
+ to_multi_byte 
+---------------
+ １．２
+(1 row)
+
+select to_multi_byte(1.2::float);
+ERROR:  function to_multi_byte(pg_catalog.float8) does not exist
+LINE 1: select to_multi_byte(1.2::float);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+select to_multi_byte(1::int);
+ERROR:  function to_multi_byte(pg_catalog.int4) does not exist
+LINE 1: select to_multi_byte(1::int);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+select to_multi_byte(1.4::numeric);
+ERROR:  function to_multi_byte(pg_catalog.numeric) does not exist
+LINE 1: select to_multi_byte(1.4::numeric);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+select to_multi_byte('abc'::bpchar);
+ to_multi_byte 
+---------------
+ ａｂｃ
+(1 row)
+
+select to_multi_byte(6.4);
+ERROR:  function to_multi_byte(pg_catalog.numeric) does not exist
+LINE 1: select to_multi_byte(6.4);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+select to_multi_byte(NULL);
+ to_multi_byte 
+---------------
+ 
+(1 row)
+
+-- Tests for to_single_byte
+select to_single_byte('123$test');
+ to_single_byte 
+----------------
+ 123$test
+(1 row)
+
+select to_single_byte('１２３＄ｔｅｓｔ');
+ to_single_byte 
+----------------
+ 123$test
+(1 row)
+
+-- Check internal representation difference
+select octet_length('ａｂｃ');
+ octet_length 
+--------------
+            9
+(1 row)
+
+select octet_length(to_single_byte('ａｂｃ'));
+ octet_length 
+--------------
+            3
+(1 row)
+
+select to_single_byte('ａｂｃ');
+ to_single_byte 
+----------------
+ abc
+(1 row)
+
+select to_single_byte('１．２');
+ to_single_byte 
+----------------
+ 1.2
+(1 row)
+
+select to_single_byte(１．２);
+ERROR:  "１．２": invalid identifier
+LINE 1: select to_single_byte(１．２);
+                              ^
+select to_single_byte(3.4);
+ERROR:  function to_single_byte(pg_catalog.numeric) does not exist
+LINE 1: select to_single_byte(3.4);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+select to_single_byte(NULL);
+ to_single_byte 
+----------------
+ 
+(1 row)
+

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1222,3 +1222,31 @@ drop table test_decode;
  select asciistr('Café') from dual;
  select asciistr('Αλφάβητο') from dual;
  select asciistr('Привет') from dual;
+
+/*
+ * compose & decompose
+ */
+
+select asciistr(decompose('é')) from dual;
+select asciistr(compose('e'||chr(769))) from dual;
+select asciistr(decompose('áéíóú')) from dual;
+select asciistr(compose('a'||chr(769)||'e'||chr(769)||'i'||chr(769)||'o'||chr(769)||'u'||chr(769))) from dual;
+select asciistr(decompose('àèìòù')) from dual;
+select asciistr(compose('a'||chr(768)||'e'||chr(768)||'i'||chr(768)||'o'||chr(768)||'u'||chr(768))) from dual;
+select asciistr(decompose('áèíóú')) from dual;
+select asciistr(compose('a'||chr(769)||'e'||chr(768)||'i'||chr(769)||'o'||chr(769)||'u'||chr(769))) from dual;
+select asciistr(decompose('hello')) from dual;
+select asciistr(compose('hello')) from dual;
+select asciistr(compose(chr(101)||chr(769))) from dual;
+select asciistr(decompose('é')) from dual;
+select unistr('\00e9') from dual;
+select compose('a'||chr(768)) from dual;
+
+-- Nested Composition and Decomposition 
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('é'))) FROM DUAL;
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('áéíóú'))) FROM DUAL;
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('àèìòù'))) FROM DUAL;
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('áèíóú'))) FROM DUAL;
+SELECT ASCIISTR(COMPOSE(DECOMPOSE('hello'))) FROM DUAL;
+SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E9')))) FROM DUAL;
+SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E1\00E9\00ED\00F3\00FA')))) FROM DUAL;

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1243,13 +1243,13 @@ select unistr('\00e9') from dual;
 select compose('a'||chr(768)) from dual;
 
 -- Nested Composition and Decomposition 
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('é'))) FROM DUAL;
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('áéíóú'))) FROM DUAL;
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('àèìòù'))) FROM DUAL;
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('áèíóú'))) FROM DUAL;
-SELECT ASCIISTR(COMPOSE(DECOMPOSE('hello'))) FROM DUAL;
-SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E9')))) FROM DUAL;
-SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E1\00E9\00ED\00F3\00FA')))) FROM DUAL;
+select asciistr(compose(decompose('é'))) from dual;
+select asciistr(compose(decompose('áéíóú'))) from dual;
+select asciistr(compose(decompose('àèìòù'))) from dual;
+select asciistr(compose(decompose('áèíóú'))) from dual;
+select asciistr(compose(decompose('hello'))) from dual;
+select asciistr(compose(decompose(unistr('\00E9')))) from dual;
+select asciistr(compose(decompose(unistr('\00E1\00E9\00ED\00F3\00FA')))) from dual;
 
 -- Tests for to_multi_byte
 select to_multi_byte('123$test');

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1250,3 +1250,31 @@ SELECT ASCIISTR(COMPOSE(DECOMPOSE('áèíóú'))) FROM DUAL;
 SELECT ASCIISTR(COMPOSE(DECOMPOSE('hello'))) FROM DUAL;
 SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E9')))) FROM DUAL;
 SELECT ASCIISTR(COMPOSE(DECOMPOSE(UNISTR('\00E1\00E9\00ED\00F3\00FA')))) FROM DUAL;
+
+-- Tests for to_multi_byte
+select to_multi_byte('123$test');
+-- Check internal representation difference
+select octet_length('abc');
+select octet_length(to_multi_byte('abc'));
+
+select to_multi_byte('abc'::text);
+select to_multi_byte('1.2'::text) ;
+select to_multi_byte(1.2::float);
+select to_multi_byte(1::int);
+select to_multi_byte(1.4::numeric);
+select to_multi_byte('abc'::bpchar);
+select to_multi_byte(6.4);
+select to_multi_byte(NULL);
+
+-- Tests for to_single_byte
+select to_single_byte('123$test');
+select to_single_byte('１２３＄ｔｅｓｔ');
+-- Check internal representation difference
+select octet_length('ａｂｃ');
+select octet_length(to_single_byte('ａｂｃ'));
+
+select to_single_byte('ａｂｃ');
+select to_single_byte('１．２');
+select to_single_byte(１．２);
+select to_single_byte(3.4);
+select to_single_byte(NULL);

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1197,3 +1197,28 @@ select decode(null, b, 2018, 2, 3) from test_decode;
 select decode(null, null, 2018, 2, 3) from test_decode; --expect:all
 
 drop table test_decode;
+
+
+/*
+ * asciistr
+ */
+  
+ -- string with only ascii chars
+ select asciistr('Hello, World!') from dual;
+ select asciistr('Hello\nWorld') from dual;
+ select asciistr('') from dual;
+
+ -- string with non-ascii chars
+ select asciistr('こんにちは') from dual;
+ select asciistr('你好') from dual;
+ select asciistr('😊👍') from dual;
+
+ -- string with mixed ascii and non-ascii
+ select asciistr('ABÄCDE') from dual;
+ select asciistr('ABCÄÊ') from dual;
+ select asciistr('ABCÕØ') from dual;
+ select asciistr('ABCÄÊÍÕØ') from dual;
+ select asciistr('Hello, こんにちは!') from dual;
+ select asciistr('Café') from dual;
+ select asciistr('Αλφάβητο') from dual;
+ select asciistr('Привет') from dual;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -4,6 +4,15 @@
  *
  ***************************************************************/
 /* length/lengthb for CHAR(n char/byte) */
+
+CREATE FUNCTION sys.asciistr(text)
+RETURNS text
+AS 'MODULE_PATHNAME','ora_asciistr'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
 CREATE FUNCTION sys.length(text)
 RETURNS integer
 AS 'MODULE_PATHNAME','oracharlen'

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -12,6 +12,34 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE;
 
+
+CREATE FUNCTION sys.decompose(text, text DEFAULT 'canonical')
+RETURNS text
+AS $$
+BEGIN
+    IF LOWER($2) = 'canonical' THEN
+        RETURN pg_catalog.normalize($1, 'NFD');
+    ELSIF LOWER($2) = 'compatibility' THEN
+        RETURN pg_catalog.normalize($1, 'NFKD');
+    ELSE
+        RAISE 'Invalid parameter string used in SQL function';
+    END IF;
+END;
+$$
+LANGUAGE plpgsql
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+
+CREATE FUNCTION sys.compose(text)
+RETURNS text
+AS $$ SELECT pg_catalog.normalize($1, 'NFC');$$
+LANGUAGE SQL
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
 /* length/lengthb for CHAR(n char/byte) */
 CREATE FUNCTION sys.length(text)
 RETURNS integer

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -40,6 +40,26 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE;
 
+
+CREATE FUNCTION sys.to_multi_byte(str text)
+RETURNS text
+AS 'MODULE_PATHNAME','ora_to_multi_byte'
+LANGUAGE C 
+STRICT
+PARALLEL SAFE
+IMMUTABLE; 
+COMMENT ON FUNCTION sys.to_multi_byte(text) IS 'Convert all single-byte characters to their corresponding multibyte characters';
+
+CREATE FUNCTION sys.to_single_byte(str text)
+RETURNS text
+AS 'MODULE_PATHNAME','ora_to_single_byte'
+LANGUAGE C 
+STRICT
+PARALLEL SAFE
+IMMUTABLE; 
+COMMENT ON FUNCTION sys.to_single_byte(text) IS 'Convert characters to their corresponding single-byte characters if possible';
+
+
 /* length/lengthb for CHAR(n char/byte) */
 CREATE FUNCTION sys.length(text)
 RETURNS integer

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -12,7 +12,6 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE;
 
-
 CREATE FUNCTION sys.decompose(text, text DEFAULT 'canonical')
 RETURNS text
 AS $$
@@ -31,7 +30,6 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE;
 
-
 CREATE FUNCTION sys.compose(text)
 RETURNS text
 AS $$ SELECT pg_catalog.normalize($1, 'NFC');$$
@@ -39,7 +37,6 @@ LANGUAGE SQL
 STRICT
 PARALLEL SAFE
 IMMUTABLE;
-
 
 CREATE FUNCTION sys.to_multi_byte(str text)
 RETURNS text
@@ -58,7 +55,6 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE; 
 COMMENT ON FUNCTION sys.to_single_byte(text) IS 'Convert characters to their corresponding single-byte characters if possible';
-
 
 /* length/lengthb for CHAR(n char/byte) */
 CREATE FUNCTION sys.length(text)

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -3,7 +3,6 @@
  * Character datatype functions.
  *
  ***************************************************************/
-/* length/lengthb for CHAR(n char/byte) */
 
 CREATE FUNCTION sys.asciistr(text)
 RETURNS text
@@ -13,6 +12,7 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE;
 
+/* length/lengthb for CHAR(n char/byte) */
 CREATE FUNCTION sys.length(text)
 RETURNS integer
 AS 'MODULE_PATHNAME','oracharlen'

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -50,6 +50,8 @@ PG_FUNCTION_INFO_V1(ora_substrb);
 PG_FUNCTION_INFO_V1(ora_replace);
 PG_FUNCTION_INFO_V1(ora_instrb);
 PG_FUNCTION_INFO_V1(ora_asciistr);
+PG_FUNCTION_INFO_V1(ora_to_multi_byte);
+PG_FUNCTION_INFO_V1(ora_to_single_byte);
 
 #define PG_STR_GET_TEXT(str_) \
 	DatumGetTextP(DirectFunctionCall1(textin, CStringGetDatum(str_)))
@@ -75,6 +77,7 @@ static int	text_position_next(int start_pos, TextPositionState *state);
 static int text_instring(text *str, text *search_str, int32 position, int32 occurrence, bool isByte);
 static int	text_position_prev(int start_pos, TextPositionState *state);
 static void appendStringInfoText(StringInfo str, const text *t);
+static int getindex(const char **map, char *mbchar, int mblen);
 
 /*
  * length/lengthb function for 'oracharchar' and 'oracharbyte' type.
@@ -1771,4 +1774,490 @@ ora_asciistr(PG_FUNCTION_ARGS) {
     }
 	
     PG_RETURN_TEXT_P(cstring_to_text_with_len(output.data, output.len));
+}
+
+
+/* 3 is enough, but it is defined as 4 in backend code. */
+#ifndef MAX_CONVERSION_GROWTH
+#define MAX_CONVERSION_GROWTH  4
+#endif
+
+/*
+ * Convert a tilde (~) to ...
+ *	1: a full width tilde. (same as JA16EUCTILDE in oracle)
+ *	0: a full width overline. (same as JA16EUC in oracle)
+ *
+ * Note - there is a difference with Oracle - it returns \342\210\274
+ * what is a tilde char. Orafce returns fullwidth tilde. If it is a
+ * problem, fix it for sef in code.
+ */
+#define JA_TO_FULL_WIDTH_TILDE	1
+
+static const char *
+TO_MULTI_BYTE_UTF8[95] =
+{
+	"\343\200\200",
+	"\357\274\201",
+	"\342\200\235",
+	"\357\274\203",
+	"\357\274\204",
+	"\357\274\205",
+	"\357\274\206",
+	"\342\200\231",
+	"\357\274\210",
+	"\357\274\211",
+	"\357\274\212",
+	"\357\274\213",
+	"\357\274\214",
+	"\357\274\215",
+	"\357\274\216",
+	"\357\274\217",
+	"\357\274\220",
+	"\357\274\221",
+	"\357\274\222",
+	"\357\274\223",
+	"\357\274\224",
+	"\357\274\225",
+	"\357\274\226",
+	"\357\274\227",
+	"\357\274\230",
+	"\357\274\231",
+	"\357\274\232",
+	"\357\274\233",
+	"\357\274\234",
+	"\357\274\235",
+	"\357\274\236",
+	"\357\274\237",
+	"\357\274\240",
+	"\357\274\241",
+	"\357\274\242",
+	"\357\274\243",
+	"\357\274\244",
+	"\357\274\245",
+	"\357\274\246",
+	"\357\274\247",
+	"\357\274\250",
+	"\357\274\251",
+	"\357\274\252",
+	"\357\274\253",
+	"\357\274\254",
+	"\357\274\255",
+	"\357\274\256",
+	"\357\274\257",
+	"\357\274\260",
+	"\357\274\261",
+	"\357\274\262",
+	"\357\274\263",
+	"\357\274\264",
+	"\357\274\265",
+	"\357\274\266",
+	"\357\274\267",
+	"\357\274\270",
+	"\357\274\271",
+	"\357\274\272",
+	"\357\274\273",
+	"\357\274\274",
+	"\357\274\275",
+	"\357\274\276",
+	"\357\274\277",
+	"\342\200\230",
+	"\357\275\201",
+	"\357\275\202",
+	"\357\275\203",
+	"\357\275\204",
+	"\357\275\205",
+	"\357\275\206",
+	"\357\275\207",
+	"\357\275\210",
+	"\357\275\211",
+	"\357\275\212",
+	"\357\275\213",
+	"\357\275\214",
+	"\357\275\215",
+	"\357\275\216",
+	"\357\275\217",
+	"\357\275\220",
+	"\357\275\221",
+	"\357\275\222",
+	"\357\275\223",
+	"\357\275\224",
+	"\357\275\225",
+	"\357\275\226",
+	"\357\275\227",
+	"\357\275\230",
+	"\357\275\231",
+	"\357\275\232",
+	"\357\275\233",
+	"\357\275\234",
+	"\357\275\235",
+#if JA_TO_FULL_WIDTH_TILDE
+	"\357\275\236"
+#else
+	"\357\277\243"
+#endif
+};
+
+static const char *
+TO_MULTI_BYTE_EUCJP[95] =
+{
+	"\241\241",
+	"\241\252",
+	"\241\311",
+	"\241\364",
+	"\241\360",
+	"\241\363",
+	"\241\365",
+	"\241\307",
+	"\241\312",
+	"\241\313",
+	"\241\366",
+	"\241\334",
+	"\241\244",
+	"\241\335",
+	"\241\245",
+	"\241\277",
+	"\243\260",
+	"\243\261",
+	"\243\262",
+	"\243\263",
+	"\243\264",
+	"\243\265",
+	"\243\266",
+	"\243\267",
+	"\243\270",
+	"\243\271",
+	"\241\247",
+	"\241\250",
+	"\241\343",
+	"\241\341",
+	"\241\344",
+	"\241\251",
+	"\241\367",
+	"\243\301",
+	"\243\302",
+	"\243\303",
+	"\243\304",
+	"\243\305",
+	"\243\306",
+	"\243\307",
+	"\243\310",
+	"\243\311",
+	"\243\312",
+	"\243\313",
+	"\243\314",
+	"\243\315",
+	"\243\316",
+	"\243\317",
+	"\243\320",
+	"\243\321",
+	"\243\322",
+	"\243\323",
+	"\243\324",
+	"\243\325",
+	"\243\326",
+	"\243\327",
+	"\243\330",
+	"\243\331",
+	"\243\332",
+	"\241\316",
+	"\241\357",
+	"\241\317",
+	"\241\260",
+	"\241\262",
+	"\241\306",		/* Oracle returns different value \241\307 */
+	"\243\341",
+	"\243\342",
+	"\243\343",
+	"\243\344",
+	"\243\345",
+	"\243\346",
+	"\243\347",
+	"\243\350",
+	"\243\351",
+	"\243\352",
+	"\243\353",
+	"\243\354",
+	"\243\355",
+	"\243\356",
+	"\243\357",
+	"\243\360",
+	"\243\361",
+	"\243\362",
+	"\243\363",
+	"\243\364",
+	"\243\365",
+	"\243\366",
+	"\243\367",
+	"\243\370",
+	"\243\371",
+	"\243\372",
+	"\241\320",
+	"\241\303",
+	"\241\321",
+#if JA_TO_FULL_WIDTH_TILDE
+	"\241\301"
+#else
+	"\241\261"
+#endif
+};
+
+static const char *
+TO_MULTI_BYTE__EUCCN[95] =
+{
+	"\241\241",
+	"\243\241",
+	"\243\242",
+	"\243\243",
+	"\243\244",
+	"\243\245",
+	"\243\246",
+	"\243\247",
+	"\243\250",
+	"\243\251",
+	"\243\252",
+	"\243\253",
+	"\243\254",
+	"\243\255",
+	"\243\256",
+	"\243\257",
+	"\243\260",
+	"\243\261",
+	"\243\262",
+	"\243\263",
+	"\243\264",
+	"\243\265",
+	"\243\266",
+	"\243\267",
+	"\243\270",
+	"\243\271",
+	"\243\272",
+	"\243\273",
+	"\243\274",
+	"\243\275",
+	"\243\276",
+	"\243\277",
+	"\243\300",
+	"\243\301",
+	"\243\302",
+	"\243\303",
+	"\243\304",
+	"\243\305",
+	"\243\306",
+	"\243\307",
+	"\243\310",
+	"\243\311",
+	"\243\312",
+	"\243\313",
+	"\243\314",
+	"\243\315",
+	"\243\316",
+	"\243\317",
+	"\243\320",
+	"\243\321",
+	"\243\322",
+	"\243\323",
+	"\243\324",
+	"\243\325",
+	"\243\326",
+	"\243\327",
+	"\243\330",
+	"\243\331",
+	"\243\332",
+	"\243\333",
+	"\243\334",
+	"\243\335",
+	"\243\336",
+	"\243\337",
+	"\243\340",
+	"\243\341",
+	"\243\342",
+	"\243\343",
+	"\243\344",
+	"\243\345",
+	"\243\346",
+	"\243\347",
+	"\243\350",
+	"\243\351",
+	"\243\352",
+	"\243\353",
+	"\243\354",
+	"\243\355",
+	"\243\356",
+	"\243\357",
+	"\243\360",
+	"\243\361",
+	"\243\362",
+	"\243\363",
+	"\243\364",
+	"\243\365",
+	"\243\366",
+	"\243\367",
+	"\243\370",
+	"\243\371",
+	"\243\372",
+	"\243\373",
+	"\243\374",
+	"\243\375",
+	"\243\376",
+};
+
+Datum
+ora_to_multi_byte(PG_FUNCTION_ARGS)
+{
+	text	   *src;
+	text	   *dst;
+	const char *s;
+	char	   *d;
+	int			srclen;
+
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(__amd64__))
+
+	__int64			dstlen;
+
+#else
+
+	int			dstlen;
+
+	#endif
+
+	int			i;
+	const char **map;
+
+	switch (GetDatabaseEncoding())
+	{
+		case PG_UTF8:
+			map = TO_MULTI_BYTE_UTF8;
+			break;
+		case PG_EUC_JP:
+		case PG_EUC_JIS_2004:
+			map = TO_MULTI_BYTE_EUCJP;
+			break;
+		case PG_EUC_CN:
+			map = TO_MULTI_BYTE__EUCCN;
+			break;
+		/*
+		 * TODO: Add converter for encodings.
+		 */
+		default:	/* no need to convert */
+			PG_RETURN_DATUM(PG_GETARG_DATUM(0));
+	}
+
+	src = PG_GETARG_TEXT_PP(0);
+	s = VARDATA_ANY(src);
+	srclen = VARSIZE_ANY_EXHDR(src);
+	dst = (text *) palloc(VARHDRSZ + srclen * MAX_CONVERSION_GROWTH);
+	d = VARDATA(dst);
+
+	for (i = 0; i < srclen; i++)
+	{
+		unsigned char	u = (unsigned char) s[i];
+		if (0x20 <= u && u <= 0x7e)
+		{
+			const char *m = map[u - 0x20];
+			while (*m)
+			{
+				*d++ = *m++;
+			}
+		}
+		else
+		{
+			*d++ = s[i];
+		}
+	}
+
+	dstlen = d - VARDATA(dst);
+	SET_VARSIZE(dst, VARHDRSZ + dstlen);
+
+	PG_RETURN_TEXT_P(dst);
+}
+
+static int
+getindex(const char **map, char *mbchar, int mblen)
+{
+	int		i;
+
+	for (i = 0; i < 95; i++)
+	{
+		if (!memcmp(map[i], mbchar, mblen))
+			return i;
+	}
+
+	return -1;
+}
+
+Datum
+ora_to_single_byte(PG_FUNCTION_ARGS)
+{
+	text	   *src;
+	text	   *dst;
+	char	   *s;
+	char	   *d;
+	int			srclen;
+
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(__amd64__))
+
+	__int64			dstlen;
+
+#else
+	
+	int			dstlen;
+
+#endif
+
+	const char **map;
+
+	switch (GetDatabaseEncoding())
+	{
+		case PG_UTF8:
+			map = TO_MULTI_BYTE_UTF8;
+			break;
+		case PG_EUC_JP:
+		case PG_EUC_JIS_2004:
+			map = TO_MULTI_BYTE_EUCJP;
+			break;
+		case PG_EUC_CN:
+			map = TO_MULTI_BYTE__EUCCN;
+			break;
+		/*
+		 * TODO: Add converter for encodings.
+		 */
+		default:	/* no need to convert */
+			PG_RETURN_DATUM(PG_GETARG_DATUM(0));
+	}
+
+	src = PG_GETARG_TEXT_PP(0);
+	s = VARDATA_ANY(src);
+	srclen = VARSIZE_ANY_EXHDR(src);
+
+	/* XXX - The output length should be <= input length */
+	dst = (text *) palloc0(VARHDRSZ + srclen);
+	d = VARDATA(dst);
+
+	while (s - VARDATA_ANY(src) < srclen)
+	{
+		char   *u = s;
+		int		clen;
+		int		mapindex;
+
+		clen = pg_mblen(u);
+		s += clen;
+
+		if (clen == 1)
+			*d++ = *u;
+		else if ((mapindex = getindex(map, u, clen)) >= 0)
+		{
+			const char m = 0x20 + mapindex;
+			*d++ = m;
+		}
+		else
+		{
+			memcpy(d, u, clen);
+			d += clen;
+		}
+	}
+
+	dstlen = d - VARDATA(dst);
+	SET_VARSIZE(dst, VARHDRSZ + dstlen);
+
+	PG_RETURN_TEXT_P(dst);
 }


### PR DESCRIPTION
Add support for oracle ASCIISTR() function.
Add test cases for verification.

https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ASCIISTR.html


This PR is related to issue https://github.com/IvorySQL/IvorySQL/issues/609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced SQL functions for character datatype conversions:
		- `sys.asciistr(text)`
		- `sys.decompose(text, text DEFAULT 'canonical')`
		- `sys.compose(text)`
		- `sys.to_multi_byte(text)`
		- `sys.to_single_byte(text)`
- **Tests**
	- Added tests for `asciistr`, `compose`, and `decompose` functions with various input strings, including ASCII, non-ASCII, and mixed characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->