### PR TITLE
build: add meson build support to dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     # Build tools
     build-essential git lcov bison flex pkg-config cppcheck \
+    # For meson/ninja installation
+    curl unzip \
     # Core dependencies
     libkrb5-dev libssl-dev libldap-dev libpam-dev \
     libxml2-dev libxslt-dev libreadline-dev libedit-dev \
@@ -17,7 +19,7 @@ RUN apt-get update && apt-get install -y \
     # ICU support
     libicu-dev \
     # Language support
-    python3-dev tcl-dev libperl-dev gettext \
+    python3-dev python3-setuptools tcl-dev libperl-dev gettext \
     # Perl test modules
     libipc-run-perl libtime-hires-perl libtest-simple-perl \
     # LLVM/Clang
@@ -33,6 +35,15 @@ RUN apt-get update && apt-get install -y \
     # For dev containers
     sudo tini \
     && rm -rf /var/lib/apt/lists/*
+
+# Install meson and ninja from source (matching workflow versions)
+RUN curl -L "https://github.com/mesonbuild/meson/releases/download/1.0.1/meson-1.0.1.tar.gz" -o /tmp/meson-1.0.1.tar.gz \
+    && curl -L "https://github.com/ninja-build/ninja/releases/download/v1.10.1/ninja-linux.zip" -o /tmp/ninja-linux.zip \
+    && unzip -o /tmp/ninja-linux.zip -d /tmp \
+    && cp /tmp/ninja /usr/bin/ \
+    && tar xzf /tmp/meson-1.0.1.tar.gz -C /tmp \
+    && cd /tmp/meson-1.0.1 && python3 setup.py install \
+    && rm -rf /tmp/meson-1.0.1* /tmp/ninja*
 
 # Set up locale
 RUN locale-gen en_US.UTF-8

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ pg_ctl -D data_ora start
 make oracle-check
 ```
 
+### Meson Build (Alternative)
+
+```bash
+# Enter the development container
+docker compose exec dev bash
+
+# Configure with meson
+meson setup build -Dcassert=true -Dbuildtype=debug
+
+# Build with ninja
+ninja -C build
+
+# Run from build directory
+./build/src/backend/postgres --version
+```
+
+Note: Meson requires a clean source tree. If you previously ran `./configure`,
+run `make distclean` first.
+
 ## Developer Formatting hooks and CI:
 - A pre-commit formatting hook is provided at `.githooks/pre-commit`. Enable it with `git config core.hooksPath .githooks`, or run `make code-format` (equivalently `bash tools/enable-git-hooks.sh`).
 - The hook depends only on in-tree tools `src/tools/pgindent` and `src/tools/pg_bsd_indent`. On commit it formats staged C/C++ files with pgindent and re-adds them to the staged area. 


### PR DESCRIPTION
Follows https://github.com/IvorySQL/IvorySQL/blob/master/.github/workflows/meson_build.yml as much as possible.

- Install meson 1.0.1 and ninja 1.10.1 from source
- Add python3-setuptools, curl, unzip as dependencies (seems included in Github pipeline nodes, need to install explicitly in dev container)
- Document meson build in README.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Meson Build (Alternative)" docs describing how to configure, build, and run the project using Meson/Ninja; includes note about starting from a clean source tree.
  * Added CI FormatCheck workflow documentation for formatting/style checks.

* **Chores**
  * Updated development container to include additional build tools, compilers, libraries, locale support, and utilities to support alternative build workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->