### PR TITLE
fix #1161: macro names fixed

### DIFF
--- a/contrib/ivorysql_ora/src/datatype/dsinterval.c
+++ b/contrib/ivorysql_ora/src/datatype/dsinterval.c
@@ -724,9 +724,9 @@ AppendSeconds(char *cp, int sec, fsec_t fsec, int precision, bool fillzeros)
 			sprintf(cp, "%d.%0*d", abs(sec), ORACLE_MAX_INTERVAL_PRECISION, (int) Abs(fsec));
 #else
 		if (fillzeros)
-			sprintf(cp, "%0*.*f", ORACLE_MAX_INTERVAL_PRECISION + 3, ORACLE_MAX_INTERVAL_PRECISIONcision, fabs(sec + fsec));
+			sprintf(cp, "%0*.*f", ORACLE_MAX_INTERVAL_PRECISION + 3, ORACLE_MAX_INTERVAL_PRECISION, fabs(sec + fsec));
 		else
-			sprintf(cp, "%.*f", ORACLE_MAX_INTERVAL_PRECISIONion, fabs(sec + fsec));
+			sprintf(cp, "%.*f", ORACLE_MAX_INTERVAL_PRECISION, fabs(sec + fsec));
 #endif
 		TrimTrailingZeros(cp, ORACLE_MAX_INTERVAL_PRECISION - precision);
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a formatting issue in interval data type values on systems without 64-bit timestamp support. The correction properly handles the display of fractional seconds with accurate precision formatting, improving data accuracy and consistency across database operations. This resolves display inconsistencies that could occur when handling interval values in different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->