### PR TITLE
reserve ivorysql prefix for gucs

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -4181,3 +4181,10 @@ reset nls_date_format;
 reset nls_timestamp_format;
 reset nls_timestamp_tz_format;
 reset default_text_search_config;
+-- should throw errors, because dummy_config is not a valid configuration name
+set ivorysql.dummy_config to dummy;
+ERROR:  invalid configuration parameter name "ivorysql.dummy_config"
+DETAIL:  "ivorysql" is a reserved prefix.
+reset ivorysql.dummy_config;
+ERROR:  invalid configuration parameter name "ivorysql.dummy_config"
+DETAIL:  "ivorysql" is a reserved prefix.

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -2345,3 +2345,6 @@ reset nls_date_format;
 reset nls_timestamp_format;
 reset nls_timestamp_tz_format;
 reset default_text_search_config;
+-- should throw errors, because dummy_config is not a valid configuration name
+set ivorysql.dummy_config to dummy;
+reset ivorysql.dummy_config;

--- a/contrib/ivorysql_ora/src/ivorysql_ora.c
+++ b/contrib/ivorysql_ora/src/ivorysql_ora.c
@@ -126,6 +126,8 @@ _PG_init(void)
 								0,
 								utl_file_umask_check_hook,
 								utl_file_umask_assign_hook, NULL);
+
+	MarkGUCPrefixReserved("ivorysql");
 }
 
 /*


### PR DESCRIPTION
Currently, the following statements execute without error, potentially causing confusion since all IvorySQL GUCs share the "ivorysql" prefix:

```
SET ivorysql.dummy_config TO 'dummy';
RESET ivorysql.dummy_config;

```
This PR reserves the "ivorysql" prefix, ensuring these statements now produce errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reserved the "ivorysql" configuration prefix so parameters using that prefix are disallowed.

* **Tests**
  * Added tests that verify proper error messages when attempting to set or reset parameters using the reserved "ivorysql" prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->