### PR TITLE
Fix the error usage of the parameter database_mode

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2008,7 +2008,7 @@ transformdecodeexpr(ParseState *pstate, CaseExpr *c)
 	arg = transformExprRecurse(pstate, (Node *) c->arg);
 
 	whenexprs = NIL;
-	if (database_mode == DB_ORACLE)
+	if (compatible_db == ORA_PARSER)
 	{
 		foreach(l, c->args)
 		{
@@ -2320,14 +2320,14 @@ transformdecodeexpr(ParseState *pstate, CaseExpr *c)
 	 * determining preferred type. This is how the code worked before, but it
 	 * seems a little bogus to me --- tgl
 	 */
-	if (database_mode == DB_PG)
+	if (compatible_db == PG_PARSER)
 		resultexprs = lcons(newc->defresult, resultexprs);
-	else if (database_mode == DB_ORACLE)
+	else if (compatible_db == ORA_PARSER)
 		resultexprs = lappend(resultexprs, newc->defresult);
 
-	if (database_mode == DB_PG)
+	if (compatible_db == PG_PARSER)
 		ptype = select_common_type(pstate, resultexprs, "DECODE", NULL);
-	else if (database_mode == DB_ORACLE)
+	else if (compatible_db == ORA_PARSER)
 		ptype = select_common_type_for_nvl(pstate, resultexprs, "DECODE", NULL);
 	Assert(OidIsValid(ptype));
 	newc->casetype = ptype;

--- a/src/backend/utils/adt/varlena.c
+++ b/src/backend/utils/adt/varlena.c
@@ -1976,7 +1976,7 @@ varstr_sortsupport(SortSupport ssup, Oid typid, Oid collid)
 	if (locale->collate_is_c)
 	{
 		if (typid == BPCHAROID ||
-			(database_mode == DB_ORACLE && (typid == ORACHARCHAROID || typid == ORACHARBYTEOID)))
+			(compatible_db == ORA_PARSER && (typid == ORACHARCHAROID || typid == ORACHARBYTEOID)))
 			ssup->comparator = bpcharfastcmp_c;
 		else if (typid == NAMEOID)
 		{
@@ -2240,7 +2240,7 @@ varstrfastcmp_locale(char *a1p, int len1, char *a2p, int len2, SortSupport ssup)
 	}
 
 	if (sss->typid == BPCHAROID ||
-		(database_mode == DB_ORACLE && (sss->typid == ORACHARCHAROID || sss->typid == ORACHARBYTEOID)))
+		(compatible_db == ORA_PARSER && (sss->typid == ORACHARCHAROID || sss->typid == ORACHARBYTEOID)))
 	{
 		/* Get true number of bytes, ignoring trailing spaces */
 		len1 = bpchartruelen(a1p, len1);
@@ -2335,7 +2335,7 @@ varstr_abbrev_convert(Datum original, SortSupport ssup)
 
 	/* Get number of bytes, ignoring trailing spaces */
 	if (sss->typid == BPCHAROID ||
-		(database_mode == DB_ORACLE && (sss->typid == ORACHARCHAROID || sss->typid == ORACHARBYTEOID)))	
+		(compatible_db == ORA_PARSER && (sss->typid == ORACHARCHAROID || sss->typid == ORACHARBYTEOID)))	
 		len = bpchartruelen(authoritative_data, len);
 
 	/*


### PR DESCRIPTION
Fix the error usage of the parameter database_mode， Compatibility behavior should be controlled by the compatible_db parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal compatibility detection used for Oracle vs PostgreSQL behavior, standardizing how Oracle-compatible expression parsing and CHAR/NCHAR-like string handling are chosen to improve consistency and predictability for mixed-compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->