### PR TITLE
Make identifier_alpha_transfor.c frontend-safe

### DIFF
--- a/src/port/identifier_alpha_transfor.c
+++ b/src/port/identifier_alpha_transfor.c
@@ -34,10 +34,13 @@
  */
 
 
+#ifndef FRONTEND
 #include "postgres.h"
-
-#include "c.h"
-#include "common/fe_memutils.h"
+#define ALLOC(size) palloc(size)
+#else
+#include "postgres_fe.h"
+#define ALLOC(size) pg_malloc(size)
+#endif
 
 /*
  * transform upper to lower
@@ -51,7 +54,7 @@ down_character(const char *src, int len)
 	Assert(src != NULL);
 	Assert(len >= 0);
 
-	res = (char*)palloc(len + 1);
+	res = ALLOC(len + 1);
 	memcpy(res, src, len);
 	res[len] = '\0';
 	s = res;
@@ -77,7 +80,7 @@ upper_character(const char *src, int len)
 	Assert(src != NULL);
 	Assert(len >= 0);
 
-	res = (char*)palloc(len + 1);
+	res = ALLOC(len + 1);
 	memcpy(res, src, len);
 	res[len] = '\0';
 	s = res;


### PR DESCRIPTION
identifier_alpha_transfor.c is compiled as part of frontend libpgport, but it previously hardwired backend-only header/allocation choices.

Build error excerpt:
```
../src/include/utils/elog.h:79:10: fatal error:
'utils/errcodes.h' file not found
```

Unify the FRONTEND split at the top of the file: choose postgres.h vs postgres_fe.h once, define ALLOC() once, and reuse ALLOC() in both conversion helpers. This keeps frontend/backend allocation behavior consistent and removes scattered per-callsite #ifdef blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to memory allocation infrastructure for better build portability. No user-facing changes or functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->