### PR TITLE
Use FLOAT8_FITS_IN_INT64 in dsinterval_mul

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime.out
@@ -1172,6 +1172,10 @@ SELECT interval'365 11:11:11' day(3) to second * 12.34;
  +000004509 20:26:24.140000000
 (1 row)
 
+-- interval day to second * huge number (overflow)
+SELECT interval'365 11:11:11' day(3) to second * 100000000000000000000;
+ERROR:  interval out of range
+
 -- interval year to month / number
 SELECT interval'10-11' year to month / 12.34;
    ?column?    
@@ -1185,6 +1189,10 @@ SELECT interval'365 11:11:11' day(3) to second / 12.34;
 -------------------------------
  +000000029 14:47:35.024311000
 (1 row)
+
+-- interval day to second / tiny number (overflow)
+SELECT interval'365 11:11:11' day(3) to second / 0.00000000000000000001;
+ERROR:  interval out of range
 
 -- number + oradate
 SELECT 123.456 + date'2016-11-26';
@@ -1235,4 +1243,3 @@ select 25::number <= to_char('1990-01-01'::oradate, 'yyyy');
 ----------
  t
 (1 row)
-

--- a/contrib/ivorysql_ora/expected/ora_datetime.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime.out
@@ -1165,6 +1165,10 @@ SELECT interval'10-11' year to month * 12.34;
  +000000134-08
 (1 row)
 
+-- interval year to month * huge number (overflow)
+SELECT interval'10-11' year to month * 100000000000000000000;
+ERROR:  interval out of range
+
 -- interval day to second * number
 SELECT interval'365 11:11:11' day(3) to second * 12.34;
            ?column?            
@@ -1182,6 +1186,10 @@ SELECT interval'10-11' year to month / 12.34;
 ---------------
  +000000000-10
 (1 row)
+
+-- interval year to month / tiny number (overflow)
+SELECT interval'10-11' year to month / 0.00000000000000000001;
+ERROR:  interval out of range
 
 -- interval day to second / number
 SELECT interval'365 11:11:11' day(3) to second / 12.34;

--- a/contrib/ivorysql_ora/expected/ora_datetime.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime.out
@@ -1168,7 +1168,6 @@ SELECT interval'10-11' year to month * 12.34;
 -- interval year to month * huge number (overflow)
 SELECT interval'10-11' year to month * 100000000000000000000;
 ERROR:  interval out of range
-
 -- interval day to second * number
 SELECT interval'365 11:11:11' day(3) to second * 12.34;
            ?column?            
@@ -1179,7 +1178,9 @@ SELECT interval'365 11:11:11' day(3) to second * 12.34;
 -- interval day to second * huge number (overflow)
 SELECT interval'365 11:11:11' day(3) to second * 100000000000000000000;
 ERROR:  interval out of range
-
+-- interval day to second * NaN number (overflow)
+SELECT interval'365 11:11:11' day(3) to second * 'NaN'::number;
+ERROR:  interval out of range
 -- interval year to month / number
 SELECT interval'10-11' year to month / 12.34;
    ?column?    
@@ -1190,7 +1191,6 @@ SELECT interval'10-11' year to month / 12.34;
 -- interval year to month / tiny number (overflow)
 SELECT interval'10-11' year to month / 0.00000000000000000001;
 ERROR:  interval out of range
-
 -- interval day to second / number
 SELECT interval'365 11:11:11' day(3) to second / 12.34;
            ?column?            
@@ -1201,7 +1201,6 @@ SELECT interval'365 11:11:11' day(3) to second / 12.34;
 -- interval day to second / tiny number (overflow)
 SELECT interval'365 11:11:11' day(3) to second / 0.00000000000000000001;
 ERROR:  interval out of range
-
 -- number + oradate
 SELECT 123.456 + date'2016-11-26';
       ?column?       
@@ -1251,3 +1250,4 @@ select 25::number <= to_char('1990-01-01'::oradate, 'yyyy');
 ----------
  t
 (1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_datetime.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime.out
@@ -1168,6 +1168,9 @@ SELECT interval'10-11' year to month * 12.34;
 -- interval year to month * huge number (overflow)
 SELECT interval'10-11' year to month * 100000000000000000000;
 ERROR:  interval out of range
+-- interval year to month * NaN number (overflow)
+SELECT interval'10-11' year to month * 'NaN'::number;
+ERROR:  interval out of range
 -- interval day to second * number
 SELECT interval'365 11:11:11' day(3) to second * 12.34;
            ?column?            
@@ -1191,6 +1194,9 @@ SELECT interval'10-11' year to month / 12.34;
 -- interval year to month / tiny number (overflow)
 SELECT interval'10-11' year to month / 0.00000000000000000001;
 ERROR:  interval out of range
+-- interval year to month / NaN number (overflow)
+SELECT interval'10-11' year to month / 'NaN'::number;
+ERROR:  interval out of range
 -- interval day to second / number
 SELECT interval'365 11:11:11' day(3) to second / 12.34;
            ?column?            
@@ -1200,6 +1206,9 @@ SELECT interval'365 11:11:11' day(3) to second / 12.34;
 
 -- interval day to second / tiny number (overflow)
 SELECT interval'365 11:11:11' day(3) to second / 0.00000000000000000001;
+ERROR:  interval out of range
+-- interval day to second / NaN number (overflow)
+SELECT interval'365 11:11:11' day(3) to second / 'NaN'::number;
 ERROR:  interval out of range
 -- number + oradate
 SELECT 123.456 + date'2016-11-26';

--- a/contrib/ivorysql_ora/sql/ora_datetime.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime.sql
@@ -570,11 +570,17 @@ SELECT interval'10-11' year to month * 12.34;
 -- interval day to second * number
 SELECT interval'365 11:11:11' day(3) to second * 12.34;
 
+-- interval day to second * huge number (overflow)
+SELECT interval'365 11:11:11' day(3) to second * 100000000000000000000;
+
 -- interval year to month / number
 SELECT interval'10-11' year to month / 12.34;
 
 -- interval day to second / number
 SELECT interval'365 11:11:11' day(3) to second / 12.34;
+
+-- interval day to second / tiny number (overflow)
+SELECT interval'365 11:11:11' day(3) to second / 0.00000000000000000001;
 
 -- number + oradate
 SELECT 123.456 + date'2016-11-26';

--- a/contrib/ivorysql_ora/sql/ora_datetime.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime.sql
@@ -567,6 +567,9 @@ SELECT interval'365 11:11:11' day(3) to second + timestamp '2016-12-12 14:41:11.
 -- interval year to month * number
 SELECT interval'10-11' year to month * 12.34;
 
+-- interval year to month * huge number (overflow)
+SELECT interval'10-11' year to month * 100000000000000000000;
+
 -- interval day to second * number
 SELECT interval'365 11:11:11' day(3) to second * 12.34;
 
@@ -575,6 +578,9 @@ SELECT interval'365 11:11:11' day(3) to second * 100000000000000000000;
 
 -- interval year to month / number
 SELECT interval'10-11' year to month / 12.34;
+
+-- interval year to month / tiny number (overflow)
+SELECT interval'10-11' year to month / 0.00000000000000000001;
 
 -- interval day to second / number
 SELECT interval'365 11:11:11' day(3) to second / 12.34;

--- a/contrib/ivorysql_ora/sql/ora_datetime.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime.sql
@@ -576,6 +576,9 @@ SELECT interval'365 11:11:11' day(3) to second * 12.34;
 -- interval day to second * huge number (overflow)
 SELECT interval'365 11:11:11' day(3) to second * 100000000000000000000;
 
+-- interval day to second * NaN number (overflow)
+SELECT interval'365 11:11:11' day(3) to second * 'NaN'::number;
+
 -- interval year to month / number
 SELECT interval'10-11' year to month / 12.34;
 

--- a/contrib/ivorysql_ora/sql/ora_datetime.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime.sql
@@ -570,6 +570,9 @@ SELECT interval'10-11' year to month * 12.34;
 -- interval year to month * huge number (overflow)
 SELECT interval'10-11' year to month * 100000000000000000000;
 
+-- interval year to month * NaN number (overflow)
+SELECT interval'10-11' year to month * 'NaN'::number;
+
 -- interval day to second * number
 SELECT interval'365 11:11:11' day(3) to second * 12.34;
 
@@ -585,11 +588,17 @@ SELECT interval'10-11' year to month / 12.34;
 -- interval year to month / tiny number (overflow)
 SELECT interval'10-11' year to month / 0.00000000000000000001;
 
+-- interval year to month / NaN number (overflow)
+SELECT interval'10-11' year to month / 'NaN'::number;
+
 -- interval day to second / number
 SELECT interval'365 11:11:11' day(3) to second / 12.34;
 
 -- interval day to second / tiny number (overflow)
 SELECT interval'365 11:11:11' day(3) to second / 0.00000000000000000001;
+
+-- interval day to second / NaN number (overflow)
+SELECT interval'365 11:11:11' day(3) to second / 'NaN'::number;
 
 -- number + oradate
 SELECT 123.456 + date'2016-11-26';

--- a/contrib/ivorysql_ora/src/datatype/dsinterval.c
+++ b/contrib/ivorysql_ora/src/datatype/dsinterval.c
@@ -52,7 +52,6 @@
 
 #include "../include/common_datatypes.h"
 
-
 PG_FUNCTION_INFO_V1(dsinterval_in);
 PG_FUNCTION_INFO_V1(dsinterval_out);
 PG_FUNCTION_INFO_V1(dsinterval_recv);
@@ -2333,7 +2332,7 @@ dsinterval_mul(PG_FUNCTION_ARGS)
 	result->day += (int32) month_remainder_days;
 #ifdef HAVE_INT64_TIMESTAMP
 	result_double = rint(span->time * factor + sec_remainder * USECS_PER_SEC);
-	if (result_double > PG_INT64_MAX || result_double < PG_INT64_MIN)
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT64(result_double))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));

