### PR TITLE
Initialize fallback command tag for CompileFunctionStmt

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -2748,6 +2748,8 @@ CreateCommandTag(Node *parsetree)
 				tag = CMDTAG_ALTER_PROCEDURE;
 			else if (((CompileFunctionStmt *) parsetree)->objtype == OBJECT_FUNCTION)
 				tag = CMDTAG_ALTER_FUNCTION;
+			else
+				tag = CMDTAG_UNKNOWN;
 			break;
 
 		case T_GrantStmt:


### PR DESCRIPTION
`CreateCommandTag()` can leave `tag` uninitialized for `CompileFunctionStmt` when objtype is neither FUNCTION nor PROCEDURE. Callers normally pass one of those two values, but Clang still reports the missing fallback path.

Warning excerpt:

```
utility.c:2757:13: warning: variable 'tag' is used uninitialized whenever 'if' condition is false
[-Wsometimes-uninitialized]
```

Set `tag = CMDTAG_UNKNOWN` in the remaining branch so the fallback behavior is explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures command processing assigns a defined fallback tag for unrecognized object types, preventing ambiguous or unspecified command state and improving stability when handling non-procedure/function objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->