### PR TITLE
support read-only view

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -149,6 +149,15 @@ static relopt_bool boolRelOpts[] =
 	},
 	{
 		{
+			"read_only",
+			"Prevents INSERT, UPDATE, and DELETE on this view (Oracle compatibility)",
+			RELOPT_KIND_VIEW,
+			AccessExclusiveLock
+		},
+		false
+	},
+	{
+		{
 			"vacuum_truncate",
 			"Enables vacuum to truncate empty pages at the end of this table",
 			RELOPT_KIND_HEAP | RELOPT_KIND_TOAST,
@@ -2053,7 +2062,9 @@ view_reloptions(Datum reloptions, bool validate)
 		{"security_invoker", RELOPT_TYPE_BOOL,
 		offsetof(ViewOptions, security_invoker)},
 		{"check_option", RELOPT_TYPE_ENUM,
-		offsetof(ViewOptions, check_option)}
+		offsetof(ViewOptions, check_option)},
+		{"read_only", RELOPT_TYPE_BOOL,
+		offsetof(ViewOptions, read_only)},
 	};
 
 	return (bytea *) build_reloptions(reloptions, validate,

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -35,6 +35,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rewriteSupport.h"
 #include "utils/builtins.h"
+#include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/lsyscache.h"
 #include "utils/guc.h"
@@ -519,6 +520,28 @@ DefineView(ViewStmt *stmt, const char *queryString,
 		/* NOTE: The grammar does not prevent SELECT INTO in this case */
 		view = copyObject(stmt->view);		/* avoid modifying the original command */
 
+		/*
+		 * Apply WITH READ ONLY to the placeholder's reloptions now, before
+		 * CreateForceVirtualPlaceholder, so the option is stored even while
+		 * the view is still invalid (the regular code path below does this
+		 * after parse analysis succeeds, which never runs for force views).
+		 *
+		 * After FlushErrorState(), CurrentMemoryContext is ErrorContext, which
+		 * will be reset by the subsequent elog(WARNING,...).  Allocate in
+		 * TopTransactionContext so the new ListCell and its nodes survive that
+		 * reset and remain valid when EventTriggerCollectSimpleCommand later
+		 * calls copyObject(parsetree).
+		 */
+		if (stmt->readOnly)
+		{
+			MemoryContext savedcxt = MemoryContextSwitchTo(TopTransactionContext);
+
+			stmt->options = lappend(stmt->options,
+									makeDefElem("read_only",
+												(Node *) makeBoolean(true), -1));
+			MemoryContextSwitchTo(savedcxt);
+		}
+
 		address = CreateForceVirtualPlaceholder(view, stmt->replace, stmt->options, &need_store);
 
 		CommandCounterIncrement();
@@ -920,11 +943,18 @@ compile_force_view_internal(ViewStmt *stmt, const char *queryString, Oid viewoid
 
 	/*
 	 * Add WITH READ ONLY if requested (Oracle compat).
+	 * WITH READ ONLY is mutually exclusive with WITH CHECK OPTION.
 	 */
 	if (stmt->readOnly)
+	{
+		if (stmt->withCheckOption != NO_CHECK_OPTION)
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("WITH READ ONLY and WITH CHECK OPTION are mutually exclusive")));
 		stmt->options = lappend(stmt->options,
 								makeDefElem("read_only",
 											(Node *) makeBoolean(true), -1));
+	}
 
 	/*
 	 * Validate auto-updatability if WITH CHECK OPTION is present.

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -587,6 +587,21 @@ DefineView(ViewStmt *stmt, const char *queryString,
 											(Node *) makeString("cascaded"), -1));
 
 	/*
+	 * If the user specified WITH READ ONLY, validate and record it.
+	 * WITH READ ONLY is mutually exclusive with WITH CHECK OPTION.
+	 */
+	if (stmt->readOnly)
+	{
+		if (stmt->withCheckOption != NO_CHECK_OPTION)
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("WITH READ ONLY and WITH CHECK OPTION are mutually exclusive")));
+		stmt->options = lappend(stmt->options,
+								makeDefElem("read_only",
+											(Node *) makeBoolean(true), -1));
+	}
+
+	/*
 	 * Check that the view is auto-updatable if WITH CHECK OPTION was
 	 * specified.
 	 */