--- a/contrib/ivorysql_ora/src/datatype/dsinterval.c
+++ b/contrib/ivorysql_ora/src/datatype/dsinterval.c
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
  * Copyright 2025 IvorySQL Global Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -122,10 +122,10 @@ ParseFractionalSecond(char *cp, fsec_t *fsec)
 
 static int
 DecodeTime(char *str, int fmask, int range,
-				int *tmask, struct tm * tm, fsec_t *fsec)
+		   int *tmask, struct tm *tm, fsec_t *fsec)
 {
-	char		*cp;
-	int			 dterr;
+	char	   *cp;
+	int			dterr;
 
 	*tmask = DTK_TIME_M;
 
@@ -182,15 +182,14 @@ DecodeTime(char *str, int fmask, int range,
 		return DTERR_BAD_FORMAT;
 
 	/*
-	 * do a sanity check
-	 * for 'tm->tm_min > MINS_PER_HOUR - 1' and 'tm->tm_sec > SECS_PER_MINUTE' check
-	 * we will do this check in 'dsinterval_in' function, because the initial value
-	 * is INT_MAX,so Cancel check in here.
+	 * do a sanity check for 'tm->tm_min > MINS_PER_HOUR - 1' and 'tm->tm_sec
+	 * > SECS_PER_MINUTE' check we will do this check in 'dsinterval_in'
+	 * function, because the initial value is INT_MAX,so Cancel check in here.
 	 *
-	 * if compatible_level is oracle, when interval range is 'MINUTE TO SECOND',
-	 * the value of 'tm->tm_min' can greater than MINS_PER_HOUR. Because the field 'MINUTE'
-	 * is leading field, not trailing field.
-	*/
+	 * if compatible_level is oracle, when interval range is 'MINUTE TO
+	 * SECOND', the value of 'tm->tm_min' can greater than MINS_PER_HOUR.
+	 * Because the field 'MINUTE' is leading field, not trailing field.
+	 */
 #ifdef HAVE_INT64_TIMESTAMP
 	if (tm->tm_hour < 0 || tm->tm_min < 0 || tm->tm_sec < 0 ||
 		*fsec < INT64CONST(0) ||
@@ -216,7 +215,7 @@ DecodeTime(char *str, int fmask, int range,
  * we can not know  the '0' is initial value or the value of the input.
  */
 static inline void
-ClearPgTm(struct tm * tm, fsec_t *fsec)
+ClearPgTm(struct tm *tm, fsec_t *fsec)
 {
 	tm->tm_year = INT_MAX;
 	tm->tm_mon = INT_MAX;
@@ -232,7 +231,7 @@ ClearPgTm(struct tm * tm, fsec_t *fsec)
  * We assume the input frac is less than 1 so overflow is not an issue.
  */
 static void
-AdjustFractSeconds(double frac, struct tm * tm, fsec_t *fsec, int scale)
+AdjustFractSeconds(double frac, struct tm *tm, fsec_t *fsec, int scale)
 {
 	int			sec;
 
@@ -240,10 +239,10 @@ AdjustFractSeconds(double frac, struct tm * tm, fsec_t *fsec, int scale)
 		return;
 	frac *= scale;
 	sec = (int) frac;
-	
+
 	if (tm->tm_sec == INT_MAX)
 		tm->tm_sec = 0;
-	
+
 	tm->tm_sec += sec;
 	frac -= sec;
 #ifdef HAVE_INT64_TIMESTAMP
@@ -255,7 +254,7 @@ AdjustFractSeconds(double frac, struct tm * tm, fsec_t *fsec, int scale)
 
 /* As above, but initial scale produces days */
 static void
-AdjustFractDays(double frac, struct tm * tm, fsec_t *fsec, int scale)
+AdjustFractDays(double frac, struct tm *tm, fsec_t *fsec, int scale)
 {
 	int			extra_days;
 
@@ -263,7 +262,7 @@ AdjustFractDays(double frac, struct tm * tm, fsec_t *fsec, int scale)
 		return;
 	frac *= scale;
 	extra_days = (int) frac;
-	
+
 	if (tm->tm_mday == INT_MAX)
 		tm->tm_mday = 0;
 	tm->tm_mday += extra_days;
@@ -271,16 +270,16 @@ AdjustFractDays(double frac, struct tm * tm, fsec_t *fsec, int scale)
 	AdjustFractSeconds(frac, tm, fsec, SECS_PER_DAY);
 }
 
-/* 
+/*
  * The same as function 'Decodeinterval' except that we don`t care
  * about year field and month field.
  */
 static int
 DecodeDsinterval(char **field, int *ftype, int nf, int range,
-			   int *dtype, struct tm * tm, fsec_t *fsec)
+				 int *dtype, struct tm *tm, fsec_t *fsec)
 {
 	bool		is_before = false;
-	char		*cp;
+	char	   *cp;
 	int			fmask = 0,
 				tmask,
 				type;
@@ -359,7 +358,7 @@ DecodeDsinterval(char **field, int *ftype, int nf, int range,
 						case INTERVAL_MASK(MONTH):
 						case INTERVAL_MASK(YEAR) | INTERVAL_MASK(MONTH):
 							return DTERR_BAD_FORMAT;
-							
+
 						case INTERVAL_MASK(DAY):
 							type = DTK_DAY;
 							break;
@@ -509,7 +508,7 @@ DecodeDsinterval(char **field, int *ftype, int nf, int range,
 						{
 							if (tm->tm_mon == INT_MAX)
 								tm->tm_mon = 0;
-							
+
 							tm->tm_mon += fval * MONTHS_PER_YEAR * 10;
 						}
 						tmask = DTK_M(DECADE);
@@ -523,7 +522,7 @@ DecodeDsinterval(char **field, int *ftype, int nf, int range,
 						{
 							if (tm->tm_mon == INT_MAX)
 								tm->tm_mon = 0;
-							
+
 							tm->tm_mon += fval * MONTHS_PER_YEAR * 100;
 						}
 						tmask = DTK_M(CENTURY);
@@ -537,7 +536,7 @@ DecodeDsinterval(char **field, int *ftype, int nf, int range,
 						{
 							if (tm->tm_mon == INT_MAX)
 								tm->tm_mon = 0;
-							
+
 							tm->tm_mon += fval * MONTHS_PER_YEAR * 1000;
 						}
 						tmask = DTK_M(MILLENNIUM);
@@ -665,18 +664,18 @@ DecodeDsinterval(char **field, int *ftype, int nf, int range,
 	return 0;
 }
 
-/* 
+/*
  * Change Note:
- * 
+ *
  * Add one parameter 'trimnum' recode the number of zero to trimed .
- * 
+ *
  */
 static void
 TrimTrailingZeros(char *str, int trimnum)
 {
 	int			len = strlen(str);
 	int			i = 0;
-	
+
 	while (len > 1 && *(str + len - 1) == '0' && *(str + len - 2) != '.' && i < trimnum)
 	{
 		len--;
@@ -696,14 +695,17 @@ TrimTrailingZeros(char *str, int trimnum)
 static void
 AppendSeconds(char *cp, int sec, fsec_t fsec, int precision, bool fillzeros)
 {
-	/* Compatible oracle, do 'fsec' as a nanosecond*/
+	/* Compatible oracle, do 'fsec' as a nanosecond */
 	fsec *= 1000;
 
 	if (fsec == 0)
 	{
 		if (fillzeros)
 		{
-			/* Compatible oracle ,if the precision of fractional second is zero ,dont show */
+			/*
+			 * Compatible oracle ,if the precision of fractional second is
+			 * zero ,dont show
+			 */
 			if (precision == 0)
 				sprintf(cp, "%02d", abs(sec));
 			else
@@ -736,7 +738,7 @@ AppendSeconds(char *cp, int sec, fsec_t fsec, int precision, bool fillzeros)
  * Interpret time structure as a delta time and convert to string.
  */
 static void
-EncodeDsinterval(struct pg_tm * tm, fsec_t fsec, int style, char *str, int day_precision, int second_precision)
+EncodeDsinterval(struct pg_tm *tm, fsec_t fsec, int style, char *str, int day_precision, int second_precision)
 {
 	char	   *cp = str;
 	int			year = tm->tm_year;
@@ -745,24 +747,24 @@ EncodeDsinterval(struct pg_tm * tm, fsec_t fsec, int style, char *str, int day_p
 	int			hour = tm->tm_hour;
 	int			min = tm->tm_min;
 	int			sec = tm->tm_sec;
-	
+
 	switch (style)
 	{
 			/* SQL Standard interval format */
 		case INTSTYLE_SQL_STANDARD:
 			{
 				bool		has_negative = year < 0 || mon < 0 ||
-				mday < 0 || hour < 0 ||
-				min < 0 || sec < 0 || fsec < 0;
+					mday < 0 || hour < 0 ||
+					min < 0 || sec < 0 || fsec < 0;
 				bool		has_positive = year > 0 || mon > 0 ||
-				mday > 0 || hour > 0 ||
-				min > 0 || sec > 0 || fsec > 0;
+					mday > 0 || hour > 0 ||
+					min > 0 || sec > 0 || fsec > 0;
 				bool		has_year_month = year != 0 || mon != 0;
 				bool		has_day_time = mday != 0 || hour != 0 ||
-				min != 0 || sec != 0 || fsec != 0;
+					min != 0 || sec != 0 || fsec != 0;
 				bool		has_day = mday != 0;
 				bool		sql_standard_value = !(has_negative && has_positive) &&
-				!(has_year_month && has_day_time);
+					!(has_year_month && has_day_time);
 
 				/*
 				 * SQL Standard wants only 1 "<sign>" preceding the whole
@@ -784,7 +786,10 @@ EncodeDsinterval(struct pg_tm * tm, fsec_t fsec, int style, char *str, int day_p
 				if (!has_negative)
 					*cp++ = '+';
 
-				/* Compatible oracle, the value of interval is zero should show "+00 00:00:00.000000" */
+				/*
+				 * Compatible oracle, the value of interval is zero should
+				 * show "+00 00:00:00.000000"
+				 */
 				if (!has_negative && !has_positive)
 				{
 					sprintf(cp, "%0*d %02d:%02d:", day_precision, mday, hour, min);
@@ -977,9 +982,9 @@ AdjustIntervalForTypmod(Interval *interval, int32 typmod)
 			if (second_precision < 0 || second_precision > ORACLE_MAX_INTERVAL_PRECISION)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				   errmsg("interval(%d) precision must be between %d and %d",
-						  second_precision, 0, MAX_INTERVAL_PRECISION)));
-						  
+						 errmsg("interval(%d) precision must be between %d and %d",
+								second_precision, 0, MAX_INTERVAL_PRECISION)));
+
 			if (second_precision > MAX_INTERVAL_PRECISION)
 				second_precision = MAX_INTERVAL_PRECISION;
 
@@ -1011,9 +1016,9 @@ AdjustIntervalForTypmod(Interval *interval, int32 typmod)
 				IntervalScales[second_precision];
 #endif
 		}
-		
+
 	}
-	
+
 	/* Convert interval->time to interval->day */
 	interval->day += interval->time / USECS_PER_DAY;
 	interval->time = interval->time % USECS_PER_DAY;
@@ -1035,7 +1040,7 @@ AdjustTypmodForDay(Interval *interval, int32 typmod)
 		{
 			/* interval'-100' day */
 			interval_day = abs(interval->day);
-			switch(day_precision)
+			switch (day_precision)
 			{
 				case 0:
 					if (interval_day != 0)
@@ -1149,7 +1154,7 @@ ora_ParseISO8601Number(const char *str, char **endptr, int *ipart, double *fpart
  */
 static int
 ora_DecodeISO8601Interval(char *str,
-					  int *dtype, struct /* pg_ */ tm *tm, fsec_t *fsec)
+						  int *dtype, struct /* pg_ */ tm *tm, fsec_t *fsec)
 {
 	bool		datepart = true;
 	bool		havefield = false;
@@ -1377,7 +1382,7 @@ interval2tm(Interval span, struct pg_tm *tm, fsec_t *fsec)
 }
 
 static int
-tm2dsinterval(struct tm * tm, fsec_t fsec, Interval *span)
+tm2dsinterval(struct tm *tm, fsec_t fsec, Interval *span)
 {
 	double		total_months = (double) tm->tm_year * MONTHS_PER_YEAR + tm->tm_mon;
 
@@ -1388,11 +1393,11 @@ tm2dsinterval(struct tm * tm, fsec_t fsec, Interval *span)
 #ifdef HAVE_INT64_TIMESTAMP
 	span->time = (((((tm->tm_hour * INT64CONST(60)) +
 					 tm->tm_min) * INT64CONST(60)) +
-					 tm->tm_sec) * USECS_PER_SEC) + fsec;
+				   tm->tm_sec) * USECS_PER_SEC) + fsec;
 #else
 	span->time = (((tm->tm_hour * (double) MINS_PER_HOUR) +
-					 tm->tm_min) * (double) SECS_PER_MINUTE) +
-					 tm->tm_sec + fsec;
+				   tm->tm_min) * (double) SECS_PER_MINUTE) +
+		tm->tm_sec + fsec;
 #endif
 
 	return 0;
@@ -1411,10 +1416,10 @@ dsinterval_cmp_value(const Interval *interval)
 	span = interval->time;
 
 #ifdef HAVE_INT64_TIMESTAMP
-//	span += interval->month * INT64CONST(30) * USECS_PER_DAY;
+/* 	span += interval->month * INT64CONST(30) * USECS_PER_DAY; */
 	span += interval->day * INT64CONST(24) * USECS_PER_HOUR;
 #else
-//	span += interval->month * ((double) DAYS_PER_MONTH * SECS_PER_DAY);
+/* 	span += interval->month * ((double) DAYS_PER_MONTH * SECS_PER_DAY); */
 	span += interval->day * ((double) HOURS_PER_DAY * SECS_PER_HOUR);
 #endif
 
@@ -1451,7 +1456,7 @@ dsinterval_in(PG_FUNCTION_ARGS)
 	int32		typmod = PG_GETARG_INT32(2);
 	Interval   *result;
 	fsec_t		fsec;
-	struct		tm tt,
+	struct tm	tt,
 			   *tm = &tt;
 	int			dtype = -1;
 	int			nf = 0;
@@ -1461,8 +1466,8 @@ dsinterval_in(PG_FUNCTION_ARGS)
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[256];
 	bool		isiso = false;
-	char 		*strsrc;
-	char 		*strold;
+	char	   *strsrc;
+	char	   *strold;
 	DateTimeErrorExtra extra;
 
 	tm->tm_year = INT_MAX;
@@ -1517,15 +1522,15 @@ dsinterval_in(PG_FUNCTION_ARGS)
 						  ftype, MAXDATEFIELDS, &nf);
 
 	/*
-	 * Compatible oracle 
-	 * interval'+1 +1:1:1' is error in oracle db.(istz > 1)
-	 * interval'1 +1:1:1' is error in oracle db. (istz == 1 && ftype[0] != DTK_TZ)
-	 * Only leading field can specify '-' or '+'
+	 * Compatible oracle interval'+1 +1:1:1' is error in oracle db.(istz > 1)
+	 * interval'1 +1:1:1' is error in oracle db. (istz == 1 && ftype[0] !=
+	 * DTK_TZ) Only leading field can specify '-' or '+'
 	 */
 	if (nf > 1 && dterr == 0)
 	{
-		int		i;
-		int		istz = 0;
+		int			i;
+		int			istz = 0;
+
 		for (i = 0; i < nf; i++)
 		{
 			if (ftype[i] == DTK_TZ)
@@ -1539,13 +1544,13 @@ dsinterval_in(PG_FUNCTION_ARGS)
 
 	if (dterr == 0)
 		dterr = DecodeDsinterval(field, ftype, nf, range,
-							   &dtype, tm, &fsec);
+								 &dtype, tm, &fsec);
 
 	/* if those functions think it's a bad format, try ISO8601 style */
 	if (dterr == DTERR_BAD_FORMAT)
 	{
 		dterr = ora_DecodeISO8601Interval(str,
-									  &dtype, tm, &fsec);
+										  &dtype, tm, &fsec);
 		isiso = true;
 	}
 
@@ -1558,24 +1563,23 @@ dsinterval_in(PG_FUNCTION_ARGS)
 
 	/*
 	 * compatible oracle, the valid range of values for the trailing field
-	 * HOUR: 0 to 23
-	 * MINUTE: 0 to 59
-	 * SECOND: 0 to 59.999999999
+	 * HOUR: 0 to 23 MINUTE: 0 to 59 SECOND: 0 to 59.999999999
 	 *
-	 * In oracle, the string and interval fields is exact matched,
-	 * for example:interval'1:1' hour to second and interval'1 1:1:1' hour to second is error.
-	 * change the initial value of 'pg_tm *tm' to INT_MAX, because if the value of 'pg_tm *tm' is 0,
-	 * we can not know  the '0' is initial value or the value of the input.
+	 * In oracle, the string and interval fields is exact matched, for
+	 * example:interval'1:1' hour to second and interval'1 1:1:1' hour to
+	 * second is error. change the initial value of 'pg_tm *tm' to INT_MAX,
+	 * because if the value of 'pg_tm *tm' is 0, we can not know  the '0' is
+	 * initial value or the value of the input.
 	 */
 	if (!isiso)
 	{
-		switch(range)
+		switch (range)
 		{
 			case INTERVAL_MASK(DAY):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
-					abs(tm->tm_min)  != INT_MAX ||
-					abs(tm->tm_sec)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
+					abs(tm->tm_min) != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_hour) != INT_MAX ||
 					abs(tm->tm_mday) == INT_MAX)
 					ereport(ERROR,
@@ -1585,9 +1589,9 @@ dsinterval_in(PG_FUNCTION_ARGS)
 
 			case INTERVAL_MASK(DAY) | INTERVAL_MASK(HOUR):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon) != INT_MAX  ||
-					abs(tm->tm_min) != INT_MAX  ||
-					abs(tm->tm_sec) != INT_MAX  ||
+					abs(tm->tm_mon) != INT_MAX ||
+					abs(tm->tm_min) != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_hour) == INT_MAX ||
 					abs(tm->tm_mday) == INT_MAX)
 					ereport(ERROR,
@@ -1602,8 +1606,8 @@ dsinterval_in(PG_FUNCTION_ARGS)
 
 			case INTERVAL_MASK(DAY) | INTERVAL_MASK(HOUR) | INTERVAL_MASK(MINUTE):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon) != INT_MAX  ||
-					abs(tm->tm_sec) != INT_MAX  ||
+					abs(tm->tm_mon) != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_mday) == INT_MAX ||
 					abs(tm->tm_hour) == INT_MAX ||
 					abs(tm->tm_min) == INT_MAX)
@@ -1625,11 +1629,11 @@ dsinterval_in(PG_FUNCTION_ARGS)
 			case INTERVAL_FULL_RANGE:
 			case INTERVAL_MASK(DAY) | INTERVAL_MASK(HOUR) | INTERVAL_MASK(MINUTE) | INTERVAL_MASK(SECOND):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
 					abs(tm->tm_mday) == INT_MAX ||
 					abs(tm->tm_hour) == INT_MAX ||
-					abs(tm->tm_min)  == INT_MAX ||
-					abs(tm->tm_sec)  == INT_MAX)
+					abs(tm->tm_min) == INT_MAX ||
+					abs(tm->tm_sec) == INT_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("The character string you specified is not a valid interval")));
@@ -1651,10 +1655,10 @@ dsinterval_in(PG_FUNCTION_ARGS)
 				break;
 			case INTERVAL_MASK(HOUR):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX ||
-					abs(tm->tm_min)  != INT_MAX ||
-					abs(tm->tm_sec)  != INT_MAX ||
+					abs(tm->tm_min) != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_hour) == INT_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
@@ -1662,11 +1666,11 @@ dsinterval_in(PG_FUNCTION_ARGS)
 				break;
 			case INTERVAL_MASK(HOUR) | INTERVAL_MASK(MINUTE):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX ||
-					abs(tm->tm_sec)  != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_hour) == INT_MAX ||
-					abs(tm->tm_min)  == INT_MAX)
+					abs(tm->tm_min) == INT_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("The character string you specified is not a valid interval")));
@@ -1678,11 +1682,11 @@ dsinterval_in(PG_FUNCTION_ARGS)
 				break;
 			case INTERVAL_MASK(HOUR) | INTERVAL_MASK(MINUTE) | INTERVAL_MASK(SECOND):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX ||
 					abs(tm->tm_hour) == INT_MAX ||
