### PR TITLE
Move GB18030 skip after buffer setup in test_escape

### DIFF
--- a/src/oracle_test/modules/test_escape/test_escape.c
+++ b/src/oracle_test/modules/test_escape/test_escape.c
@@ -633,10 +633,6 @@ test_psql_parse(pe_test_config *tc, PQExpBuffer testname,
 static void
 test_one_vector_escape(pe_test_config *tc, const pe_test_vector *tv, const pe_test_escape_func *ef)
 {
-	if (strcmp(tv->client_encoding, "GB18030") == 0 &&
-		(memchr(tv->escape, 0x81, tv->escape_len) != NULL)) {
-		goto out;
-	}
 	PQExpBuffer testname;
 	PQExpBuffer details;
 	PQExpBuffer raw_buf;
@@ -655,6 +651,10 @@ test_one_vector_escape(pe_test_config *tc, const pe_test_vector *tv, const pe_te
 	details = createPQExpBuffer();
 	raw_buf = createPQExpBuffer();
 	escape_buf = createPQExpBuffer();
+
+	if (strcmp(tv->client_encoding, "GB18030") == 0 &&
+		(memchr(tv->escape, 0x81, tv->escape_len) != NULL))
+		goto out;
 
 	if (ef->supports_only_ascii_overlap &&
 		encoding_conflicts_ascii(PQclientEncoding(tc->conn)))

--- a/src/test/modules/test_escape/test_escape.c
+++ b/src/test/modules/test_escape/test_escape.c
@@ -633,10 +633,6 @@ test_psql_parse(pe_test_config *tc, PQExpBuffer testname,
 static void
 test_one_vector_escape(pe_test_config *tc, const pe_test_vector *tv, const pe_test_escape_func *ef)
 {
-	if (strcmp(tv->client_encoding, "GB18030") == 0 &&
-		(memchr(tv->escape, 0x81, tv->escape_len) != NULL)) {
-		goto out;
-	}
 	PQExpBuffer testname;
 	PQExpBuffer details;
 	PQExpBuffer raw_buf;
@@ -655,6 +651,10 @@ test_one_vector_escape(pe_test_config *tc, const pe_test_vector *tv, const pe_te
 	details = createPQExpBuffer();
 	raw_buf = createPQExpBuffer();
 	escape_buf = createPQExpBuffer();
+
+	if (strcmp(tv->client_encoding, "GB18030") == 0 &&
+		(memchr(tv->escape, 0x81, tv->escape_len) != NULL))
+		goto out;
 
 	if (ef->supports_only_ascii_overlap &&
 		encoding_conflicts_ascii(PQclientEncoding(tc->conn)))


### PR DESCRIPTION
IvorySQL keeps a GB18030-specific skip path in test_one_vector_escape(), but placing that branch before local declarations and buffer setup triggered Clang diagnostics in both test_escape modules.

Warning excerpt:

```
test_escape.c:640:14: warning:
mixing declarations and code is incompatible with standards before C99
[-Wdeclaration-after-statement]
test_escape.c:636:6: warning:
variable 'escape_err' is used uninitialized whenever 'if' condition is true
[-Wsometimes-uninitialized]
```

Allocate PQExpBuffer objects first, then apply the existing GB18030 memchr-based skip check. This preserves IvorySQL behavior while making the early-exit cleanup path safe in both modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test execution sequence for escape functionality validation to modify allocation timing during test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->