@@ -902,6 +917,14 @@ compile_force_view_internal(ViewStmt *stmt, const char *queryString, Oid viewoid
 		stmt->options = lappend(stmt->options,
 								makeDefElem("check_option",
 											(Node *) makeString("cascaded"), -1));
+
+	/*
+	 * Add WITH READ ONLY if requested (Oracle compat).
+	 */
+	if (stmt->readOnly)
+		stmt->options = lappend(stmt->options,
+								makeDefElem("read_only",
+											(Node *) makeBoolean(true), -1));
 
 	/*
 	 * Validate auto-updatability if WITH CHECK OPTION is present.

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1097,6 +1097,18 @@ CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation,
 		case RELKIND_VIEW:
 
 			/*
+			 * If the view is defined WITH READ ONLY, reject DML even if an
+			 * INSTEAD OF trigger is defined.  This covers views that bypass
+			 * the rewriter auto-update path.
+			 */
+			if (RelationIsReadOnlyView(resultRel))
+				ereport(ERROR,
+						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+						 errmsg("cannot modify view \"%s\"",
+								RelationGetRelationName(resultRel)),
+						 errhint("The view is defined as read-only.")));
+
+			/*
 			 * Okay only if there's a suitable INSTEAD OF trigger.  Otherwise,
 			 * complain, but omit errdetail because we haven't got the
 			 * information handy (and given that it really shouldn't happen,

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -12676,7 +12676,8 @@ ViewStmt: CREATE OptTemp OptViewForce VIEW qualified_name opt_column_list opt_re
 					n->replace = false;
 					n->force = $3;
 					n->options = $7;
-					n->withCheckOption = $10;
+					n->readOnly = ($10 == READ_ONLY_OPTION);
+					n->withCheckOption = n->readOnly ? NO_CHECK_OPTION : $10;
 					/*
 					 * Save the source text of the force view definition in ViewStmt to avoid
 					 * incorrectly obtaining the view definition when using a multi-statement
@@ -12700,7 +12701,8 @@ ViewStmt: CREATE OptTemp OptViewForce VIEW qualified_name opt_column_list opt_re
 					n->replace = true;
 					n->force = $5;
 					n->options = $9;
-					n->withCheckOption = $12;
+					n->readOnly = ($12 == READ_ONLY_OPTION);
+					n->withCheckOption = n->readOnly ? NO_CHECK_OPTION : $12;
 					/*
 					 * Save the source text of the force view definition in ViewStmt to avoid
 					 * incorrectly obtaining the view definition when using a multi-statement
@@ -12724,7 +12726,8 @@ ViewStmt: CREATE OptTemp OptViewForce VIEW qualified_name opt_column_list opt_re
 					n->force = false;
 					n->stmt_literal = NULL;
 					n->options = $9;
-					n->withCheckOption = $12;
+					n->readOnly = ($12 == READ_ONLY_OPTION);
+					n->withCheckOption = n->readOnly ? NO_CHECK_OPTION : $12;
 					if (n->withCheckOption != NO_CHECK_OPTION)
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -12745,7 +12748,8 @@ ViewStmt: CREATE OptTemp OptViewForce VIEW qualified_name opt_column_list opt_re
 					n->force = false;
 					n->stmt_literal= NULL;
 					n->options = $11;
-					n->withCheckOption = $14;
+					n->readOnly = ($14 == READ_ONLY_OPTION);
+					n->withCheckOption = n->readOnly ? NO_CHECK_OPTION : $14;
 					if (n->withCheckOption != NO_CHECK_OPTION)
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -12759,6 +12763,7 @@ opt_check_option:
 		WITH CHECK OPTION				{ $$ = CASCADED_CHECK_OPTION; }
 		| WITH CASCADED CHECK OPTION	{ $$ = CASCADED_CHECK_OPTION; }
 		| WITH LOCAL CHECK OPTION		{ $$ = LOCAL_CHECK_OPTION; }
+		| WITH READ ONLY				{ $$ = READ_ONLY_OPTION; }
 		| /* EMPTY */					{ $$ = NO_CHECK_OPTION; }
 		;
 

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -12682,10 +12682,29 @@ ViewStmt: CREATE OptTemp OptViewForce VIEW qualified_name opt_column_list opt_re
 					 * Save the source text of the force view definition in ViewStmt to avoid
 					 * incorrectly obtaining the view definition when using a multi-statement
 					 * parser tree.
+					 *
+					 * When opt_check_option is non-empty (e.g. WITH READ ONLY), bison may
+					 * perform a default reduce for ViewStmt without advancing yylloc past the
+					 * last token of opt_check_option.  In that case yylloc points to the
+					 * start of ONLY, not to ';', and the naïve capture truncates the text.
+					 * For WITH READ ONLY we reconstruct the clause from @10 (start of WITH)
+					 * rather than relying on yylloc.
 					 */
-					stmt_iteral = pnstrdup(pg_yyget_extra(yyscanner)->core_yy_extra.scanbuf + @1, yylloc - @1);
-					n->stmt_literal = psprintf("%s;", stmt_iteral);
-					pfree(stmt_iteral);
+					{
+						const char *scanbuf = pg_yyget_extra(yyscanner)->core_yy_extra.scanbuf;
+
+						if (n->readOnly)
+						{
+							stmt_iteral = pnstrdup(scanbuf + @1, @10 - @1);
+							n->stmt_literal = psprintf("%sWITH READ ONLY;", stmt_iteral);
+						}
+						else
+						{
+							stmt_iteral = pnstrdup(scanbuf + @1, yylloc - @1);
+							n->stmt_literal = psprintf("%s;", stmt_iteral);
+						}
+						pfree(stmt_iteral);
+					}
 					$$ = (Node *) n;
 				}
 		| CREATE OR REPLACE OptTemp OptViewForce VIEW qualified_name opt_column_list opt_reloptions
@@ -12706,11 +12725,24 @@ ViewStmt: CREATE OptTemp OptViewForce VIEW qualified_name opt_column_list opt_re
 					/*
 					 * Save the source text of the force view definition in ViewStmt to avoid
 					 * incorrectly obtaining the view definition when using a multi-statement
-					 * parser tree.
+					 * parser tree.  Same yylloc truncation issue as for the non-OR-REPLACE
+					 * variant above; fix by reconstructing WITH READ ONLY from @12.
 					 */
