### PR TITLE
fix the bug in ivy_extractvalue and ivy_extractvalue2

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_xml_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_xml_functions.out
@@ -110,7 +110,7 @@ SELECT extractvalue(XMLType('<a><b>b1</b><b>b2</b></a>'),'/a/b[2]') from dual;
 SELECT extractvalue(XMLType('<a><b>b1</b><b>b2</b></a>'),'/a/b') from dual;
 ERROR:  EXTRACTVALUE returns value of only one node
 SELECT extractvalue(XMLType('<a><b><c><d><e>111></e><f>222</f></d></c></b></a>'),'/a/b/c/d') from dual;
-ERROR:  EXTRACTVALUE returns value of only one node
+ERROR:  EXTRACTVALUE can only retrieve value of leaf node
 SELECT extractvalue(data, 'soapenv:Envelope/soapenv:Body/web:BBB/typ:EEE', 'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:typ="http://www.def.com" xmlns:web="http://www.abc.com"') from xmlnstest where id = 1;
  extractvalue 
 --------------
@@ -867,7 +867,7 @@ select DELETEXML(warehouse_spec, 'Envelope/Body/AAA/BBB/DDD/DDDs/DDD')
 -- BUG#Z203
 select EXTRACTVALUE(warehouse_spec, 'Envelope/Body/AAA/BBB/DDD/DDDs/DDD')
   from warehouse_1 where warehouse_id = 1;
-ERROR:  EXTRACTVALUE returns value of only one node
+ERROR:  EXTRACTVALUE can only retrieve value of leaf node
 -- BUG#Z204
 select INSERTCHILDXML(warehouse_spec, 'Envelope/Body/AAA/BBB/DDD/DDDs', '"TTT"', xmltype ('<TTT>test</TTT>'))
  from warehouse_1 where warehouse_id = 1;

--- a/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
+++ b/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
@@ -1048,23 +1048,15 @@ ivy_extractvalue(PG_FUNCTION_ARGS)
 				errmsg("EXTRACTVALUE returns value of only one node")));
 	}
 
-	/* Begin - Bug#Z203, Bug#Z214 */
-	if (res->nodesetval && res->nodesetval->nodeTab &&
-		res->nodesetval->nodeTab[0]->parent->type == XML_DOCUMENT_NODE)
+	if (res->nodesetval && res->nodesetval->nodeNr > 0 && 
+	    res->nodesetval->nodeTab &&
+	    res->nodesetval->nodeTab[0]->children != NULL &&
+		res->nodesetval->nodeTab[0]->children->type == XML_ELEMENT_NODE)
 	{
 		cleanup_ws(&ws);
 		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
 				errmsg("EXTRACTVALUE can only retrieve value of leaf node")));
 	}
-
-	if (res->nodesetval && res->nodesetval->nodeTab &&
-		res->nodesetval->nodeTab[0]->children->type == XML_ELEMENT_NODE)
-	{
-		cleanup_ws(&ws);
-		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
-				errmsg("EXTRACTVALUE returns value of only one node")));
-	}
-	/* End - Bug#Z203, Bug#Z214 */
 
 	ret = ivy_xml_xpathobjtostring(res);
 
@@ -1123,23 +1115,15 @@ ivy_extractvalue2(PG_FUNCTION_ARGS)
 				errmsg("EXTRACTVALUE returns value of only one node")));
 	}
 
-	/* Begin - Bug#Z203, Bug#Z214 */
-	if (res->nodesetval && res->nodesetval->nodeTab &&
-		res->nodesetval->nodeTab[0]->parent->type == XML_DOCUMENT_NODE)
+	if (res->nodesetval && res->nodesetval->nodeNr > 0 &&
+	    res->nodesetval->nodeTab &&
+	    res->nodesetval->nodeTab[0]->children != NULL &&
+		res->nodesetval->nodeTab[0]->children->type == XML_ELEMENT_NODE)
 	{
 		cleanup_ws(&ws);
 		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
 				errmsg("EXTRACTVALUE can only retrieve value of leaf node")));
 	}
-
-	if (res->nodesetval && res->nodesetval->nodeTab &&
-		res->nodesetval->nodeTab[0]->children->type == XML_ELEMENT_NODE)
-	{
-		cleanup_ws(&ws);
-		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
-				errmsg("EXTRACTVALUE returns value of only one node")));
-	}
-	/* End - Bug#Z203, Bug#Z214 */
 
 	ret = ivy_xml_xpathobjtostring(res);
 

--- a/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
+++ b/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
@@ -138,6 +138,21 @@ static xmlChar *ivy_xmlCharStrndup(const char *str, size_t len);
 #endif
 
 #ifdef USE_LIBXML
+
+static bool 
+ivy_xml_has_element_child(xmlNodePtr node) 
+{
+	xmlNodePtr	child;   
+
+	for (child = node ? node->children : NULL; child != NULL; child = child->next)
+	{
+		if (child->type == XML_ELEMENT_NODE)
+			return true;
+	}
+
+	return false;
+}
+
 /*
  * Initialize for xml parsing.
  *
@@ -1050,8 +1065,7 @@ ivy_extractvalue(PG_FUNCTION_ARGS)
 
 	if (res->nodesetval && res->nodesetval->nodeNr > 0 && 
 	    res->nodesetval->nodeTab &&
-	    res->nodesetval->nodeTab[0]->children != NULL &&
-		res->nodesetval->nodeTab[0]->children->type == XML_ELEMENT_NODE)
+	    ivy_xml_has_element_child(res->nodesetval->nodeTab[0]))
 	{
 		cleanup_ws(&ws);
 		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
@@ -1117,8 +1131,7 @@ ivy_extractvalue2(PG_FUNCTION_ARGS)
 
 	if (res->nodesetval && res->nodesetval->nodeNr > 0 &&
 	    res->nodesetval->nodeTab &&
-	    res->nodesetval->nodeTab[0]->children != NULL &&
-		res->nodesetval->nodeTab[0]->children->type == XML_ELEMENT_NODE)
+	    ivy_xml_has_element_child(res->nodesetval->nodeTab[0]))
 	{
 		cleanup_ws(&ws);
 		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized and clarified EXTRACTVALUE error messaging for non-leaf XPath matches. Users will now see a consistent, more specific message indicating that only leaf-node values can be retrieved when a query selects a non-leaf node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->