### PR TITLE
master banch: fix Los Angeles Time Zones changes -  PST→PDT→PST→PDT

### DIFF
--- a/src/oracle_test/regress/expected/jsonb_jsonpath.out
+++ b/src/oracle_test/regress/expected/jsonb_jsonpath.out
@@ -2684,12 +2684,15 @@ select jsonb_path_query('"12:34:56 +5:30"', '$.time_tz().string()');
  "12:34:56+05:30"
 (1 row)
 
+begin;
+set local timezone = '-7';
 select jsonb_path_query_tz('"12:34:56"', '$.time_tz().string()');
  jsonb_path_query_tz 
 ---------------------
  "12:34:56-07:00"
 (1 row)
 
+rollback;
 select jsonb_path_query('"12:34:56"', '$.time().string()');
  jsonb_path_query 
 ------------------

--- a/src/oracle_test/regress/sql/jsonb_jsonpath.sql
+++ b/src/oracle_test/regress/sql/jsonb_jsonpath.sql
@@ -607,7 +607,10 @@ select jsonb_path_query_tz('"2023-08-15 12:34:56"', '$.timestamp_tz().string()')
 select jsonb_path_query('"2023-08-15 12:34:56 +5:30"', '$.timestamp_tz().string()');
 select jsonb_path_query('"2023-08-15 12:34:56"', '$.timestamp().string()');
 select jsonb_path_query('"12:34:56 +5:30"', '$.time_tz().string()');
+begin;
+set local timezone = '-7';
 select jsonb_path_query_tz('"12:34:56"', '$.time_tz().string()');
+rollback;
 select jsonb_path_query('"12:34:56"', '$.time().string()');
 select jsonb_path_query('"2023-08-15"', '$.date().string()');
 


### PR DESCRIPTION
Since Time Changes in Los Angeles, test case src/oracle_test/regress/sql/jsonb_jsonpath.sql 
`select jsonb_path_query_tz('"12:34:56"', '$.time_tz().string()');`
will get unexpected results 
```
select jsonb_path_query_tz('"12:34:56"', '$.time_tz().string()');
 jsonb_path_query_tz 
---------------------
 "12:34:56-07:00"
```

or 
```
select jsonb_path_query_tz('"12:34:56"', '$.time_tz().string()');
 jsonb_path_query_tz 
---------------------
 "12:34:56-08:00"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation for timezone-sensitive operations to improve test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->