### PR TITLE
Fix/remove v5 warnings

### DIFF
--- a/src/backend/utils/adt/varlena.c
+++ b/src/backend/utils/adt/varlena.c
@@ -3994,7 +3994,8 @@ SplitGUCList(char *rawstring, char separator,
 			char	   *new_name;
 
 			new_name = identifier_case_transform(curname, strlen(curname));
-			strncpy(curname, new_name, strlen(new_name));
+			memcpy(curname, new_name, strlen(new_name));
+			curname[strlen(new_name)] = '\0';
 			pfree(new_name);
 		}
 

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -2895,6 +2895,7 @@ ExecQueryUsingCursor(const char *query, double *elapsed_msec)
 	int			flush_error;
 
 	*elapsed_msec = 0;
+	INSTR_TIME_SET_ZERO(before);
 
 	/* initialize print options for partial table output */
 	my_popt.topt.start_table = true;

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -2730,12 +2730,10 @@ static void
 plisql_remove_function_references(PLiSQL_function *func, PackageCacheItem *item)
 {
 	PLiSQL_package *psource = (PLiSQL_package *) item->source;
-	int pre_len = list_length(psource->source.funclist);
+
+	Assert(list_member_ptr(psource->source.funclist, func));
 
 	psource->source.funclist = list_delete_ptr(psource->source.funclist, (void *) func);
-
-	Assert(pre_len == list_length(psource->source.funclist) + 1);
-
 	psource->source.use_count--;
 
 	/*

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -3626,7 +3626,6 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 	{
 		/* only one out-parameter, change the rettype to be out-parameter type */
 		ListCell *lc;
-		bool found = false;
 
 		foreach (lc, subprocfunc->arg)
 		{
@@ -3635,7 +3634,6 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 			if (argitem->argmode == ARGMODE_OUT ||
 				argitem->argmode == ARGMODE_INOUT)
 			{
-				found = true;
 				result = true;
 				*rettype = argitem->type->typoid;
 				*typmod = argitem->type->atttypmod;
@@ -3643,7 +3641,7 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 				break;
 			}
 		}
-		Assert(found);
+		Assert(result);
 	}
 	return result;
 }

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -2731,8 +2731,11 @@ plisql_remove_function_references(PLiSQL_function *func, PackageCacheItem *item)
 {
 	PLiSQL_package *psource = (PLiSQL_package *) item->source;
 
-	Assert(list_member_ptr(psource->source.funclist, func));
-
+	if (!list_member_ptr(psource->source.funclist, func))
+	{
+		Assert(false);
+		return;
+	}
 	psource->source.funclist = list_delete_ptr(psource->source.funclist, (void *) func);
 	psource->source.use_count--;
 

--- a/src/pl/plisql/src/pl_subproc_function.c
+++ b/src/pl/plisql/src/pl_subproc_function.c
@@ -3024,7 +3024,6 @@ plisql_dynamic_compile_subproc(FunctionCallInfo fcinfo,
 static void
 plsql_init_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_level)
 {
-	bool		match = false;
 	int			connected;
 	PLiSQL_execstate *parestate;
 	PLiSQL_function *func;
@@ -3042,11 +3041,11 @@ plsql_init_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_l
 		if (dno >= parestate->ndatums)
 			continue;
 		plisql_assign_in_global_var(estate, parestate, dno);
-		match = true;
 		*start_level = connected;
-		break;
+
+		return;
 	}
-	Assert(match);
+	Assert(false);
 	return;
 }
 
@@ -3056,7 +3055,6 @@ plsql_init_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_l
 static void
 plsql_assign_out_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_level)
 {
-	bool		match = false;
 	int			connected;
 	PLiSQL_execstate *parestate;
 	PLiSQL_function *func;
@@ -3075,10 +3073,10 @@ plsql_assign_out_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *s
 			continue;
 		plisql_assign_out_global_var(estate, parestate, dno, connected);
 		*start_level = connected;
-		match = true;
-		break;
+
+		return;
 	}
-	Assert(match);
+	Assert(false);
 	return;
 }
 


### PR DESCRIPTION
This PR fixes all the warnings in IVORY_REL_5_STABLE branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure timing baseline initializes correctly for accurate elapsed-time reporting.
  * Fix string copy to guarantee null-termination and avoid unterminated name handling.

* **Refactor**
  * Streamlined function-removal and return-type validation logic for clarity.
  * Simplified control flow in variable initialization/assignment to make match/error paths clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->