### PR TITLE
Silence Clang warning in generated psqlplus parser

### DIFF
--- a/src/bin/psql/psqlplusparse.y
+++ b/src/bin/psql/psqlplusparse.y
@@ -73,6 +73,7 @@ psqlplus_toplevel_stmt:
 		variable_stmt opt_semi
 			{
 				psql_yyget_extra(yyscanner)->psqlpluscmd = $1;
+				(void) yynerrs;		/* suppress compiler warning */
 			}
 		| print_stmt opt_semi
 			{


### PR DESCRIPTION
Clang warns that the generated SQL*Plus parser keeps a local yynerrs counter that is assigned but never read. The warning comes from Bison output, not from handwritten parser actions.

Warning excerpt:

```
psqlplusparse.c:983:9: warning: variable psqlplus_yynerrs set but not used
 [-Wunused-but-set-variable]
```

Follow the existing PostgreSQL grammar pattern by referencing yynerrs with (void) yynerrs in the top-level rule action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code quality by suppressing a compiler warning with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->