### PR TITLE
IvorySQL:rename ModifyTableContext and UpdateContext

### DIFF
--- a/contrib/ivorysql_ora/src/include/ivorysql_ora.h
+++ b/contrib/ivorysql_ora/src/include/ivorysql_ora.h
@@ -25,7 +25,7 @@
 
 /* Hooks */
 extern bool pg_compatible_oracle_precedence(Oid arg1, Oid arg2, char *opname_p, Oid *result_arg1, Oid *result_arg2);
-extern TupleTableSlot *IvyExecMergeMatched(ModifyTableContext *context,
+extern TupleTableSlot *IvyExecMergeMatched(IvyModifyTableContext *context,
 										ResultRelInfo *resultRelInfo,
 										ItemPointer tupleid,
 										HeapTuple oldtuple,

--- a/contrib/ivorysql_ora/src/merge/ora_merge.c
+++ b/contrib/ivorysql_ora/src/merge/ora_merge.c
@@ -64,7 +64,7 @@
 #include "nodes/nodes.h"
 
 
-static TM_Result execDelete4Merge(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+static TM_Result execDelete4Merge(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 							ItemPointer tupleid, bool changingPart);
 static TM_Result heapDelete4Merge(Relation relation, ItemPointer tid,
 							CommandId cid, Snapshot crosscheck, bool wait,
@@ -114,7 +114,7 @@ IvyExecProcessReturning(ResultRelInfo *resultRelInfo,
  * execute oracle Merge UPDATE/UPDATE
  */
 TupleTableSlot *
-IvyExecMergeMatched(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+IvyExecMergeMatched(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 				 ItemPointer tupleid, HeapTuple oldtuple, bool canSetTag,
 				 bool *matched)
 {
@@ -186,7 +186,7 @@ lmerge_matched:
 		MergeActionState *relaction = (MergeActionState *) lfirst(l);
 		CmdType	 commandType = relaction->mas_action->commandType;
 		TM_Result	 result;
-		UpdateContext updateCxt = {0};
+		IvyUpdateContext updateCxt = {0};
 
 		/*
 		 * Test condition, if any.
@@ -908,7 +908,7 @@ IvytransformMergeStmt(ParseState *pstate, MergeStmt *stmt)
 }
 
 static TM_Result
-execDelete4Merge(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+execDelete4Merge(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 			  				ItemPointer tupleid, bool changingPart)
 {
 	EState	   *estate = context->estate;

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -85,13 +85,13 @@ static void ExecBatchInsert(ModifyTableState *mtstate,
 							EState *estate,
 							bool canSetTag);
 static void ExecPendingInserts(EState *estate);
-static void ExecCrossPartitionUpdateForeignKey(ModifyTableContext *context,
+static void ExecCrossPartitionUpdateForeignKey(IvyModifyTableContext *context,
 											   ResultRelInfo *sourcePartInfo,
 											   ResultRelInfo *destPartInfo,
 											   ItemPointer tupleid,
 											   TupleTableSlot *oldslot,
 											   TupleTableSlot *newslot);
-static bool ExecOnConflictUpdate(ModifyTableContext *context,
+static bool ExecOnConflictUpdate(IvyModifyTableContext *context,
 								 ResultRelInfo *resultRelInfo,
 								 ItemPointer conflictTid,
 								 TupleTableSlot *excludedSlot,
@@ -104,13 +104,13 @@ static TupleTableSlot *ExecPrepareTupleRouting(ModifyTableState *mtstate,
 											   TupleTableSlot *slot,
 											   ResultRelInfo **partRelInfo);
 
-static TupleTableSlot *ExecMerge(ModifyTableContext *context,
+static TupleTableSlot *ExecMerge(IvyModifyTableContext *context,
 								 ResultRelInfo *resultRelInfo,
 								 ItemPointer tupleid,
 								 HeapTuple oldtuple,
 								 bool canSetTag);
 static void ExecInitMerge(ModifyTableState *mtstate, EState *estate);
-static TupleTableSlot *ExecMergeNotMatched(ModifyTableContext *context,
+static TupleTableSlot *ExecMergeNotMatched(IvyModifyTableContext *context,
 										   ResultRelInfo *resultRelInfo,
 										   bool canSetTag);
 
@@ -704,7 +704,7 @@ ExecGetUpdateNewTuple(ResultRelInfo *relinfo,
  * ----------------------------------------------------------------
  */
 static TupleTableSlot *
-ExecInsert(ModifyTableContext *context,
+ExecInsert(IvyModifyTableContext *context,
 		   ResultRelInfo *resultRelInfo,
 		   TupleTableSlot *slot,
 		   bool canSetTag,
@@ -1262,7 +1262,7 @@ ExecPendingInserts(EState *estate)
  * the delete a no-op; otherwise, return true.
  */
 bool
-ExecDeletePrologue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecDeletePrologue(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 				   ItemPointer tupleid, HeapTuple oldtuple,
 				   TupleTableSlot **epqreturnslot, TM_Result *result)
 {
@@ -1293,7 +1293,7 @@ ExecDeletePrologue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
  * Caller is in charge of doing EvalPlanQual as necessary
  */
 TM_Result
-ExecDeleteAct(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecDeleteAct(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 			  ItemPointer tupleid, bool changingPart)
 {
 	EState	   *estate = context->estate;
@@ -1315,7 +1315,7 @@ ExecDeleteAct(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
  * cross-partition tuple move.
  */
 void
-ExecDeleteEpilogue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecDeleteEpilogue(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 				   ItemPointer tupleid, HeapTuple oldtuple, bool changingPart)
 {
 	ModifyTableState *mtstate = context->mtstate;
@@ -1373,7 +1373,7 @@ ExecDeleteEpilogue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
  * ----------------------------------------------------------------
  */
 static TupleTableSlot *
-ExecDelete(ModifyTableContext *context,
+ExecDelete(IvyModifyTableContext *context,
 		   ResultRelInfo *resultRelInfo,
 		   ItemPointer tupleid,
 		   HeapTuple oldtuple,
@@ -1687,12 +1687,12 @@ ldelete:
  * logic.
  */
 static bool
-ExecCrossPartitionUpdate(ModifyTableContext *context,
+ExecCrossPartitionUpdate(IvyModifyTableContext *context,
 						 ResultRelInfo *resultRelInfo,
 						 ItemPointer tupleid, HeapTuple oldtuple,
 						 TupleTableSlot *slot,
 						 bool canSetTag,
-						 UpdateContext *updateCxt,
+						 IvyUpdateContext *updateCxt,
 						 TM_Result *tmresult,
 						 TupleTableSlot **retry_slot,
 						 TupleTableSlot **inserted_tuple,
@@ -1848,7 +1848,7 @@ ExecCrossPartitionUpdate(ModifyTableContext *context,
  * otherwise, return true.
  */
 bool
-ExecUpdatePrologue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecUpdatePrologue(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 				   ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot *slot,
 				   TM_Result *result)
 {
@@ -1925,9 +1925,9 @@ ExecUpdatePrepareSlot(ResultRelInfo *resultRelInfo,
  * this routine does it.
  */
 TM_Result
-ExecUpdateAct(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecUpdateAct(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 			  ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot *slot,
-			  bool canSetTag, UpdateContext *updateCxt)
+			  bool canSetTag, IvyUpdateContext *updateCxt)
 {
 	EState	   *estate = context->estate;
 	Relation	resultRelationDesc = resultRelInfo->ri_RelationDesc;
@@ -2076,7 +2076,7 @@ lreplace:
  * returns indicating that the tuple was updated.
  */
 void
-ExecUpdateEpilogue(ModifyTableContext *context, UpdateContext *updateCxt,
+ExecUpdateEpilogue(IvyModifyTableContext *context, IvyUpdateContext *updateCxt,
 				   ResultRelInfo *resultRelInfo, ItemPointer tupleid,
 				   HeapTuple oldtuple, TupleTableSlot *slot)
 {
@@ -2123,7 +2123,7 @@ ExecUpdateEpilogue(ModifyTableContext *context, UpdateContext *updateCxt,
  * keys pointing into it.
  */
 static void
-ExecCrossPartitionUpdateForeignKey(ModifyTableContext *context,
+ExecCrossPartitionUpdateForeignKey(IvyModifyTableContext *context,
 								   ResultRelInfo *sourcePartInfo,
 								   ResultRelInfo *destPartInfo,
 								   ItemPointer tupleid,
@@ -2215,13 +2215,13 @@ ExecCrossPartitionUpdateForeignKey(ModifyTableContext *context,
  * ----------------------------------------------------------------
  */
 static TupleTableSlot *
-ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecUpdate(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 		   ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot *slot,
 		   bool canSetTag)
 {
 	EState	   *estate = context->estate;
 	Relation	resultRelationDesc = resultRelInfo->ri_RelationDesc;
-	UpdateContext updateCxt = {0};
+	IvyUpdateContext updateCxt = {0};
 	TM_Result	result;
 
 	/*
@@ -2456,7 +2456,7 @@ redo_act:
  * the caller must retry the INSERT from scratch.
  */
 static bool
-ExecOnConflictUpdate(ModifyTableContext *context,
+ExecOnConflictUpdate(IvyModifyTableContext *context,
 					 ResultRelInfo *resultRelInfo,
 					 ItemPointer conflictTid,
 					 TupleTableSlot *excludedSlot,
@@ -2668,7 +2668,7 @@ ExecOnConflictUpdate(ModifyTableContext *context,
  * Perform MERGE.
  */
 static TupleTableSlot *
-ExecMerge(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecMerge(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 		  ItemPointer tupleid, HeapTuple oldtuple, bool canSetTag)
 {
 	TupleTableSlot *rslot = NULL;
@@ -2794,7 +2794,7 @@ ExecMerge(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
  * to also execute a WHEN NOT MATCHED [BY TARGET] action.
  */
 TupleTableSlot *
-ExecMergeMatched(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecMergeMatched(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 				 ItemPointer tupleid, HeapTuple oldtuple, bool canSetTag,
 				 bool *matched)
 {
@@ -2868,7 +2868,7 @@ lmerge_matched:
 		MergeActionState *relaction = (MergeActionState *) lfirst(l);
 		CmdType		commandType = relaction->mas_action->commandType;
 		TM_Result	result;
-		UpdateContext updateCxt = {0};
+		IvyUpdateContext updateCxt = {0};
 
 		/*
 		 * Test condition, if any.
@@ -3267,7 +3267,7 @@ lmerge_matched:
  * Execute the first qualifying NOT MATCHED [BY TARGET] action.
  */
 static TupleTableSlot *
-ExecMergeNotMatched(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+ExecMergeNotMatched(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 					bool canSetTag)
 {
 	ModifyTableState *mtstate = context->mtstate;
@@ -3715,7 +3715,7 @@ static TupleTableSlot *
 ExecModifyTable(PlanState *pstate)
 {
 	ModifyTableState *node = castNode(ModifyTableState, pstate);
-	ModifyTableContext context;
+	IvyModifyTableContext context;
 	EState	   *estate = node->ps.state;
 	CmdType		operation = node->operation;
 	ResultRelInfo *resultRelInfo;

--- a/src/include/executor/nodeModifyTable.h
+++ b/src/include/executor/nodeModifyTable.h
@@ -22,7 +22,7 @@
  * state and some output variables populated by ExecUpdateAct() and
  * ExecDeleteAct() to report the result of their actions to callers.
  */
-typedef struct ModifyTableContext
+typedef struct IvyModifyTableContext
 {
 	/* Operation state */
 	ModifyTableState *mtstate;
@@ -52,12 +52,12 @@ typedef struct ModifyTableContext
 	 * cross-partition UPDATE
 	 */
 	TupleTableSlot *cpUpdateReturningSlot;
-} ModifyTableContext;
+} IvyModifyTableContext;
 
 /*
  * Context struct containing output data specific to UPDATE operations.
  */
-typedef struct UpdateContext
+typedef struct IvyUpdateContext
 {
 	bool		crossPartUpdate;	/* was it a cross-partition update? */
 	TU_UpdateIndexes updateIndexes;	/* Which index updates are required? */
@@ -67,7 +67,7 @@ typedef struct UpdateContext
 	 * EvalPlanQual on it
 	 */
 	LockTupleMode lockmode;
-} UpdateContext;
+} IvyUpdateContext;
 
 extern void ExecInitStoredGenerated(ResultRelInfo *resultRelInfo,
 									EState *estate,
@@ -84,31 +84,31 @@ extern void ExecReScanModifyTable(ModifyTableState *node);
 extern void ExecInitMergeTupleSlots(ModifyTableState *mtstate,
 									ResultRelInfo *resultRelInfo);
 
-extern bool ExecDeletePrologue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+extern bool ExecDeletePrologue(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 							ItemPointer tupleid, HeapTuple oldtuple,
 							TupleTableSlot **epqreturnslot, TM_Result *result);
-extern TM_Result ExecDeleteAct(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+extern TM_Result ExecDeleteAct(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 							ItemPointer tupleid, bool changingPart);
-extern void ExecDeleteEpilogue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+extern void ExecDeleteEpilogue(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 							ItemPointer tupleid, HeapTuple oldtuple, bool changingPart);
-extern TM_Result ExecUpdateAct(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+extern TM_Result ExecUpdateAct(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 							ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot *slot,
-							bool canSetTag, UpdateContext *updateCxt);
-extern void ExecUpdateEpilogue(ModifyTableContext *context, UpdateContext *updateCxt,
+							bool canSetTag, IvyUpdateContext *updateCxt);
+extern void ExecUpdateEpilogue(IvyModifyTableContext *context, IvyUpdateContext *updateCxt,
 							ResultRelInfo *resultRelInfo, ItemPointer tupleid,
 							HeapTuple oldtuple, TupleTableSlot *slot);
-extern bool ExecUpdatePrologue(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+extern bool ExecUpdatePrologue(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 							ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot *slot,
 							TM_Result *result);
 extern void ExecUpdatePrepareSlot(ResultRelInfo *resultRelInfo,
 							TupleTableSlot *slot, EState *estate);
-extern TupleTableSlot *ExecMergeMatched(ModifyTableContext *context,
+extern TupleTableSlot *ExecMergeMatched(IvyModifyTableContext *context,
 										ResultRelInfo *resultRelInfo,
 										ItemPointer tupleid,
 										HeapTuple oldtuple,
 										bool canSetTag,
 										bool *matched);
-typedef TupleTableSlot *(* exec_merge_matched_hook_type)(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
+typedef TupleTableSlot *(* exec_merge_matched_hook_type)(IvyModifyTableContext *context, ResultRelInfo *resultRelInfo,
 									ItemPointer tupleid, HeapTuple oldtuple, 
 									bool canSetTag, bool *matched);
 extern PGDLLIMPORT exec_merge_matched_hook_type pg_exec_merge_matched_hook;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1648,7 +1648,7 @@ MinimalTupleTableSlot
 MinmaxMultiOpaque
 MinmaxOpaque
 ModifyTable
-ModifyTableContext
+IvyModifyTableContext
 ModifyTablePath
 ModifyTableState
 MonotonicFunction
@@ -3027,7 +3027,7 @@ UniqueState
 UnlistenStmt
 UnresolvedTup
 UnresolvedTupData
-UpdateContext
+IvyUpdateContext
 UpdateStmt
 UploadManifestCmd
 UpperRelationKind


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal type names related to table modification and update operations for consistency and clarity across the system. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->