### PR TITLE
create minimal SYS.V$SESSION view

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_sysview.out
+++ b/contrib/ivorysql_ora/expected/ora_sysview.out
@@ -137,3 +137,47 @@ WHERE OBJECT_NAME = 'FUNC_WITH_DEFAULT';
 
 -- clean data
 DROP FUNCTION IF EXISTS FUNC_WITH_DEFAULT;
+-- Oracle dynamic views
+\d SYS.V$SESSION
+                            View "sys.v$session"
+      Column       |          Type          | Collation | Nullable | Default 
+-------------------+------------------------+-----------+----------+---------
+ sid               | number                 |           |          | 
+ username          | varchar2(128)          | C         |          | 
+ status            | varchar2(40)           |           |          | 
+ machine           | varchar2(128)          |           |          | 
+ program           | varchar2(256)          |           |          | 
+ type              | varchar2(30)           |           |          | 
+ logon_time        | pg_catalog.timestamptz |           |          | 
+ sql_exec_start    | pg_catalog.timestamptz |           |          | 
+ sql_id            | varchar2(19)           |           |          | 
+ sql_text          | varchar2(4000)         |           |          | 
+ blocking_session  | number                 |           |          | 
+ event             | varchar2(64)           |           |          | 
+ wait_class        | varchar2(64)           |           |          | 
+ transaction_start | pg_catalog.timestamptz |           |          | 
+ port              | number                 |           |          | 
+
+\d SYS.V$PROCESS
+                    View "sys.v$process"
+   Column   |     Type      | Collation | Nullable | Default 
+------------+---------------+-----------+----------+---------
+ spid       | number        |           |          | 
+ username   | varchar2(128) | C         |          | 
+ program    | varchar2(256) |           |          | 
+ pname      | varchar2(30)  |           |          | 
+ background | varchar2(1)   |           |          | 
+
+SELECT * 
+FROM SYS.V$PARAMETER 
+WHERE NAME IN ('listen_addresses','application_name','archive_command','archive_mode','block_size')
+ORDER BY NAME;
+       name       | type |         value          | default_value | isdefault | isses_modifiable | issys_modifiable |                            description                            
+------------------+------+------------------------+---------------+-----------+------------------+------------------+-------------------------------------------------------------------
+ application_name | 2    | pg_regress/ora_sysview |               | FALSE     | TRUE             | IMMEDIATE        | Sets the application name to be reported in statistics and logs.
+ archive_command  | 2    | (disabled)             |               | FALSE     | FALSE            | IMMEDIATE        | Sets the shell command that will be called to archive a WAL file.
+ archive_mode     | 2    | off                    | off           | TRUE      | FALSE            | FALSE            | Allows archiving of WAL files using "archive_command".
+ block_size       | 3    | 8192                   | 8192          | TRUE      | FALSE            | FALSE            | Shows the size of a disk block.
+ listen_addresses | 2    |                        | localhost     | FALSE     | FALSE            | FALSE            | Sets the host name or IP address(es) to listen to.
+(5 rows)
+

--- a/contrib/ivorysql_ora/sql/ora_sysview.sql
+++ b/contrib/ivorysql_ora/sql/ora_sysview.sql
@@ -82,3 +82,11 @@ SELECT ARGUMENT_NAME, IN_OUT, POSITION, DEFAULTED FROM ALL_ARGUMENTS
 WHERE OBJECT_NAME = 'FUNC_WITH_DEFAULT';
 -- clean data
 DROP FUNCTION IF EXISTS FUNC_WITH_DEFAULT;
+
+-- Oracle dynamic views
+\d SYS.V$SESSION
+\d SYS.V$PROCESS
+SELECT * 
+FROM SYS.V$PARAMETER 
+WHERE NAME IN ('listen_addresses','application_name','archive_command','archive_mode','block_size')
+ORDER BY NAME;

--- a/contrib/ivorysql_ora/src/sysview/sysview--1.0.sql
+++ b/contrib/ivorysql_ora/src/sysview/sysview--1.0.sql
@@ -1192,3 +1192,84 @@ WHERE
   AND PG_GET_USERBYID(C.RELOWNER) = CURRENT_USER;
 GRANT SELECT ON SYS.USER_VIEWS TO PUBLIC;
 
