### PR TITLE
Compatible with Oracle's sys_guid function

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -95,7 +95,7 @@ GNUmakefile: GNUmakefile.in $(top_builddir)/config.status
 
 $(call recurse,oracle-pg-check-world,src/test,oracle-pg-check)
 #add oracle regression
-$(call recurse,oracle-check-world,src/oracle_test src/pl src/interfaces/ecpg contrib contrib/ivorysql_ora contrib/uuid-ossp  contrib/ora_btree_gist contrib/ora_btree_gin src/bin,oracle-check)
+$(call recurse,oracle-check-world,src/oracle_test src/pl src/interfaces/ecpg src/interfaces/libpq/ivytest contrib contrib/ivorysql_ora contrib/uuid-ossp contrib/ora_btree_gist contrib/ora_btree_gin src/bin,oracle-check)
 $(call recurse,oracle-checkprep,  src/oracle_test src/pl src/interfaces/ecpg contrib src/bin)
 
 $(call recurse,oracle-installcheck-world,src/oracle_test src/pl src/interfaces/ecpg contrib src/bin,oracle-installcheck)

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -8,7 +8,7 @@ subdir =
 top_builddir = .
 include $(top_builddir)/src/Makefile.global
 
-$(call recurse,all install,src config contrib/ivorysql_ora contrib/ora_btree_gist contrib/ora_btree_gin)
+$(call recurse,all install,src config contrib/ivorysql_ora contrib/uuid-ossp contrib/ora_btree_gist contrib/ora_btree_gin)
 
 docs:
 	$(MAKE) -C doc all
@@ -45,7 +45,7 @@ $(call recurse,coverage,doc src config contrib)
 
 # clean, distclean, etc should apply to contrib too, even though
 # it's not built by default
-$(call recurse,clean,doc contrib contrib/ivorysql_ora contrib/ora_btree_gist contrib/ora_btree_gin src config)
+$(call recurse,clean,doc contrib contrib/ivorysql_ora contrib/uuid-ossp contrib/ora_btree_gist contrib/ora_btree_gin src config)
 clean:
 	rm -rf tmp_install/ portlock/
 # Garbage from autoconf:
@@ -95,7 +95,7 @@ GNUmakefile: GNUmakefile.in $(top_builddir)/config.status
 
 $(call recurse,oracle-pg-check-world,src/test,oracle-pg-check)
 #add oracle regression
-$(call recurse,oracle-check-world,src/oracle_test src/pl src/interfaces/ecpg src/interfaces/libpq/ivytest contrib contrib/ivorysql_ora contrib/ora_btree_gist contrib/ora_btree_gin src/bin,oracle-check)
+$(call recurse,oracle-check-world,src/oracle_test src/pl src/interfaces/ecpg contrib contrib/ivorysql_ora contrib/uuid-ossp  contrib/ora_btree_gist contrib/ora_btree_gin src/bin,oracle-check)
 $(call recurse,oracle-checkprep,  src/oracle_test src/pl src/interfaces/ecpg contrib src/bin)
 
 $(call recurse,oracle-installcheck-world,src/oracle_test src/pl src/interfaces/ecpg contrib src/bin,oracle-installcheck)

--- a/contrib/ivorysql_ora/preload_ora_misc.sql
+++ b/contrib/ivorysql_ora/preload_ora_misc.sql
@@ -13,3 +13,8 @@ CREATE TYPE sys.urowid AS(rowoid OID, rowno bigint);
 
 CREATE CAST (sys.rowid AS sys.urowid) WITH INOUT AS IMPLICIT;
 CREATE CAST (sys.urowid AS sys.rowid) WITH INOUT AS IMPLICIT;
+
+--
+-- Plugin uuid-ossp
+--
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/contrib/uuid-ossp/expected/ivy_uuid_ossp.out
+++ b/contrib/uuid-ossp/expected/ivy_uuid_ossp.out
@@ -1,3 +1,4 @@
+DROP EXTENSION IF EXISTS "uuid-ossp" CASCADE;
 CREATE EXTENSION "uuid-ossp";
 SELECT uuid_nil();
                uuid_nil               
@@ -138,6 +139,12 @@ SELECT uuid_version_bits(uuid_generate_v4()),
 (1 row)
 
 SELECT uuid_generate_v4() <> uuid_generate_v4();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT sys_guid() <> sys_guid();
  ?column? 
 ----------
  t

--- a/contrib/uuid-ossp/sql/ivy_uuid_ossp.sql
+++ b/contrib/uuid-ossp/sql/ivy_uuid_ossp.sql
@@ -79,3 +79,5 @@ SELECT uuid_version_bits(uuid_generate_v4()),
        uuid_reserved_bits(uuid_generate_v4());
 
 SELECT uuid_generate_v4() <> uuid_generate_v4();
+
+SELECT sys_guid() <> sys_guid();

--- a/contrib/uuid-ossp/sql/ivy_uuid_ossp.sql
+++ b/contrib/uuid-ossp/sql/ivy_uuid_ossp.sql
@@ -1,3 +1,4 @@
+DROP EXTENSION IF EXISTS "uuid-ossp" CASCADE;
 CREATE EXTENSION "uuid-ossp";
 
 SELECT uuid_nil();