-					abs(tm->tm_min)  == INT_MAX ||
-					abs(tm->tm_sec)  == INT_MAX)
+					abs(tm->tm_min) == INT_MAX ||
+					abs(tm->tm_sec) == INT_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("The character string you specified is not a valid interval")));
@@ -1699,22 +1703,22 @@ dsinterval_in(PG_FUNCTION_ARGS)
 				break;
 			case INTERVAL_MASK(MINUTE):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX ||
 					abs(tm->tm_hour) != INT_MAX ||
-					abs(tm->tm_sec)  != INT_MAX ||
-					abs(tm->tm_min)  == INT_MAX)
+					abs(tm->tm_sec) != INT_MAX ||
+					abs(tm->tm_min) == INT_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("The character string you specified is not a valid interval")));
 				break;
 			case INTERVAL_MASK(MINUTE) | INTERVAL_MASK(SECOND):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX ||
 					abs(tm->tm_hour) != INT_MAX ||
-					abs(tm->tm_min)  == INT_MAX ||
-					abs(tm->tm_sec)  == INT_MAX)
+					abs(tm->tm_min) == INT_MAX ||
+					abs(tm->tm_sec) == INT_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("The character string you specified is not a valid interval")));
@@ -1726,11 +1730,11 @@ dsinterval_in(PG_FUNCTION_ARGS)
 				break;
 			case INTERVAL_MASK(SECOND):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX ||
 					abs(tm->tm_hour) != INT_MAX ||
