### PR TITLE
fix the issue invalid case-conversion-mode value doesn't terminate initdb execution

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -3476,8 +3476,8 @@ main(int argc, char *argv[])
 				}
 				else
 				{
-					pg_log_error("Unknown case conversion mode： %s", switchmode);
-					pg_log_error_hint("Valid case conversion mode value is normal, interchange, lowercase.");
+					pg_log_error("Unknown case conversion mode: %s", switchmode);
+					pg_log_error_hint("Valid case conversion mode values are normal, interchange, or lowercase.");
 					exit(1);
 				}
 				break;


### PR DESCRIPTION
Changes
when the input case-conversion-mode value is invalid, error information is printed and provide hint on correct value.
update --help content to show valid case-conversion-mode value.
Related Issue
This pull request resolves https://github.com/IvorySQL/IvorySQL/issues/893 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI help for the case-conversion option with a clear, multi-line description of available modes (normal / interchange / lowercase) and the default.
* **Bug Fixes**
  * Replaced vague messaging for unknown mode with explicit error and hint output.
  * Command now exits with a failure status on invalid input and presents clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->