### PR TITLE
Fix compiler warnings in timing and function removal code

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
@@ -66,33 +66,34 @@ static bool lookup_attempted = false;
 static void
 lookup_plisql_functions(void)
 {
-	void *fn;
 	if (lookup_attempted)
 		return;
 
 	lookup_attempted = true;
 
 #ifndef WIN32
-	/*
-	 * Use RTLD_DEFAULT to search all loaded shared objects.
-	 * plisql.so should already be loaded when these functions are called
-	 * from within a PL/iSQL context.
-	 */
-	fn = dlsym(RTLD_DEFAULT, "plisql_get_current_exception_context");
-	if (fn != NULL)
-		get_exception_context_fn = (plisql_get_context_fn) fn;
+	{
+		/*
+		* Use RTLD_DEFAULT to search all loaded shared objects.
+		* plisql.so should already be loaded when these functions are called
+		* from within a PL/iSQL context.
+		*/
+		void *fn = dlsym(RTLD_DEFAULT, "plisql_get_current_exception_context");
+		if (fn != NULL)
+			get_exception_context_fn = (plisql_get_context_fn) fn;
 
-	fn = dlsym(RTLD_DEFAULT, "plisql_get_current_exception_message");
-	if (fn != NULL)
-		get_exception_message_fn = (plisql_get_message_fn) fn;
+		fn = dlsym(RTLD_DEFAULT, "plisql_get_current_exception_message");
+		if (fn != NULL)
+			get_exception_message_fn = (plisql_get_message_fn) fn;
 
-	fn = dlsym(RTLD_DEFAULT, "plisql_get_current_exception_sqlerrcode");
-	if (fn != NULL)
-		get_exception_sqlerrcode_fn = (plisql_get_sqlerrcode_fn) fn;
+		fn = dlsym(RTLD_DEFAULT, "plisql_get_current_exception_sqlerrcode");
+		if (fn != NULL)
+			get_exception_sqlerrcode_fn = (plisql_get_sqlerrcode_fn) fn;
 
-	fn = dlsym(RTLD_DEFAULT, "plisql_get_call_stack");
-	if (fn != NULL)
-		get_call_stack_fn = (plisql_get_call_stack_fn) fn;
+		fn = dlsym(RTLD_DEFAULT, "plisql_get_call_stack");
+		if (fn != NULL)
+			get_call_stack_fn = (plisql_get_call_stack_fn) fn;
+	}
 #endif
 	/* On Windows, function pointers remain NULL - features require plisql */
 }

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
@@ -66,6 +66,7 @@ static bool lookup_attempted = false;
 static void
 lookup_plisql_functions(void)
 {
+	void *fn;
 	if (lookup_attempted)
 		return;
 
@@ -77,8 +78,6 @@ lookup_plisql_functions(void)
 	 * plisql.so should already be loaded when these functions are called
 	 * from within a PL/iSQL context.
 	 */
-	void *fn;
-
 	fn = dlsym(RTLD_DEFAULT, "plisql_get_current_exception_context");
 	if (fn != NULL)
 		get_exception_context_fn = (plisql_get_context_fn) fn;

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -104,6 +104,7 @@ ExecResult(PlanState *pstate)
 	 */
 	if (!node->rs_done)
 	{
+		TupleTableSlot *result;
 		outerPlan = outerPlanState(node);
 
 		if (outerPlan != NULL)
@@ -132,7 +133,7 @@ ExecResult(PlanState *pstate)
 		}
 
 		/* form the result tuple using ExecProject(), and return it */
-		TupleTableSlot *result = ExecProject(node->ps.ps_ProjInfo);
+		result = ExecProject(node->ps.ps_ProjInfo);
 
 		/*
 		 * If the projection contains ROWNUM expressions, materialize

--- a/src/backend/utils/adt/varlena.c
+++ b/src/backend/utils/adt/varlena.c
@@ -3994,7 +3994,8 @@ SplitGUCList(char *rawstring, char separator,
 			char	   *new_name;
 
 			new_name = identifier_case_transform(curname, strlen(curname));
-			strncpy(curname, new_name, strlen(new_name));
+			memcpy(curname, new_name, strlen(new_name));
+			curname[strlen(new_name)] = '\0';
 			pfree(new_name);
 		}
 

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -2860,6 +2860,7 @@ ExecQueryUsingCursor(const char *query, double *elapsed_msec)
 	int			flush_error;
 
 	*elapsed_msec = 0;
+	before.ticks = 0;
 
 	/* initialize print options for partial table output */
 	my_popt.topt.start_table = true;

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -2860,7 +2860,7 @@ ExecQueryUsingCursor(const char *query, double *elapsed_msec)
 	int			flush_error;
 
 	*elapsed_msec = 0;
-	before.ticks = 0;
+	INSTR_TIME_SET_ZERO(before);
 
 	/* initialize print options for partial table output */
 	my_popt.topt.start_table = true;

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -2730,12 +2730,10 @@ static void
 plisql_remove_function_references(PLiSQL_function *func, PackageCacheItem *item)
 {
 	PLiSQL_package *psource = (PLiSQL_package *) item->source;
-	int pre_len = list_length(psource->source.funclist);
+
+	Assert(list_member_ptr(psource->source.funclist, func));
 
 	psource->source.funclist = list_delete_ptr(psource->source.funclist, (void *) func);
-
-	Assert(pre_len == list_length(psource->source.funclist) + 1);
-
 	psource->source.use_count--;
 
 	/*

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -3636,7 +3636,6 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 	{
 		/* only one out-parameter, change the rettype to be out-parameter type */
 		ListCell *lc;
-		bool found = false;
 
 		foreach (lc, subprocfunc->arg)
 		{
@@ -3645,7 +3644,6 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 			if (argitem->argmode == ARGMODE_OUT ||
 				argitem->argmode == ARGMODE_INOUT)
 			{
-				found = true;
 				result = true;
 				*rettype = argitem->type->typoid;
 				*typmod = argitem->type->atttypmod;
@@ -3653,7 +3651,7 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 				break;
 			}
 		}
-		Assert(found);
+		Assert(result);
 	}
 	return result;
 }

