### PR TITLE
add format-check cirrus workflow and pre-commit hooks.

### DIFF
--- a/.cirrus.format.yml
+++ b/.cirrus.format.yml
@@ -1,0 +1,64 @@
+## Cirrus CI: PR-only Linux FormatCheck
+task:
+  name: FormatCheck
+  only_if: $CIRRUS_PR != ''
+
+  container:
+    image: debian:bookworm-slim
+    cpu: 2
+    memory: 2G
+
+  format_check_script: |
+    set -euo pipefail
+    echo "[FormatCheck] Installing build dependencies..."
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+      build-essential git ca-certificates perl python3 meson ninja-build pkg-config flex bison
+
+    echo "[FormatCheck] Configuring minimal Meson build..."
+    meson setup build --buildtype=release --auto-features=disabled
+
+    echo "[FormatCheck] Building pg_bsd_indent via Meson..."
+    ninja -C build src/tools/pg_bsd_indent/pg_bsd_indent || ninja -C build pg_bsd_indent || ninja -C build
+
+    echo "[FormatCheck] Determining changed files..."
+    HEAD_SHA=$(git rev-parse HEAD)
+    BASE_BRANCH="${CIRRUS_BASE_BRANCH:-}"
+    if [ -z "$BASE_BRANCH" ]; then
+      BASE_BRANCH=$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')
+    fi
+    BASE=""
+    if [ -n "$BASE_BRANCH" ]; then
+      git fetch --quiet origin "$BASE_BRANCH" || true
+      BASE=$(git merge-base HEAD "origin/$BASE_BRANCH" || true)
+    fi
+    if [ -z "$BASE" ]; then
+      BASE="${CIRRUS_BASE_SHA:-}"
+    fi
+    if [ -z "$BASE" ] || [ "$BASE" = "$HEAD_SHA" ]; then
+      BASE=$(git rev-parse HEAD~1 2>/dev/null || echo "$HEAD_SHA")
+    fi
+    echo "HEAD=$HEAD_SHA BASE_BRANCH=$BASE_BRANCH BASE=$BASE"
+
+    files=$(git diff --name-only "$BASE"..HEAD | grep -E -i '\.(c|h|cpp|hpp)$' | grep -v '^src/tools/pg_bsd_indent/' || true)
+    if [ -z "$files" ]; then
+      echo "[FormatCheck] No C/C++ changes detected; skipping."
+      exit 0
+    fi
+    export PGTYPEDEFS=$(pwd)/src/tools/pgindent/typedefs.list
+    export PGINDENT=$(pwd)/build/src/tools/pg_bsd_indent/pg_bsd_indent
+
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+
+    echo "[FormatCheck] Running pgindent --check..."
+    set +e
+    ./src/tools/pgindent/pgindent --check $files
+    rc=$?
+    set -e
+    if [ $rc -ne 0 ]; then
+      echo "[FormatCheck] Unformatted changes detected; suggested patch below:"
+      ./src/tools/pgindent/pgindent --diff $files || true
+      exit $rc
+    fi
+    echo "[FormatCheck] Passed."

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -39,7 +39,10 @@ def main():
         output += "\n# REPO_CI_CONFIG_URL was not set\n"
 
     # Add 3)
-    output += config_from(".cirrus.tasks.yml")
+    # output += config_from(".cirrus.tasks.yml")
+
+    # PR-only format check
+    output += config_from(".cirrus.format.yml")
 
     return output
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Allow skipping via env var (e.g. to temporarily skip formatting):
+#   PG_NO_FORMAT=1 git commit -m "..."
+if [[ "${PG_NO_FORMAT:-}" == "1" ]]; then
+  exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# Process only staged C/C++ files (exclude pg_bsd_indent sources)
+mapfile -t files < <(\
+  git diff --cached --name-only --diff-filter=ACMR | \
+  grep -E '\.(c|h|cpp|hpp)$' | \
+  grep -vE '^src/tools/pg_bsd_indent/' || true)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+echo "[pre-commit] Ensuring pg_bsd_indent is built..."
+if ! make -C src/tools/pg_bsd_indent -s pg_bsd_indent >/dev/null; then
+  echo "[pre-commit] Failed to build src/tools/pg_bsd_indent/pg_bsd_indent." >&2
+  echo "[pre-commit] Install build tools and try: make -C src/tools/pg_bsd_indent V=1" >&2
+  exit 1
+fi
+
+if [[ ! -x src/tools/pg_bsd_indent/pg_bsd_indent ]]; then
+  echo "[pre-commit] Built binary not found: src/tools/pg_bsd_indent/pg_bsd_indent" >&2
+  exit 1
+fi
+
+export PGINDENT="$repo_root/src/tools/pg_bsd_indent/pg_bsd_indent"
+
+# Pin typedefs list
+export PGTYPEDEFS="$repo_root/src/tools/pgindent/typedefs.list"
+
+pgindent_script="$repo_root/src/tools/pgindent/pgindent"
+if [[ ! -x "$pgindent_script" ]]; then
+  echo "[pre-commit] Executable $pgindent_script not found; cannot format." >&2
+  exit 1
+fi
+
+echo "[pre-commit] Formatting staged files with pgindent..."
+"$pgindent_script" "${files[@]}"
+
+# Re-add formatted files to the index
+git add -- "${files[@]}"
+
+# Second check to ensure no remaining diffs
+echo "[pre-commit] Verifying formatting consistency..."
+if ! "$pgindent_script" --check "${files[@]}"; then
+  echo "[pre-commit] Unformatted changes remain. Review the diff and retry commit." >&2
+  exit 1
+fi
+
+exit 0
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,11 @@ When it comes to C and C++ parts of IvorySQL, we try to follow PostgreSQL Coding
 
 For **C** and **Perl** code, please run pgindent if necessary. We recommend using **git diff --color** when reviewing your changes so that you don't have any spurious whitespace issues in the code that you submit.
 
