### PR TITLE
Oracle regression framework restructure 

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -69,7 +69,7 @@ check check-tests installcheck installcheck-parallel installcheck-tests oracle-p
 check check-tests installcheck installcheck-parallel installcheck-tests oracle-pg-check: submake-generated-headers
 	$(MAKE) -C src/test/regress $@
 
-
+oracle-check-tests: | oracle-temp-install
 
 # add oracle regression
 oracle-check oracle-check-tests oracle-installcheck oracle-installcheck-parallel oracle-installcheck-tests: CHECKPREP_TOP=src/oracle_test/regress

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -463,7 +463,7 @@ ifeq ($(MAKELEVEL),0)
 	rm -rf '$(abs_top_builddir)'/tmp_install
 	$(MKDIR_P) '$(abs_top_builddir)'/tmp_install/log
 	$(MAKE) -C '$(top_builddir)' DESTDIR='$(abs_top_builddir)'/tmp_install install >'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
-	$(MAKE) -j1 $(if $(CHECKPREP_TOP),-C $(CHECKPREP_TOP),) checkprep >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
+	$(MAKE) -j1 $(if $(CHECKPREP_TOP),-C $(CHECKPREP_TOP),) oracle-checkprep >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
 
 	$(with_temp_install) initdb --auth trust --no-sync -m oracle -C normal --no-instructions --lc-messages=C --no-clean '$(abs_top_builddir)'/tmp_install/initdb-template >>'$(abs_top_builddir)'/tmp_install/log/initdb-template.log 2>&1
 endif

--- a/src/oracle_test/isolation/Makefile
+++ b/src/oracle_test/isolation/Makefile
@@ -75,8 +75,8 @@ oracle-check: all
 # Non-default tests.  It only makes sense to run these if set up to use
 # prepared transactions, via TEMP_CONFIG for the check case, or via the
 # postgresql.conf for the installcheck case.
-oracle-installcheck-prepared-txns: all temp-install
+oracle-installcheck-prepared-txns: all oracle-temp-install
 	$(oracle_isolation_regress_installcheck) --schedule=$(srcdir)/isolation_schedule prepared-transactions prepared-transactions-cic
 
-oracle-check-prepared-txns: all temp-install
+oracle-check-prepared-txns: all oracle-temp-install
 	$(oracle_isolation_regress_check) --schedule=$(srcdir)/isolation_schedule prepared-transactions prepared-transactions-cic

--- a/src/oracle_test/modules/injection_points/expected/injection_points.out
+++ b/src/oracle_test/modules/injection_points/expected/injection_points.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION injection_points;
 \getenv libdir PG_LIBDIR
 \getenv dlsuffix PG_DLSUFFIX
-\set regresslib :libdir '/regress' :dlsuffix
+\set regresslib :libdir '/oraregress' :dlsuffix
 CREATE FUNCTION wait_pid(int)
   RETURNS void
   AS :'regresslib'

--- a/src/oracle_test/modules/injection_points/sql/injection_points.sql
+++ b/src/oracle_test/modules/injection_points/sql/injection_points.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION injection_points;
 
 \getenv libdir PG_LIBDIR
 \getenv dlsuffix PG_DLSUFFIX
-\set regresslib :libdir '/regress' :dlsuffix
+\set regresslib :libdir '/oraregress' :dlsuffix
 
 CREATE FUNCTION wait_pid(int)
   RETURNS void

--- a/src/oracle_test/modules/test_oat_hooks/Makefile
+++ b/src/oracle_test/modules/test_oat_hooks/Makefile
@@ -1,4 +1,4 @@
-# src/test/modules/test_oat_hooks/Makefile
+# src/oracle_test/modules/test_oat_hooks/Makefile
 
 MODULE_big = test_oat_hooks
 OBJS = \
@@ -19,7 +19,7 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
-subdir = src/test/modules/test_oat_hooks
+subdir = src/oracle_test/modules/test_oat_hooks
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk

--- a/src/oracle_test/modules/test_resowner/Makefile
+++ b/src/oracle_test/modules/test_resowner/Makefile
@@ -1,4 +1,4 @@
-# src/test/modules/test_resowner/Makefile
+# src/oracle_test/modules/test_resowner/Makefile
 
 MODULE_big = test_resowner
 OBJS = \
