### PR TITLE
Fix mixing of database_mode and compatible_db variables

### DIFF
--- a/src/backend/executor/execSRF.c
+++ b/src/backend/executor/execSRF.c
@@ -137,7 +137,7 @@ ExecMakeTableFunctionResult(SetExprState *setexpr,
 
 	if (nodeTag(setexpr->expr) == T_FuncExpr &&
 		SPI_get_connected() < 0 &&
-		DB_ORACLE == compatible_db)
+		ORA_PARSER == compatible_db)
 	{
 		FuncExpr *funcexpr = (FuncExpr *) setexpr->expr;
 		Oid		resulttype;

--- a/src/backend/oracle_parser/ora_scan.l
+++ b/src/backend/oracle_parser/ora_scan.l
@@ -949,7 +949,7 @@ other			.
 					 * case to the upper case, if the identifier is quoted by the double
 					 * quotes.
 					 */
-					if (compatible_db == DB_ORACLE && enable_case_switch
+					if (compatible_db == ORA_PARSER && enable_case_switch
 						&& identifier_case_switch != NORMAL
 						&& !identifier_case_from_pg_dump)
 					{

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2579,7 +2579,7 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 		}
 	}
 
-	if (DB_ORACLE == compatible_db)
+	if (ORA_PARSER == compatible_db)
 	{
 		qry->targetList = transformIvyUpdateTargetList(pstate, stmt->targetList);
 	}

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2009,7 +2009,7 @@ transformdecodeexpr(ParseState *pstate, CaseExpr *c)
 	arg = transformExprRecurse(pstate, (Node *) c->arg);
 
 	whenexprs = NIL;
-	if (database_mode == DB_ORACLE)
+	if (compatible_db == ORA_PARSER)
 	{
 		foreach(l, c->args)
 		{
@@ -2321,14 +2321,14 @@ transformdecodeexpr(ParseState *pstate, CaseExpr *c)
 	 * determining preferred type. This is how the code worked before, but it
 	 * seems a little bogus to me --- tgl
 	 */
-	if (database_mode == DB_PG)
+	if (compatible_db == PG_PARSER)
 		resultexprs = lcons(newc->defresult, resultexprs);
-	else if (database_mode == DB_ORACLE)
+	else if (compatible_db == ORA_PARSER)
 		resultexprs = lappend(resultexprs, newc->defresult);
 
-	if (database_mode == DB_PG)
+	if (compatible_db == PG_PARSER)
 		ptype = select_common_type(pstate, resultexprs, "DECODE", NULL);
-	else if (database_mode == DB_ORACLE)
+	else if (compatible_db == ORA_PARSER)
 		ptype = select_common_type_for_nvl(pstate, resultexprs, "DECODE", NULL);
 	Assert(OidIsValid(ptype));
 	newc->casetype = ptype;

--- a/src/backend/tcop/backend_startup.c
+++ b/src/backend/tcop/backend_startup.c
@@ -804,7 +804,7 @@ ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done)
 				/* Oracle compatibility: transform uppercase identifiers to lowercase. */
 				char *database_name = pstrdup(valptr);
 
-				if (ORA_PARSER == compatible_db && database_name != NULL)
+				if (DB_ORACLE == database_mode && database_name != NULL)
 				{
 					if (identifier_case_switch == LOWERCASE &&
 						is_all_upper(database_name, strlen(database_name)))
@@ -857,7 +857,7 @@ ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done)
 				/* Oracle compatibility: transform uppercase identifiers to lowercase. */
 				char *user_name = pstrdup(valptr);
 
-				if (ORA_PARSER == compatible_db && user_name != NULL)
+				if (DB_ORACLE == database_mode && user_name != NULL)
 				{
 					if (identifier_case_switch == LOWERCASE &&
 						is_all_upper(user_name, strlen(user_name)))


### PR DESCRIPTION
#1292 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Oracle compatibility mode detection for table function execution to properly adjust return types.
  * Enhanced identifier case transformation logic in parser and lexer for consistent Oracle mode behavior.
  * Improved DECODE/CASE expression handling under Oracle compatibility mode.
  * Refined startup parameter processing for database and user identifiers in Oracle mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->