### PR TITLE
CI not ignore warning, with make  CPPFLAGS="$CPPFLAGS -Werror"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points
     - name: compile
-      run: make CFLAGS="$CFLAGS -Werror -Wshadow"
+      run: make CPPFLAGS="$CPPFLAGS -Werror"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process updated to enforce stricter code-quality checks by treating compiler warnings as errors during compilation, helping prevent new warnings from being introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->