-					abs(tm->tm_min)  != INT_MAX ||
-					abs(tm->tm_sec)  == INT_MAX)
+					abs(tm->tm_min) != INT_MAX ||
+					abs(tm->tm_sec) == INT_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("The character string you specified is not a valid interval")));
@@ -1747,7 +1751,8 @@ dsinterval_in(PG_FUNCTION_ARGS)
 		tm->tm_hour = (abs(tm->tm_hour) == INT_MAX) ? 0 : tm->tm_hour;
 		tm->tm_mday = (abs(tm->tm_mday) == INT_MAX) ? 0 : tm->tm_mday;
 
-		/* Compatible oracle: if interval type is INTERVAL DAY TO SECOND that
+		/*
+		 * Compatible oracle: if interval type is INTERVAL DAY TO SECOND that
 		 * year and month are invalid.
 		 */
 		tm->tm_mon = 0;
@@ -1755,7 +1760,8 @@ dsinterval_in(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		/* Interval is ISO8601 format
+		/*
+		 * Interval is ISO8601 format
 		 *
 		 * Compatible oracle: if interval type is INTERVAL DAY TO SECOND that
 		 * year and month can not be specified.
@@ -1772,7 +1778,7 @@ dsinterval_in(PG_FUNCTION_ARGS)
 	}
 
 	result = (Interval *) palloc(sizeof(Interval));
-	
+
 	switch (dtype)
 	{
 		case DTK_DELTA:
@@ -1804,7 +1810,7 @@ dsinterval_out(PG_FUNCTION_ARGS)
 	int32		typmod;
 	char	   *result;
 	int			second_precision;
-	int			day_precision;	
+	int			day_precision;
 	struct pg_tm tt,
 			   *tm = &tt;
 	fsec_t		fsec;
@@ -1828,8 +1834,8 @@ dsinterval_out(PG_FUNCTION_ARGS)
 		{
 			ereport(WARNING,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			  errmsg("The typmod in dsinterval_out is invalid, second_precision reduced to maximum allowed, %d",
-					 ORACLE_MAX_INTERVAL_PRECISION)));
+					 errmsg("The typmod in dsinterval_out is invalid, second_precision reduced to maximum allowed, %d",
+							ORACLE_MAX_INTERVAL_PRECISION)));
 			second_precision = ORACLE_MAX_INTERVAL_PRECISION;
 		}
 
@@ -1837,8 +1843,8 @@ dsinterval_out(PG_FUNCTION_ARGS)
 		{
 			ereport(WARNING,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			  errmsg("The typmod in dsinterval_out is invalid, day_precision reduced to maximum allowed, %d",
-					 ORACLE_MAX_INTERVAL_PRECISION)));
+					 errmsg("The typmod in dsinterval_out is invalid, day_precision reduced to maximum allowed, %d",
+							ORACLE_MAX_INTERVAL_PRECISION)));
 			day_precision = ORACLE_MAX_INTERVAL_PRECISION;
 		}
 	}
@@ -1918,12 +1924,12 @@ dsintervaltypmodin(PG_FUNCTION_ARGS)
 	tl = ArrayGetIntegerTypmods(ta, &n);
 
 	/*
-	 * tl[0] - interval range (fields bitmask)
-	 * tl[1] - precision (day_precision)
-	 * tl[2] - precision (second_precision)
+	 * tl[0] - interval range (fields bitmask) tl[1] - precision
+	 * (day_precision) tl[2] - precision (second_precision)
 	 *
-	 * tl[0] can not be INTERVAL_FULL_RANGE, because interval'100' is error syntax in oracle,
-	 * 'precison' come from gram.y, so the value of 'n' must be equal or greater than 2.
+	 * tl[0] can not be INTERVAL_FULL_RANGE, because interval'100' is error
+	 * syntax in oracle, 'precison' come from gram.y, so the value of 'n' must
+	 * be equal or greater than 2.
 	 */
 	if (n >= 2)
 	{
@@ -1953,8 +1959,8 @@ dsintervaltypmodin(PG_FUNCTION_ARGS)
 							ereport(ERROR,
 									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 									 errmsg("interval precision is out of range")));
-						
-						typmod = INTERVAL_DAY_TYPMOD(tl[1], tl[0]);	
+
+						typmod = INTERVAL_DAY_TYPMOD(tl[1], tl[0]);
 					}
 				}
 				break;
