### PR TITLE
Fix build failure with --with-llvm

### DIFF
--- a/contrib/gb18030_2022/Makefile
+++ b/contrib/gb18030_2022/Makefile
@@ -4,15 +4,13 @@ MODULES = gb18030_2022
 MODULE_big = gb18030_2022
 OBJS = \
 	$(WIN32RES) \
-	utf8_and_gb18030_2022.o \
-
+	utf8_and_gb18030_2022.o
 
 EXTENSION = gb18030_2022
 PGFILEDESC = "gb18030_2022,support gb18030 2022 with extension"
-DATA=gb18030_2022--1.0.sql
-REGRESS = 	gb18030_2022_and_utf8 \
-			copy
-
+DATA = gb18030_2022--1.0.sql
+REGRESS = gb18030_2022_and_utf8 \
+		copy
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config
@@ -24,3 +22,26 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+ifeq ($(with_llvm), yes)
+BITCODE_CFLAGS += -fPIC
+
+%.bc: %.c
+	$(COMPILE.c.bc) -o $@ $<
+
+gb18030_2022.bc: utf8_and_gb18030_2022.bc
+	cp $< $@
+
+else
+# create empty bitcode files to satisfy dependencies
+%.bc: %.c
+	@echo "LLVM disabled, creating empty bitcode file: $@"
+	@touch $@
+
+gb18030_2022.bc: utf8_and_gb18030_2022.bc
+	@echo "LLVM disabled, creating empty bitcode file: $@"
+	@touch $@
+
+endif
+
+all: $(patsubst %.o,%.bc,$(OBJS)) gb18030_2022.bc


### PR DESCRIPTION
Correct Makefile for gb18030_2022 generating LLVM bitcode when configured with the --with-llvm option.

Fix for #872 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional JIT bitcode build support when building with LLVM/Clang enabled.

- **Bug Fixes**
  - Fixed a trailing line continuation in the build configuration to prevent potential build issues.

- **Chores**
  - Standardized build file spacing/formatting for readability.
  - Added conditional gating with a clear fallback that creates placeholder bitcode artifacts when LLVM is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->