### PR TITLE
set identifier_vase_switch to value from pg_control file

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5447,17 +5447,17 @@ void SetCaseGucOption(char* path)
 		if (casemode == NORMAL)
 		{
 			SetConfigOption("ivorysql.identifier_case_switch", "normal",
-				PGC_USERSET, PGC_S_OVERRIDE);
+				PGC_USERSET, PGC_S_DEFAULT);
 		}
 		else if (casemode == INTERCHANGE)
 		{
 			SetConfigOption("ivorysql.identifier_case_switch", "interchange",
-				PGC_USERSET, PGC_S_OVERRIDE);
+				PGC_USERSET, PGC_S_DEFAULT);
 		}
 		else if (casemode == LOWERCASE)
 		{
 			SetConfigOption("ivorysql.identifier_case_switch", "lowercase",
-				PGC_USERSET, PGC_S_OVERRIDE);
+				PGC_USERSET, PGC_S_DEFAULT);
 		}
 		else
 			ereport(FATAL,

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -773,15 +773,15 @@ PostmasterMain(int argc, char *argv[])
 		ExitPostmaster(1);
 	}
 
+	/* set database_style here */
+	SetCaseGucOption(userDoption);
+
 	/*
 	 * Locate the proper configuration files and data directory, and read
 	 * postgresql.conf for the first time.
 	 */
 	if (!SelectConfigFiles(userDoption, progname))
 		ExitPostmaster(2);
-
-	/* set database_style here */
-	SetCaseGucOption(userDoption);
 
 	if (output_config_variable != NULL)
 	{

--- a/src/backend/utils/misc/ivorysql.conf.sample
+++ b/src/backend/utils/misc/ivorysql.conf.sample
@@ -10,4 +10,4 @@
 
 ivorysql.enable_emptystring_to_NULL = 'on'
 shared_preload_libraries = 'liboracle_parser, ivorysql_ora'		# (change requires restart)
-ivorysql.identifier_case_switch = interchange				# set the case conversion mode. range [normal,interchange,lowercase]
+#ivorysql.identifier_case_switch = interchange				# set the case conversion mode. range [normal,interchange,lowercase]


### PR DESCRIPTION
so that configure file value can take effect.

Also comment out the identifier_vase_switch in ivorysql.conf.sample to avoid overriding the "initdb -C case_mode" operation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the default behavior for identifier case conversion settings.
  - Updated the timing of internal configuration initialization during startup.
  - Commented out the sample configuration for identifier case conversion, making it inactive by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->