### PR TITLE
Keep scanner quote types self-consistent

### DIFF
--- a/src/bin/psql/ora_psqlscanslash.l
+++ b/src/bin/psql/ora_psqlscanslash.l
@@ -250,8 +250,8 @@ other			.
 															 yytext + 1,
 															 yyleng - 1);
 						value = cur_state->oracallbacks->get_variable(varname,
-																   PQUOTE_PLAIN,
-																   cur_state->cb_passthrough);
+										   ORAPQUOTE_PLAIN,
+										   cur_state->cb_passthrough);
 						free(varname);
 
 						/*
@@ -276,7 +276,7 @@ other			.
 
 :'{variable_char}+'	{
 					ora_psqlscan_escape_variable(cur_state, yytext, yyleng,
-											 PQUOTE_SQL_LITERAL);
+										 ORAPQUOTE_SQL_LITERAL);
 					*option_quote = ':';
 					unquoted_option_chars = 0;
 				}
@@ -284,7 +284,7 @@ other			.
 
 :\"{variable_char}+\"	{
 					ora_psqlscan_escape_variable(cur_state, yytext, yyleng,
-											 PQUOTE_SQL_IDENT);
+										 ORAPQUOTE_SQL_IDENT);
 					*option_quote = ':';
 					unquoted_option_chars = 0;
 				}
@@ -389,8 +389,8 @@ other			.
 															 yytext + 1,
 															 yyleng - 1);
 						value = cur_state->oracallbacks->get_variable(varname,
-																   PQUOTE_PLAIN,
-																   cur_state->cb_passthrough);
+										   ORAPQUOTE_PLAIN,
+										   cur_state->cb_passthrough);
 						free(varname);
 
 						if (value)
@@ -405,7 +405,7 @@ other			.
 
 :'{variable_char}+'	{
 					ora_psqlscan_escape_variable(cur_state, yytext, yyleng,
-											 PQUOTE_SHELL_ARG);
+										 ORAPQUOTE_SHELL_ARG);
 				}
 
 :'{variable_char}*	{

--- a/src/include/fe_utils/psqlscan_int.h
+++ b/src/include/fe_utils/psqlscan_int.h
@@ -319,7 +319,7 @@ extern YY_BUFFER_STATE ora_psqlscan_prepare_buffer(PsqlScanState state, const ch
 extern void ora_psqlscan_emit(PsqlScanState state, const char *txt, int len);
 extern char * ora_psqlscan_extract_substring(PsqlScanState state, const char *txt, int len);
 extern void ora_psqlscan_escape_variable(PsqlScanState state, const char *txt, int len,
-								 PsqlScanQuoteType quote);
+							 Ora_psqlScanQuoteType quote);
 extern void ora_psqlscan_test_variable(PsqlScanState state, const char *txt, int len);
 
 #endif							/* PSQLSCAN_INT_H */

--- a/src/oracle_fe_utils/ora_psqlscan.l
+++ b/src/oracle_fe_utils/ora_psqlscan.l
@@ -848,10 +848,10 @@ other			.
 					varname = ora_psqlscan_extract_substring(cur_state,
 														 yytext + 1,
 														 yyleng - 1);
-					if (cur_state->oracallbacks->get_variable)
-						value = cur_state->oracallbacks->get_variable(varname,
-																   PQUOTE_PLAIN,
-																   cur_state->cb_passthrough);
+	if (cur_state->oracallbacks->get_variable)
+		value = cur_state->oracallbacks->get_variable(varname,
+									   ORAPQUOTE_PLAIN,
+									   cur_state->cb_passthrough);
 					else
 						value = NULL;
 
@@ -888,12 +888,12 @@ other			.
 
 :'{variable_char}+'	{
 					ora_psqlscan_escape_variable(cur_state, yytext, yyleng,
-											 PQUOTE_SQL_LITERAL);
+							 ORAPQUOTE_SQL_LITERAL);
 				}
 
 :\"{variable_char}+\"	{
 					ora_psqlscan_escape_variable(cur_state, yytext, yyleng,
-											 PQUOTE_SQL_IDENT);
+							 ORAPQUOTE_SQL_IDENT);
 				}
 
 :\{\?{variable_char}+\}	{
@@ -1801,7 +1801,7 @@ ora_psqlscan_extract_substring(PsqlScanState state, const char *txt, int len)
  */
 void
 ora_psqlscan_escape_variable(PsqlScanState state, const char *txt, int len,
-						 PsqlScanQuoteType quote)
+						 Ora_psqlScanQuoteType quote)
 {
 	char	   *varname;
 	char	   *value;
@@ -1836,8 +1836,8 @@ ora_psqlscan_test_variable(PsqlScanState state, const char *txt, int len)
 
 	varname = ora_psqlscan_extract_substring(state, txt + 3, len - 4);
 	if (state->oracallbacks->get_variable)
-		value = state->oracallbacks->get_variable(varname, PQUOTE_PLAIN,
-											   state->cb_passthrough);
+		value = state->oracallbacks->get_variable(varname, ORAPQUOTE_PLAIN,
+									   state->cb_passthrough);
 	else
 		value = NULL;
 	free(varname);


### PR DESCRIPTION
The Oracle scanner path mixed PsqlScanQuoteType values into helpers that are typed for Ora_psqlScanQuoteType. Clang reports those implicit enum-to-enum conversions, and the mismatch also weakens separation between PostgreSQL and Oracle scanner code paths.

Warning excerpt:

```
ora_psqlscanslash.l:254:20: warning:
implicit conversion from enumeration type PsqlScanQuoteType to different enumeration type Ora_psqlScanQuoteType
[-Wimplicit-enum-enum-cast]
```

Use Ora_psqlScanQuoteType consistently in declarations and call sites across both Oracle scanner files to keep the enum domain coherent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Updated quote type handling constants across Oracle-specific psql scanner modules for improved consistency in variable substitution and SQL identifier escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->