--- a/contrib/uuid-ossp/uuid-ossp--1.0--1.1.sql
+++ b/contrib/uuid-ossp/uuid-ossp--1.0--1.1.sql
@@ -13,3 +13,8 @@ ALTER FUNCTION uuid_generate_v1mc() PARALLEL SAFE;
 ALTER FUNCTION uuid_generate_v3(uuid, text) PARALLEL SAFE;
 ALTER FUNCTION uuid_generate_v4() PARALLEL SAFE;
 ALTER FUNCTION uuid_generate_v5(uuid, text) PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.sys_guid()
+    RETURNS bytea
+AS 'MODULE_PATHNAME', 'ora_sys_guid'
+VOLATILE STRICT LANGUAGE C;

--- a/contrib/uuid-ossp/uuid-ossp--1.1.sql
+++ b/contrib/uuid-ossp/uuid-ossp--1.1.sql
@@ -52,3 +52,8 @@ CREATE FUNCTION uuid_generate_v5(namespace uuid, name text)
 RETURNS uuid
 AS 'MODULE_PATHNAME', 'uuid_generate_v5'
 IMMUTABLE STRICT LANGUAGE C PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.sys_guid()
+    RETURNS bytea
+AS 'MODULE_PATHNAME', 'ora_sys_guid'
+VOLATILE STRICT LANGUAGE C;

--- a/contrib/uuid-ossp/uuid-ossp.c
+++ b/contrib/uuid-ossp/uuid-ossp.c
@@ -577,7 +577,7 @@ ora_sys_guid(PG_FUNCTION_ARGS)
     uuid_generate_random(uu);
     memcpy(VARDATA(result), uu, SYS_GUID_LENGTH);
 
-#else
+#else	/* BSD */
 	int i;
     unsigned char byte_array[SYS_GUID_LENGTH];
     for (i = 0; i < SYS_GUID_LENGTH; i++) {

--- a/contrib/uuid-ossp/uuid-ossp.c
+++ b/contrib/uuid-ossp/uuid-ossp.c
@@ -102,6 +102,9 @@ do { \
 
 #endif							/* !HAVE_UUID_OSSP */
 
+/** The byte length of the value returned by ora_sys_guid **/
+#define SYS_GUID_LENGTH 16
+
 PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(uuid_nil);
@@ -115,7 +118,7 @@ PG_FUNCTION_INFO_V1(uuid_generate_v1mc);
 PG_FUNCTION_INFO_V1(uuid_generate_v3);
 PG_FUNCTION_INFO_V1(uuid_generate_v4);
 PG_FUNCTION_INFO_V1(uuid_generate_v5);
-
+PG_FUNCTION_INFO_V1(ora_sys_guid);
 #ifdef HAVE_UUID_OSSP
 
 static void
@@ -549,4 +552,38 @@ uuid_generate_v5(PG_FUNCTION_ARGS)
 	return uuid_generate_internal(UUID_MAKE_V5, (unsigned char *) ns,
 								  VARDATA_ANY(name), VARSIZE_ANY_EXHDR(name));
 #endif
+}
+
+
+Datum
+ora_sys_guid(PG_FUNCTION_ARGS)
+{
+    bytea *result;
+    result = (bytea *)palloc(VARHDRSZ + SYS_GUID_LENGTH);
+    SET_VARSIZE(result, VARHDRSZ + SYS_GUID_LENGTH);
+
+#ifdef HAVE_UUID_OSSP
+    uuid_t      *uuid;
+    uuid_rc_t   rc;
+    uuid = get_cached_uuid_t(0);
+    rc = uuid_make(uuid, UUID_MAKE_V4, NULL, NULL);
+    if (rc != UUID_RC_OK) {
+        pguuid_complain(rc);
+    }
+    memcpy(VARDATA(result), (unsigned char *)uuid, SYS_GUID_LENGTH);
+
+#elif defined(HAVE_UUID_E2FS)
+    uuid_t uu;
+    uuid_generate_random(uu);
+    memcpy(VARDATA(result), uu, SYS_GUID_LENGTH);
+
+#else
+	int i;
+    unsigned char byte_array[SYS_GUID_LENGTH];
+    for (i = 0; i < SYS_GUID_LENGTH; i++) {
+        byte_array[i] = (unsigned char)arc4random();
+    }
+    memcpy(VARDATA(result), byte_array, SYS_GUID_LENGTH);
+#endif
+    PG_RETURN_BYTEA_P(result);
 }


### PR DESCRIPTION
- Add sys_guid() function support
- Use uuid_make() if uuid-ossp exists; otherwise check for uuid-e2fs, use uuid_generate_random() if present, else use arc4random()
- Auto-load uuid-ossp plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new function, `sys_guid()`, which generates a 16-byte binary UUID value.
  * The `uuid-ossp` extension is now automatically installed if not present during certain setup scripts.

* **Improvements**
  * Build, installation, cleaning, and regression check processes now include the `uuid-ossp` module.

* **Tests**
  * Added a new SQL check to verify that consecutive calls to `sys_guid()` produce different values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->