### PR TITLE
Fix output string to create IDENTITY sequence

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -19103,7 +19103,7 @@ dumpSequence(Archive *fout, const TableInfo *tbinfo)
 			else if (owning_tab->attidentity[tbinfo->owning_col - 1] == ATTRIBUTE_ORA_IDENTITY_BY_DEFAULT)
 				appendPQExpBufferStr(query, "BY DEFAULT");
 			else if (owning_tab->attidentity[tbinfo->owning_col - 1] == ATTRIBUTE_IDENTITY_DEFAULT_ON_NULL)
-				appendPQExpBufferStr(query, "BY DEFAULT NO NULL");
+				appendPQExpBufferStr(query, "BY DEFAULT ON NULL");
 			appendPQExpBuffer(query, " AS IDENTITY (\n");
 		}
 	}


### PR DESCRIPTION
was "NO NULL" insteaf of "ON NULL".

no test added, though it outlines the pg_dump/pg_restore CI is maybe not efficient enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pg_dump output for identity columns to correctly generate `BY DEFAULT ON NULL` syntax instead of the previously incorrect `BY DEFAULT NO NULL`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->