### PR TITLE
Fix raw_expression_tree_walker for ColumnRefOrFuncCall (issue #1182)

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -4465,17 +4465,12 @@ raw_expression_tree_walker_impl(Node *node,
 			break;
 		case T_ColumnRefOrFuncCall:
 			{
-				FuncCall   *fcall = ((ColumnRefOrFuncCall *) node)->func;
+				ColumnRefOrFuncCall *colf = (ColumnRefOrFuncCall *) node;
 
-				if (WALK(fcall->args))
+				if (colf->cref && WALK(colf->cref))
 					return true;
-				if (WALK(fcall->agg_order))
+				if (colf->func && WALK(colf->func))
 					return true;
-				if (WALK(fcall->agg_filter))
-					return true;
-				if (WALK(fcall->over))
-					return true;
-				/* function name is deemed uninteresting */
 			}
 			break;
 		case T_NamedArgExpr:


### PR DESCRIPTION
This commit fixes raw_expression_tree_walker_impl() handling of T_ColumnRefOrFuncCall.
Previously it only walked into colf->func’s members (e.g., args, agg_order, agg_filter, over) and did not WALK(colf->func) itself, so walker callbacks could not observe the FuncCall node when it was wrapped by ColumnRefOrFuncCall (Oracle parser output).
The new logic walks both children explicitly: colf->cref and colf->func (with NULL checks). This makes raw tree traversal complete and consistent with other node cases, and allows callbacks to correctly find FuncCall nodes under ColumnRefOrFuncCall, addressing issue https://github.com/IvorySQL/IvorySQL/issues/1182.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal expression evaluation logic for improved handling of complex database queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->