### PR TITLE
fix Issue#887 ivorysql-wasm meson build error

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -160,7 +160,7 @@ option('systemd', type: 'feature', value: 'auto',
   description: 'systemd support')
 
 option('uuid', type: 'combo', choices: ['none', 'bsd', 'e2fs', 'ossp'],
-  value: 'ossp',
+  value: 'e2fs',
   description: 'Use LIB for contrib/uuid-ossp support')
 
 option('zlib', type: 'feature', value: 'auto',

--- a/src/bin/initdb/po/zh_CN.po
+++ b/src/bin/initdb/po/zh_CN.po
@@ -776,11 +776,8 @@ msgstr "\"%s\" 是用于 \"%s\" 连接的无效认证方法"
 
 #: initdb.c:2521
 #, c-format
-msgid "	NOTICE: If you set this to gb18030,\n\
-		the database will initilized with gb18030_2000,but not gb18030_2022,\n\
-		if you want to use gb18030_2022,please set this option to gb18030_2022,\n"
-msgstr "    注意: 如果设置了这个参数为gb18030,数据库会以gb18030_2000标准进行初始化,\n\
-        如果想要使用gb18030_2022标准,将此选项设置为gb18030_2022\n"
+msgid "NOTICE: If you set this to gb18030, the database will initilized with gb18030_2000,but not gb18030_2022, if you want to use gb18030_2022,please set this option to gb18030_2022,\n"
+msgstr "注意: 如果设置了这个参数为gb18030, 数据库会以gb18030_2000标准进行初始化, 如果想要使用gb18030_2022标准,将此选项设置为gb18030_2022\n"
 
 #: initdb.c:2531
 #, c-format


### PR DESCRIPTION
drop to master branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated default UUID library selection to use e2fs by default when enabling uuid-related functionality, improving out-of-the-box compatibility on most systems.
  - Adjusted Simplified Chinese (zh_CN) translation for an initdb NOTICE to a cleaner single-line format, aligning with the source message.

- Style
  - Minor formatting cleanup in localized messaging to ensure consistent punctuation and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->