@@ -17,7 +17,7 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
-subdir = src/test/modules/test_resowner
+subdir = src/oracle_test/modules/test_resowner
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk

--- a/src/oracle_test/recovery/Makefile
+++ b/src/oracle_test/recovery/Makefile
@@ -14,7 +14,7 @@
 EXTRA_INSTALL=contrib/pg_prewarm \
 	contrib/pg_stat_statements \
 	contrib/test_decoding \
-	src/test/modules/injection_points
+	src/oracle_test/modules/injection_points
 
 subdir = src/oracle_test/recovery
 top_builddir = ../../..

--- a/src/oracle_test/regress/GNUmakefile
+++ b/src/oracle_test/regress/GNUmakefile
@@ -101,7 +101,7 @@ ORACLE_REGRESS_OPTS = --dlpath=. --max-concurrent-tests=20 \
 oracle-check: all
 	$(oracle_regress_check) $(ORACLE_REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule $(MAXCONNOPT) $(EXTRA_TESTS)
 
-oracle-check-tests: all | temp-install
+oracle-check-tests: all | oracle-temp-install
 	$(oracle_regress_check) $(ORACLE_REGRESS_OPTS) $(MAXCONNOPT) $(TESTS) $(EXTRA_TESTS)
 
 oracle-installcheck: all
@@ -124,7 +124,7 @@ bigtest: all
 	$(oracle_regress_installcheck) $(ORACLE_REGRESS_OPTS) --schedule=$(srcdir)/serial_schedule --max-connections=1 numeric_big
 	$(oracle_regress_installcheck) $(ORACLE_REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule --max-connections=1 numeric_big
 
-bigcheck: all | temp-install
+bigcheck: all | oracle-temp-install
 	$(oracle_regress_check) $(ORACLE_REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule $(MAXCONNOPT) numeric_big
 
 

--- a/src/oracle_test/regress/GNUmakefile
+++ b/src/oracle_test/regress/GNUmakefile
@@ -13,7 +13,7 @@
 #
 #-------------------------------------------------------------------------
 
-PGFILEDESC = "pg_regress - test driver"
+PGFILEDESC = "ora_pg_regress - test driver"
 PGAPPICON = win32
 
 subdir = src/oracle_test/regress

--- a/src/oracle_test/regress/expected/type_sanity.out
+++ b/src/oracle_test/regress/expected/type_sanity.out
@@ -14,7 +14,7 @@
 -- directory paths and dlsuffix are passed to us in environment variables
 \getenv libdir PG_LIBDIR
 \getenv dlsuffix PG_DLSUFFIX
-\set regresslib :libdir '/regress' :dlsuffix
+\set regresslib :libdir '/oraregress' :dlsuffix
 -- **************** pg_type ****************
 -- Look for illegal values in pg_type fields.
 SELECT t1.oid, t1.typname

--- a/src/oracle_test/regress/sql/type_sanity.sql
+++ b/src/oracle_test/regress/sql/type_sanity.sql
@@ -16,7 +16,7 @@
 \getenv libdir PG_LIBDIR
 \getenv dlsuffix PG_DLSUFFIX
 
-\set regresslib :libdir '/regress' :dlsuffix
+\set regresslib :libdir '/oraregress' :dlsuffix
 
 -- **************** pg_type ****************
 


### PR DESCRIPTION
1. cherry-pick from V4 Stable PR #861
2. fix issue after make clean under oracle_test/regression, then make oracle-check failed when load regress.so

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a dedicated Oracle regression test target and updated related targets to depend on an Oracle-specific temporary install.
  * Switched isolation and recovery tests to Oracle module paths and updated regression library references to /oraregress.
  * Ensured bigcheck and oracle-check-tests run after Oracle temp install for consistent setup.
  * Relocated Oracle test modules to oracle_test paths.

* **Chores**
  * Updated test driver description to “ora_pg_regress.”
  * Standardized pre-install preparation to use the Oracle-specific check preparation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->