+Formatting hooks and CI:
+- A pre-commit formatting hook is provided at `.githooks/pre-commit`. Enable it with `git config core.hooksPath .githooks`, or run `make enable-git-hooks` (equivalently `bash tools/enable-git-hooks.sh`).
+- The hook depends only on in-tree tools `src/tools/pgindent` and `src/tools/pg_bsd_indent`. On commit it formats staged C/C++ files with pgindent and re-adds them to the index. 
+- A Cirrus workflow `FormatCheck` runs `pgindent --check` on files changed in a PR.
+
 All new functionality that is contributed to IvorySQL should be covered by regression tests that are contributed alongside it. If you are uncertain about how to test or document your work, please raise the question on the ivorysql-hackers mailing list and the developer community will do its best to help you.
 
 At the very minimum, you should always be running make installcheck-world to make sure that you're not breaking anything.

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,8 @@ all check oracle-check all-check install installdirs installcheck oracle-install
 	   echo "You must use GNU make to build PostgreSQL." ; \
 	   false; \
 	 fi
+
+
+.PHONY: enable-git-hooks
+enable-git-hooks:
+	@bash tools/enable-git-hooks.sh

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Furthermore, for more detailed installation instructions, please refer to the [I
 - [Rpm installation](https://docs.ivorysql.org/en/ivorysql-doc/v4.5/v4.5/6#Rpm-installation)
 - [Source code installation](https://docs.ivorysql.org/en/ivorysql-doc/v4.5/v4.5/6#Source-code-installation)
 
-
+## Developer Formatting hooks and CI:
+- A pre-commit formatting hook is provided at `.githooks/pre-commit`. Enable it with `git config core.hooksPath .githooks`, or run `make enable-git-hooks` (equivalently `bash tools/enable-git-hooks.sh`).
+- The hook depends only on in-tree tools `src/tools/pgindent` and `src/tools/pg_bsd_indent`. On commit it formats staged C/C++ files with pgindent and re-adds them to the index. 
+- A Cirrus workflow `FormatCheck` runs `pgindent --check` on files changed in a PR.
 
 ## Contributing to the IvorySQL
 There are plenty of ways to contribute to IvorySQL. You can contribute by providing the documentation updates, by providing the

--- a/README_CN.md
+++ b/README_CN.md
@@ -16,6 +16,12 @@ IvorySQL 项目采用 Apache 2.0 许可协议发布，并鼓励各种形式的�
 
 </br>
 
+## 开发者代码格式化
+- 提交前自动格式化（推荐）：
+  - 已克隆仓库：在仓库根目录执行 `make enable-git-hooks`（或 `bash tools/enable-git-hooks.sh`）
+- 提交时行为：Git 钩子会自动用 `pgindent` 格式化已暂存的 C/C++ 文件并回加到暂存区，未通过二次校验会阻止提交。
+- PR 阶段：Cirrus 将运行 `FormatCheck`（pgindent --check）对差异文件做只读校验。
+
 ## 我们致力于遵循开源理念的原则
 我们致力于遵循[开源之道](https://opensource.com/open-source-way)的原则，并坚定地相信构建一个健康且包容的社区至关重要。我们始终坚信，优秀的想法可以来源于任何地方，而最优的想法应当脱颖而出。只有在多元观点的碰撞下，才能做出最明智的决策。尽管 IvorySQL 的首个版本主要聚焦于 Oracle 兼容性功能，但未来的路线图和功能集将由社区以开源的方式共同决定。
 </br>

--- a/tools/enable-git-hooks.sh
+++ b/tools/enable-git-hooks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Enable the repository's pre-commit hook and prebuild pg_bsd_indent.
+# Usage: bash tools/enable-git-hooks.sh
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$repo_root" ]]; then
+  echo "Please run this script inside a Git repository." >&2
+  exit 1
+fi
+cd "$repo_root"
+
+echo "[enable-git-hooks] Setting core.hooksPath=.githooks ..."
+git config --local core.hooksPath .githooks
+
+# Optional: support tools that only check .git/hooks
+if [[ ! -e .git/hooks/pre-commit ]]; then
+  mkdir -p .git/hooks
+  ln -s ../.githooks/pre-commit .git/hooks/pre-commit || true
+fi
+
+if [[ -x src/tools/pg_bsd_indent/pg_bsd_indent ]]; then
+  echo "[enable-git-hooks] pg_bsd_indent already present; skipping build."
+else
+  echo "[enable-git-hooks] Building pg_bsd_indent ..."
+  if ! make -C src/tools/pg_bsd_indent -j$(nproc 2>/dev/null || echo 2) >/dev/null; then
+    echo "[enable-git-hooks] Warning: build failed. you can build manually: make -C src/tools/pg_bsd_indent pg_bsd_indent"
+  fi
+fi
+
+echo "[enable-git-hooks] Done. Commits will now auto-run pgindent."
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a pre-commit hook that auto-formats staged C/C++ files and blocks commits if formatting fails.
  - Added a make target and helper script to enable and install developer Git hooks and ensure formatter availability.

- Chores
  - Added a PR-only CI job that checks formatting on changed C/C++ files and emits suggested patches on failures.

- Documentation
  - Updated contributor and project READMEs (including Chinese) with hook and CI formatting workflow details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->