### PR TITLE
Add two-argument and three-argument EXTRACT function forms to grammar

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_xml_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_xml_functions.out
@@ -27,45 +27,69 @@ INSERT INTO xmlnstest VALUES(1, xmltype('<soapenv:Envelope xmlns:soapenv="http:/
 -- extrct(XML)
 --
 SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA/ID') from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA/ID') fro...
-                              ^
+  extract   
+------------
+ <ID>1</ID>
+(1 row)
+
 SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA') from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA') from d...
-                              ^
+   extract    
+--------------
+ <AA>        +
+   <ID>1</ID>+
+ </AA>
+(1 row)
+
 SELECT extract(XMLType('<Co Attr ="Test Attr"><ID>1</ID></Co>'), '/Co') from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<Co Attr ="Test Attr"><ID>1</ID></Co...
-                              ^
+        extract        
+-----------------------
+ <Co Attr="Test Attr">+
+   <ID>1</ID>         +
+ </Co>
+(1 row)
+
 SELECT extract(XMLType('<Co Attr ="Test Attr"><ID>1</ID></Co>'), '/Co/@ Attr') from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<Co Attr ="Test Attr"><ID>1</ID></Co...
-                              ^
+  extract  
+-----------
+ Test Attr
+(1 row)
+
 SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),'/a/b[2]') from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),'/a/b[2]...
-                              ^
+  extract  
+-----------
+ <b>b2</b>
+(1 row)
+
 SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),'/a/b[3]') from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),'/a/b[3]...
-                              ^
+ extract 
+---------
+ 
+(1 row)
+
 SELECT extract(b, '/a/b') from inaf where a = 2;
-ERROR:  syntax error at or near ","
-LINE 1: SELECT extract(b, '/a/b') from inaf where a = 2;
-                        ^
+ extract 
+---------
+ 
+(1 row)
+
 SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),'') from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),'') from...
-                              ^
+ extract 
+---------
+ 
+(1 row)
+
 SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),null) from dual;
-ERROR:  syntax error at or near "("
-LINE 1: SELECT extract(XMLType('<a><b>b1</b><b>b2</b></a>'),null) fr...
-                              ^
+ extract 
+---------
+ 
+(1 row)
+
 SELECT extract(data, 'soapenv:Envelope/soapenv:Body/web:BBB/typ:EEE', 'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:typ="http://www.def.com" xmlns:web="http://www.abc.com"') from xmlnstest where id = 1;
-ERROR:  syntax error at or near "data"
-LINE 1: SELECT extract(data, 'soapenv:Envelope/soapenv:Body/web:BBB/...
-                       ^
+                       extract                        
+------------------------------------------------------
+ <typ:EEE xmlns:typ="http://www.def.com">41</typ:EEE>
+(1 row)
+
 --
 -- extractvalue
 --

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -18025,6 +18025,20 @@ func_expr_common_subexpr:
 											   COERCE_SQL_SYNTAX,
 											   @1);
 				}
+			| EXTRACT '(' a_expr ',' a_expr ')'
+				{
+					$$ = (Node *) makeFuncCall(list_make1(makeString("extract")),
+											   list_make2($3, $5),
+											   COERCE_EXPLICIT_CALL,
+											   @1);
+				}
+			| EXTRACT '(' a_expr ',' a_expr ',' a_expr ')'
+				{
+					$$ = (Node *) makeFuncCall(list_make1(makeString("extract")),
+											   list_make3($3, $5, $7),
+											   COERCE_EXPLICIT_CALL,
+											   @1);
+				}
 			/* End - ReqID:SRS-SQL-XML */
 			| NORMALIZE '(' a_expr ')'
 				{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced EXTRACT function support to accept additional syntax variations in SQL queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Fix for #1220 