@@ -1977,7 +1983,7 @@ dsintervaltypmodin(PG_FUNCTION_ARGS)
 							ereport(ERROR,
 									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 									 errmsg("interval precision is out of range")));
-						
+
 						typmod = INTERVAL_DS_TYPMOD(tl[1], 2, tl[0]);
 					}
 					else if (n == 3)
@@ -1991,8 +1997,8 @@ dsintervaltypmodin(PG_FUNCTION_ARGS)
 							ereport(ERROR,
 									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 									 errmsg("interval precision is out of range")));
-						
-						typmod = INTERVAL_DS_TYPMOD(tl[2], tl[1], tl[0]);	
+
+						typmod = INTERVAL_DS_TYPMOD(tl[2], tl[1], tl[0]);
 					}
 				}
 				break;
@@ -2004,7 +2010,7 @@ dsintervaltypmodin(PG_FUNCTION_ARGS)
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-								 errmsg("invalid INTERVAL type modifier")));	
+								 errmsg("invalid INTERVAL type modifier")));
 					}
 					else
 					{
@@ -2017,7 +2023,7 @@ dsintervaltypmodin(PG_FUNCTION_ARGS)
 							ereport(ERROR,
 									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 									 errmsg("interval precision is out of range")));
-						
+
 						typmod = INTERVAL_DS_TYPMOD(tl[2], tl[1], tl[0]);
 					}
 				}
@@ -2047,7 +2053,8 @@ dsintervaltypmodout(PG_FUNCTION_ARGS)
 	int32		typmod = PG_GETARG_INT32(0);
 	char	   *res = (char *) palloc(64);
 	int			fields;
-	int			day_precision, second_precision;
+	int			day_precision,
+				second_precision;
 
 	if (typmod < 0)
 	{
@@ -2072,7 +2079,7 @@ dsintervaltypmodout(PG_FUNCTION_ARGS)
 		case INTERVAL_MASK(HOUR) | INTERVAL_MASK(MINUTE) | INTERVAL_MASK(SECOND):
 		case INTERVAL_MASK(MINUTE) | INTERVAL_MASK(SECOND):
 			{
-				if (day_precision >= 0 && second_precision >=0)
+				if (day_precision >= 0 && second_precision >= 0)
 					snprintf(res, 64, "%s(%d)%s(%d)", " day", day_precision, " to second", second_precision);
 				else
 					ereport(ERROR,
@@ -2199,10 +2206,10 @@ dsinterval_pl(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
-	/* 
-	 * compatible oracle 
-	 * For Interval day to second, the field of datetime 'YEAR' and 'MONTH' will be zero.
-	 * Recompute the value of result->day and result->time .
+	/*
+	 * compatible oracle For Interval day to second, the field of datetime
+	 * 'YEAR' and 'MONTH' will be zero. Recompute the value of result->day and
+	 * result->time .
 	 */
 	result->month = 0;
 	result->day += result->time / USECS_PER_DAY;
@@ -2227,21 +2234,21 @@ dsinterval_mi(PG_FUNCTION_ARGS)
 
 	span1_usecs = span1->time;
 	span1_usecs += span1->day * INT64CONST(24) * USECS_PER_HOUR;
-	
+
 	span2_usecs = span2->time;
 	span2_usecs += span2->day * INT64CONST(24) * USECS_PER_HOUR;
 
 	result = (Interval *) palloc(sizeof(Interval));
 
-	/* 
-	 * Compatible oracle 
-	 * For Interval day to second, the field of datetime 'YEAR' 'MONTH' will be zero.
-	 * Recompute the value of result->day and result->time .
+	/*
+	 * Compatible oracle For Interval day to second, the field of datetime
+	 * 'YEAR' 'MONTH' will be zero. Recompute the value of result->day and
+	 * result->time .
 	 */
 	result->month = 0;
 	result->day = (span1_usecs - span2_usecs) / USECS_PER_DAY;
 	result->time = (span1_usecs - span2_usecs) % USECS_PER_DAY;
-	
+
 	/* overflow check copied from int4mi */
 	if (!SAMESIGN(span1->day, span2->day) &&
 		!SAMESIGN(result->day, span1->day))
@@ -2260,7 +2267,7 @@ dsinterval_mi(PG_FUNCTION_ARGS)
 
 /*
  * '*' operator function
- * left operand = interval day to second 
+ * left operand = interval day to second
  * right operand = number
  */
 Datum
@@ -2314,7 +2321,7 @@ dsinterval_mul(PG_FUNCTION_ARGS)
 	month_remainder_days = (orig_month * factor - result->month) * DAYS_PER_MONTH;
 	month_remainder_days = TSROUND(month_remainder_days);
 	sec_remainder = (orig_day * factor - result->day +
-		   month_remainder_days - (int) month_remainder_days) * SECS_PER_DAY;
+					 month_remainder_days - (int) month_remainder_days) * SECS_PER_DAY;
 	sec_remainder = TSROUND(sec_remainder);
 
 	/*
@@ -2341,9 +2348,9 @@ dsinterval_mul(PG_FUNCTION_ARGS)
 	result->time = span->time * factor + sec_remainder;
 #endif
 
-	/* 
-	 * compatible oracle 
-	 * For Interval day to second, the field of datetime 'year' 'month' will be truncated.
+	/*
+	 * compatible oracle For Interval day to second, the field of datetime
+	 * 'year' 'month' will be truncated.
 	 */
 	result->month = 0;
 	result->day += result->time / USECS_PER_DAY;
@@ -2355,7 +2362,7 @@ dsinterval_mul(PG_FUNCTION_ARGS)
 /*
  * '*' operator function
  * left operand = number
- * right operand = interval day to second 
+ * right operand = interval day to second
  */
 Datum
 mul_d_dsinterval(PG_FUNCTION_ARGS)
@@ -2380,6 +2387,7 @@ dsinterval_div(PG_FUNCTION_ARGS)
 	float8		factor;
 	double		month_remainder_days,
 				sec_remainder;
+	double		result_double;
 	int32		orig_month = span->month,
 				orig_day = span->day;
 	Interval   *result;
@@ -2401,7 +2409,7 @@ dsinterval_div(PG_FUNCTION_ARGS)
 	month_remainder_days = (orig_month / factor - result->month) * DAYS_PER_MONTH;
 	month_remainder_days = TSROUND(month_remainder_days);
 	sec_remainder = (orig_day / factor - result->day +
-		   month_remainder_days - (int) month_remainder_days) * SECS_PER_DAY;
+					 month_remainder_days - (int) month_remainder_days) * SECS_PER_DAY;
 	sec_remainder = TSROUND(sec_remainder);
 	if (Abs(sec_remainder) >= SECS_PER_DAY)
 	{
@@ -2412,15 +2420,20 @@ dsinterval_div(PG_FUNCTION_ARGS)
 	/* cascade units down */
 	result->day += (int32) month_remainder_days;
 #ifdef HAVE_INT64_TIMESTAMP
-	result->time = rint(span->time / factor + sec_remainder * USECS_PER_SEC);
+	result_double = rint(span->time / factor + sec_remainder * USECS_PER_SEC);
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT64(result_double))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("interval out of range")));
+	result->time = (int64) result_double;
 #else
 	/* See TSROUND comment in interval_mul(). */
 	result->time = span->time / factor + sec_remainder;
 #endif
 
