### PR TITLE
fix: allow COMMIT/ROLLBACK in nested PL/iSQL procedure calls

### DIFF
--- a/src/oracle_test/regress/expected/ora_package.out
+++ b/src/oracle_test/regress/expected/ora_package.out
@@ -6278,6 +6278,44 @@ call test_pkg.test_p1(NULL, 23);
 (1 row)
 
 DROP package test_pkg;
+-- Test COMMIT in nested package procedure calls (Issue #1007)
+CREATE TABLE test_nested_commit (id int);
+CREATE OR REPLACE PACKAGE pkg_commit_test IS
+  PROCEDURE do_commit;
+  PROCEDURE main;
+END;
+/
+CREATE OR REPLACE PACKAGE BODY pkg_commit_test IS
+  PROCEDURE do_commit IS
+  BEGIN
+    INSERT INTO test_nested_commit VALUES (1);
+    COMMIT;
+    INSERT INTO test_nested_commit VALUES (2);
+  END;
+  PROCEDURE main IS
+  BEGIN
+    INSERT INTO test_nested_commit VALUES (0);
+    do_commit();
+    INSERT INTO test_nested_commit VALUES (3);
+  END;
+END;
+/
+TRUNCATE test_nested_commit;
+BEGIN
+  pkg_commit_test.main();
+END;
+/
+SELECT * FROM test_nested_commit ORDER BY id;
+ id 
+----
+  0
+  1
+  2
+  3
+(4 rows)
+
+DROP PACKAGE pkg_commit_test;
+DROP TABLE test_nested_commit;
 --clean data
 RESET ivorysql.allow_out_parameter_const;
 DROP FUNCTION test_event_trigger;

--- a/src/pl/plisql/src/expected/plisql_transaction.out
+++ b/src/pl/plisql/src/expected/plisql_transaction.out
@@ -472,6 +472,7 @@ INSERT INTO test4 SELECT repeat('xyzzy', 2000);
 -- that will return a still-toasted value
 CREATE FUNCTION data_source(i int) RETURNS TEXT LANGUAGE sql
 AS 'select f1 from test4' IMMUTABLE;
+/
 DO $$
 declare x text;
 begin
@@ -481,9 +482,8 @@ begin
   end loop;
   raise notice 'length(x) = %', length(x);
 end $$;
+NOTICE:  length(x) = 10000
 /
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function inline_code_block line 6 at COMMIT
 -- operations on composite types vs. internal transactions
 DO LANGUAGE plisql $$
 declare
@@ -748,6 +748,162 @@ SELECT * FROM test1;
  2 | 
 (2 rows)
 
+-- Test nested procedure calls with COMMIT/ROLLBACK (Issue #1007)
+--
+-- Note: Oracle-syntax procedures (CREATE PROCEDURE ... IS) default to
+-- AUTHID DEFINER (prosecdef=true), which forces atomic mode and blocks
+-- COMMIT/ROLLBACK. Use AUTHID CURRENT_USER to allow transaction control.
+-- This matches Oracle behavior where COMMIT is allowed regardless of AUTHID.
+-- Tests below verify COMMIT/ROLLBACK in nested procedure calls
+-- using AUTHID CURRENT_USER (Oracle-compatible syntax).
+-- Without AUTHID CURRENT_USER, Oracle-syntax procedures default to
+-- SECURITY DEFINER (prosecdef=true), which forces atomic mode and
+-- blocks COMMIT/ROLLBACK. This is a known limitation (see Test 0).
+CREATE TABLE test_nested_commit (id int);
+-- Inner procedure with COMMIT
+CREATE OR REPLACE PROCEDURE nested_inner_commit AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (1);
+    COMMIT;
+    INSERT INTO test_nested_commit VALUES (2);
+END;
+/
+-- Outer procedure calling inner with CALL keyword
+CREATE OR REPLACE PROCEDURE nested_outer_commit AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (0);
+    CALL nested_inner_commit();
+    INSERT INTO test_nested_commit VALUES (3);
+END;
+/
+-- Test 1: Basic nested call with COMMIT
+TRUNCATE test_nested_commit;
+CALL nested_outer_commit();
+SELECT * FROM test_nested_commit ORDER BY id;
+ id 
+----
+  0
+  1
+  2
+  3
+(4 rows)
+
+-- Test 2: Oracle-style call (without CALL keyword) with COMMIT
+CREATE OR REPLACE PROCEDURE nested_outer_oracle_style AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (10);
+    nested_inner_commit();  -- Oracle-style call
+    INSERT INTO test_nested_commit VALUES (13);
+END;
+/
+TRUNCATE test_nested_commit;
+CALL nested_outer_oracle_style();
+SELECT * FROM test_nested_commit ORDER BY id;
+ id 
+----
+  1
+  2
+ 10
+ 13
+(4 rows)
+
+-- Test 3: Deeply nested Oracle-style calls (4 levels) with COMMIT
+CREATE OR REPLACE PROCEDURE nested_level4 AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (104);
+    COMMIT;
+    INSERT INTO test_nested_commit VALUES (105);
+END;
+/
+CREATE OR REPLACE PROCEDURE nested_level3 AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (103);
+    nested_level4();  -- Oracle-style call
+    INSERT INTO test_nested_commit VALUES (106);
+END;
+/
+CREATE OR REPLACE PROCEDURE nested_level2 AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (102);
+    nested_level3();  -- Oracle-style call
+    INSERT INTO test_nested_commit VALUES (107);
+END;
+/
+CREATE OR REPLACE PROCEDURE nested_level1 AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (101);
+    nested_level2();  -- Oracle-style call
+    INSERT INTO test_nested_commit VALUES (108);
+END;
+/
+TRUNCATE test_nested_commit;
+CALL nested_level1();
+SELECT * FROM test_nested_commit ORDER BY id;
+ id  
+-----
+ 101
+ 102
+ 103
+ 104
+ 105
+ 106
+ 107
+ 108
+(8 rows)
+
+-- Test 4: ROLLBACK in nested procedure with CALL keyword
+CREATE OR REPLACE PROCEDURE nested_inner_rollback AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (201);
+    ROLLBACK;
+    INSERT INTO test_nested_commit VALUES (202);
+END;
+/
+CREATE OR REPLACE PROCEDURE nested_outer_rollback AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (200);
+    CALL nested_inner_rollback();
+    INSERT INTO test_nested_commit VALUES (203);
+END;
+/
+TRUNCATE test_nested_commit;
+CALL nested_outer_rollback();
+SELECT * FROM test_nested_commit ORDER BY id;
+ id  
+-----
+ 202
+ 203
+(2 rows)
+
+-- Test 5: Oracle-style call (without CALL keyword) with ROLLBACK
+CREATE OR REPLACE PROCEDURE nested_outer_rollback_oracle_style AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (300);
+    nested_inner_rollback();  -- Oracle-style call
+    INSERT INTO test_nested_commit VALUES (303);
+END;
+/
+TRUNCATE test_nested_commit;
+CALL nested_outer_rollback_oracle_style();
+SELECT * FROM test_nested_commit ORDER BY id;
+ id  
+-----
+ 202
+ 303
+(2 rows)
+
+-- Clean up nested commit tests
+DROP PROCEDURE nested_inner_commit;
+DROP PROCEDURE nested_outer_commit;
+DROP PROCEDURE nested_outer_oracle_style;
+DROP PROCEDURE nested_level1;
+DROP PROCEDURE nested_level2;
+DROP PROCEDURE nested_level3;
+DROP PROCEDURE nested_level4;
+DROP PROCEDURE nested_inner_rollback;
+DROP PROCEDURE nested_outer_rollback;
+DROP PROCEDURE nested_outer_rollback_oracle_style;
+DROP TABLE test_nested_commit;
 DROP TABLE test1;
 DROP TABLE test2;
 DROP TABLE test3;

--- a/src/pl/plisql/src/pl_gram.y
+++ b/src/pl/plisql/src/pl_gram.y
@@ -2737,6 +2737,9 @@ stmt_execsql	: K_IMPORT
 							new->expr = build_call_expr(T_WORD, @1, &yylval, &yylloc, yyscanner);
 							new->is_call = true;
 
+							/* Remember we may need a procedure resource owner */
+							plisql_curr_compile->requires_procedure_resowner = true;
+
 							$$ = (PLiSQL_stmt *)new;
 						}
 						else
@@ -2763,6 +2766,9 @@ stmt_execsql	: K_IMPORT
 							new->stmtid = ++plisql_curr_compile->nstatements;
 							new->expr = build_call_expr(T_CWORD, @1, &yylval, &yylloc, yyscanner);
 							new->is_call = true;
+
+							/* Remember we may need a procedure resource owner */
+							plisql_curr_compile->requires_procedure_resowner = true;
 
 							$$ = (PLiSQL_stmt *)new;
 						}


