### PR TITLE
fix typo in ivorysql_ora comment

### DIFF
--- a/contrib/ivorysql_ora/ivorysql_ora.control
+++ b/contrib/ivorysql_ora/ivorysql_ora.control
@@ -1,5 +1,5 @@
 # ivorysql_ora extension
-comment = 'Oracle Compatible extenison on Postgres Database'
+comment = 'Oracle Compatible extension on Postgres Database'
 default_version = '1.0'
 module_pathname = '$libdir/ivorysql_ora'
 superuser = true


### PR DESCRIPTION
This is only to fix:

comment = 'Oracle Compatible extenison on Postgres Database'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the Oracle Compatible extension documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->