-	/* 
-	 * compatible oracle
-	 * For Interval day to second, the field of datetime 'year' 'month' will be truncated.
+	/*
+	 * compatible oracle For Interval day to second, the field of datetime
+	 * 'year' 'month' will be truncated.
 	 */
 	result->month = 0;
 	result->day += result->time / USECS_PER_DAY;
@@ -2474,9 +2487,9 @@ in_range_dsinterval_dsinterval(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
- *	 Hash index support procedure 
+ *	 Hash index support procedure
  *****************************************************************************/
- 
+
 /*
  * Hashing for intervals
  *
@@ -2509,7 +2522,7 @@ dsinterval_hash_extended(PG_FUNCTION_ARGS)
 
 
 /*****************************************************************************
- *	 AGGREGATE FUNCTION 
+ *	 AGGREGATE FUNCTION
  *****************************************************************************/
 Datum
 dsinterval_smaller(PG_FUNCTION_ARGS)

--- a/contrib/ivorysql_ora/src/datatype/dsinterval.c
+++ b/contrib/ivorysql_ora/src/datatype/dsinterval.c
@@ -2287,14 +2287,14 @@ dsinterval_mul(PG_FUNCTION_ARGS)
 	result = (Interval *) palloc(sizeof(Interval));
 
 	result_double = span->month * factor;
-	if (result_double > INT_MAX || result_double < INT_MIN)
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT32(result_double))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->month = (int32) result_double;
 
 	result_double = span->day * factor;
-	if (result_double > INT_MAX || result_double < INT_MIN)
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT32(result_double))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));

--- a/contrib/ivorysql_ora/src/datatype/dsinterval.c
+++ b/contrib/ivorysql_ora/src/datatype/dsinterval.c
@@ -2349,11 +2349,15 @@ dsinterval_mul(PG_FUNCTION_ARGS)
 #endif
 
 	/*
-	 * compatible oracle For Interval day to second, the field of datetime
-	 * 'year' 'month' will be truncated.
+	 * compatible oracle
+	 * For Interval day to second, the field of datetime 'year' 'month' will be truncated.
 	 */
 	result->month = 0;
 	result->day += result->time / USECS_PER_DAY;
+	if (result->day > INT_MAX || result->day < INT_MIN)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("interval out of range")));
 	result->time = result->time % USECS_PER_DAY;
 
 	PG_RETURN_INTERVAL_P(result);
@@ -2386,8 +2390,8 @@ dsinterval_div(PG_FUNCTION_ARGS)
 	Numeric		num = PG_GETARG_NUMERIC(1);
 	float8		factor;
 	double		month_remainder_days,
-				sec_remainder;
-	double		result_double;
+				sec_remainder,
+				result_double;
 	int32		orig_month = span->month,
 				orig_day = span->day;
 	Interval   *result;
@@ -2400,8 +2404,19 @@ dsinterval_div(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
-	result->month = (int32) (span->month / factor);
-	result->day = (int32) (span->day / factor);
+	result_double = span->month / factor;
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT32(result_double))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("interval out of range")));
+	result->month = (int32) result_double;
+
+	result_double = span->day / factor;
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT32(result_double))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("interval out of range")));
+	result->day = (int32) result_double;
 
 	/*
 	 * Fractional months full days into days.  See comment in interval_mul().
@@ -2432,11 +2447,15 @@ dsinterval_div(PG_FUNCTION_ARGS)
 #endif
 
 	/*
-	 * compatible oracle For Interval day to second, the field of datetime
-	 * 'year' 'month' will be truncated.
+	 * compatible oracle
+	 * For Interval day to second, the field of datetime 'year' 'month' will be truncated.
 	 */
 	result->month = 0;
 	result->day += result->time / USECS_PER_DAY;
+	if (result->day > INT_MAX || result->day < INT_MIN)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("interval out of range")));
 	result->time = result->time % USECS_PER_DAY;
 
 	PG_RETURN_INTERVAL_P(result);

