### PR TITLE
fix: Use snprintf instead of sprintf in pl_scanner.c

### DIFF
--- a/src/pl/plisql/src/pl_scanner.c
+++ b/src/pl/plisql/src/pl_scanner.c
@@ -241,18 +241,18 @@ plisql_yylex(YYSTYPE *yylvalp, YYLTYPE *yyllocp, yyscan_t yyscanner)
 
 				if (i != plisql_curr_compile->fn_nargs)
 				{
-					sprintf(buf, "%s", plisql_curr_compile->paramnames[i]);
+                    snprintf(buf, sizeof(buf), "%s", plisql_curr_compile->paramnames[i]);
 				}
 				else
 				{
 					num = calculate_oraparamnumber(aux1.lval.str);
-					sprintf(buf, "$%d", num);
+                    snprintf(buf, sizeof(buf), "$%d", num);
 				}
 			}
 			else
 			{
 				num = calculate_oraparamnumber(aux1.lval.str);
-				sprintf(buf, "$%d", num);
+                snprintf(buf, sizeof(buf), "$%d", num);
 			}
 
 			paramname = buf;


### PR DESCRIPTION
Replace sprintf with snprintf to prevent buffer overflow vulnerabilities.

This change ensures that the buffer is not overwritten by limiting the number of characters written to the size of the buffer.

Closes #1160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal buffer safety in parameter processing to prevent potential memory overflow conditions during query compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->