### PR TITLE
fix issue #898 MainLoop Segmentation fault due to dangle pointer

### DIFF
--- a/src/bin/psql/mainloop.c
+++ b/src/bin/psql/mainloop.c
@@ -656,6 +656,7 @@ MainLoop(FILE *source)
 		                {
 		                    pg_free(pl->items);
 		                    pg_free(pl);
+							break;
 		                }
 		            }
 		        }


### PR DESCRIPTION
Since code restructure remove break not noticed; re-add it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined an internal cleanup loop to exit earlier, reducing unnecessary iterations during resource cleanup.
  - Minor efficiency improvement in edge cases; does not alter commands, outputs, or user workflows.
  - No changes to error messages, configuration, or compatibility; behavior remains consistent for all user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->