+------------------------------------------------
+-- V$ DYNAMIC VIEWS
+------------------------------------------------
+
+-- V$SESSION:
+-- 1. For SID we use PG_STAT_ACTIVITY.PID and do not set SERIAL#:
+-- we should avoid implementing "killing by SID" without either an additional counter or second factor like PG_STAT_ACTIVITY.BACKEND_START.
+-- 2. SQL_ID is based on PG_STAT_ACTIVITY.QUERY_ID which depends on compute_query_id setting: SQL_ID is NULL if compute_query_id is 'off'.
+-- SQL_ID is incompatible with Oracle because QUERY_ID a integer string in PostgreSQL and in Oracle SQL_ID is 13-character base32-encoded
+-- hash.
+-- 
+-- We do not grant SELECT privilege on V$SESSION to PUBLIC because SQL_TEXT is retrieved.
+-- We do not grant SELECT privilege on V$PROCESS or on V$PARAMETER to PUBLIC
+-- because it contradicts with least security privilege principle.
+
+CREATE OR REPLACE VIEW SYS.V$SESSION AS
+SELECT
+    PG_STAT_ACTIVITY.PID::NUMBER AS SID,
+    USENAME::VARCHAR2(128) AS USERNAME,
+    CASE WHEN STATE = 'active' OR STATE = 'fastpath function call' THEN 'ACTIVE'
+         WHEN STATE = 'idle' OR STATE = 'idle in transaction'
+               OR STATE = 'idle in transaction (aborted)' THEN 'INACTIVE'
+         ELSE 'INACTIVE' 
+         END::VARCHAR2(40) AS STATUS,
+    COALESCE(CLIENT_HOSTNAME, HOST(CLIENT_ADDR),CLIENT_ADDR::TEXT)::VARCHAR2(128) AS MACHINE,
+    APPLICATION_NAME::VARCHAR2(256) AS PROGRAM,
+    CASE WHEN BACKEND_TYPE = 'client backend' THEN 'USER'
+    ELSE 'BACKGROUND'
+    END::VARCHAR2(30) AS TYPE,
+    BACKEND_START AS LOGON_TIME,
+    QUERY_START AS SQL_EXEC_START,
+    QUERY_ID::VARCHAR2(19) AS SQL_ID,
+    QUERY::VARCHAR2(4000) AS SQL_TEXT,
+    (PG_CATALOG.PG_BLOCKING_PIDS(PID))[1]::NUMBER AS BLOCKING_SESSION,
+    WAIT_EVENT::VARCHAR2(64) AS EVENT,
+    WAIT_EVENT_TYPE::VARCHAR2(64) AS WAIT_CLASS,
+    XACT_START AS TRANSACTION_START,
+    CLIENT_PORT::NUMBER AS PORT
+FROM PG_STAT_ACTIVITY;
+
+
+-- V$PROCESS: USERNAME maps to the database username (pg_stat_activity.usename),
+-- not the OS username as in Oracle V$PROCESS.
+CREATE OR REPLACE VIEW SYS.V$PROCESS AS
+SELECT
+    PID::NUMBER AS SPID,
+    USENAME::VARCHAR2(128) AS USERNAME,
+    APPLICATION_NAME::VARCHAR2(256) AS PROGRAM,
+    BACKEND_TYPE::VARCHAR2(30) AS PNAME,
+    CASE WHEN BACKEND_TYPE =  'client backend' THEN NULL
+         ELSE '1'
+    END::VARCHAR2(1) AS BACKGROUND
+FROM PG_STAT_ACTIVITY;
+
+CREATE OR REPLACE VIEW SYS.V$PARAMETER AS
+SELECT
+    NAME::VARCHAR2(80) AS NAME,
+    CASE
+        WHEN VARTYPE = 'bool'    THEN 1
+        WHEN VARTYPE = 'integer' THEN 3
+        ELSE 2
+    END::NUMBER AS TYPE,
+    SETTING::VARCHAR2(4000) AS VALUE,
+    BOOT_VAL::VARCHAR2(255) AS DEFAULT_VALUE,
+    -- Mapping update levels
+    CASE
+        WHEN setting IS NOT DISTINCT FROM boot_val THEN 'TRUE'
+        ELSE 'FALSE'
+    END::VARCHAR2(5) AS ISDEFAULT,
+    CASE
+        WHEN CONTEXT IN ('user', 'superuser') THEN 'TRUE'
+        ELSE 'FALSE'
+    END::VARCHAR2(5) AS ISSES_MODIFIABLE,
+    CASE
+        WHEN CONTEXT IN ('user', 'superuser','sighup') THEN 'IMMEDIATE'
+        WHEN CONTEXT IN ('postmaster','internal') THEN 'FALSE'
+        ELSE 'DEFERRED'
+    END::VARCHAR2(9) AS ISSYS_MODIFIABLE,
+    SHORT_DESC::VARCHAR2(255) AS DESCRIPTION
+FROM PG_SETTINGS;
+


### PR DESCRIPTION
Hello,

I propose this patch to create a minimal view for Oracle SYS.V$SESSION.

Could you please confirm that this is right way to create a dynamic Oracle view.

Thanks and regards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three public dynamic views—V$SESSION, V$PROCESS, and V$PARAMETER—to surface session, process, and configuration parameter details (status, process info, and parameter name/value metadata).

* **Permissions**
  * Granted read (SELECT) access on V$SESSION, V$PROCESS, and V$PARAMETER to all users for broad visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->