--- a/contrib/ivorysql_ora/src/datatype/yminterval.c
+++ b/contrib/ivorysql_ora/src/datatype/yminterval.c
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
  * Copyright 2025 IvorySQL Global Development Team
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -118,7 +118,7 @@ ParseFractionalSecond(char *cp, fsec_t *fsec)
 
 static int
 DecodeTime(char *str, int fmask, int range,
-		   int *tmask, struct tm * tm, fsec_t *fsec)
+		   int *tmask, struct tm *tm, fsec_t *fsec)
 {
 	char	   *cp;
 	int			dterr;
@@ -207,7 +207,7 @@ DecodeTime(char *str, int fmask, int range,
  * we can not know  the '0' is initial value or the value of the input.
  */
 static inline void
-ClearPgTm(struct tm * tm, fsec_t *fsec)
+ClearPgTm(struct tm *tm, fsec_t *fsec)
 {
 	tm->tm_year = INT_MAX;
 	tm->tm_mon = INT_MAX;
@@ -219,7 +219,7 @@ ClearPgTm(struct tm * tm, fsec_t *fsec)
 }
 
 static void
-AdjustFractSeconds(double frac, struct tm * tm, fsec_t *fsec, int scale)
+AdjustFractSeconds(double frac, struct tm *tm, fsec_t *fsec, int scale)
 {
 	int			sec;
 
@@ -227,10 +227,10 @@ AdjustFractSeconds(double frac, struct tm * tm, fsec_t *fsec, int scale)
 		return;
 	frac *= scale;
 	sec = (int) frac;
-	
+
 	if (tm->tm_sec == INT_MAX)
 		tm->tm_sec = 0;
-	
+
 	tm->tm_sec += sec;
 	frac -= sec;
 #ifdef HAVE_INT64_TIMESTAMP
@@ -242,7 +242,7 @@ AdjustFractSeconds(double frac, struct tm * tm, fsec_t *fsec, int scale)
 
 /* As above, but initial scale produces days */
 static void
-AdjustFractDays(double frac, struct tm * tm, fsec_t *fsec, int scale)
+AdjustFractDays(double frac, struct tm *tm, fsec_t *fsec, int scale)
 {
 	int			extra_days;
 
@@ -250,7 +250,7 @@ AdjustFractDays(double frac, struct tm * tm, fsec_t *fsec, int scale)
 		return;
 	frac *= scale;
 	extra_days = (int) frac;
-	
+
 	if (tm->tm_mday == INT_MAX)
 		tm->tm_mday = 0;
 	tm->tm_mday += extra_days;
@@ -316,7 +316,7 @@ AppendSeconds(char *cp, int sec, fsec_t fsec, int precision, bool fillzeros)
  * Interpret time structure as a delta time and convert to string.
  */
 static void
-EncodeYminterval(struct pg_tm * tm, fsec_t fsec, int style, char *str, int precision)
+EncodeYminterval(struct pg_tm *tm, fsec_t fsec, int style, char *str, int precision)
 {
 	char	   *cp = str;
 	int			year = tm->tm_year;
@@ -338,17 +338,17 @@ EncodeYminterval(struct pg_tm * tm, fsec_t fsec, int style, char *str, int preci
 		case INTSTYLE_SQL_STANDARD:
 			{
 				bool		has_negative = year < 0 || mon < 0 ||
-				mday < 0 || hour < 0 ||
-				min < 0 || sec < 0 || fsec < 0;
+					mday < 0 || hour < 0 ||
+					min < 0 || sec < 0 || fsec < 0;
 				bool		has_positive = year > 0 || mon > 0 ||
-				mday > 0 || hour > 0 ||
-				min > 0 || sec > 0 || fsec > 0;
+					mday > 0 || hour > 0 ||
+					min > 0 || sec > 0 || fsec > 0;
 				bool		has_year_month = year != 0 || mon != 0;
 				bool		has_day_time = mday != 0 || hour != 0 ||
-				min != 0 || sec != 0 || fsec != 0;
+					min != 0 || sec != 0 || fsec != 0;
 				bool		has_day = mday != 0;
 				bool		sql_standard_value = !(has_negative && has_positive) &&
-				!(has_year_month && has_day_time);
+					!(has_year_month && has_day_time);
 
 				/*
 				 * SQL Standard wants only 1 "<sign>" preceding the whole
@@ -369,8 +369,11 @@ EncodeYminterval(struct pg_tm * tm, fsec_t fsec, int style, char *str, int preci
 				/* Compatible oracle, show sign '+' or '-' */
 				if (!has_negative)
 					*cp++ = '+';
-				
-				/* Compatible oracle, the value of interval is zero should show "+00-00" */
+
+				/*
+				 * Compatible oracle, the value of interval is zero should
+				 * show "+00-00"
+				 */
 				if (!has_negative && !has_positive)
 				{
 					sprintf(cp, "%0*d-%02d", precision, year, mon);
@@ -437,7 +440,7 @@ EncodeYminterval(struct pg_tm * tm, fsec_t fsec, int style, char *str, int preci
  */
 static int
 DecodeYminterval(char **field, int *ftype, int nf, int range,
-			   int *dtype, struct tm * tm, fsec_t *fsec)
+				 int *dtype, struct tm *tm, fsec_t *fsec)
 {
 	bool		is_before = false;
 	char	   *cp;
@@ -568,7 +571,7 @@ DecodeYminterval(char **field, int *ftype, int nf, int range,
 					if (((double) val * MONTHS_PER_YEAR + val2) > INT_MAX ||
 						((double) val * MONTHS_PER_YEAR + val2) < INT_MIN)
 						return DTERR_FIELD_OVERFLOW;
-//					val = val * MONTHS_PER_YEAR + val2;
+/* 					val = val * MONTHS_PER_YEAR + val2; */
 					fval = 0;
 				}
 				else if (*cp == '.')
@@ -685,21 +688,21 @@ DecodeYminterval(char **field, int *ftype, int nf, int range,
 							tm->tm_mon += fval * MONTHS_PER_YEAR;
 						tmask = DTK_M(YEAR);
 						break;
-						
+
 					case DTK_DATE:
 						if (tm->tm_year == INT_MAX)
 							tm->tm_year = 0;
 						if (tm->tm_mon == INT_MAX)
 							tm->tm_mon = 0;
-						
+
 						tm->tm_year += val;
 						tm->tm_mon += val2;
-						
+
 						if (fval != 0)
 							tm->tm_mon += fval * MONTHS_PER_YEAR;
 						tmask = DTK_M(MONTH);
 						break;
-						
+
 					case DTK_DECADE:
 						if (tm->tm_year == INT_MAX)
 							tm->tm_year = 0;
@@ -708,7 +711,7 @@ DecodeYminterval(char **field, int *ftype, int nf, int range,
 						{
 							if (tm->tm_mon == INT_MAX)
 								tm->tm_mon = 0;
-							
+
 							tm->tm_mon += fval * MONTHS_PER_YEAR * 10;
 						}
 						tmask = DTK_M(DECADE);
@@ -722,7 +725,7 @@ DecodeYminterval(char **field, int *ftype, int nf, int range,
 						{
 							if (tm->tm_mon == INT_MAX)
 								tm->tm_mon = 0;
-							
+
 							tm->tm_mon += fval * MONTHS_PER_YEAR * 100;
 						}
 						tmask = DTK_M(CENTURY);
@@ -736,7 +739,7 @@ DecodeYminterval(char **field, int *ftype, int nf, int range,
 						{
 							if (tm->tm_mon == INT_MAX)
 								tm->tm_mon = 0;
-							
+
 							tm->tm_mon += fval * MONTHS_PER_YEAR * 1000;
 						}
 						tmask = DTK_M(MILLENNIUM);
@@ -851,7 +854,7 @@ DecodeYminterval(char **field, int *ftype, int nf, int range,
 		tm->tm_mday = (tm->tm_mday == INT_MAX) ? 0 : tm->tm_mday;
 		tm->tm_mon = (tm->tm_mon == INT_MAX) ? 0 : tm->tm_mon;
 		tm->tm_year = (tm->tm_year == INT_MAX) ? 0 : tm->tm_year;
-		
+
 		*fsec = -(*fsec);
 		tm->tm_sec = -tm->tm_sec;
 		tm->tm_min = -tm->tm_min;
@@ -872,16 +875,16 @@ AdjustYmintervalForTypmod(Interval *interval, int32 typmod)
 {
 	if (typmod > 0)
 	{
-		int		range = INTERVAL_RANGE(typmod);
-		int		precision = INTERVAL_PRECISION(typmod);
-		int64	interval_year;
-		
+		int			range = INTERVAL_RANGE(typmod);
+		int			precision = INTERVAL_PRECISION(typmod);
+		int64		interval_year;
+
 		if (range == INTERVAL_MASK(YEAR) ||
 			range == INTERVAL_MASK(MONTH) ||
 			range == (INTERVAL_MASK(YEAR) | INTERVAL_MASK(MONTH)))
 		{
 			interval_year = abs(interval->month / MONTHS_PER_YEAR);
-			switch(precision)
+			switch (precision)
 			{
 				case 0:
 					if (interval_year != 0)
@@ -995,7 +998,7 @@ ora_ParseISO8601Number(const char *str, char **endptr, int *ipart, double *fpart
  */
 static int
 ora_DecodeISO8601Interval(char *str,
-					  int *dtype, struct /* pg_ */ tm *tm, fsec_t *fsec)
+						  int *dtype, struct /* pg_ */ tm *tm, fsec_t *fsec)
 {
 	bool		datepart = true;
 	bool		havefield = false;
@@ -1249,15 +1252,15 @@ yminterval_cmp_value(const Interval *interval)
 {
 	TimeOffset	span;
 
-//	span = interval->time;
+/* 	span = interval->time; */
 	span = 0;
 
 #ifdef HAVE_INT64_TIMESTAMP
 	span += interval->month * INT64CONST(30) * USECS_PER_DAY;
-//	span += interval->day * INT64CONST(24) * USECS_PER_HOUR;
+/* 	span += interval->day * INT64CONST(24) * USECS_PER_HOUR; */
 #else
 	span += interval->month * ((double) DAYS_PER_MONTH * SECS_PER_DAY);
-//	span += interval->day * ((double) HOURS_PER_DAY * SECS_PER_HOUR);
+/* 	span += interval->day * ((double) HOURS_PER_DAY * SECS_PER_HOUR); */
 #endif
 
 	return span;
@@ -1289,7 +1292,7 @@ yminterval_in(PG_FUNCTION_ARGS)
 	int32		typmod = PG_GETARG_INT32(2);
 	Interval   *result;
 	fsec_t		fsec;
-	struct	tm  tt,
+	struct tm	tt,
 			   *tm = &tt;
 	int			dtype = -1;
 	int			nf;
@@ -1299,8 +1302,8 @@ yminterval_in(PG_FUNCTION_ARGS)
 	int			ftype[MAXDATEFIELDS];
 	char		workbuf[256];
 	bool		isiso = false;
-	char 		*strold;
-	char 		*strsrc;
+	char	   *strold;
+	char	   *strsrc;
 	DateTimeErrorExtra extra;
 
 	tm->tm_year = INT_MAX;
@@ -1352,13 +1355,13 @@ yminterval_in(PG_FUNCTION_ARGS)
 						  ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
 		dterr = DecodeYminterval(field, ftype, nf, range,
-							     &dtype, tm, &fsec);
+								 &dtype, tm, &fsec);
 
 	/* if those functions think it's a bad format, try ISO8601 style */
 	if (dterr == DTERR_BAD_FORMAT)
 	{
 		dterr = ora_DecodeISO8601Interval(str,
-									  &dtype, tm, &fsec);
+										  &dtype, tm, &fsec);
 		isiso = true;
 	}
 
@@ -1369,24 +1372,25 @@ yminterval_in(PG_FUNCTION_ARGS)
 		DateTimeParseError(dterr, &extra, str, "interval year to month", NULL);
 	}
 
-	/* 
+	/*
 	 * compatible oracle, the valid range of values for the trailing field
 	 * MONTH: 0 to 11
 	 *
-	 * In oracle, the string and interval fields is exact matched,
-	 * for example:interval'1:1' hour to second and interval'1 1:1:1' hour to second is error.
-	 * change the initial value of 'pg_tm *tm' to INT_MAX, because if the value of 'pg_tm *tm' is 0,
-	 * we can not know  the '0' is initial value or the value of the input.
+	 * In oracle, the string and interval fields is exact matched, for
+	 * example:interval'1:1' hour to second and interval'1 1:1:1' hour to
+	 * second is error. change the initial value of 'pg_tm *tm' to INT_MAX,
+	 * because if the value of 'pg_tm *tm' is 0, we can not know  the '0' is
+	 * initial value or the value of the input.
 	 */
-	if(!isiso)
+	if (!isiso)
 	{
-		switch(range)
+		switch (range)
 		{
 			case INTERVAL_MASK(YEAR):
 				if (abs(tm->tm_year) == INT_MAX ||
-					abs(tm->tm_mon)  != INT_MAX ||
-					abs(tm->tm_min)  != INT_MAX ||
-					abs(tm->tm_sec)  != INT_MAX ||
+					abs(tm->tm_mon) != INT_MAX ||
+					abs(tm->tm_min) != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_hour) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX)
 					ereport(ERROR,
@@ -1396,9 +1400,9 @@ yminterval_in(PG_FUNCTION_ARGS)
 
 			case INTERVAL_MASK(MONTH):
 				if (abs(tm->tm_year) != INT_MAX ||
-					abs(tm->tm_mon)  == INT_MAX ||
-					abs(tm->tm_min)  != INT_MAX ||
-					abs(tm->tm_sec)  != INT_MAX ||
+					abs(tm->tm_mon) == INT_MAX ||
+					abs(tm->tm_min) != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_hour) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX)
 					ereport(ERROR,
@@ -1409,9 +1413,9 @@ yminterval_in(PG_FUNCTION_ARGS)
 			case INTERVAL_MASK(YEAR) | INTERVAL_MASK(MONTH):
 			case INTERVAL_FULL_RANGE:
 				if (abs(tm->tm_year) == INT_MAX ||
-					abs(tm->tm_mon)  == INT_MAX ||
-					abs(tm->tm_min)  != INT_MAX ||
-					abs(tm->tm_sec)  != INT_MAX ||
+					abs(tm->tm_mon) == INT_MAX ||
+					abs(tm->tm_min) != INT_MAX ||
+					abs(tm->tm_sec) != INT_MAX ||
 					abs(tm->tm_hour) != INT_MAX ||
 					abs(tm->tm_mday) != INT_MAX)
 					ereport(ERROR,
@@ -1434,7 +1438,8 @@ yminterval_in(PG_FUNCTION_ARGS)
 		tm->tm_mon = (abs(tm->tm_mon) == INT_MAX) ? 0 : tm->tm_mon;
 		tm->tm_year = (abs(tm->tm_year) == INT_MAX) ? 0 : tm->tm_year;
 
-		/* Compatible oracle: if interval type is INTERVAL YEAR TO MONTH that
+		/*
+		 * Compatible oracle: if interval type is INTERVAL YEAR TO MONTH that
 		 * days, hours, minutes, seconds, and frac_secs are invalid.
 		 */
 		tm->tm_sec = 0;
@@ -1445,7 +1450,8 @@ yminterval_in(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		/* Interval is ISO8601 format 
+		/*
+		 * Interval is ISO8601 format
 		 *
 		 * Compatible oracle: if interval type is INTERVAL YEAR TO MONTH that
 		 * days, hours, minutes, seconds, and frac_secs are ignored.
@@ -1474,7 +1480,7 @@ yminterval_in(PG_FUNCTION_ARGS)
 	}
 
 	AdjustYmintervalForTypmod(result, typmod);
-	
+
 	PG_RETURN_INTERVAL_P(result);
 }
 
@@ -1487,7 +1493,7 @@ yminterval_out(PG_FUNCTION_ARGS)
 {
 	Interval   *span = PG_GETARG_INTERVAL_P(0);
 	int32		typmod;
-	int		precision;
+	int			precision;
 	char	   *result;
 	struct pg_tm tt,
 			   *tm = &tt;
@@ -1513,7 +1519,7 @@ yminterval_out(PG_FUNCTION_ARGS)
 			ereport(WARNING,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("The typmod in yminterval_out is invalid, reduced to maximum allowed, %d",
-					 ORACLE_MAX_INTERVAL_PRECISION)));
+							ORACLE_MAX_INTERVAL_PRECISION)));
 			precision = ORACLE_MAX_INTERVAL_PRECISION;
 		}
 	}
@@ -1669,7 +1675,7 @@ yminterval_recv(PG_FUNCTION_ARGS)
 	interval->month = pq_getmsgint(buf, sizeof(interval->month));
 
 	AdjustYmintervalForTypmod(interval, typmod);
-	
+
 	PG_RETURN_INTERVAL_P(interval);
 }
 
@@ -1788,15 +1794,15 @@ yminterval_mul(PG_FUNCTION_ARGS)
 	result = (Interval *) palloc(sizeof(Interval));
 
 	result_double = span->month * factor;
-	if (result_double > INT_MAX || result_double < INT_MIN)
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT32(result_double))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->month = (int32) result_double;
 
-	/* 
-	 * compatible oracle
-	 * For Interval year to month, the field of datetime 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be truncated.
+	/*
+	 * compatible oracle For Interval year to month, the field of datetime
+	 * 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be truncated.
 	 */
 	result->day = 0;
 	result->time = 0;
@@ -1807,7 +1813,7 @@ yminterval_mul(PG_FUNCTION_ARGS)
 /*
  * '*' operator function
  * left operand = number
- * right operand = interval year to month 
+ * right operand = interval year to month
  */
 Datum
 mul_d_yminterval(PG_FUNCTION_ARGS)
@@ -1822,15 +1828,15 @@ mul_d_yminterval(PG_FUNCTION_ARGS)
 	result = (Interval *) palloc(sizeof(Interval));
 
 	result_double = span->month * factor;
-	if (result_double > INT_MAX || result_double < INT_MIN)
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT32(result_double))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->month = (int32) result_double;
 
 	/*
-	 * compatible oracle
-	 * For Interval year to month, the field of datetime 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be truncated.
+	 * compatible oracle For Interval year to month, the field of datetime
+	 * 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be truncated.
 	 */
 	result->day = 0;
 	result->time = 0;
@@ -1860,9 +1866,9 @@ yminterval_mi(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
-	/* 
-	 * compatible oracle
-	 * For Interval year to month, the field of datetime 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be zero.
+	/*
+	 * compatible oracle For Interval year to month, the field of datetime
+	 * 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be zero.
 	 */
 	result->day = 0;
 	result->time = 0;
@@ -1892,9 +1898,9 @@ yminterval_pl(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
-	/* 
-	 * compatible oracle
-	 * For Interval year to month, the field of datetime 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be zero.
+	/*
+	 * compatible oracle For Interval year to month, the field of datetime
+	 * 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be zero.
 	 */
 	result->day = 0;
 	result->time = 0;
@@ -1913,6 +1919,7 @@ yminterval_div(PG_FUNCTION_ARGS)
 	Interval   *span = PG_GETARG_INTERVAL_P(0);
 	Numeric		num = PG_GETARG_NUMERIC(1);
 	float8		factor;
+	double		result_double;
 	Interval   *result;
 
 	factor = DatumGetFloat8(DirectFunctionCall1(numeric_float8, NumericGetDatum(num)));
@@ -1923,11 +1930,16 @@ yminterval_div(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
-	result->month = (int32) (span->month / factor);
+	result_double = span->month / factor;
+	if (isnan(result_double) || !FLOAT8_FITS_IN_INT32(result_double))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("interval out of range")));
+	result->month = (int32) result_double;
 
 	/*
-	 * compatible oracle
-	 * For Interval year to month, the field of datetime 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be zero.
+	 * compatible oracle For Interval year to month, the field of datetime
+	 * 'DAY' 'HOUR' 'MINUTE' 'SECOND' will be zero.
 	 */
 	result->day = 0;
 	result->time = 0;
@@ -1979,7 +1991,7 @@ in_range_yminterval_yminterval(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
- *	 Hash index support procedure 
+ *	 Hash index support procedure
  *****************************************************************************/
 
 /*
@@ -2013,7 +2025,7 @@ yminterval_hash_extended(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
- *	 AGGREGATE FUNCTION 
+ *	 AGGREGATE FUNCTION
  *****************************************************************************/
 Datum
 yminterval_smaller(PG_FUNCTION_ARGS)


### PR DESCRIPTION
dsinterval_mul() compared a rounded double directly to PG_INT64_MAX, which triggers Clang because that integer constant is not exactly representable as double near 2^63.

Warning excerpt:

```
src/datatype/dsinterval.c:2336:22: warning:
implicit conversion from long to double changes value from 9223372036854775807 to 9223372036854775808
[-Wimplicit-const-int-float-conversion]
```

Follow the same integer-fit pattern used in timestamp.c by checking isnan() and FLOAT8_FITS_IN_INT64() after rint(). This avoids custom bound constants and keeps overflow checks consistent with core code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datetime/interval multiplication and division checks to detect NaN and out-of-range intermediate results, returning clearer “interval out of range” errors instead of producing invalid interval values.

* **Tests**
  * Expanded interval arithmetic test coverage with additional overflow and near-zero divisor cases, including NaN inputs, for both year-to-month and day-to-second intervals.

* **Style / Refactor**
  * Applied minor interval-handling code cleanup and parsing/formatting adjustments without changing public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


close  #1366 