### PR DESCRIPTION
## Summary

- Enable COMMIT/ROLLBACK in PL/iSQL anonymous blocks (DO) and procedure calls in Oracle compatibility mode
- Fix crash in multi-statement queries when nested procedures contain COMMIT/ROLLBACK
- Add regression tests for nested procedure call scenarios

## Changes

**src/backend/tcop/utility.c**

- Pass `atomic=false` for DO and CALL statements in Oracle mode at top-level

**src/pl/plisql/src/pl_gram.y**

- Set `requires_procedure_resowner = true` for Oracle-style procedure calls (T_WORD/T_CWORD)

**src/pl/plisql/src/pl_exec.c**

- Clear `simple_econtext_stack` in `exec_stmt_commit()` and `exec_stmt_rollback()` to handle cases where xact callbacks are not fired

## Test plan

- [x] 17/17 PL/iSQL tests pass
- [x] 234/234 Oracle compatibility tests pass
- [x] 228/228 PostgreSQL tests pass
- [x] New tests for nested calls with COMMIT/ROLLBACK in multi-statement queries

## Known limitations

- Procedures must use `SECURITY INVOKER` (PL/iSQL defaults to `SECURITY DEFINER` which forces atomic mode)
- Procedures with `SET` options also force atomic mode

Fixes #1007


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Procedure call execution now marks calls with a resource-owner requirement, improving resource management during calls.

* **Tests**
  * Added extensive SQL tests and test objects exercising nested COMMIT/ROLLBACK scenarios (multiple nesting levels, CALL and Oracle-style invocations) and cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->