--- a/src/pl/plisql/src/pl_subproc_function.c
+++ b/src/pl/plisql/src/pl_subproc_function.c
@@ -3024,7 +3024,6 @@ plisql_dynamic_compile_subproc(FunctionCallInfo fcinfo,
 static void
 plsql_init_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_level)
 {
-	bool		match = false;
 	int			connected;
 	PLiSQL_execstate *parestate;
 	PLiSQL_function *func;
@@ -3042,11 +3041,11 @@ plsql_init_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_l
 		if (dno >= parestate->ndatums)
 			continue;
 		plisql_assign_in_global_var(estate, parestate, dno);
-		match = true;
 		*start_level = connected;
-		break;
+
+		return;
 	}
-	Assert(match);
+	Assert(false);
 	return;
 }
 
@@ -3056,7 +3055,6 @@ plsql_init_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_l
 static void
 plsql_assign_out_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *start_level)
 {
-	bool		match = false;
 	int			connected;
 	PLiSQL_execstate *parestate;
 	PLiSQL_function *func;
@@ -3075,10 +3073,10 @@ plsql_assign_out_glovalvar_from_stack(PLiSQL_execstate * estate, int dno, int *s
 			continue;
 		plisql_assign_out_global_var(estate, parestate, dno, connected);
 		*start_level = connected;
-		match = true;
-		break;
+
+		return;
 	}
-	Assert(match);
+	Assert(false);
 	return;
 }
 


### PR DESCRIPTION
This PR fixes all the warnings in master branch introduced in recent months. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal cleanup and reorganization of local declarations and loop/control flow to improve clarity and maintainability.
* **Bug Fix**
  * Ensure timing accumulator is reliably initialized to avoid stale timing state.
  * Improve string handling to guarantee proper termination of transformed identifiers, avoiding potential truncation or corruption.

No changes to public interfaces or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->