### PR TITLE
move the attisinvisible to be with other bool attributes.

### DIFF
--- a/src/include/catalog/pg_attribute.h
+++ b/src/include/catalog/pg_attribute.h
@@ -155,15 +155,15 @@ CATALOG(pg_attribute,1249,AttributeRelationId) BKI_BOOTSTRAP BKI_ROWTYPE_OID(75,
 	 */
 	bool		attislocal BKI_DEFAULT(t);
 
-	/* Number of times inherited from direct parent relation(s) */
-	int16		attinhcount BKI_DEFAULT(0);
-
 	/*
 	 * This flag specifies whether this column is visible in
 	 * a SELECT *, an INSERT without column list, or not. It is true when
 	 * a column is defined with the INVISIBLE attribute, false otherwise.
 	 */
 	bool		attisinvisible BKI_DEFAULT(f);
+
+	/* Number of times inherited from direct parent relation(s) */
+	int16		attinhcount BKI_DEFAULT(0);
 
 	/* attribute's collation, if any */
 	Oid			attcollation BKI_LOOKUP_OPT(pg_collation);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Reorganized the declaration order of the `attinhcount` field in the attribute structure for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->