-					stmt_iteral = pnstrdup(pg_yyget_extra(yyscanner)->core_yy_extra.scanbuf + @1, yylloc - @1);
-					n->stmt_literal = psprintf("%s;", stmt_iteral);
-					pfree(stmt_iteral);
+					{
+						const char *scanbuf = pg_yyget_extra(yyscanner)->core_yy_extra.scanbuf;
+
+						if (n->readOnly)
+						{
+							stmt_iteral = pnstrdup(scanbuf + @1, @12 - @1);
+							n->stmt_literal = psprintf("%sWITH READ ONLY;", stmt_iteral);
+						}
+						else
+						{
+							stmt_iteral = pnstrdup(scanbuf + @1, yylloc - @1);
+							n->stmt_literal = psprintf("%s;", stmt_iteral);
+						}
+						pfree(stmt_iteral);
+					}
 					$$ = (Node *) n;
 				}
 		| CREATE OptTemp RECURSIVE VIEW qualified_name '(' columnList ')' opt_reloptions

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -3369,6 +3369,17 @@ rewriteTargetView(Query *parsetree, Relation view)
 						RelationGetRelationName(view))));
 
 	/*
+	 * If the view is defined WITH READ ONLY, reject all DML unconditionally.
+	 * This check covers views that are auto-updatable (no INSTEAD OF triggers).
+	 */
+	if (RelationIsReadOnlyView(view))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot modify view \"%s\"",
+						RelationGetRelationName(view)),
+				 errhint("The view is defined as read-only.")));
+
+	/*
 	 * The view must be updatable, else fail.
 	 *
 	 * If we are doing INSERT/UPDATE (or MERGE containing INSERT/UPDATE), we

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7440,10 +7440,14 @@ getTables(Archive *fout, int *numTables)
 
 	if (fout->remoteVersion >= 90300)
 		appendPQExpBufferStr(query,
-							 "array_remove(array_remove(array_remove(c.reloptions,'check_option=local'),'check_option=cascaded'),'read_only=true') AS reloptions, "
+							 "array_remove(array_remove("
+							 "  ARRAY(SELECT opt FROM unnest(c.reloptions) opt WHERE opt !~ '^read_only='),"
+							 "  'check_option=local'), 'check_option=cascaded') AS reloptions, "
 							 "CASE WHEN 'check_option=local' = ANY (c.reloptions) THEN 'LOCAL'::text "
 							 "WHEN 'check_option=cascaded' = ANY (c.reloptions) THEN 'CASCADED'::text ELSE NULL END AS checkoption, "
-							 "'read_only=true' = ANY (c.reloptions) AS read_only_view, ");
+							 "coalesce((SELECT option_value::boolean"
+							 "  FROM pg_catalog.pg_options_to_table(c.reloptions)"
+							 "  WHERE option_name = 'read_only'), false) AS read_only_view, ");
 	else
 		appendPQExpBufferStr(query,
 							 "c.reloptions, NULL AS checkoption, false AS read_only_view, ");
@@ -17440,7 +17444,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 
 		if (tbinfo->checkoption != NULL && !tbinfo->dummy_view)
 			appendPQExpBuffer(q, "\n  WITH %s CHECK OPTION", tbinfo->checkoption);
-		if (tbinfo->readOnly)
+		if (tbinfo->readOnly && !tbinfo->dummy_view)
 			appendPQExpBufferStr(q, "\n  WITH READ ONLY");
 		appendPQExpBufferStr(q, ";\n");
 	}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7319,6 +7319,7 @@ getTables(Archive *fout, int *numTables)
 	int			i_toastminmxid;
 	int			i_reloptions;
 	int			i_checkoption;
+	int			i_read_only_view;
 	int			i_toastreloptions;
 	int			i_reloftype;
 	int			i_foreignserver;
@@ -7439,12 +7440,13 @@ getTables(Archive *fout, int *numTables)
 
 	if (fout->remoteVersion >= 90300)
 		appendPQExpBufferStr(query,
-							 "array_remove(array_remove(c.reloptions,'check_option=local'),'check_option=cascaded') AS reloptions, "
+							 "array_remove(array_remove(array_remove(c.reloptions,'check_option=local'),'check_option=cascaded'),'read_only=true') AS reloptions, "
 							 "CASE WHEN 'check_option=local' = ANY (c.reloptions) THEN 'LOCAL'::text "
-							 "WHEN 'check_option=cascaded' = ANY (c.reloptions) THEN 'CASCADED'::text ELSE NULL END AS checkoption, ");
+							 "WHEN 'check_option=cascaded' = ANY (c.reloptions) THEN 'CASCADED'::text ELSE NULL END AS checkoption, "
+							 "'read_only=true' = ANY (c.reloptions) AS read_only_view, ");
 	else
 		appendPQExpBufferStr(query,
-							 "c.reloptions, NULL AS checkoption, ");
+							 "c.reloptions, NULL AS checkoption, false AS read_only_view, ");
 
 	if (fout->remoteVersion >= 90600)
 		appendPQExpBufferStr(query,
@@ -7570,6 +7572,7 @@ getTables(Archive *fout, int *numTables)
 	i_toastminmxid = PQfnumber(res, "tminmxid");
 	i_reloptions = PQfnumber(res, "reloptions");
 	i_checkoption = PQfnumber(res, "checkoption");
+	i_read_only_view = PQfnumber(res, "read_only_view");
 	i_toastreloptions = PQfnumber(res, "toast_reloptions");
 	i_reloftype = PQfnumber(res, "reloftype");
 	i_foreignserver = PQfnumber(res, "foreignserver");
@@ -7652,6 +7655,8 @@ getTables(Archive *fout, int *numTables)
 			tblinfo[i].checkoption = NULL;
 		else
 			tblinfo[i].checkoption = pg_strdup(PQgetvalue(res, i, i_checkoption));
+		tblinfo[i].readOnly = (i_read_only_view >= 0 &&
+							   strcmp(PQgetvalue(res, i, i_read_only_view), "t") == 0);
 		tblinfo[i].toast_reloptions = pg_strdup(PQgetvalue(res, i, i_toastreloptions));
 		tblinfo[i].reloftype = atooid(PQgetvalue(res, i, i_reloftype));
 		tblinfo[i].foreign_server = atooid(PQgetvalue(res, i, i_foreignserver));
@@ -17435,6 +17440,8 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 
 		if (tbinfo->checkoption != NULL && !tbinfo->dummy_view)
 			appendPQExpBuffer(q, "\n  WITH %s CHECK OPTION", tbinfo->checkoption);
+		if (tbinfo->readOnly)
+			appendPQExpBufferStr(q, "\n  WITH READ ONLY");
 		appendPQExpBufferStr(q, ";\n");
 	}
 	else
@@ -19923,6 +19930,8 @@ dumpRule(Archive *fout, const RuleInfo *rinfo)
 		if (tbinfo->checkoption != NULL)
 			appendPQExpBuffer(cmd, "\n  WITH %s CHECK OPTION",
 							  tbinfo->checkoption);
+		if (tbinfo->readOnly)
+			appendPQExpBufferStr(cmd, "\n  WITH READ ONLY");
 		appendPQExpBufferStr(cmd, ";\n");
 	}
 	else

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -327,6 +327,7 @@ typedef struct _tableInfo
 	char	   *reltablespace;	/* relation tablespace */
 	char	   *reloptions;		/* options specified by WITH (...) */
 	char	   *checkoption;	/* WITH CHECK OPTION, if any */
