### PR TITLE
Fix OraParam walker callback typing and skip scalar fields

### DIFF
--- a/src/backend/parser/parse_param.c
+++ b/src/backend/parser/parse_param.c
@@ -1051,8 +1051,6 @@ raw_calculate_oraparamnumbers_walker(Node *node,
 		{
 			 AlterExtensionContentsStmt *stmt = (AlterExtensionContentsStmt *)node;
 
-			 if (WALK(stmt->extname))
-				 return true;
 			 if (WALK(stmt->object))
 				 return true;
 		}
@@ -1570,15 +1568,11 @@ raw_calculate_oraparamnumbers_walker(Node *node,
 				return true;
 			if (WALK(stmt->subquery))
 				return true;
-			if (WALK(stmt->jointype))
-				return true;
 			if (WALK(stmt->joinaliasvars))
 				return true;
 			if (WALK(stmt->functions))
 				return true;
 			if (WALK(stmt->values_lists))
-				return true;
-			if (WALK(stmt->ctename))
 				return true;
 			if (WALK(stmt->coltypes))
 				return true;


### PR DESCRIPTION
Make `raw_calculate_oraparamnumbers_walker()` follow PostgreSQL's tree-walker conventions.

The walker used a legacy callback type (`bool (*)()`) that depends on non-prototype function semantics. Newer Clang rejects that pattern in warning-as-error builds. After switching to `tree_walker_callback`, a few call sites still routed scalar members through `WALK()`, even though they are not `Node`/`List` subtrees and should not participate in recursive traversal.

- removes `WALK()` calls on scalar fields `extname`, `jointype`,  and `ctename`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal callback infrastructure for parameter processing to improve code maintainability and consistency across recursive node operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->