+	bool		readOnly;		/* WITH READ ONLY (Oracle compat) */
 	char	   *toast_reloptions;	/* WITH options for the TOAST table */
 	bool		hasindex;		/* does it have any indexes? */
 	bool		hasrules;		/* does it have any rules? */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3912,6 +3912,9 @@ typedef enum ViewCheckOption
 	NO_CHECK_OPTION,
 	LOCAL_CHECK_OPTION,
 	CASCADED_CHECK_OPTION,
+	READ_ONLY_OPTION,			/* WITH READ ONLY (Oracle compat); only set
+								 * transiently in grammar actions, never stored
+								 * in ViewStmt.withCheckOption */
 } ViewCheckOption;
 
 typedef struct ViewStmt
@@ -3925,6 +3928,7 @@ typedef struct ViewStmt
 	char	   *stmt_literal;	/* the original text that defines the force view */
 	List	   *options;		/* options from WITH clause */
 	ViewCheckOption withCheckOption;	/* WITH CHECK OPTION */
+	bool		readOnly;		/* WITH READ ONLY (Oracle compat) */
 } ViewStmt;
 
 /* ----------------------

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -429,6 +429,7 @@ typedef struct ViewOptions
 	bool		security_barrier;
 	bool		security_invoker;
 	ViewOptCheckOption check_option;
+	bool		read_only;		/* WITH READ ONLY (Oracle compat) */
 } ViewOptions;
 
 /*
@@ -483,6 +484,16 @@ typedef struct ViewOptions
 	 (relation)->rd_options &&												\
 	 ((ViewOptions *) (relation)->rd_options)->check_option ==				\
 	  VIEW_OPTION_CHECK_OPTION_CASCADED)
+
+/*
+ * RelationIsReadOnlyView
+ *		Returns true if the view was defined WITH READ ONLY (Oracle compat).
+ *		Note multiple eval of argument!
+ */
+#define RelationIsReadOnlyView(relation)									\
+	(AssertMacro(relation->rd_rel->relkind == RELKIND_VIEW),				\
+	 (relation)->rd_options &&												\
+	 ((ViewOptions *) (relation)->rd_options)->read_only)
 
 /*
  * RelationIsValid

--- a/src/oracle_test/regress/expected/ora_read_only_view.out
+++ b/src/oracle_test/regress/expected/ora_read_only_view.out
@@ -1,0 +1,87 @@
+--
+-- Tests for WITH READ ONLY views (Oracle compatibility)
+--
+CREATE TABLE t_ro (a int, b text);
+INSERT INTO t_ro VALUES (1, 'hello'), (2, 'world');
+-- 1. Basic WITH READ ONLY view: SELECT succeeds, DML fails
+CREATE VIEW ro_view AS SELECT * FROM t_ro WITH READ ONLY;
+SELECT * FROM ro_view ORDER BY a;
+ a |   b   
+---+-------
+ 1 | hello
+ 2 | world
+(2 rows)
+
+INSERT INTO ro_view VALUES (3, 'fail');
+ERROR:  cannot modify view "ro_view"
+HINT:  The view is defined as read-only.
+UPDATE ro_view SET b = 'fail' WHERE a = 1;
+ERROR:  cannot modify view "ro_view"
+HINT:  The view is defined as read-only.
+DELETE FROM ro_view WHERE a = 1;
+ERROR:  cannot modify view "ro_view"
+HINT:  The view is defined as read-only.
+-- 2. CREATE OR REPLACE preserves WITH READ ONLY
+CREATE OR REPLACE VIEW ro_view AS SELECT a FROM t_ro WITH READ ONLY;
+ERROR:  cannot drop columns from view
+INSERT INTO ro_view VALUES (3);
+ERROR:  cannot modify view "ro_view"
+HINT:  The view is defined as read-only.
+-- 3. Plain view (no WITH READ ONLY) remains updatable
+CREATE VIEW writable_view AS SELECT * FROM t_ro;
+INSERT INTO writable_view VALUES (3, 'ok');
+SELECT * FROM writable_view ORDER BY a;
+ a |   b   
+---+-------
+ 1 | hello
+ 2 | world
+ 3 | ok
+(3 rows)
+
+-- 4. WITH READ ONLY and WITH CHECK OPTION are mutually exclusive
+CREATE VIEW bad_view AS SELECT * FROM t_ro WITH CHECK OPTION WITH READ ONLY;
+ERROR:  syntax error at or near "WITH"
+LINE 1: ... bad_view AS SELECT * FROM t_ro WITH CHECK OPTION WITH READ ...
+                                                             ^
+CREATE VIEW bad_view AS SELECT * FROM t_ro WITH READ ONLY WITH CHECK OPTION;
+ERROR:  syntax error at or near "WITH"
+LINE 1: ...IEW bad_view AS SELECT * FROM t_ro WITH READ ONLY WITH CHECK...
+                                                             ^
+-- 5. WITH READ ONLY on RECURSIVE VIEW is allowed
+CREATE RECURSIVE VIEW ro_recursive_view (a) AS
+    SELECT 1
+    UNION ALL
+    SELECT a + 1 FROM ro_recursive_view WHERE a < 3
+WITH READ ONLY;
+SELECT * FROM ro_recursive_view ORDER BY a;
+ a 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+INSERT INTO ro_recursive_view VALUES (99);
+ERROR:  cannot modify view "ro_recursive_view"
+HINT:  The view is defined as read-only.
+-- 6. FORCE VIEW with WITH READ ONLY (base table does not exist yet)
+CREATE FORCE VIEW force_ro_view AS SELECT * FROM nonexistent_for_ro WITH READ ONLY;
+WARNING:  View created with compilation errors
+-- 7. Verify reloptions stores read_only
+SELECT relname, reloptions
+FROM pg_class
+WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view')
+ORDER BY relname;
+      relname      |    reloptions    
+-------------------+------------------
+ ro_recursive_view | {read_only=true}
+ ro_view           | {read_only=true}
+ writable_view     | 
+(3 rows)
+
+-- Cleanup
+DROP VIEW IF EXISTS ro_view;
+DROP VIEW IF EXISTS writable_view;
+DROP VIEW IF EXISTS ro_recursive_view;
+DROP VIEW IF EXISTS force_ro_view;
+DROP TABLE t_ro;

--- a/src/oracle_test/regress/expected/ora_read_only_view.out
+++ b/src/oracle_test/regress/expected/ora_read_only_view.out
@@ -21,12 +21,26 @@ HINT:  The view is defined as read-only.
 DELETE FROM ro_view WHERE a = 1;
 ERROR:  cannot modify view "ro_view"
 HINT:  The view is defined as read-only.
--- 2. CREATE OR REPLACE preserves WITH READ ONLY
-CREATE OR REPLACE VIEW ro_view AS SELECT a FROM t_ro WITH READ ONLY;
-ERROR:  cannot drop columns from view
-INSERT INTO ro_view VALUES (3);
+-- 2. CREATE OR REPLACE behaviour across the read-only boundary
+-- 2a. Column-compatible replace WITH READ ONLY: DML is still blocked
+CREATE OR REPLACE VIEW ro_view AS SELECT a, b FROM t_ro WITH READ ONLY;
+INSERT INTO ro_view VALUES (3, 'fail');
 ERROR:  cannot modify view "ro_view"
 HINT:  The view is defined as read-only.
+-- 2b. Replacing WITHOUT WITH READ ONLY clears read_only reloption: view becomes writable
+CREATE OR REPLACE VIEW ro_view AS SELECT a, b FROM t_ro;
+INSERT INTO ro_view VALUES (3, 'now_writable');
+SELECT * FROM ro_view ORDER BY a;
+ a |      b       
+---+--------------
+ 1 | hello
+ 2 | world
+ 3 | now_writable
+(3 rows)
+
+DELETE FROM t_ro WHERE a = 3;
+-- Restore ro_view as read-only for subsequent tests
+CREATE OR REPLACE VIEW ro_view AS SELECT a, b FROM t_ro WITH READ ONLY;
 -- 3. Plain view (no WITH READ ONLY) remains updatable
 CREATE VIEW writable_view AS SELECT * FROM t_ro;
 INSERT INTO writable_view VALUES (3, 'ok');
@@ -64,20 +78,29 @@ SELECT * FROM ro_recursive_view ORDER BY a;
 INSERT INTO ro_recursive_view VALUES (99);
 ERROR:  cannot modify view "ro_recursive_view"
 HINT:  The view is defined as read-only.
--- 6. FORCE VIEW with WITH READ ONLY (base table does not exist yet)
+-- 6. FORCE VIEW with WITH READ ONLY
+-- Create while base table does not yet exist
 CREATE FORCE VIEW force_ro_view AS SELECT * FROM nonexistent_for_ro WITH READ ONLY;
 WARNING:  View created with compilation errors
--- 7. Verify reloptions stores read_only
+-- Create the base table and compile the force view
+CREATE TABLE nonexistent_for_ro (a int, b text);
+ALTER VIEW force_ro_view COMPILE;
+-- DML must be blocked after compilation
+INSERT INTO force_ro_view VALUES (1, 'fail');
+ERROR:  cannot modify view "force_ro_view"
+HINT:  The view is defined as read-only.
+-- 7. Verify reloptions stores read_only (including force view)
 SELECT relname, reloptions
 FROM pg_class
-WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view')
+WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view', 'force_ro_view')
 ORDER BY relname;
       relname      |    reloptions    
 -------------------+------------------
+ force_ro_view     | {read_only=true}
  ro_recursive_view | {read_only=true}
  ro_view           | {read_only=true}
  writable_view     | 
-(3 rows)
+(4 rows)
 
 -- 8. MERGE with INSERT action against WITH READ ONLY view must fail
 MERGE INTO ro_view USING (SELECT 4 AS a, 'merge_ins' AS b) AS src
@@ -103,4 +126,5 @@ DROP VIEW IF EXISTS ro_view;
 DROP VIEW IF EXISTS writable_view;
 DROP VIEW IF EXISTS ro_recursive_view;
 DROP VIEW IF EXISTS force_ro_view;
+DROP TABLE IF EXISTS nonexistent_for_ro;
 DROP TABLE t_ro;

--- a/src/oracle_test/regress/expected/ora_read_only_view.out
+++ b/src/oracle_test/regress/expected/ora_read_only_view.out
@@ -79,6 +79,25 @@ ORDER BY relname;
  writable_view     | 
 (3 rows)
 
+-- 8. MERGE with INSERT action against WITH READ ONLY view must fail
+MERGE INTO ro_view USING (SELECT 4 AS a, 'merge_ins' AS b) AS src
+ON (ro_view.a = src.a)
+WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);
+ERROR:  cannot modify view "ro_view"
+HINT:  The view is defined as read-only.
+-- 9. MERGE with UPDATE action against WITH READ ONLY view must fail
+MERGE INTO ro_view USING (SELECT 1 AS a, 'merge_upd' AS b) AS src
+ON (ro_view.a = src.a)
+WHEN MATCHED THEN UPDATE SET b = src.b;
+ERROR:  cannot modify view "ro_view"
+HINT:  The view is defined as read-only.
+-- 10. MERGE with both UPDATE and INSERT against WITH READ ONLY view must fail
+MERGE INTO ro_view USING (SELECT 1 AS a, 'test' AS b) AS src
+ON (ro_view.a = src.a)
+WHEN MATCHED THEN UPDATE SET b = src.b
+WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);
+ERROR:  cannot modify view "ro_view"
+HINT:  The view is defined as read-only.
 -- Cleanup
 DROP VIEW IF EXISTS ro_view;
 DROP VIEW IF EXISTS writable_view;

--- a/src/oracle_test/regress/expected/ora_read_only_view.out
+++ b/src/oracle_test/regress/expected/ora_read_only_view.out
@@ -1,7 +1,7 @@
 --
 -- Tests for WITH READ ONLY views (Oracle compatibility)
 --
-CREATE TABLE t_ro (a int, b text);
+CREATE TABLE t_ro (a int, b varchar2(100));
 INSERT INTO t_ro VALUES (1, 'hello'), (2, 'world');
 -- 1. Basic WITH READ ONLY view: SELECT succeeds, DML fails
 CREATE VIEW ro_view AS SELECT * FROM t_ro WITH READ ONLY;
@@ -83,7 +83,7 @@ HINT:  The view is defined as read-only.
 CREATE FORCE VIEW force_ro_view AS SELECT * FROM nonexistent_for_ro WITH READ ONLY;
 WARNING:  View created with compilation errors
 -- Create the base table and compile the force view
-CREATE TABLE nonexistent_for_ro (a int, b text);
+CREATE TABLE nonexistent_for_ro (a int, b varchar2(100));
 ALTER VIEW force_ro_view COMPILE;
 -- DML must be blocked after compilation
 INSERT INTO force_ro_view VALUES (1, 'fail');
@@ -103,19 +103,19 @@ ORDER BY relname;
 (4 rows)
 
 -- 8. MERGE with INSERT action against WITH READ ONLY view must fail
-MERGE INTO ro_view USING (SELECT 4 AS a, 'merge_ins' AS b) AS src
+MERGE INTO ro_view USING (SELECT 4 AS a, 'merge_ins' AS b) src
 ON (ro_view.a = src.a)
 WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);
 ERROR:  cannot modify view "ro_view"
 HINT:  The view is defined as read-only.
 -- 9. MERGE with UPDATE action against WITH READ ONLY view must fail
-MERGE INTO ro_view USING (SELECT 1 AS a, 'merge_upd' AS b) AS src
+MERGE INTO ro_view USING (SELECT 1 AS a, 'merge_upd' AS b) src
 ON (ro_view.a = src.a)
 WHEN MATCHED THEN UPDATE SET b = src.b;
 ERROR:  cannot modify view "ro_view"
 HINT:  The view is defined as read-only.
 -- 10. MERGE with both UPDATE and INSERT against WITH READ ONLY view must fail
-MERGE INTO ro_view USING (SELECT 1 AS a, 'test' AS b) AS src
+MERGE INTO ro_view USING (SELECT 1 AS a, 'test' AS b) src
 ON (ro_view.a = src.a)
 WHEN MATCHED THEN UPDATE SET b = src.b
 WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);

--- a/src/oracle_test/regress/parallel_schedule
+++ b/src/oracle_test/regress/parallel_schedule
@@ -159,7 +159,7 @@ test: emptystring_to_null
 
 test: ora_package
 
-test: ora_force_view
+test: ora_force_view ora_read_only_view
 
 # ----------
 # Oracle ROWNUM pseudocolumn

--- a/src/oracle_test/regress/sql/ora_read_only_view.sql
+++ b/src/oracle_test/regress/sql/ora_read_only_view.sql
@@ -1,0 +1,52 @@
+--
+-- Tests for WITH READ ONLY views (Oracle compatibility)
+--
+
+CREATE TABLE t_ro (a int, b text);
+INSERT INTO t_ro VALUES (1, 'hello'), (2, 'world');
+
+-- 1. Basic WITH READ ONLY view: SELECT succeeds, DML fails
+CREATE VIEW ro_view AS SELECT * FROM t_ro WITH READ ONLY;
+SELECT * FROM ro_view ORDER BY a;
+
+INSERT INTO ro_view VALUES (3, 'fail');
+UPDATE ro_view SET b = 'fail' WHERE a = 1;
+DELETE FROM ro_view WHERE a = 1;
+
+-- 2. CREATE OR REPLACE preserves WITH READ ONLY
+CREATE OR REPLACE VIEW ro_view AS SELECT a FROM t_ro WITH READ ONLY;
+INSERT INTO ro_view VALUES (3);
+
+-- 3. Plain view (no WITH READ ONLY) remains updatable
+CREATE VIEW writable_view AS SELECT * FROM t_ro;
+INSERT INTO writable_view VALUES (3, 'ok');
+SELECT * FROM writable_view ORDER BY a;
+
+-- 4. WITH READ ONLY and WITH CHECK OPTION are mutually exclusive
+CREATE VIEW bad_view AS SELECT * FROM t_ro WITH CHECK OPTION WITH READ ONLY;
+CREATE VIEW bad_view AS SELECT * FROM t_ro WITH READ ONLY WITH CHECK OPTION;
+
+-- 5. WITH READ ONLY on RECURSIVE VIEW is allowed
+CREATE RECURSIVE VIEW ro_recursive_view (a) AS
+    SELECT 1
+    UNION ALL
+    SELECT a + 1 FROM ro_recursive_view WHERE a < 3
+WITH READ ONLY;
+SELECT * FROM ro_recursive_view ORDER BY a;
+INSERT INTO ro_recursive_view VALUES (99);
+
+-- 6. FORCE VIEW with WITH READ ONLY (base table does not exist yet)
+CREATE FORCE VIEW force_ro_view AS SELECT * FROM nonexistent_for_ro WITH READ ONLY;
+
+-- 7. Verify reloptions stores read_only
+SELECT relname, reloptions
+FROM pg_class
+WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view')
+ORDER BY relname;
+
+-- Cleanup
+DROP VIEW IF EXISTS ro_view;
+DROP VIEW IF EXISTS writable_view;
+DROP VIEW IF EXISTS ro_recursive_view;
+DROP VIEW IF EXISTS force_ro_view;
+DROP TABLE t_ro;

--- a/src/oracle_test/regress/sql/ora_read_only_view.sql
+++ b/src/oracle_test/regress/sql/ora_read_only_view.sql
@@ -13,9 +13,19 @@ INSERT INTO ro_view VALUES (3, 'fail');
 UPDATE ro_view SET b = 'fail' WHERE a = 1;
 DELETE FROM ro_view WHERE a = 1;
 
--- 2. CREATE OR REPLACE preserves WITH READ ONLY
-CREATE OR REPLACE VIEW ro_view AS SELECT a FROM t_ro WITH READ ONLY;
-INSERT INTO ro_view VALUES (3);
+-- 2. CREATE OR REPLACE behaviour across the read-only boundary
+-- 2a. Column-compatible replace WITH READ ONLY: DML is still blocked
+CREATE OR REPLACE VIEW ro_view AS SELECT a, b FROM t_ro WITH READ ONLY;
+INSERT INTO ro_view VALUES (3, 'fail');
+
+-- 2b. Replacing WITHOUT WITH READ ONLY clears read_only reloption: view becomes writable
+CREATE OR REPLACE VIEW ro_view AS SELECT a, b FROM t_ro;
+INSERT INTO ro_view VALUES (3, 'now_writable');
+SELECT * FROM ro_view ORDER BY a;
+DELETE FROM t_ro WHERE a = 3;
+
+-- Restore ro_view as read-only for subsequent tests
+CREATE OR REPLACE VIEW ro_view AS SELECT a, b FROM t_ro WITH READ ONLY;
 
 -- 3. Plain view (no WITH READ ONLY) remains updatable
 CREATE VIEW writable_view AS SELECT * FROM t_ro;
@@ -35,13 +45,19 @@ WITH READ ONLY;
 SELECT * FROM ro_recursive_view ORDER BY a;
 INSERT INTO ro_recursive_view VALUES (99);
 
--- 6. FORCE VIEW with WITH READ ONLY (base table does not exist yet)
+-- 6. FORCE VIEW with WITH READ ONLY
+-- Create while base table does not yet exist
 CREATE FORCE VIEW force_ro_view AS SELECT * FROM nonexistent_for_ro WITH READ ONLY;
+-- Create the base table and compile the force view
+CREATE TABLE nonexistent_for_ro (a int, b text);
+ALTER VIEW force_ro_view COMPILE;
+-- DML must be blocked after compilation
+INSERT INTO force_ro_view VALUES (1, 'fail');
 
--- 7. Verify reloptions stores read_only
+-- 7. Verify reloptions stores read_only (including force view)
 SELECT relname, reloptions
 FROM pg_class
-WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view')
+WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view', 'force_ro_view')
 ORDER BY relname;
 
 -- 8. MERGE with INSERT action against WITH READ ONLY view must fail
@@ -65,4 +81,5 @@ DROP VIEW IF EXISTS ro_view;
 DROP VIEW IF EXISTS writable_view;
 DROP VIEW IF EXISTS ro_recursive_view;
 DROP VIEW IF EXISTS force_ro_view;
+DROP TABLE IF EXISTS nonexistent_for_ro;
 DROP TABLE t_ro;

--- a/src/oracle_test/regress/sql/ora_read_only_view.sql
+++ b/src/oracle_test/regress/sql/ora_read_only_view.sql
@@ -44,6 +44,22 @@ FROM pg_class
 WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view')
 ORDER BY relname;
 
+-- 8. MERGE with INSERT action against WITH READ ONLY view must fail
+MERGE INTO ro_view USING (SELECT 4 AS a, 'merge_ins' AS b) AS src
+ON (ro_view.a = src.a)
+WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);
+
+-- 9. MERGE with UPDATE action against WITH READ ONLY view must fail
+MERGE INTO ro_view USING (SELECT 1 AS a, 'merge_upd' AS b) AS src
+ON (ro_view.a = src.a)
+WHEN MATCHED THEN UPDATE SET b = src.b;
+
+-- 10. MERGE with both UPDATE and INSERT against WITH READ ONLY view must fail
+MERGE INTO ro_view USING (SELECT 1 AS a, 'test' AS b) AS src
+ON (ro_view.a = src.a)
+WHEN MATCHED THEN UPDATE SET b = src.b
+WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);
+
 -- Cleanup
 DROP VIEW IF EXISTS ro_view;
 DROP VIEW IF EXISTS writable_view;

--- a/src/oracle_test/regress/sql/ora_read_only_view.sql
+++ b/src/oracle_test/regress/sql/ora_read_only_view.sql
@@ -2,7 +2,7 @@
 -- Tests for WITH READ ONLY views (Oracle compatibility)
 --
 
-CREATE TABLE t_ro (a int, b text);
+CREATE TABLE t_ro (a int, b varchar2(100));
 INSERT INTO t_ro VALUES (1, 'hello'), (2, 'world');
 
 -- 1. Basic WITH READ ONLY view: SELECT succeeds, DML fails
@@ -49,7 +49,7 @@ INSERT INTO ro_recursive_view VALUES (99);
 -- Create while base table does not yet exist
 CREATE FORCE VIEW force_ro_view AS SELECT * FROM nonexistent_for_ro WITH READ ONLY;
 -- Create the base table and compile the force view
-CREATE TABLE nonexistent_for_ro (a int, b text);
+CREATE TABLE nonexistent_for_ro (a int, b varchar2(100));
 ALTER VIEW force_ro_view COMPILE;
 -- DML must be blocked after compilation
 INSERT INTO force_ro_view VALUES (1, 'fail');
@@ -61,17 +61,17 @@ WHERE relname IN ('ro_view', 'writable_view', 'ro_recursive_view', 'force_ro_vie
 ORDER BY relname;
 
 -- 8. MERGE with INSERT action against WITH READ ONLY view must fail
-MERGE INTO ro_view USING (SELECT 4 AS a, 'merge_ins' AS b) AS src
+MERGE INTO ro_view USING (SELECT 4 AS a, 'merge_ins' AS b) src
 ON (ro_view.a = src.a)
 WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);
 
 -- 9. MERGE with UPDATE action against WITH READ ONLY view must fail
-MERGE INTO ro_view USING (SELECT 1 AS a, 'merge_upd' AS b) AS src
+MERGE INTO ro_view USING (SELECT 1 AS a, 'merge_upd' AS b) src
 ON (ro_view.a = src.a)
 WHEN MATCHED THEN UPDATE SET b = src.b;
 
 -- 10. MERGE with both UPDATE and INSERT against WITH READ ONLY view must fail
-MERGE INTO ro_view USING (SELECT 1 AS a, 'test' AS b) AS src
+MERGE INTO ro_view USING (SELECT 1 AS a, 'test' AS b) src
 ON (ro_view.a = src.a)
 WHEN MATCHED THEN UPDATE SET b = src.b
 WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b);


### PR DESCRIPTION
fix #1066 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oracle-compatible WITH READ ONLY for views; such views now reject INSERT/UPDATE/DELETE/MERGE and show a read-only hint.

* **Improvements**
  * CREATE/REPLACE/FORCE VIEW accepts WITH READ ONLY, disallows combining it with WITH CHECK OPTION, and preserves the setting for dump/export.

* **Tests**
  * Added regression coverage for creation, force-compile, replacement semantics, recursive views, DML/MERGE rejection, reloptions visibility; included in parallel test schedule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->