### PR TITLE
support function and procedure in WITH clause

### DIFF
--- a/contrib/ivorysql_ora/src/merge/ora_merge.c
+++ b/contrib/ivorysql_ora/src/merge/ora_merge.c
@@ -698,6 +698,7 @@ IvytransformMergeStmt(ParseState *pstate, MergeStmt *stmt)
 
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = stmt->withClause->plsql_defs;
 	}
 
 	/*

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -30,7 +30,9 @@
 #include "nodes/extensible.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
+#include "oracle_parser/ora_with_function.h"
 #include "parser/analyze.h"
+#include "parser/parse_type.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/bufmgr.h"
@@ -67,6 +69,7 @@ explain_per_node_hook_type explain_per_node_hook = NULL;
 static void ExplainOneQuery(Query *query, int cursorOptions,
 							IntoClause *into, ExplainState *es,
 							ParseState *pstate, ParamListInfo params);
+static void ExplainPrintWithFunctions(ExplainState *es, PlannedStmt *pstmt);
 static void ExplainPrintJIT(ExplainState *es, int jit_flags,
 							JitInstrumentation *ji);
 static void ExplainPrintSerialize(ExplainState *es,
@@ -748,6 +751,148 @@ ExplainPrintSettings(ExplainState *es)
 }
 
 /*
+ * ExplainPrintWithFunctions -
+ *	  Append WITH FUNCTION / WITH PROCEDURE definitions to the EXPLAIN output.
+ *
+ * Only called (and meaningful) when the planned statement originated from an
+ * Oracle-mode query with inline subprogram definitions.  Each function is
+ * shown as "FUNCTION name(mode argname type, ...) RETURN rettype" (or
+ * "PROCEDURE name(...)" for procedures).
+ */
+static void
+ExplainPrintWithFunctions(ExplainState *es, PlannedStmt *pstmt)
+{
+	ListCell   *lc;
+
+	if (pstmt->withFuncDefs == NIL)
+		return;
+
+	if (es->format != EXPLAIN_FORMAT_TEXT)
+	{
+		ExplainOpenGroup("WITH Functions", "WITH Functions", false, es);
+
+		foreach(lc, pstmt->withFuncDefs)
+		{
+			InlineFunctionDef *ifd = (InlineFunctionDef *) lfirst(lc);
+			StringInfoData	sig;
+			ListCell	   *alc;
+			bool			first_arg = true;
+
+			initStringInfo(&sig);
+
+			ExplainOpenGroup("WITH Function", NULL, true, es);
+
+			ExplainPropertyText("Name", ifd->funcname, es);
+			ExplainPropertyText("Kind", ifd->is_proc ? "procedure" : "function", es);
+
+			/* Build signature string */
+			appendStringInfo(&sig, "%s(", ifd->funcname);
+			foreach(alc, ifd->args)
+			{
+				FunctionParameter *fp = (FunctionParameter *) lfirst(alc);
+
+				if (!first_arg)
+					appendStringInfoString(&sig, ", ");
+				first_arg = false;
+
+				switch (fp->mode)
+				{
+					case FUNC_PARAM_OUT:
+						appendStringInfoString(&sig, "OUT ");
+						break;
+					case FUNC_PARAM_INOUT:
+						appendStringInfoString(&sig, "IN OUT ");
+						break;
+					default:
+						break;
+				}
+
+				if (fp->name)
+					appendStringInfo(&sig, "%s ", fp->name);
+				appendStringInfoString(&sig, TypeNameToString(fp->argType));
+			}
+			appendStringInfoChar(&sig, ')');
+			if (!ifd->is_proc && ifd->rettype != NULL)
+				appendStringInfo(&sig, " RETURN %s",
+								 TypeNameToString(ifd->rettype));
+
+			ExplainPropertyText("Signature", sig.data, es);
+
+			if (es->verbose && ifd->src)
+				ExplainPropertyText("Body", ifd->src, es);
+
+			pfree(sig.data);
+
+			ExplainCloseGroup("WITH Function", NULL, true, es);
+		}
+
+		ExplainCloseGroup("WITH Functions", "WITH Functions", false, es);
+	}
+	else
+	{
+		foreach(lc, pstmt->withFuncDefs)
+		{
+			InlineFunctionDef *ifd = (InlineFunctionDef *) lfirst(lc);
+			StringInfoData	sig;
+			ListCell	   *alc;
+			bool			first_arg = true;
+
+			initStringInfo(&sig);
+
+			appendStringInfo(&sig, "WITH %s: %s(",
+							 ifd->is_proc ? "Procedure" : "Function",
+							 ifd->funcname);
+
+			foreach(alc, ifd->args)
+			{
+				FunctionParameter *fp = (FunctionParameter *) lfirst(alc);
+
+				if (!first_arg)
+					appendStringInfoString(&sig, ", ");
+				first_arg = false;
+
+				switch (fp->mode)
+				{
+					case FUNC_PARAM_OUT:
+						appendStringInfoString(&sig, "OUT ");
+						break;
+					case FUNC_PARAM_INOUT:
+						appendStringInfoString(&sig, "IN OUT ");
+						break;
+					default:
+						break;
+				}
+
+				if (fp->name)
+					appendStringInfo(&sig, "%s ", fp->name);
+				appendStringInfoString(&sig, TypeNameToString(fp->argType));
+			}
+			appendStringInfoChar(&sig, ')');
+			if (!ifd->is_proc && ifd->rettype != NULL)
+				appendStringInfo(&sig, " RETURN %s",
+								 TypeNameToString(ifd->rettype));
+
+			ExplainIndentText(es);
+			appendStringInfo(es->str, "%s\n", sig.data);
+
+			/*
+			 * In VERBOSE mode also show the function body, mirroring the
+			 * "Body" property emitted by the non-TEXT branch above.
+			 */
+			if (es->verbose && ifd->src)
+			{
+				es->indent++;
+				ExplainIndentText(es);
+				appendStringInfo(es->str, "Body: %s\n", ifd->src);
+				es->indent--;
+			}
+
+			pfree(sig.data);
+		}
+	}
+}
+
+/*
  * ExplainPrintPlan -
  *	  convert a QueryDesc's plan tree to text and append it to es->str
  *
@@ -802,6 +947,9 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
 		es->hide_workers = true;
 	}
 	ExplainNode(ps, NIL, NULL, NULL, es);
+
+	/* Show WITH FUNCTION / WITH PROCEDURE definitions if any */
+	ExplainPrintWithFunctions(es, queryDesc->plannedstmt);
 
 	/*
 	 * If requested, include information about GUC parameters with values that

--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -58,6 +58,7 @@
 #include "utils/syscache.h"
 #include "catalog/pg_proc.h"
 #include "parser/parse_param.h"
+#include "oracle_parser/ora_with_function.h"
 
 
 
@@ -2774,16 +2775,19 @@ ExecInitFunc(ExprEvalStep *scratch, Expr *node, List *args, Oid funcid,
 	int			argno;
 	ListCell   *lc;
 	bool		is_subproc_func = false;
+	bool		is_with_func = false;
 
 	if (nodeTag(node) == T_FuncExpr)
 	{
 		FuncExpr   *funcexpr = (FuncExpr *) node;
 
-		if (!FUNC_EXPR_FROM_PG_PROC(funcexpr->function_from))
+		if (funcexpr->function_from == FUNC_FROM_WITH_CLAUSE)
+			is_with_func = true;
+		else if (!FUNC_EXPR_FROM_PG_PROC(funcexpr->function_from))
 			is_subproc_func = true;
 	}
 
-	if (!is_subproc_func)
+	if (!is_subproc_func && !is_with_func)
 	{
 		/* Verify EXECUTE privilege before invoking the function. */
 		aclresult = object_aclcheck(ProcedureRelationId, funcid, GetUserId(), ACL_EXECUTE);
@@ -2813,7 +2817,36 @@ ExecInitFunc(ExprEvalStep *scratch, Expr *node, List *args, Oid funcid,
 	fcinfo = scratch->d.func.fcinfo_data;
 
 	/* Set up the primary fmgr lookup information */
-	if (is_subproc_func)
+	if (is_with_func)
+	{
+		/*
+		 * WITH-clause inline functions dispatch through the plisql call
+		 * handler.  fn_oid stores the function's index within the WITH clause
+		 * (not a real pg_proc OID), and fn_extra stores the query EState so
+		 * the handler can find/build the WithFuncContainer.
+		 *
+		 * We must store the EState of the outermost query that owns the WITH
+		 * clause, NOT the EState of any intermediate SPI execution.
+		 * plisql_active_with_func_estate (set by plisql_call_handler before
+		 * invoking each WITH function) always points to the correct EState, so
+		 * use it whenever it is available.  The fallback via state->parent->state
+		 * handles the initial call from the outer query before any WITH function
+		 * has started executing.
+		 */
+		EState	   *qstate;
+
+		if (plisql_active_with_func_estate != NULL)
+			qstate = plisql_active_with_func_estate;
+		else if (state->parent && state->parent->state)
+			qstate = state->parent->state;
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("cannot execute WITH clause function outside a query")));
+		fmgr_subproc_info_cxt(funcid, flinfo, CurrentMemoryContext);
+		flinfo->fn_extra = qstate;	/* override: EState, not NULL */
+	}
+	else if (is_subproc_func)
 		fmgr_subproc_info_cxt(funcid, flinfo, CurrentMemoryContext);
 	else
 		fmgr_info(funcid, flinfo);
@@ -5187,12 +5220,17 @@ ExecInitFuncWithOutParams(Expr *node, ExprState *state,
 			}
 
 			/*
-			 * Get the argument names and modes 
+			 * Get the argument names and modes
 			 */
 			num_all_args = get_func_arg_info(func_tuple, &argtypes,
 								&argnames, &argmodes);
 			rettype = get_func_real_rettype(func_tuple);
 			funcname = NameStr(((Form_pg_proc) GETSTRUCT(func_tuple))->proname);
+		}
+		else if (funcexpr->function_from == FUNC_FROM_WITH_CLAUSE)
+		{
+			/* WITH-clause inline functions have no OUT params */
+			return;
 		}
 		else
 		{

--- a/src/backend/executor/execSRF.c
+++ b/src/backend/executor/execSRF.c
@@ -154,6 +154,7 @@ ExecMakeTableFunctionResult(SetExprState *setexpr,
 			funcexpr->funccollid = chcollationoid;
 		}
 		else if (!FUNC_EXPR_FROM_PG_PROC(funcexpr->function_from) &&
+				funcexpr->function_from != FUNC_FROM_WITH_CLAUSE &&
 				subproc_should_change_return_type(funcexpr,
 									&resulttype,
 									&chtypmod,
@@ -740,6 +741,20 @@ init_sexpr(Oid foid, Oid input_collation, Expr *node,
 	if (node != NULL && nodeTag(node) == T_FuncExpr)
 	{
 		FuncExpr   *funcexpr = (FuncExpr *) node;
+
+		/*
+		 * WITH-clause inline functions are scalar-only by design (the lookup
+		 * hook forces retset = false), so they must not appear here — this
+		 * function only handles table-function and set-returning paths.
+		 * Reject with a clear message rather than letting the call fall
+		 * through to the PL/iSQL subproc machinery, which would surface a
+		 * confusing internal error.
+		 */
+		if (funcexpr->function_from == FUNC_FROM_WITH_CLAUSE)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("WITH clause function cannot be used as a table or set-returning function"),
+					 errhint("WITH FUNCTION/PROCEDURE definitions can only be invoked from scalar expression contexts.")));
 
 		if (!FUNC_EXPR_FROM_PG_PROC(funcexpr->function_from))
 			is_subproc_func = true;

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -2206,6 +2206,7 @@ ExecTypeFromTLInternal(List *targetList, bool hasrowid, bool skipjunk)
 				func->funccollid = chcollationoid;
 			}
 			else if (!FUNC_EXPR_FROM_PG_PROC(func->function_from) &&
+				func->function_from != FUNC_FROM_WITH_CLAUSE &&
 				subproc_should_change_return_type(func, &resulttype, &chtypmod, &chcollationoid))
 			{
 				typoid = resulttype;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -622,6 +622,7 @@ standard_planner(Query *parse, const char *query_string, int cursorOptions,
 	result->utilityStmt = parse->utilityStmt;
 	result->stmt_location = parse->stmt_location;
 	result->stmt_len = parse->stmt_len;
+	result->withFuncDefs = parse->withFuncDefs;
 
 	result->jitFlags = PGJIT_NONE;
 	if (jit_enabled && jit_above_cost >= 0 &&

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -635,6 +635,8 @@ static void determineLanguage(List *options);
 %type <node>	func_application func_expr_common_subexpr exec_func_application
 %type <node>	func_expr func_expr_windowless
 %type <node>	common_table_expr
+%type <node>	plsql_declaration
+%type <list>	plsql_declarations
 %type <with>	with_clause opt_with_clause
 %type <list>	cte_list
 
@@ -981,6 +983,19 @@ static void determineLanguage(List *options);
  * left-associativity among the JOIN rules themselves.
  */
 %left		JOIN CROSS LEFT FULL RIGHT INNER_P NATURAL
+/*
+ * Precedences used to resolve the shift/reduce conflicts that arise from
+ * "WITH plsql_declarations" when followed by an unreserved DML keyword
+ * (DELETE_P, INSERT, UPDATE, MERGE) that could be either a CTE name or
+ * the start of the main DML statement.
+ *
+ * We declare the DML keywords at a lower precedence level and PLSQL_DEFS_END
+ * at a higher level.  The rule "WITH plsql_declarations %prec PLSQL_DEFS_END"
+ * then wins the conflict via reduce (rule prec > token prec), so the DML
+ * keyword is treated as the main statement, not a CTE name.
+ */
+%nonassoc	DELETE_P INSERT UPDATE MERGE
+%nonassoc	PLSQL_DEFS_END
 
 %%
 
@@ -14340,6 +14355,9 @@ simple_select:
  *		AS (query) [ SEARCH or CYCLE clause ]
  *
  * Recognizing WITH_LA here allows a CTE to be named TIME or ORDINALITY.
+ *
+ * Oracle extension: WITH clause may begin with PL/SQL function/procedure
+ * declarations before the CTE list (ORA_PARSER mode only).
  */
 with_clause:
 		WITH cte_list
@@ -14362,6 +14380,85 @@ with_clause:
 				$$->ctes = $3;
 				$$->recursive = true;
 				$$->location = @1;
+			}
+		/* Oracle-compatible: WITH plsql_declarations cte_list */
+		| WITH plsql_declarations cte_list
+			{
+				$$ = makeNode(WithClause);
+				$$->plsql_defs = $2;
+				$$->ctes = $3;
+				$$->recursive = false;
+				$$->location = @1;
+			}
+		/* Oracle-compatible: WITH plsql_declarations only (no CTEs).
+		 * %prec PLSQL_DEFS_END forces reduce over shift when the lookahead
+		 * is an unreserved DML keyword (DELETE/INSERT/UPDATE/MERGE) so that
+		 * the keyword is treated as the main DML statement, not a CTE name. */
+		| WITH plsql_declarations %prec PLSQL_DEFS_END
+			{
+				$$ = makeNode(WithClause);
+				$$->plsql_defs = $2;
+				$$->ctes = NIL;
+				$$->recursive = false;
+				$$->location = @1;
+			}
+		;
+
+/*
+ * plsql_declarations: one or more inline FUNCTION/PROCEDURE definitions.
+ * Each definition ends with a ';' after the captured function body.
+ *
+ * The function/procedure body text (from IS/AS to matching END) is captured
+ * as a single Sconst by the Oracle lexer via the OraBody_FUNC mechanism,
+ * triggered by ora_func_is_or_as.
+ */
+plsql_declarations:
+		plsql_declaration
+			{ $$ = list_make1($1); }
+		| plsql_declarations plsql_declaration
+			{ $$ = lappend($1, $2); }
+		;
+
+plsql_declaration:
+		FUNCTION ora_func_name opt_ora_func_args_with_defaults
+		RETURN func_return
+		ora_func_is_or_as Sconst ';'
+			{
+				InlineFunctionDef *n = makeNode(InlineFunctionDef);
+				/*
+				 * WITH FUNCTION names are local to the statement and have no
+				 * schema, so a qualified name (e.g. schema.func) is invalid.
+				 * Reject explicitly rather than silently dropping qualifiers.
+				 */
+				if (list_length($2) != 1)
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("qualified name is not allowed in WITH FUNCTION declaration"),
+							 parser_errposition(@2)));
+				n->funcname = strVal(linitial($2));
+				n->args = $3;
+				n->rettype = $5;
+				n->is_proc = false;
+				n->src = $7;
+				n->location = @2;
+				$$ = (Node *) n;
+			}
+		| PROCEDURE ora_func_name opt_procedure_args_with_defaults
+		ora_func_is_or_as Sconst ';'
+			{
+				InlineFunctionDef *n = makeNode(InlineFunctionDef);
+				if (list_length($2) != 1)
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("qualified name is not allowed in WITH PROCEDURE declaration"),
+							 parser_errposition(@2)));
+				n->funcname = strVal(linitial($2));
+				n->args = $3;
+				n->rettype = NULL;
+				n->is_proc = true;
+				n->src = $5;
+				n->location = @2;
+				$$ = (Node *) n;
 			}
 		;
 

--- a/src/backend/parser/Makefile
+++ b/src/backend/parser/Makefile
@@ -35,7 +35,8 @@ OBJS = \
 	parser.o \
 	scan.o \
 	scansup.o \
-	parse_package.o
+	parse_package.o \
+	parse_with_plsql.o
 
 include $(top_srcdir)/src/backend/common.mk
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -581,6 +581,7 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = stmt->withClause->plsql_defs;
 	}
 
 	/* set up range table with just the result rel */
@@ -670,6 +671,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = stmt->withClause->plsql_defs;
 	}
 
 	qry->override = stmt->override;
@@ -1447,6 +1449,7 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt,
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = stmt->withClause->plsql_defs;
 	}
 
 	/* Complain if we get called from someplace where INTO is not allowed */
@@ -1620,6 +1623,7 @@ transformValuesClause(ParseState *pstate, SelectStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = stmt->withClause->plsql_defs;
 	}
 
 	/*
@@ -1887,6 +1891,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 		qry->hasRecursive = withClause->recursive;
 		qry->cteList = transformWithClause(pstate, withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = withClause->plsql_defs;
 	}
 
 	/*
@@ -2538,6 +2543,7 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = stmt->withClause->plsql_defs;
 	}
 
 	qry->resultRelation = setTargetTable(pstate, stmt->relation,

--- a/src/backend/parser/meson.build
+++ b/src/backend/parser/meson.build
@@ -22,6 +22,7 @@ backend_sources += files(
   'parse_utilcmd.c',
   'scansup.c',
   'parse_package.c',
+  'parse_with_plsql.c',
 )
 
 # Build a small utility static lib for the parser. The generation of the

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -4066,16 +4066,10 @@ check_funcexpr_outparams(List *funcexprs)
 		else if (func->function_from == FUNC_FROM_WITH_CLAUSE)
 		{
 			/*
-			 * WITH-clause inline functions are scalar-only — they are
-			 * rejected from table-function/SRF contexts upstream by
-			 * get_internal_function_result_type.  Since this validator is
-			 * only invoked from transformRangeFunction (FROM-clause table
-			 * function path), WITH-clause references that reach here will
-			 * be reported by the FROM-clause rejection a few lines later;
-			 * skipping the OUT-mode check here is therefore harmless.
-			 * (Note: WITH FUNCTIONs *can* declare IN OUT parameters; the
-			 * OUT-must-be-variable rule does not apply because scalar
-			 * SELECT contexts have no write-back semantics.)
+			 * WITH-clause inline functions never have OUT/IN OUT parameters:
+			 * transformWithFuncDefs() rejects any such declaration up front,
+			 * matching Oracle's ORA-06572 restriction on SQL-callable
+			 * functions.  There is nothing for this OUT-mode validator to do.
 			 */
 			continue;
 		}

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -4063,7 +4063,23 @@ check_funcexpr_outparams(List *funcexprs)
 			if (argmodes == NULL)
 				continue;
 		}
-		else 
+		else if (func->function_from == FUNC_FROM_WITH_CLAUSE)
+		{
+			/*
+			 * WITH-clause inline functions are scalar-only — they are
+			 * rejected from table-function/SRF contexts upstream by
+			 * get_internal_function_result_type.  Since this validator is
+			 * only invoked from transformRangeFunction (FROM-clause table
+			 * function path), WITH-clause references that reach here will
+			 * be reported by the FROM-clause rejection a few lines later;
+			 * skipping the OUT-mode check here is therefore harmless.
+			 * (Note: WITH FUNCTIONs *can* declare IN OUT parameters; the
+			 * OUT-must-be-variable rule does not apply because scalar
+			 * SELECT contexts have no write-back semantics.)
+			 */
+			continue;
+		}
+		else
 		{
 			get_subproc_arg_info(func, &argtypes,
 										&argnames, &argmodes);

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -129,7 +129,7 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("WITH FUNCTION/PROCEDURE is only supported in Oracle compatibility mode"),
-					 errhint("Set ivorysql.compatible_mode = ORA_PARSER to enable this feature.")));
+					 errhint("Set ivorysql.compatible_mode = oracle to enable this feature.")));
 		transformWithFuncDefs(pstate, withClause->plsql_defs);
 	}
 

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -17,13 +17,16 @@
 #include "catalog/pg_collation.h"
 #include "catalog/pg_type.h"
 #include "nodes/nodeFuncs.h"
+#include "oracle_parser/ora_with_function.h"
 #include "parser/analyze.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_collate.h"
 #include "parser/parse_cte.h"
 #include "parser/parse_expr.h"
 #include "utils/builtins.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/ora_compatible.h"
 #include "utils/typcache.h"
 
 
@@ -114,6 +117,21 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 	/* Only one WITH clause per query level */
 	Assert(pstate->p_ctenamespace == NIL);
 	Assert(pstate->p_future_ctes == NIL);
+
+	/*
+	 * Oracle extension: process inline FUNCTION/PROCEDURE declarations that
+	 * precede the CTE list.  This registers their signatures in ParseState
+	 * so that subsequent expression analysis can resolve calls to them.
+	 */
+	if (withClause->plsql_defs != NIL)
+	{
+		if (compatible_db != ORA_PARSER)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("WITH FUNCTION/PROCEDURE is only supported in Oracle compatibility mode"),
+					 errhint("Set ivorysql.compatible_mode = ORA_PARSER to enable this feature.")));
+		transformWithFuncDefs(pstate, withClause->plsql_defs);
+	}
 
 	/*
 	 * For either type of WITH, there must not be duplicate CTE names in the

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -30,6 +30,7 @@
 #include "parser/parse_func.h"
 #include "parser/parse_relation.h"
 #include "parser/parse_target.h"
+#include "oracle_parser/ora_with_function.h"
 #include "parser/parse_type.h"
 #include "parser/parse_package.h"
 #include "utils/builtins.h"
@@ -324,7 +325,18 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 											  &nvargs, &vatype,
 											  &declared_arg_types, &argdefaults, &pfunc);
 		if (fdresult != FUNCDETAIL_NOTFOUND)
-			function_from = FUNC_FROM_SUBPROCFUNC;
+		{
+			/*
+			 * Distinguish WITH-clause inline functions from PL/iSQL nested
+			 * subprograms.  The WITH-clause hook (withFuncLookupHook) always
+			 * leaves pfunc == NULL; the PL/iSQL subproc hook always sets it
+			 * to a non-NULL PLiSQL_function pointer.
+			 */
+			if (pstate->p_subprocfunc_hook == withFuncLookupHook)
+				function_from = FUNC_FROM_WITH_CLAUSE;
+			else
+				function_from = FUNC_FROM_SUBPROCFUNC;
+		}
 		else if (list_length(funcname) == 1)
 		{
 			/* lookup standard package func */
@@ -343,6 +355,56 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 				function_from = FUNC_FROM_PACKAGE;
 		}
 	}
+	/*
+	 * If the current pstate doesn't have a WITH-clause hook (e.g. the SELECT
+	 * inside INSERT...SELECT lives in a child pstate), walk up the parent
+	 * chain and retry the WITH-clause lookup.  Standard subproc hooks are
+	 * intentionally NOT propagated this way — only the WITH-clause hook.
+	 */
+	if (fdresult == FUNCDETAIL_NOTFOUND)
+	{
+		ParseState *ancestor = pstate->parentParseState;
+
+		while (ancestor != NULL && fdresult == FUNCDETAIL_NOTFOUND)
+		{
+			if (ancestor->p_subprocfunc_hook == withFuncLookupHook &&
+				ancestor->p_with_func_list != NIL)
+			{
+				fdresult = withFuncLookupHook(ancestor, funcname, &fargs,
+											  argnames, nargs, actual_arg_types,
+											  !func_variadic, true, proc_call,
+											  &funcid, &rettype, &retset,
+											  &nvargs, &vatype,
+											  &declared_arg_types, &argdefaults,
+											  &pfunc);
+				if (fdresult != FUNCDETAIL_NOTFOUND)
+					function_from = FUNC_FROM_WITH_CLAUSE;
+			}
+			ancestor = ancestor->parentParseState;
+		}
+	}
+
+	/*
+	 * If p_with_func_list is set but the hook is NOT withFuncLookupHook (e.g.
+	 * inside a PL/iSQL body that is part of a WITH-clause function executing
+	 * recursively), try the WITH-clause lookup directly.  This covers T10
+	 * recursive and mutually-recursive WITH function calls.
+	 */
+	if (fdresult == FUNCDETAIL_NOTFOUND &&
+		pstate->p_with_func_list != NIL &&
+		pstate->p_subprocfunc_hook != withFuncLookupHook)
+	{
+		fdresult = withFuncLookupHook(pstate, funcname, &fargs,
+									  argnames, nargs, actual_arg_types,
+									  !func_variadic, true, proc_call,
+									  &funcid, &rettype, &retset,
+									  &nvargs, &vatype,
+									  &declared_arg_types, &argdefaults,
+									  &pfunc);
+		if (fdresult != FUNCDETAIL_NOTFOUND)
+			function_from = FUNC_FROM_WITH_CLAUSE;
+	}
+
 	if (fdresult == FUNCDETAIL_NOTFOUND)
 	{
 		fdresult = LookupPkgFunc(pstate, funcname, &fargs, argnames, nargs,
@@ -833,6 +895,46 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 					 parser_errposition(pstate, location)));
 
 		actual_arg_types[nargsplusdefs++] = exprType(expr);
+	}
+
+	/*
+	 * A WITH-clause lookup hook may have appended default-expression nodes
+	 * directly to fargs (for parameters omitted at the call site).  Sync
+	 * actual_arg_types for those extra positions so make_fn_arguments sees
+	 * consistent arrays and can coerce if needed.
+	 */
+	{
+		int			new_nargs = list_length(fargs);
+
+		if (new_nargs > nargs)
+		{
+			ListCell   *lc;
+			int			j = 0;
+
+			/*
+			 * Defensive guard: actual_arg_types is FUNC_MAX_ARGS-sized.  The
+			 * grammar already caps WITH FUNCTION parameter counts, but mirror
+			 * the bound check used by the argdefaults loop above to prevent
+			 * a stack-array overrun if that invariant is ever violated.
+			 */
+			if (new_nargs > FUNC_MAX_ARGS)
+				ereport(ERROR,
+						(errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+						 errmsg_plural("cannot pass more than %d argument to a function",
+									   "cannot pass more than %d arguments to a function",
+									   FUNC_MAX_ARGS,
+									   FUNC_MAX_ARGS),
+						 parser_errposition(pstate, location)));
+
+			foreach(lc, fargs)
+			{
+				if (j >= nargs)
+					actual_arg_types[j] = exprType((Node *) lfirst(lc));
+				j++;
+			}
+			nargs = new_nargs;
+			nargsplusdefs = nargs;
+		}
 	}
 
 	/*

--- a/src/backend/parser/parse_merge.c
+++ b/src/backend/parser/parse_merge.c
@@ -130,6 +130,7 @@ transformMergeStmt(ParseState *pstate, MergeStmt *stmt)
 
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+		qry->withFuncDefs = stmt->withClause->plsql_defs;
 	}
 
 	/*

--- a/src/backend/parser/parse_with_plsql.c
+++ b/src/backend/parser/parse_with_plsql.c
@@ -62,8 +62,9 @@ struct EState *plisql_active_with_func_estate = NULL;
 /*
  * resolveWithFuncArgTypes — resolve FunctionParameter list to an Oid list.
  *
- * Only IN and INOUT parameters are included; OUT-only parameters are skipped
- * because they do not participate in call-site overload resolution.
+ * WITH-clause subprograms only accept IN parameters (see
+ * rejectNonInParamsInWithFunc); every entry in this list contributes to the
+ * argument type vector.
  */
 static List *
 resolveWithFuncArgTypes(ParseState *pstate, List *args)
@@ -75,14 +76,45 @@ resolveWithFuncArgTypes(ParseState *pstate, List *args)
 	{
 		FunctionParameter *fp = (FunctionParameter *) lfirst(lc);
 
-		if (fp->mode == FUNC_PARAM_OUT)
-			continue;
-
 		result = lappend_oid(result,
 							 typenameTypeId(pstate, fp->argType));
 	}
 
 	return result;
+}
+
+/*
+ * rejectNonInParamsInWithFunc — enforce Oracle's SQL-callable rule that
+ * functions invoked from a SQL statement may not declare OUT or IN OUT
+ * parameters.  A WITH FUNCTION / WITH PROCEDURE definition only ever runs
+ * from inside the enclosing SQL statement, so the same restriction applies.
+ *
+ * Oracle raises ORA-06572 ("PL/SQL function string has OUT parameter in
+ * argument list") for the equivalent case on schema-level functions.
+ */
+static void
+rejectNonInParamsInWithFunc(ParseState *pstate, InlineFunctionDef *ifd)
+{
+	ListCell   *lc;
+
+	foreach(lc, ifd->args)
+	{
+		FunctionParameter *fp = (FunctionParameter *) lfirst(lc);
+
+		if (fp->mode == FUNC_PARAM_IN ||
+			fp->mode == FUNC_PARAM_DEFAULT)
+			continue;
+
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("WITH %s \"%s\" cannot declare OUT or IN OUT parameters",
+						ifd->is_proc ? "PROCEDURE" : "FUNCTION",
+						ifd->funcname),
+				 errdetail("Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters."),
+				 errhint("Remove the OUT/IN OUT/NOCOPY mode from parameter \"%s\", or move the subprogram into a schema-level PL/SQL block.",
+						 fp->name ? fp->name : "?"),
+				 parser_errposition(pstate, ifd->location)));
+	}
 }
 
 /*
@@ -139,6 +171,13 @@ transformWithFuncDefs(ParseState *pstate, List *plsql_defs)
 
 		Assert(IsA(ifd, InlineFunctionDef));
 
+		/*
+		 * Oracle disallows OUT / IN OUT parameters on any SQL-callable
+		 * function (ORA-06572).  Enforce the same rule for WITH-clause
+		 * subprograms before we resolve types or pre-analyze defaults.
+		 */
+		rejectNonInParamsInWithFunc(pstate, ifd);
+
 		entry = palloc(sizeof(WithFuncEntry));
 		entry->funcname = ifd->funcname;
 		entry->is_proc = ifd->is_proc;
@@ -148,10 +187,10 @@ transformWithFuncDefs(ParseState *pstate, List *plsql_defs)
 		entry->argtypes = resolveWithFuncArgTypes(pstate, ifd->args);
 
 		/*
-		 * Count IN/INOUT parameters with DEFAULT and pre-analyze each default
-		 * expression in the current ParseState context.  Storing analyzed
-		 * expressions here avoids calling transformExpr inside the hook
-		 * (which runs in a narrower context and can trigger a crash).
+		 * Pre-analyze each parameter's DEFAULT expression in the current
+		 * ParseState context.  Storing analyzed expressions here avoids
+		 * calling transformExpr inside the hook (which runs in a narrower
+		 * context and can trigger a crash).
 		 */
 		{
 			int			ndefaults = 0;
@@ -161,9 +200,6 @@ transformWithFuncDefs(ParseState *pstate, List *plsql_defs)
 			foreach(alc, ifd->args)
 			{
 				FunctionParameter *fp = (FunctionParameter *) lfirst(alc);
-
-				if (fp->mode == FUNC_PARAM_OUT)
-					continue;
 
 				if (fp->defexpr != NULL)
 				{

--- a/src/backend/parser/parse_with_plsql.c
+++ b/src/backend/parser/parse_with_plsql.c
@@ -246,11 +246,32 @@ withFuncLookupHook(ParseState *pstate,
 
 		nentryargs = list_length(entry->argtypes);
 
-		/* Accept exact match or short call if trailing params have defaults */
+		/* Accept exact match or short call if every omitted param is a
+		 * trailing defaulted parameter.  ndefaults alone is not sufficient:
+		 * defaults may be interspersed, and we must reject calls that omit
+		 * a parameter without a default. */
 		if (nargs > nentryargs)
 			continue;
-		if (nargs < nentryargs && (nentryargs - nargs) > entry->ndefaults)
-			continue;
+		if (nargs < nentryargs)
+		{
+			int			omitted = nentryargs - nargs;
+			int			trailing_defaults = 0;
+			int			j;
+
+			/*
+			 * Defaults are recorded positionally in entry->analyzeddefaults
+			 * (NULL where the IN/INOUT parameter has no default).  Scan from
+			 * the end and count contiguous trailing non-NULL entries.
+			 */
+			for (j = nentryargs - 1; j >= 0; j--)
+			{
+				if (list_nth(entry->analyzeddefaults, j) == NULL)
+					break;
+				trailing_defaults++;
+			}
+			if (omitted > trailing_defaults)
+				continue;
+		}
 
 		/* All provided argument types must be implicitly coercible */
 		i = 0;
@@ -285,12 +306,16 @@ withFuncLookupHook(ParseState *pstate,
 			*true_typeids = NULL;
 
 		/*
-		 * If the call omits trailing defaulted parameters, append their
-		 * pre-analyzed default expressions to *fargs so the FuncExpr carries
-		 * all arguments.  parse_func.c will sync actual_arg_types from
-		 * declared_arg_types for these extra positions before coercion.
+		 * If the caller asked us to expand defaults and the call omits
+		 * trailing defaulted parameters, append their pre-analyzed default
+		 * expressions to *fargs so the FuncExpr carries all arguments.
+		 * parse_func.c will sync actual_arg_types from declared_arg_types for
+		 * these extra positions before coercion.
+		 *
+		 * The trailing-defaults check above guarantees every omitted position
+		 * has a non-NULL default, so this loop never copies a NULL.
 		 */
-		if (nargs < nentryargs)
+		if (expand_defaults && nargs < nentryargs)
 		{
 			int			skip = 0;	/* IN/INOUT params seen so far */
 			ListCell   *dlc;
@@ -303,8 +328,6 @@ withFuncLookupHook(ParseState *pstate,
 				if (skip <= nargs)
 					continue;	/* provided by caller */
 
-				Assert(defexpr != NULL);	/* ensured by earlier default
-											 * check */
 				*fargs = lappend(*fargs, copyObject(defexpr));
 			}
 		}

--- a/src/backend/parser/parse_with_plsql.c
+++ b/src/backend/parser/parse_with_plsql.c
@@ -62,9 +62,9 @@ struct EState *plisql_active_with_func_estate = NULL;
 /*
  * resolveWithFuncArgTypes — resolve FunctionParameter list to an Oid list.
  *
- * WITH-clause subprograms only accept IN parameters (see
- * rejectNonInParamsInWithFunc); every entry in this list contributes to the
- * argument type vector.
+ * Every parameter (IN, OUT, IN OUT) contributes to the argument type vector.
+ * WITH FUNCTION only accepts IN parameters (enforced by
+ * rejectNonInParamsInWithFunc); WITH PROCEDURE may also have OUT/IN OUT.
  */
 static List *
 resolveWithFuncArgTypes(ParseState *pstate, List *args)
@@ -86,16 +86,23 @@ resolveWithFuncArgTypes(ParseState *pstate, List *args)
 /*
  * rejectNonInParamsInWithFunc — enforce Oracle's SQL-callable rule that
  * functions invoked from a SQL statement may not declare OUT or IN OUT
- * parameters.  A WITH FUNCTION / WITH PROCEDURE definition only ever runs
- * from inside the enclosing SQL statement, so the same restriction applies.
+ * parameters.  WITH PROCEDURE definitions are exempt: Oracle allows OUT/IN OUT
+ * parameters on WITH procedures because procedures are not called directly from
+ * SQL expressions — they are invoked from other PL/SQL subprograms within the
+ * same WITH block.
  *
  * Oracle raises ORA-06572 ("PL/SQL function string has OUT parameter in
- * argument list") for the equivalent case on schema-level functions.
+ * argument list") for schema-level functions called from SQL, and the same
+ * rule applies to WITH FUNCTION.  WITH PROCEDURE does not trigger ORA-06572.
  */
 static void
 rejectNonInParamsInWithFunc(ParseState *pstate, InlineFunctionDef *ifd)
 {
 	ListCell   *lc;
+
+	/* Procedures may freely declare OUT / IN OUT parameters. */
+	if (ifd->is_proc)
+		return;
 
 	foreach(lc, ifd->args)
 	{
@@ -107,10 +114,9 @@ rejectNonInParamsInWithFunc(ParseState *pstate, InlineFunctionDef *ifd)
 
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("WITH %s \"%s\" cannot declare OUT or IN OUT parameters",
-						ifd->is_proc ? "PROCEDURE" : "FUNCTION",
+				 errmsg("WITH FUNCTION \"%s\" cannot declare OUT or IN OUT parameters",
 						ifd->funcname),
-				 errdetail("Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters."),
+				 errdetail("WITH FUNCTION subprograms are invoked directly from SQL expressions, which only accept IN parameters."),
 				 errhint("Remove the OUT/IN OUT/NOCOPY mode from parameter \"%s\", or move the subprogram into a schema-level PL/SQL block.",
 						 fp->name ? fp->name : "?"),
 				 parser_errposition(pstate, ifd->location)));
@@ -172,9 +178,9 @@ transformWithFuncDefs(ParseState *pstate, List *plsql_defs)
 		Assert(IsA(ifd, InlineFunctionDef));
 
 		/*
-		 * Oracle disallows OUT / IN OUT parameters on any SQL-callable
-		 * function (ORA-06572).  Enforce the same rule for WITH-clause
-		 * subprograms before we resolve types or pre-analyze defaults.
+		 * Oracle disallows OUT / IN OUT parameters on SQL-callable functions
+		 * (ORA-06572).  WITH PROCEDURE is exempt because procedures are not
+		 * called directly from SQL expressions.
 		 */
 		rejectNonInParamsInWithFunc(pstate, ifd);
 

--- a/src/backend/parser/parse_with_plsql.c
+++ b/src/backend/parser/parse_with_plsql.c
@@ -1,0 +1,320 @@
+/*-------------------------------------------------------------------------
+ *
+ * parse_with_plsql.c
+ *    Oracle-compatible WITH FUNCTION / WITH PROCEDURE support — parse phase.
+ *
+ * This file implements the two parse-time phases of WITH-clause inline
+ * subprograms:
+ *
+ *   1. Parse-analysis (transformWithFuncDefs):
+ *        Resolves argument and return types, registers each function
+ *        signature in ParseState.p_with_func_list, and installs the
+ *        withFuncLookupHook so that subsequent expression analysis can
+ *        resolve calls to the inline functions before falling through to
+ *        the catalog.
+ *
+ *   2. Function call resolution (withFuncLookupHook):
+ *        Called from ParseFuncOrColumn() as the p_subprocfunc_hook.
+ *        Returns FUNCDETAIL_NORMAL / FUNCDETAIL_PROCEDURE when a WITH-
+ *        clause function matches, with funcid set to the function index
+ *        (not a catalog OID) and function_from = FUNC_FROM_WITH_CLAUSE.
+ *
+ * The execution-time compilation phase (Phase 3) lives in
+ * src/pl/plisql/src/pl_handler.c so that it can call plisql_compile_inline()
+ * without creating a dependency from the main backend on plisql.so.
+ *
+ * Copyright 2025 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * src/backend/parser/parse_with_plsql.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
+#include "oracle_parser/ora_with_function.h"
+#include "parser/parse_coerce.h"
+#include "parser/parse_expr.h"
+#include "parser/parse_func.h"
+#include "parser/parse_type.h"
+#include "utils/guc.h"
+#include "utils/ora_compatible.h"
+
+/*
+ * EState fallback for recursive WITH function calls.  Set by plisql.so when
+ * executing a WITH function so that ExecInitFunc can use it when the
+ * expression is evaluated via PL/iSQL's simple-expression path (which creates
+ * ExprStates without a parent PlanState).
+ */
+struct EState *plisql_active_with_func_estate = NULL;
+
+/* -----------------------------------------------------------------------
+ * Internal helpers
+ * ----------------------------------------------------------------------- */
+
+/*
+ * resolveWithFuncArgTypes — resolve FunctionParameter list to an Oid list.
+ *
+ * Only IN and INOUT parameters are included; OUT-only parameters are skipped
+ * because they do not participate in call-site overload resolution.
+ */
+static List *
+resolveWithFuncArgTypes(ParseState *pstate, List *args)
+{
+	List	   *result = NIL;
+	ListCell   *lc;
+
+	foreach(lc, args)
+	{
+		FunctionParameter *fp = (FunctionParameter *) lfirst(lc);
+
+		if (fp->mode == FUNC_PARAM_OUT)
+			continue;
+
+		result = lappend_oid(result,
+							 typenameTypeId(pstate, fp->argType));
+	}
+
+	return result;
+}
+
+/*
+ * checkDuplicateWithFunc — error if funcname already registered with the
+ * same argument types (same overload).
+ */
+static void
+checkDuplicateWithFunc(List *func_list, WithFuncEntry * newentry)
+{
+	ListCell   *lc;
+
+	foreach(lc, func_list)
+	{
+		WithFuncEntry *existing = (WithFuncEntry *) lfirst(lc);
+
+		if (strcmp(existing->funcname, newentry->funcname) != 0)
+			continue;
+
+		if (list_length(existing->argtypes) != list_length(newentry->argtypes))
+			continue;
+
+		if (equal(existing->argtypes, newentry->argtypes))
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_FUNCTION),
+					 errmsg("WITH clause function \"%s\" is defined more than once with the same argument types",
+							newentry->funcname),
+					 parser_errposition(NULL, newentry->def->location)));
+	}
+}
+
+/* -----------------------------------------------------------------------
+ * Phase 1: parse-analysis
+ * ----------------------------------------------------------------------- */
+
+/*
+ * transformWithFuncDefs — process InlineFunctionDef nodes from the WITH
+ * clause during query semantic analysis.
+ *
+ * Called from transformWithClause() when WithClause.plsql_defs is non-NIL.
+ * Populates pstate->p_with_func_list and installs withFuncLookupHook.
+ */
+void
+transformWithFuncDefs(ParseState *pstate, List *plsql_defs)
+{
+	int			funcindex = 0;
+	ListCell   *lc;
+
+	Assert(ORA_PARSER == compatible_db);
+
+	foreach(lc, plsql_defs)
+	{
+		InlineFunctionDef *ifd = (InlineFunctionDef *) lfirst(lc);
+		WithFuncEntry *entry;
+
+		Assert(IsA(ifd, InlineFunctionDef));
+
+		entry = palloc(sizeof(WithFuncEntry));
+		entry->funcname = ifd->funcname;
+		entry->is_proc = ifd->is_proc;
+		entry->funcindex = funcindex++;
+		entry->def = ifd;
+
+		entry->argtypes = resolveWithFuncArgTypes(pstate, ifd->args);
+
+		/*
+		 * Count IN/INOUT parameters with DEFAULT and pre-analyze each default
+		 * expression in the current ParseState context.  Storing analyzed
+		 * expressions here avoids calling transformExpr inside the hook
+		 * (which runs in a narrower context and can trigger a crash).
+		 */
+		{
+			int			ndefaults = 0;
+			List	   *analyzed = NIL;
+			ListCell   *alc;
+
+			foreach(alc, ifd->args)
+			{
+				FunctionParameter *fp = (FunctionParameter *) lfirst(alc);
+
+				if (fp->mode == FUNC_PARAM_OUT)
+					continue;
+
+				if (fp->defexpr != NULL)
+				{
+					Node	   *expr = transformExpr(pstate,
+													 copyObject(fp->defexpr),
+													 EXPR_KIND_FUNCTION_DEFAULT);
+
+					analyzed = lappend(analyzed, expr);
+					ndefaults++;
+				}
+				else
+					analyzed = lappend(analyzed, NULL);
+			}
+			entry->ndefaults = ndefaults;
+			entry->analyzeddefaults = analyzed;
+		}
+
+		if (ifd->rettype != NULL)
+			entry->rettype = typenameTypeId(pstate, ifd->rettype);
+		else
+			entry->rettype = InvalidOid;
+
+		checkDuplicateWithFunc(pstate->p_with_func_list, entry);
+
+		pstate->p_with_func_list = lappend(pstate->p_with_func_list, entry);
+	}
+
+	if (pstate->p_subprocfunc_hook == NULL)
+		pstate->p_subprocfunc_hook = withFuncLookupHook;
+}
+
+/* -----------------------------------------------------------------------
+ * Phase 2: call-site resolution hook
+ * ----------------------------------------------------------------------- */
+
+/*
+ * withFuncLookupHook — ParseSubprocFuncHook implementation.
+ *
+ * Called from ParseFuncOrColumn() before any catalog lookup.  Returns
+ * FUNCDETAIL_NORMAL (or FUNCDETAIL_PROCEDURE) when a matching WITH-clause
+ * function is found; FUNCDETAIL_NOTFOUND otherwise.
+ */
+int
+withFuncLookupHook(ParseState *pstate,
+				   List *funcname,
+				   List **fargs,
+				   List *fargnames,
+				   int nargs,
+				   Oid *argtypes,
+				   bool expand_variadic,
+				   bool expand_defaults,
+				   bool proc_call,
+				   Oid *funcid,
+				   Oid *rettype,
+				   bool *retset,
+				   int *nvargs,
+				   Oid *vatype,
+				   Oid **true_typeids,
+				   List **argdefaults,
+				   void **pfunc)
+{
+	char	   *fname;
+	ListCell   *lc;
+
+	/* WITH-clause functions are always simple (unqualified) names */
+	if (list_length(funcname) != 1)
+		return FUNCDETAIL_NOTFOUND;
+
+	fname = strVal(linitial(funcname));
+
+	foreach(lc, pstate->p_with_func_list)
+	{
+		WithFuncEntry *entry = (WithFuncEntry *) lfirst(lc);
+		int			nentryargs;
+		int			i;
+		ListCell   *alc;
+
+		if (strcmp(entry->funcname, fname) != 0)
+			continue;
+
+		nentryargs = list_length(entry->argtypes);
+
+		/* Accept exact match or short call if trailing params have defaults */
+		if (nargs > nentryargs)
+			continue;
+		if (nargs < nentryargs && (nentryargs - nargs) > entry->ndefaults)
+			continue;
+
+		/* All provided argument types must be implicitly coercible */
+		i = 0;
+		foreach(alc, entry->argtypes)
+		{
+			Oid			expected = lfirst_oid(alc);
+
+			if (i >= nargs)
+				break;			/* remaining params covered by defaults */
+			if (!can_coerce_type(1, &argtypes[i], &expected, COERCION_IMPLICIT))
+				goto next_entry;
+			i++;
+		}
+
+		/* Match found — populate output parameters */
+		*funcid = (Oid) entry->funcindex;
+		*rettype = entry->rettype;
+		*retset = false;
+		*nvargs = 0;
+		*vatype = InvalidOid;
+		*pfunc = NULL;
+
+		/* Build true_typeids covering all nentryargs (provided + defaults) */
+		if (nentryargs > 0)
+		{
+			*true_typeids = (Oid *) palloc(nentryargs * sizeof(Oid));
+			i = 0;
+			foreach(alc, entry->argtypes)
+				(*true_typeids)[i++] = lfirst_oid(alc);
+		}
+		else
+			*true_typeids = NULL;
+
+		/*
+		 * If the call omits trailing defaulted parameters, append their
+		 * pre-analyzed default expressions to *fargs so the FuncExpr carries
+		 * all arguments.  parse_func.c will sync actual_arg_types from
+		 * declared_arg_types for these extra positions before coercion.
+		 */
+		if (nargs < nentryargs)
+		{
+			int			skip = 0;	/* IN/INOUT params seen so far */
+			ListCell   *dlc;
+
+			foreach(dlc, entry->analyzeddefaults)
+			{
+				Node	   *defexpr = (Node *) lfirst(dlc);
+
+				skip++;
+				if (skip <= nargs)
+					continue;	/* provided by caller */
+
+				Assert(defexpr != NULL);	/* ensured by earlier default
+											 * check */
+				*fargs = lappend(*fargs, copyObject(defexpr));
+			}
+		}
+
+		*argdefaults = NIL;
+
+		return entry->is_proc ? FUNCDETAIL_PROCEDURE : FUNCDETAIL_NORMAL;
+
+next_entry:;
+	}
+
+	return FUNCDETAIL_NOTFOUND;
+}

--- a/src/backend/parser/parse_with_plsql.c
+++ b/src/backend/parser/parse_with_plsql.c
@@ -39,6 +39,7 @@
 
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
+#include "catalog/namespace.h"
 #include "oracle_parser/ora_with_function.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_expr.h"
@@ -58,6 +59,53 @@ struct EState *plisql_active_with_func_estate = NULL;
 /* -----------------------------------------------------------------------
  * Internal helpers
  * ----------------------------------------------------------------------- */
+
+/*
+ * Oracle SQL single-row built-in function names that WITH FUNCTION must not
+ * shadow.  These correspond to Oracle's documented SQL Functions (SQL Language
+ * Reference, "Functions" chapter) that are part of the SQL language itself.
+ *
+ * When one of these names appears with a matching pg_catalog entry, the
+ * catalog function wins — exactly as Oracle resolves its own built-ins before
+ * any user-supplied query-level definition.
+ *
+ * PostgreSQL-specific catalog entries (e.g. factorial, array_append) are
+ * intentionally absent so that WITH FUNCTION can still override them.
+ *
+ * Temporary: superseded once IvorySQL ships its STANDARD package.
+ */
+static const char *const oracle_builtin_func_names[] = {
+	/* Numeric single-row functions */
+	"abs", "acos", "asin", "atan", "atan2",
+	"bitand", "ceil", "cos", "cosh",
+	"exp", "floor", "greatest", "least",
+	"ln", "log", "mod", "power",
+	"round", "sign", "sin", "sinh", "sqrt",
+	"tan", "tanh", "trunc", "width_bucket",
+	/* Character single-row functions */
+	"ascii", "chr", "concat", "initcap",
+	"instr", "length", "lower", "lpad", "ltrim",
+	"replace", "rpad", "rtrim", "soundex",
+	"substr", "translate", "trim", "upper",
+	/* Regular-expression functions */
+	"regexp_count", "regexp_instr", "regexp_replace", "regexp_substr",
+	/* NULL-handling */
+	"coalesce", "nullif",
+	/* Aggregate functions */
+	"avg", "count", "max", "min", "stddev", "sum", "variance",
+	NULL						/* sentinel */
+};
+
+static bool
+is_oracle_builtin_name(const char *fname)
+{
+	for (int i = 0; oracle_builtin_func_names[i] != NULL; i++)
+	{
+		if (strcmp(oracle_builtin_func_names[i], fname) == 0)
+			return true;
+	}
+	return false;
+}
 
 /*
  * resolveWithFuncArgTypes — resolve FunctionParameter list to an Oid list.
@@ -275,6 +323,36 @@ withFuncLookupHook(ParseState *pstate,
 		return FUNCDETAIL_NOTFOUND;
 
 	fname = strVal(linitial(funcname));
+
+	/*
+	 * Oracle compatibility: Oracle SQL built-in functions take priority over
+	 * WITH FUNCTION definitions with the same name.  In Oracle, documented
+	 * single-row SQL functions (ABS, ROUND, SUBSTR, etc.) are always resolved
+	 * before any query-local definitions; a WITH FUNCTION of the same name is
+	 * silently bypassed.
+	 *
+	 * We gate on a whitelist of Oracle SQL function names so that PostgreSQL-
+	 * specific pg_catalog entries (e.g. factorial) are still overridable.
+	 *
+	 * NOTE: this is a temporary bridge.  Once IvorySQL implements the STANDARD
+	 * package, LookupPkgFunc("standard.name") will naturally win in
+	 * ParseFuncOrColumn before this hook is reached, making this check
+	 * redundant.
+	 */
+	if (is_oracle_builtin_name(fname))
+	{
+		List	   *pg_cat_name = list_make2(makeString("pg_catalog"),
+											 makeString(fname));
+		int			dummy_flags = 0;
+		FuncCandidateList cands;
+
+		cands = FuncnameGetCandidates(pg_cat_name, nargs, fargnames,
+									  expand_variadic, expand_defaults,
+									  false, true, &dummy_flags);
+		list_free_deep(pg_cat_name);
+		if (cands != NULL)
+			return FUNCDETAIL_NOTFOUND;
+	}
 
 	foreach(lc, pstate->p_with_func_list)
 	{

--- a/src/backend/utils/fmgr/funcapi.c
+++ b/src/backend/utils/fmgr/funcapi.c
@@ -1839,6 +1839,21 @@ get_internal_function_result_type(FuncExpr *fexpr,
 								  Oid *resultTypeId,
 								  TupleDesc *resultTupleDesc)
 {
+	/*
+	 * WITH-clause inline functions are scalar-only by design (the lookup hook
+	 * forces retset = false).  This function is reached when a FuncExpr is
+	 * used in a context that needs to inspect a composite/SRF result type —
+	 * typical examples are FROM-clause table function references or SELECT
+	 * list SRF calls.  Reject with a clear message rather than letting the
+	 * call fall through to the PL/iSQL subproc machinery, which would surface
+	 * the confusing internal error "parent_func has not set".
+	 */
+	if (fexpr->function_from == FUNC_FROM_WITH_CLAUSE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("WITH clause function cannot be used as a table or set-returning function"),
+				 errhint("WITH FUNCTION/PROCEDURE definitions can only be invoked from scalar expression contexts.")));
+
 	plisql_internel_funcs_init();
 
 	if (FUNC_EXPR_FROM_PACKAGE(fexpr->function_from))

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -647,6 +647,9 @@ typedef struct AsyncRequest
 								 * tuples) */
 } AsyncRequest;
 
+/* Forward declaration for WITH clause function container (defined in ora_with_function.h) */
+struct WithFuncContainer;
+
 /* ----------------
  *	  EState information
  *
@@ -707,6 +710,9 @@ typedef struct EState
 	ParamExecData *es_param_exec_vals;	/* values of internal params */
 
 	QueryEnvironment *es_queryEnv;	/* query environment */
+
+	/* WITH clause inline function container (ORA_PARSER mode only) */
+	struct WithFuncContainer *es_with_func_container;
 
 	/* Other working state: */
 	MemoryContext es_query_cxt; /* per-query context in which EState lives */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1659,8 +1659,11 @@ typedef struct InlineFunctionDef
  * WithClause -
  *	   representation of WITH clause
  *
- * Note: WithClause does not propagate into the Query representation;
- * but CommonTableExpr does.
+ * Note: the WithClause node itself does not propagate into the Query
+ * representation, but data derived from it does: CommonTableExpr entries
+ * are carried in Query.cteList as before, and (for ORA_PARSER) inline
+ * function/procedure definitions from plsql_defs are carried in
+ * Query.withFuncDefs.
  */
 typedef struct WithClause
 {

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -173,6 +173,8 @@ typedef struct Query
 	bool		isReturn pg_node_attr(query_jumble_ignore);
 
 	List	   *cteList;		/* WITH list (of CommonTableExpr's) */
+	/* WITH clause inline functions/procedures (ORA_PARSER only) */
+	List	   *withFuncDefs pg_node_attr(query_jumble_ignore);
 
 	List	   *rtable;			/* list of range table entries */
 
@@ -1633,6 +1635,27 @@ typedef struct RowMarkClause
 } RowMarkClause;
 
 /*
+ * InlineFunctionDef -
+ *	   representation of a FUNCTION or PROCEDURE definition in a WITH clause
+ *	   (Oracle compatibility, ORA_PARSER mode only)
+ *
+ * The function body source text is captured by the Oracle lexer via the
+ * OraBody_FUNC mechanism and stored verbatim in 'src'.  It is compiled at
+ * query execution time and never written to the system catalog.
+ */
+typedef struct InlineFunctionDef
+{
+	pg_node_attr(nodetag_number(498))
+	NodeTag		type;
+	char	   *funcname;		/* function/procedure name (unqualified) */
+	List	   *args;			/* list of FunctionParameter nodes */
+	TypeName   *rettype;		/* return type, or NULL for procedures */
+	bool		is_proc;		/* true = procedure, false = function */
+	char	   *src;			/* body source text (IS/AS ... END) */
+	ParseLoc	location pg_node_attr(query_jumble_ignore);
+} InlineFunctionDef;
+
+/*
  * WithClause -
  *	   representation of WITH clause
  *
@@ -1642,6 +1665,7 @@ typedef struct RowMarkClause
 typedef struct WithClause
 {
 	NodeTag		type;
+	List	   *plsql_defs;		/* list of InlineFunctionDef (ORA_PARSER only) */
 	List	   *ctes;			/* list of CommonTableExprs */
 	bool		recursive;		/* true = WITH RECURSIVE */
 	ParseLoc	location;		/* token location, or -1 if unknown */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -146,6 +146,9 @@ typedef struct PlannedStmt
 	/* type OIDs for PARAM_EXEC Params */
 	List	   *paramExecTypes;
 
+	/* WITH clause inline functions/procedures (ORA_PARSER only) */
+	List	   *withFuncDefs;
+
 	/* non-null if this is utility stmt */
 	Node	   *utilityStmt;
 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -775,10 +775,12 @@ typedef enum CoercionForm
 
 #define FUNC_FROM_PACKAGE		'p'
 #define FUNC_FROM_PACKGE_INITBODY 'b'
+#define FUNC_FROM_WITH_CLAUSE	'w'	/* WITH clause inline function/procedure */
 
 #define FUNC_EXPR_FROM_PG_PROC(function_from) \
 	(function_from != FUNC_FROM_SUBPROCFUNC && function_from != FUNC_FROM_PACKAGE \
-	&& function_from != FUNC_FROM_PACKGE_INITBODY)
+	&& function_from != FUNC_FROM_PACKGE_INITBODY \
+	&& function_from != FUNC_FROM_WITH_CLAUSE)
 
 #define FUNC_EXPR_FROM_PACKAGE(function_from) \
 	(function_from == FUNC_FROM_PACKAGE)

--- a/src/include/oracle_parser/ora_with_function.h
+++ b/src/include/oracle_parser/ora_with_function.h
@@ -1,0 +1,124 @@
+/*-------------------------------------------------------------------------
+ *
+ * ora_with_function.h
+ *    Support for Oracle-compatible WITH FUNCTION / WITH PROCEDURE
+ *    (inline subprograms defined in the SQL WITH clause).
+ *
+ * This header is included by both the main backend (for the parse-analysis
+ * phase) and by plisql.so (for the execution phase).  It intentionally avoids
+ * including PL/iSQL-internal headers so that files in the main backend do not
+ * depend on plisql internals; forward declarations are used instead.
+ *
+ * Copyright 2025 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * src/include/oracle_parser/ora_with_function.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef ORA_WITH_FUNCTION_H
+#define ORA_WITH_FUNCTION_H
+
+#include "nodes/parsenodes.h"
+#include "nodes/plannodes.h"
+#include "parser/parse_node.h"
+#include "fmgr.h"
+
+/* Forward declarations — full types are defined in their respective headers */
+struct PLiSQL_function;			/* pl/plisql/src/plisql.h */
+struct PLiSQL_subproc_function; /* pl/plisql/src/pl_subproc_function.h */
+struct EState;					/* nodes/execnodes.h */
+
+/*
+ * WithFuncContainer — runtime container for compiled WITH clause functions.
+ *
+ * Created lazily on first invocation of any WITH-clause function within a
+ * query and stored in EState.es_with_func_container.  Its memory context is a
+ * child of EState.es_query_cxt so it is freed automatically when the query
+ * ends.
+ *
+ * The funcs array uses a forward-declared pointer type so this header can be
+ * included by the main backend without dragging in plisql internals.
+ */
+typedef struct WithFuncContainer
+{
+	int							nfuncs;		/* number of inline functions */
+	struct PLiSQL_subproc_function **funcs;	/* compiled function array */
+	MemoryContext				mcxt;		/* owning memory context */
+	List					   *func_entries; /* WithFuncEntry list, for expr context */
+} WithFuncContainer;
+
+/*
+ * WithFuncEntry — per-function descriptor kept in ParseState.p_with_func_list
+ * during semantic analysis.  Carries only the information needed to resolve
+ * call-sites; the full InlineFunctionDef (with body source) is preserved in
+ * Query.withFuncDefs for later compilation.
+ */
+typedef struct WithFuncEntry
+{
+	char	   *funcname;		/* function/procedure name */
+	List	   *argtypes;		/* Oid list of resolved argument types */
+	Oid			rettype;		/* resolved return type OID */
+	bool		is_proc;		/* true = procedure */
+	int			funcindex;		/* sequential index (used as FuncExpr.funcid) */
+	InlineFunctionDef *def;		/* back-pointer to parse node */
+	int			ndefaults;		/* number of IN parameters that have DEFAULT exprs */
+	List	   *analyzeddefaults; /* analyzed Expr list: one per IN param (NULL if no default) */
+} WithFuncEntry;
+
+/* -------------------------
+ * Phase 1: parse-analysis
+ * -------------------------
+ * Defined in src/backend/parser/parse_with_plsql.c (main backend)
+ */
+extern void transformWithFuncDefs(ParseState *pstate, List *plsql_defs);
+
+/* -------------------------
+ * Phase 2: call-site resolution hook (ParseSubprocFuncHook signature)
+ * -------------------------
+ * Defined in src/backend/parser/parse_with_plsql.c (main backend)
+ */
+extern int withFuncLookupHook(ParseState *pstate,
+							  List *funcname,
+							  List **fargs,
+							  List *fargnames,
+							  int nargs,
+							  Oid *argtypes,
+							  bool expand_variadic,
+							  bool expand_defaults,
+							  bool proc_call,
+							  Oid *funcid,
+							  Oid *rettype,
+							  bool *retset,
+							  int *nvargs,
+							  Oid *vatype,
+							  Oid **true_typeids,
+							  List **argdefaults,
+							  void **pfunc);
+
+/*
+ * plisql_active_with_func_estate — EState of the outermost query that owns the
+ * active WithFuncContainer.  Defined in parse_with_plsql.c (main backend) and
+ * set/restored by plisql_call_handler() (plisql.so) around each WITH function
+ * execution.  Used by ExecInitFunc() as a fallback when state->parent is NULL
+ * (i.e., when a WITH function is called recursively from inside a PL/iSQL
+ * simple-expression path that has no parent PlanState).
+ */
+extern struct EState *plisql_active_with_func_estate;
+
+/* -------------------------
+ * Phase 3: execution-time compilation
+ * -------------------------
+ * Defined in src/pl/plisql/src/pl_handler.c (plisql.so)
+ */
+
+/* Compile all WITH functions from estate->es_plannedstmt->withFuncDefs */
+extern WithFuncContainer *buildWithFuncContainer(struct EState *estate);
+
+/* Look up the compiled PLiSQL_function for a WITH-clause function call */
+extern struct PLiSQL_function *plisql_get_with_func(FunctionCallInfo fcinfo);
+
+#endif							/* ORA_WITH_FUNCTION_H */

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -223,6 +223,7 @@ struct ParseState
 	List	   *p_ctenamespace; /* current namespace for common table exprs */
 	List	   *p_future_ctes;	/* common table exprs not yet in namespace */
 	CommonTableExpr *p_parent_cte;	/* this query's containing CTE */
+	List	   *p_with_func_list;	/* WITH clause inline funcs (ORA_PARSER only) */
 	Relation	p_target_relation;	/* INSERT/UPDATE/DELETE/MERGE target rel */
 	ParseNamespaceItem *p_target_nsitem;	/* target rel's NSItem, or NULL */
 	ParseNamespaceItem *p_grouping_nsitem;	/* NSItem for grouping, or NULL */

--- a/src/oracle_fe_utils/ora_psqlscan.l
+++ b/src/oracle_fe_utils/ora_psqlscan.l
@@ -796,12 +796,66 @@ other			.
 				}
 
 ";"				{
+					bool	skip_this_semi = false;
+
 					/* update Symbol State */
 					if (cur_state->ora_plsql_expect_end_symbol == END_SYMBOL_SEMICOLON)
-						cur_state->ora_plsql_expect_end_symbol = END_SYMBOL_SLASH;
-					
+					{
+						if (cur_state->identifiers[0] == 'w' ||
+							cur_state->identifiers[0] == 'e')
+						{
+							/*
+							 * WITH FUNCTION/PROCEDURE (or EXPLAIN WITH ...): the
+							 * preceding END just decremented begin_depth, so we
+							 * can use it to distinguish an inner nested END from
+							 * the END that closes the body itself.
+							 *
+							 *   begin_depth == 0 → outer body fully closed;
+							 *     reset cancel and the identifier tracking so
+							 *     the upcoming SELECT/INSERT/etc. can terminate
+							 *     normally and so a subsequent FUNCTION/PROCEDURE
+							 *     definition in the same WITH clause is detected.
+							 *
+							 *   begin_depth > 0  → an inner BEGIN…END; — the body
+							 *     is still open.  Preserve cancel_semicolon_
+							 *     terminator and the identifier tracking so the
+							 *     outer END is still recognized; just clear
+							 *     expect_end_symbol and suppress this ';'.
+							 */
+							if (cur_state->begin_depth == 0)
+							{
+								cur_state->cancel_semicolon_terminator = false;
+								cur_state->ora_plsql_expect_end_symbol = END_SYMBOL_INVALID;
+								if (cur_state->identifiers[0] == 'e')
+								{
+									/* EXPLAIN WITH: preserve [0]='e' and [1]='w' */
+									cur_state->identifiers[2] = 0;
+									cur_state->identifiers[3] = 0;
+									cur_state->identifier_count = 2;
+								}
+								else
+								{
+									/* plain WITH: preserve [0]='w' */
+									cur_state->identifiers[1] = 0;
+									cur_state->identifiers[2] = 0;
+									cur_state->identifiers[3] = 0;
+									cur_state->identifier_count = 1;
+								}
+							}
+							else
+							{
+								/* nested END;: leave identifiers/cancel intact */
+								cur_state->ora_plsql_expect_end_symbol = END_SYMBOL_INVALID;
+							}
+							skip_this_semi = true;
+						}
+						else
+							cur_state->ora_plsql_expect_end_symbol = END_SYMBOL_SLASH;
+					}
+
 					ECHO;
-					if (cur_state->paren_depth == 0 &&
+					if (!skip_this_semi &&
+							cur_state->paren_depth == 0 &&
 							cur_state->begin_depth == 0 &&
 							!cur_state->cancel_semicolon_terminator)
 					{
@@ -1080,9 +1134,11 @@ other			.
 						memset(cur_state->identifiers, 0, sizeof(cur_state->identifiers));
 
 					if (pg_strcasecmp(yytext, "create") == 0 ||
+						pg_strcasecmp(yytext, "explain") == 0 ||
+						pg_strcasecmp(yytext, "with") == 0 ||
 						pg_strcasecmp(yytext, "function") == 0 ||
 						pg_strcasecmp(yytext, "procedure") == 0 ||
-						pg_strcasecmp(yytext, "package") == 0 || 
+						pg_strcasecmp(yytext, "package") == 0 ||
 						pg_strcasecmp(yytext, "or") == 0 ||
 						pg_strcasecmp(yytext, "replace") == 0)
 					{
@@ -1090,21 +1146,52 @@ other			.
 							cur_state->identifiers[cur_state->identifier_count] = pg_tolower((unsigned char) yytext[0]);
 					}
 					
-					/* Not final End state .This state needs to be cleared */
-					if (cur_state->ora_plsql_expect_end_symbol)
+					/*
+					 * If the previous token was END (expect_end_symbol ==
+					 * SEMICOLON) and this identifier is a control-flow
+					 * closer (IF / LOOP / CASE), this is END-of-inner-
+					 * structure — clear the state so the upcoming ';' is
+					 * treated as a regular non-terminating semicolon.
+					 *
+					 * Otherwise, when expect_end_symbol == SEMICOLON, leave
+					 * it intact so the labeled-END pattern (e.g. "END
+					 * my_func;") still triggers the WITH-clause termination
+					 * logic in the ';' rule.  For other non-zero states
+					 * (e.g. END_SYMBOL_SLASH set after a body semicolon in
+					 * CREATE FUNCTION), clear unconditionally as before.
+					 */
+					if (cur_state->ora_plsql_expect_end_symbol == END_SYMBOL_SEMICOLON)
+					{
+						if (pg_strcasecmp(yytext, "if") == 0 ||
+							pg_strcasecmp(yytext, "loop") == 0 ||
+							pg_strcasecmp(yytext, "case") == 0)
+							cur_state->ora_plsql_expect_end_symbol = END_SYMBOL_INVALID;
+						/* else: keep SEMICOLON for "END label;" pattern */
+					}
+					else if (cur_state->ora_plsql_expect_end_symbol)
 						cur_state->ora_plsql_expect_end_symbol = END_SYMBOL_INVALID;
 					/*
 					 * Simply discard EDITIONABLE and NONEDITIONABLE that occur in
 					 * the first 4 identifiers at the beginning of the command.
+					 * Also discard identifiers inside parentheses — this lets
+					 * EXPLAIN (COSTS OFF) WITH FUNCTION be recognized by the
+					 * scanner even though options appear between EXPLAIN and WITH.
 					 */
 					if (pg_strcasecmp(yytext, "editionable") != 0 &&
-						pg_strcasecmp(yytext, "noneditionable") != 0)
+						pg_strcasecmp(yytext, "noneditionable") != 0 &&
+						cur_state->paren_depth == 0)
 						cur_state->identifier_count++;
 
-					if (cur_state->identifiers[0] == 'c' &&
-						(cur_state->identifiers[1] == 'f' || cur_state->identifiers[1] == 'p' ||
-						 (cur_state->identifiers[1] == 'o' && cur_state->identifiers[2] == 'r' &&
-						  (cur_state->identifiers[3] == 'f' || cur_state->identifiers[3] == 'p'))) &&
+					if (((cur_state->identifiers[0] == 'c' &&
+						  (cur_state->identifiers[1] == 'f' || cur_state->identifiers[1] == 'p' ||
+						   (cur_state->identifiers[1] == 'o' && cur_state->identifiers[2] == 'r' &&
+							(cur_state->identifiers[3] == 'f' || cur_state->identifiers[3] == 'p')))) ||
+						 (cur_state->identifiers[0] == 'w' &&
+						  (cur_state->identifiers[1] == 'f' || cur_state->identifiers[1] == 'p')) ||
+						 /* EXPLAIN WITH FUNCTION/PROCEDURE */
+						 (cur_state->identifiers[0] == 'e' &&
+						  cur_state->identifiers[1] == 'w' &&
+						  (cur_state->identifiers[2] == 'f' || cur_state->identifiers[2] == 'p'))) &&
 						cur_state->paren_depth == 0)
 					{
 						/*

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -42,10 +42,10 @@ SELECT mul2(add1(3)) FROM dual;
  8
 (1 row)
 
--- T05: WITH FUNCTION/PROCEDURE reject OUT and IN OUT parameters.
+-- T05: WITH FUNCTION rejects OUT and IN OUT parameters; WITH PROCEDURE allows them.
 -- Oracle raises ORA-06572 for any SQL-callable function declared with an
--- OUT/IN OUT argument; WITH-clause subprograms run from inside SQL, so the
--- same rule applies.  Each of the three forms below is expected to error.
+-- OUT/IN OUT argument; WITH FUNCTION follows the same rule.  WITH PROCEDURE
+-- is exempt because procedures are not called directly from SQL expressions.
 WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
 BEGIN
   x := x * 3;
@@ -55,7 +55,7 @@ SELECT bump_inout(5) FROM dual;
 ERROR:  WITH FUNCTION "bump_inout" cannot declare OUT or IN OUT parameters
 LINE 1: WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
                       ^
-DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+DETAIL:  WITH FUNCTION subprograms are invoked directly from SQL expressions, which only accept IN parameters.
 HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
 WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
 BEGIN
@@ -66,18 +66,19 @@ SELECT bump_out(NULL) FROM dual;
 ERROR:  WITH FUNCTION "bump_out" cannot declare OUT or IN OUT parameters
 LINE 1: WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
                       ^
-DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+DETAIL:  WITH FUNCTION subprograms are invoked directly from SQL expressions, which only accept IN parameters.
 HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+-- WITH PROCEDURE with an OUT parameter is valid (matches Oracle behaviour).
 WITH PROCEDURE set_val(x OUT NUMBER) IS
 BEGIN
   x := 1;
 END;
 SELECT 'unused' FROM dual;
-ERROR:  WITH PROCEDURE "set_val" cannot declare OUT or IN OUT parameters
-LINE 1: WITH PROCEDURE set_val(x OUT NUMBER) IS
-                       ^
-DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
-HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+ ?column? 
+----------
+ unused
+(1 row)
+
 -- T06: Default parameter value — call with one arg (uses default) and two args
 WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS
 BEGIN RETURN greeting || ', ' || name || '!'; END;

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -1,0 +1,363 @@
+\set SHOW_CONTEXT never
+-- T01: Basic WITH FUNCTION returning a number
+WITH FUNCTION double_it(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 2; END;
+SELECT double_it(5) FROM dual;
+ double_it 
+-----------
+ 10
+(1 row)
+
+-- T02: WITH PROCEDURE (void — verified via side-effect SELECT)
+WITH PROCEDURE do_nothing IS
+BEGIN
+  NULL;
+END;
+SELECT 'procedure ok' AS result FROM dual;
+    result    
+--------------
+ procedure ok
+(1 row)
+
+-- T03: WITH FUNCTION mixed with a regular CTE
+WITH
+  FUNCTION tax(amt NUMBER) RETURN NUMBER IS
+  BEGIN RETURN amt * 0.1; END;
+  orders AS (SELECT 100 AS amount FROM dual)
+SELECT amount, tax(amount) FROM orders;
+ amount | tax  
+--------+------
+    100 | 10.0
+(1 row)
+
+-- T04: Multiple WITH FUNCTION definitions composed
+WITH
+  FUNCTION add1(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n + 1; END;
+  FUNCTION mul2(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n * 2; END;
+SELECT mul2(add1(3)) FROM dual;
+ mul2 
+------
+ 8
+(1 row)
+
+-- T05: IN OUT parameter (value is modified inside the body)
+WITH FUNCTION bump(x IN OUT NUMBER) RETURN NUMBER IS
+BEGIN
+  x := x * 3;
+  RETURN x;
+END;
+SELECT bump(5) FROM dual;
+ bump 
+------
+ 15
+(1 row)
+
+-- T06: Default parameter value — call with one arg (uses default) and two args
+WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS
+BEGIN RETURN greeting || ', ' || name || '!'; END;
+SELECT greet('World'), greet('World', 'Hi') FROM dual;
+     greet     |   greet    
+---------------+------------
+ Hello, World! | Hi, World!
+(1 row)
+
+-- T07: Multiple parameters
+WITH FUNCTION add_nums(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a + b;
+END;
+SELECT add_nums(3, 4) FROM dual;
+ add_nums 
+----------
+ 7
+(1 row)
+
+-- T08: IF/ELSE control flow
+WITH FUNCTION abs_val(n NUMBER) RETURN NUMBER IS
+BEGIN
+  IF n < 0 THEN RETURN -n; ELSE RETURN n; END IF;
+END;
+SELECT abs_val(-5), abs_val(3) FROM dual;
+ abs_val | abs_val 
+---------+---------
+ 5       | 3
+(1 row)
+
+-- T09: LOOP construct (iterative factorial)
+WITH FUNCTION loop_fact(n NUMBER) RETURN NUMBER IS
+  result NUMBER := 1;
+  i NUMBER;
+BEGIN
+  FOR i IN 1..n LOOP
+    result := result * i;
+  END LOOP;
+  RETURN result;
+END;
+SELECT loop_fact(5) FROM dual;
+ loop_fact 
+-----------
+ 120
+(1 row)
+
+-- T10: Recursive function call (factorial via recursion)
+WITH FUNCTION factorial(n NUMBER) RETURN NUMBER IS
+BEGIN
+  IF n <= 1 THEN RETURN 1; END IF;
+  RETURN n * factorial(n-1);
+END;
+SELECT factorial(5) FROM dual;
+ factorial 
+-----------
+ 120
+(1 row)
+
+-- T11: EXCEPTION WHEN handler
+WITH FUNCTION safe_div(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a / b;
+EXCEPTION
+  WHEN OTHERS THEN RETURN NULL;
+END;
+SELECT safe_div(10, 2), safe_div(10, 0) FROM dual;
+      safe_div      | safe_div 
+--------------------+----------
+ 5.0000000000000000 | 
+(1 row)
+
+-- T12: Runtime error propagation (unhandled exception reaches caller)
+WITH FUNCTION bad_div(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a / b;
+END;
+SELECT bad_div(1, 0) FROM dual;
+ERROR:  division by zero
+-- T13: WITH FUNCTION inside INSERT...SELECT
+CREATE TABLE _wf_dml_test (val NUMBER);
+WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN n * 3;
+END;
+INSERT INTO _wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
+SELECT * FROM _wf_dml_test ORDER BY val;
+ val 
+-----
+ 3
+ 6
+ 9
+ 12
+(4 rows)
+
+DROP TABLE _wf_dml_test;
+-- T14: WITH FUNCTION inside UPDATE...SET
+CREATE TABLE _wf_upd_test (id INT, val NUMBER);
+INSERT INTO _wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
+WITH FUNCTION halve(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n / 2; END;
+UPDATE _wf_upd_test SET val = halve(val);
+SELECT id, val FROM _wf_upd_test ORDER BY id;
+ id |         val         
+----+---------------------
+  1 | 5.0000000000000000
+  2 | 10.0000000000000000
+  3 | 15.0000000000000000
+(3 rows)
+
+DROP TABLE _wf_upd_test;
+-- T15: WITH FUNCTION inside DELETE...WHERE
+CREATE TABLE _wf_del_test (id INT, val NUMBER);
+INSERT INTO _wf_del_test VALUES (1, 5), (2, 15), (3, 25);
+WITH FUNCTION is_big(n NUMBER) RETURN NUMBER IS
+BEGIN IF n > 10 THEN RETURN 1; ELSE RETURN 0; END IF; END;
+DELETE FROM _wf_del_test WHERE is_big(val) = 1;
+SELECT id, val FROM _wf_del_test ORDER BY id;
+ id | val 
+----+-----
+  1 | 5
+(1 row)
+
+DROP TABLE _wf_del_test;
+-- T16: WITH FUNCTION inside MERGE WHEN MATCHED THEN UPDATE
+CREATE TABLE _wf_merge_test (id INT, val NUMBER);
+INSERT INTO _wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
+WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 3; END;
+MERGE INTO _wf_merge_test t USING dual ON (1=1)
+WHEN MATCHED THEN UPDATE SET val = triple(t.val);
+SELECT id, val FROM _wf_merge_test ORDER BY id;
+ id | val 
+----+-----
+  1 | 30
+  2 | 60
+  3 | 90
+(3 rows)
+
+DROP TABLE _wf_merge_test;
+-- T17: WITH FUNCTION scope — function works inside its statement,
+-- and is no longer visible in a separate statement afterward.
+WITH FUNCTION _wf_scope_test(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 42; END;
+SELECT _wf_scope_test(1) FROM dual;
+ _wf_scope_test 
+----------------
+ 43
+(1 row)
+
+-- Separate statement: same name should now fail because the WITH-clause
+-- definition went out of scope when the previous statement completed.
+SELECT _wf_scope_test(1) FROM dual;
+ERROR:  function _wf_scope_test(pg_catalog.int4) does not exist
+LINE 1: SELECT _wf_scope_test(1) FROM dual;
+               ^
+DETAIL:  There is no function of that name.
+-- T18: WITH FUNCTION shadows a catalog function of the same name
+WITH FUNCTION abs(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN 999; END;
+SELECT abs(-5) FROM dual;
+ abs 
+-----
+ 999
+(1 row)
+
+-- T19: WITH FUNCTION visible inside a subquery
+WITH FUNCTION add2(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 2; END;
+SELECT add2(v) FROM (SELECT 10 AS v FROM dual) sub;
+ add2 
+------
+ 12
+(1 row)
+
+-- E01: Duplicate WITH FUNCTION definition (same name and types) — expect error
+WITH
+  FUNCTION dup(n NUMBER) RETURN NUMBER IS BEGIN RETURN n; END;
+  FUNCTION dup(n NUMBER) RETURN NUMBER IS BEGIN RETURN n * 2; END;
+SELECT dup(1) FROM dual;
+ERROR:  WITH clause function "dup" is defined more than once with the same argument types
+-- E02: Return type mismatch — function returns NUMBER but body returns text — expect error
+WITH FUNCTION bad_ret(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN 'hello'; END;
+SELECT bad_ret(1) FROM dual;
+ERROR:  invalid input syntax for type numeric: "hello"
+-- E03: Wrong argument type at call site — expect error
+WITH FUNCTION only_nums(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT only_nums('not a number') FROM dual;
+ERROR:  invalid input syntax for type numeric: "not a number"
+LINE 3: SELECT only_nums('not a number') FROM dual;
+                         ^
+-- E04: WITH FUNCTION syntax in PG_PARSER mode — expect error
+SET ivorysql.compatible_mode = pg;
+WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
+BEGIN RETURN n; END;
+SELECT pg_mode_test(1);
+ERROR:  syntax error at or near "pg_mode_test"
+LINE 1: WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
+                      ^
+SET ivorysql.compatible_mode = oracle;
+-- E05: Syntax error in function body — expect error
+WITH FUNCTION broken_body(n NUMBER) RETURN NUMBER IS
+BEGIN RETRUN n; END;
+SELECT broken_body(1) FROM dual;
+ERROR:  syntax error at or near "RETRUN"
+LINE 1: BEGIN RETRUN n; END
+              ^
+QUERY:  BEGIN RETRUN n; END
+-- E06: WITH function used as a table function — expect clear error
+WITH FUNCTION as_table(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT * FROM as_table(5);
+ERROR:  WITH clause function cannot be used as a table or set-returning function
+HINT:  WITH FUNCTION/PROCEDURE definitions can only be invoked from scalar expression contexts.
+-- T20: Nested BEGIN…END inside WITH FUNCTION body
+-- (inner END; must not dismantle WITH-clause tracking on the client side)
+WITH FUNCTION nested_begin(n NUMBER) RETURN NUMBER IS
+BEGIN
+  BEGIN
+    RETURN n * 2;
+  END;
+END;
+SELECT nested_begin(5) FROM dual;
+ nested_begin 
+--------------
+ 10
+(1 row)
+
+-- E07: Qualified name in WITH FUNCTION declaration — expect clear error
+WITH FUNCTION public.qual_func(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT public.qual_func(5) FROM dual;
+ERROR:  qualified name is not allowed in WITH FUNCTION declaration
+LINE 1: WITH FUNCTION public.qual_func(n NUMBER) RETURN NUMBER IS
+                      ^
+-- E08: Qualified name in WITH PROCEDURE declaration — expect clear error
+WITH PROCEDURE public.qual_proc IS
+BEGIN NULL; END;
+SELECT 'unused' FROM dual;
+ERROR:  qualified name is not allowed in WITH PROCEDURE declaration
+LINE 1: WITH PROCEDURE public.qual_proc IS
+                       ^
+-- E09: WITH-clause names must NOT leak into catalog functions called from
+-- within the WITH execution frame.  catalog_caller is a regular PL/iSQL
+-- function whose body references _wf_leak_target.  When invoked from inside
+-- a WITH FUNCTION body, the WITH-clause name must remain invisible to the
+-- catalog function's lexical scope.
+CREATE OR REPLACE FUNCTION catalog_caller(n NUMBER) RETURN NUMBER IS
+  result NUMBER;
+BEGIN
+  result := _wf_leak_target(n);
+  RETURN result;
+END;
+/
+WITH
+  FUNCTION _wf_leak_target(x NUMBER) RETURN NUMBER IS
+  BEGIN RETURN x + 1000; END;
+  FUNCTION calls_catalog(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN catalog_caller(n); END;
+SELECT calls_catalog(5) FROM dual;
+ERROR:  function _wf_leak_target(number) does not exist
+LINE 1: result := _wf_leak_target(n)
+                  ^
+DETAIL:  There is no function of that name.
+QUERY:  result := _wf_leak_target(n)
+DROP FUNCTION catalog_caller;
+-- X01: EXPLAIN shows WITH Function/Procedure signatures
+EXPLAIN (COSTS OFF)
+WITH FUNCTION double_it(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 2; END;
+SELECT double_it(5) FROM dual;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Seq Scan on dual
+ WITH Function: double_it(n sys.number) RETURN sys.number
+(2 rows)
+
+-- X02: EXPLAIN shows multiple WITH definitions
+EXPLAIN (COSTS OFF)
+WITH
+  FUNCTION add1(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n + 1; END;
+  PROCEDURE do_nothing IS
+  BEGIN NULL; END;
+SELECT add1(1) FROM dual;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Seq Scan on dual
+ WITH Function: add1(n sys.number) RETURN sys.number
+ WITH Procedure: do_nothing()
+(3 rows)
+
+-- X03: EXPLAIN VERBOSE shows function body in TEXT mode
+EXPLAIN (COSTS OFF, VERBOSE)
+WITH FUNCTION shows_body(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 100; END;
+SELECT shows_body(5) FROM dual;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Seq Scan on sys.dual
+   Output: (null)(VARIADIC (5)::number)
+ WITH Function: shows_body(n sys.number) RETURN sys.number
+   Body: BEGIN RETURN n + 100; END
+(4 rows)
+

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -159,13 +159,13 @@ END;
 SELECT bad_div(1, 0) FROM dual;
 ERROR:  division by zero
 -- T13: WITH FUNCTION inside INSERT...SELECT
-CREATE TABLE _wf_dml_test (val NUMBER);
+CREATE TABLE wf_dml_test (val NUMBER);
 WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
 BEGIN
   RETURN n * 3;
 END;
-INSERT INTO _wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
-SELECT * FROM _wf_dml_test ORDER BY val;
+INSERT INTO wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
+SELECT * FROM wf_dml_test ORDER BY val;
  val 
 -----
  3
@@ -174,14 +174,14 @@ SELECT * FROM _wf_dml_test ORDER BY val;
  12
 (4 rows)
 
-DROP TABLE _wf_dml_test;
+DROP TABLE wf_dml_test;
 -- T14: WITH FUNCTION inside UPDATE...SET
-CREATE TABLE _wf_upd_test (id INT, val NUMBER);
-INSERT INTO _wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE wf_upd_test (id INT, val NUMBER);
+INSERT INTO wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
 WITH FUNCTION halve(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n / 2; END;
-UPDATE _wf_upd_test SET val = halve(val);
-SELECT id, val FROM _wf_upd_test ORDER BY id;
+UPDATE wf_upd_test SET val = halve(val);
+SELECT id, val FROM wf_upd_test ORDER BY id;
  id |         val         
 ----+---------------------
   1 | 5.0000000000000000
@@ -189,28 +189,28 @@ SELECT id, val FROM _wf_upd_test ORDER BY id;
   3 | 15.0000000000000000
 (3 rows)
 
-DROP TABLE _wf_upd_test;
+DROP TABLE wf_upd_test;
 -- T15: WITH FUNCTION inside DELETE...WHERE
-CREATE TABLE _wf_del_test (id INT, val NUMBER);
-INSERT INTO _wf_del_test VALUES (1, 5), (2, 15), (3, 25);
+CREATE TABLE wf_del_test (id INT, val NUMBER);
+INSERT INTO wf_del_test VALUES (1, 5), (2, 15), (3, 25);
 WITH FUNCTION is_big(n NUMBER) RETURN NUMBER IS
 BEGIN IF n > 10 THEN RETURN 1; ELSE RETURN 0; END IF; END;
-DELETE FROM _wf_del_test WHERE is_big(val) = 1;
-SELECT id, val FROM _wf_del_test ORDER BY id;
+DELETE FROM wf_del_test WHERE is_big(val) = 1;
+SELECT id, val FROM wf_del_test ORDER BY id;
  id | val 
 ----+-----
   1 | 5
 (1 row)
 
-DROP TABLE _wf_del_test;
+DROP TABLE wf_del_test;
 -- T16: WITH FUNCTION inside MERGE WHEN MATCHED THEN UPDATE
-CREATE TABLE _wf_merge_test (id INT, val NUMBER);
-INSERT INTO _wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE wf_merge_test (id INT, val NUMBER);
+INSERT INTO wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
 WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n * 3; END;
-MERGE INTO _wf_merge_test t USING dual ON (1=1)
+MERGE INTO wf_merge_test t USING dual ON (1=1)
 WHEN MATCHED THEN UPDATE SET val = triple(t.val);
-SELECT id, val FROM _wf_merge_test ORDER BY id;
+SELECT id, val FROM wf_merge_test ORDER BY id;
  id | val 
 ----+-----
   1 | 30
@@ -218,22 +218,22 @@ SELECT id, val FROM _wf_merge_test ORDER BY id;
   3 | 90
 (3 rows)
 
-DROP TABLE _wf_merge_test;
+DROP TABLE wf_merge_test;
 -- T17: WITH FUNCTION scope — function works inside its statement,
 -- and is no longer visible in a separate statement afterward.
-WITH FUNCTION _wf_scope_test(n NUMBER) RETURN NUMBER IS
+WITH FUNCTION wf_scope_test(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n + 42; END;
-SELECT _wf_scope_test(1) FROM dual;
- _wf_scope_test 
+SELECT wf_scope_test(1) FROM dual;
+ wf_scope_test 
 ----------------
  43
 (1 row)
 
 -- Separate statement: same name should now fail because the WITH-clause
 -- definition went out of scope when the previous statement completed.
-SELECT _wf_scope_test(1) FROM dual;
-ERROR:  function _wf_scope_test(pg_catalog.int4) does not exist
-LINE 1: SELECT _wf_scope_test(1) FROM dual;
+SELECT wf_scope_test(1) FROM dual;
+ERROR:  function wf_scope_test(pg_catalog.int4) does not exist
+LINE 1: SELECT wf_scope_test(1) FROM dual;
                ^
 DETAIL:  There is no function of that name.
 -- T18: WITH FUNCTION does not shadow a catalog function of the same name
@@ -325,27 +325,27 @@ LINE 1: WITH PROCEDURE public.qual_proc IS
                        ^
 -- E09: WITH-clause names must NOT leak into catalog functions called from
 -- within the WITH execution frame.  catalog_caller is a regular PL/iSQL
--- function whose body references _wf_leak_target.  When invoked from inside
+-- function whose body references wf_leak_target.  When invoked from inside
 -- a WITH FUNCTION body, the WITH-clause name must remain invisible to the
 -- catalog function's lexical scope.
 CREATE OR REPLACE FUNCTION catalog_caller(n NUMBER) RETURN NUMBER IS
   result NUMBER;
 BEGIN
-  result := _wf_leak_target(n);
+  result := wf_leak_target(n);
   RETURN result;
 END;
 /
 WITH
-  FUNCTION _wf_leak_target(x NUMBER) RETURN NUMBER IS
+  FUNCTION wf_leak_target(x NUMBER) RETURN NUMBER IS
   BEGIN RETURN x + 1000; END;
   FUNCTION calls_catalog(n NUMBER) RETURN NUMBER IS
   BEGIN RETURN catalog_caller(n); END;
 SELECT calls_catalog(5) FROM dual;
-ERROR:  function _wf_leak_target(number) does not exist
-LINE 1: result := _wf_leak_target(n)
+ERROR:  function wf_leak_target(number) does not exist
+LINE 1: result := wf_leak_target(n)
                   ^
 DETAIL:  There is no function of that name.
-QUERY:  result := _wf_leak_target(n)
+QUERY:  result := wf_leak_target(n)
 DROP FUNCTION catalog_caller;
 -- X01: EXPLAIN shows WITH Function/Procedure signatures
 EXPLAIN (COSTS OFF)

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -42,18 +42,42 @@ SELECT mul2(add1(3)) FROM dual;
  8
 (1 row)
 
--- T05: IN OUT parameter (value is modified inside the body)
-WITH FUNCTION bump(x IN OUT NUMBER) RETURN NUMBER IS
+-- T05: WITH FUNCTION/PROCEDURE reject OUT and IN OUT parameters.
+-- Oracle raises ORA-06572 for any SQL-callable function declared with an
+-- OUT/IN OUT argument; WITH-clause subprograms run from inside SQL, so the
+-- same rule applies.  Each of the three forms below is expected to error.
+WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
 BEGIN
   x := x * 3;
   RETURN x;
 END;
-SELECT bump(5) FROM dual;
- bump 
-------
- 15
-(1 row)
-
+SELECT bump_inout(5) FROM dual;
+ERROR:  WITH FUNCTION "bump_inout" cannot declare OUT or IN OUT parameters
+LINE 1: WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
+                      ^
+DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
+BEGIN
+  x := 7;
+  RETURN x;
+END;
+SELECT bump_out(NULL) FROM dual;
+ERROR:  WITH FUNCTION "bump_out" cannot declare OUT or IN OUT parameters
+LINE 1: WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
+                      ^
+DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+WITH PROCEDURE set_val(x OUT NUMBER) IS
+BEGIN
+  x := 1;
+END;
+SELECT 'unused' FROM dual;
+ERROR:  WITH PROCEDURE "set_val" cannot declare OUT or IN OUT parameters
+LINE 1: WITH PROCEDURE set_val(x OUT NUMBER) IS
+                       ^
+DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
 -- T06: Default parameter value — call with one arg (uses default) and two args
 WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS
 BEGIN RETURN greeting || ', ' || name || '!'; END;

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -225,7 +225,7 @@ WITH FUNCTION wf_scope_test(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n + 42; END;
 SELECT wf_scope_test(1) FROM dual;
  wf_scope_test 
-----------------
+---------------
  43
 (1 row)
 
@@ -283,12 +283,12 @@ LINE 1: WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
 SET ivorysql.compatible_mode = oracle;
 -- E05: Syntax error in function body — expect error
 WITH FUNCTION broken_body(n NUMBER) RETURN NUMBER IS
-BEGIN RETRUN n; END;
+BEGIN RETURN n + ; END;
 SELECT broken_body(1) FROM dual;
-ERROR:  syntax error at or near "RETRUN"
-LINE 1: BEGIN RETRUN n; END
-              ^
-QUERY:  BEGIN RETRUN n; END
+ERROR:  syntax error at end of input
+LINE 1: BEGIN RETURN n + ; END
+                        ^
+QUERY:  BEGIN RETURN n + ; END
 -- E06: WITH function used as a table function — expect clear error
 WITH FUNCTION as_table(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n; END;

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -236,13 +236,13 @@ ERROR:  function _wf_scope_test(pg_catalog.int4) does not exist
 LINE 1: SELECT _wf_scope_test(1) FROM dual;
                ^
 DETAIL:  There is no function of that name.
--- T18: WITH FUNCTION shadows a catalog function of the same name
+-- T18: WITH FUNCTION does not shadow a catalog function of the same name
 WITH FUNCTION abs(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN 999; END;
 SELECT abs(-5) FROM dual;
  abs 
 -----
- 999
+   5
 (1 row)
 
 -- T19: WITH FUNCTION visible inside a subquery

--- a/src/oracle_test/regress/expected/with_function_1.out
+++ b/src/oracle_test/regress/expected/with_function_1.out
@@ -42,10 +42,10 @@ SELECT mul2(add1(3)) FROM dual;
  8
 (1 row)
 
--- T05: WITH FUNCTION/PROCEDURE reject OUT and IN OUT parameters.
+-- T05: WITH FUNCTION rejects OUT and IN OUT parameters; WITH PROCEDURE allows them.
 -- Oracle raises ORA-06572 for any SQL-callable function declared with an
--- OUT/IN OUT argument; WITH-clause subprograms run from inside SQL, so the
--- same rule applies.  Each of the three forms below is expected to error.
+-- OUT/IN OUT argument; WITH FUNCTION follows the same rule.  WITH PROCEDURE
+-- is exempt because procedures are not called directly from SQL expressions.
 WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
 BEGIN
   x := x * 3;
@@ -55,7 +55,7 @@ SELECT bump_inout(5) FROM dual;
 ERROR:  WITH FUNCTION "bump_inout" cannot declare OUT or IN OUT parameters
 LINE 1: WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
                       ^
-DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+DETAIL:  WITH FUNCTION subprograms are invoked directly from SQL expressions, which only accept IN parameters.
 HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
 WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
 BEGIN
@@ -66,18 +66,19 @@ SELECT bump_out(NULL) FROM dual;
 ERROR:  WITH FUNCTION "bump_out" cannot declare OUT or IN OUT parameters
 LINE 1: WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
                       ^
-DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+DETAIL:  WITH FUNCTION subprograms are invoked directly from SQL expressions, which only accept IN parameters.
 HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+-- WITH PROCEDURE with an OUT parameter is valid (matches Oracle behaviour).
 WITH PROCEDURE set_val(x OUT NUMBER) IS
 BEGIN
   x := 1;
 END;
 SELECT 'unused' FROM dual;
-ERROR:  WITH PROCEDURE "set_val" cannot declare OUT or IN OUT parameters
-LINE 1: WITH PROCEDURE set_val(x OUT NUMBER) IS
-                       ^
-DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
-HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+ ?column? 
+----------
+ unused
+(1 row)
+
 -- T06: Default parameter value — call with one arg (uses default) and two args
 WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS
 BEGIN RETURN greeting || ', ' || name || '!'; END;

--- a/src/oracle_test/regress/expected/with_function_1.out
+++ b/src/oracle_test/regress/expected/with_function_1.out
@@ -1,0 +1,363 @@
+\set SHOW_CONTEXT never
+-- T01: Basic WITH FUNCTION returning a number
+WITH FUNCTION double_it(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 2; END;
+SELECT double_it(5) FROM dual;
+ double_it 
+-----------
+ 10
+(1 row)
+
+-- T02: WITH PROCEDURE (void — verified via side-effect SELECT)
+WITH PROCEDURE do_nothing IS
+BEGIN
+  NULL;
+END;
+SELECT 'procedure ok' AS result FROM dual;
+    result    
+--------------
+ procedure ok
+(1 row)
+
+-- T03: WITH FUNCTION mixed with a regular CTE
+WITH
+  FUNCTION tax(amt NUMBER) RETURN NUMBER IS
+  BEGIN RETURN amt * 0.1; END;
+  orders AS (SELECT 100 AS amount FROM dual)
+SELECT amount, tax(amount) FROM orders;
+ amount | tax  
+--------+------
+    100 | 10.0
+(1 row)
+
+-- T04: Multiple WITH FUNCTION definitions composed
+WITH
+  FUNCTION add1(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n + 1; END;
+  FUNCTION mul2(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n * 2; END;
+SELECT mul2(add1(3)) FROM dual;
+ mul2 
+------
+ 8
+(1 row)
+
+-- T05: IN OUT parameter (value is modified inside the body)
+WITH FUNCTION bump(x IN OUT NUMBER) RETURN NUMBER IS
+BEGIN
+  x := x * 3;
+  RETURN x;
+END;
+SELECT bump(5) FROM dual;
+ bump 
+------
+ 15
+(1 row)
+
+-- T06: Default parameter value — call with one arg (uses default) and two args
+WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS
+BEGIN RETURN greeting || ', ' || name || '!'; END;
+SELECT greet('World'), greet('World', 'Hi') FROM dual;
+     greet     |   greet    
+---------------+------------
+ Hello, World! | Hi, World!
+(1 row)
+
+-- T07: Multiple parameters
+WITH FUNCTION add_nums(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a + b;
+END;
+SELECT add_nums(3, 4) FROM dual;
+ add_nums 
+----------
+ 7
+(1 row)
+
+-- T08: IF/ELSE control flow
+WITH FUNCTION abs_val(n NUMBER) RETURN NUMBER IS
+BEGIN
+  IF n < 0 THEN RETURN -n; ELSE RETURN n; END IF;
+END;
+SELECT abs_val(-5), abs_val(3) FROM dual;
+ abs_val | abs_val 
+---------+---------
+ 5       | 3
+(1 row)
+
+-- T09: LOOP construct (iterative factorial)
+WITH FUNCTION loop_fact(n NUMBER) RETURN NUMBER IS
+  result NUMBER := 1;
+  i NUMBER;
+BEGIN
+  FOR i IN 1..n LOOP
+    result := result * i;
+  END LOOP;
+  RETURN result;
+END;
+SELECT loop_fact(5) FROM dual;
+ loop_fact 
+-----------
+ 120
+(1 row)
+
+-- T10: Recursive function call (factorial via recursion)
+WITH FUNCTION factorial(n NUMBER) RETURN NUMBER IS
+BEGIN
+  IF n <= 1 THEN RETURN 1; END IF;
+  RETURN n * factorial(n-1);
+END;
+SELECT factorial(5) FROM dual;
+ factorial 
+-----------
+ 120
+(1 row)
+
+-- T11: EXCEPTION WHEN handler
+WITH FUNCTION safe_div(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a / b;
+EXCEPTION
+  WHEN OTHERS THEN RETURN NULL;
+END;
+SELECT safe_div(10, 2), safe_div(10, 0) FROM dual;
+      safe_div      | safe_div 
+--------------------+----------
+ 5.0000000000000000 | 
+(1 row)
+
+-- T12: Runtime error propagation (unhandled exception reaches caller)
+WITH FUNCTION bad_div(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a / b;
+END;
+SELECT bad_div(1, 0) FROM dual;
+ERROR:  division by zero
+-- T13: WITH FUNCTION inside INSERT...SELECT
+CREATE TABLE _wf_dml_test (val NUMBER);
+WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN n * 3;
+END;
+INSERT INTO _wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
+SELECT * FROM _wf_dml_test ORDER BY val;
+ val 
+-----
+ 3
+ 6
+ 9
+ 12
+(4 rows)
+
+DROP TABLE _wf_dml_test;
+-- T14: WITH FUNCTION inside UPDATE...SET
+CREATE TABLE _wf_upd_test (id INT, val NUMBER);
+INSERT INTO _wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
+WITH FUNCTION halve(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n / 2; END;
+UPDATE _wf_upd_test SET val = halve(val);
+SELECT id, val FROM _wf_upd_test ORDER BY id;
+ id |         val         
+----+---------------------
+  1 | 5.0000000000000000
+  2 | 10.0000000000000000
+  3 | 15.0000000000000000
+(3 rows)
+
+DROP TABLE _wf_upd_test;
+-- T15: WITH FUNCTION inside DELETE...WHERE
+CREATE TABLE _wf_del_test (id INT, val NUMBER);
+INSERT INTO _wf_del_test VALUES (1, 5), (2, 15), (3, 25);
+WITH FUNCTION is_big(n NUMBER) RETURN NUMBER IS
+BEGIN IF n > 10 THEN RETURN 1; ELSE RETURN 0; END IF; END;
+DELETE FROM _wf_del_test WHERE is_big(val) = 1;
+SELECT id, val FROM _wf_del_test ORDER BY id;
+ id | val 
+----+-----
+  1 | 5
+(1 row)
+
+DROP TABLE _wf_del_test;
+-- T16: WITH FUNCTION inside MERGE WHEN MATCHED THEN UPDATE
+CREATE TABLE _wf_merge_test (id INT, val NUMBER);
+INSERT INTO _wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
+WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 3; END;
+MERGE INTO _wf_merge_test t USING dual ON (1=1)
+WHEN MATCHED THEN UPDATE SET val = triple(t.val);
+SELECT id, val FROM _wf_merge_test ORDER BY id;
+ id | val 
+----+-----
+  1 | 30
+  2 | 60
+  3 | 90
+(3 rows)
+
+DROP TABLE _wf_merge_test;
+-- T17: WITH FUNCTION scope — function works inside its statement,
+-- and is no longer visible in a separate statement afterward.
+WITH FUNCTION _wf_scope_test(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 42; END;
+SELECT _wf_scope_test(1) FROM dual;
+ _wf_scope_test 
+----------------
+ 43
+(1 row)
+
+-- Separate statement: same name should now fail because the WITH-clause
+-- definition went out of scope when the previous statement completed.
+SELECT _wf_scope_test(1) FROM dual;
+ERROR:  function _wf_scope_test(pg_catalog.int4) does not exist
+LINE 1: SELECT _wf_scope_test(1) FROM dual;
+               ^
+DETAIL:  There is no function of that name.
+-- T18: WITH FUNCTION shadows a catalog function of the same name
+WITH FUNCTION abs(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN 999; END;
+SELECT abs(-5) FROM dual;
+ abs 
+-----
+ 999
+(1 row)
+
+-- T19: WITH FUNCTION visible inside a subquery
+WITH FUNCTION add2(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 2; END;
+SELECT add2(v) FROM (SELECT 10 AS v FROM dual) sub;
+ add2 
+------
+ 12
+(1 row)
+
+-- E01: Duplicate WITH FUNCTION definition (same name and types) — expect error
+WITH
+  FUNCTION dup(n NUMBER) RETURN NUMBER IS BEGIN RETURN n; END;
+  FUNCTION dup(n NUMBER) RETURN NUMBER IS BEGIN RETURN n * 2; END;
+SELECT dup(1) FROM dual;
+ERROR:  WITH clause function "dup" is defined more than once with the same argument types
+-- E02: Return type mismatch — function returns NUMBER but body returns text — expect error
+WITH FUNCTION bad_ret(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN 'hello'; END;
+SELECT bad_ret(1) FROM dual;
+ERROR:  invalid input syntax for type numeric: "hello"
+-- E03: Wrong argument type at call site — expect error
+WITH FUNCTION only_nums(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT only_nums('not a number') FROM dual;
+ERROR:  invalid input syntax for type numeric: "not a number"
+LINE 3: SELECT only_nums('not a number') FROM dual;
+                         ^
+-- E04: WITH FUNCTION syntax in PG_PARSER mode — expect error
+SET ivorysql.compatible_mode = pg;
+WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
+BEGIN RETURN n; END;
+SELECT pg_mode_test(1);
+ERROR:  syntax error at or near "pg_mode_test"
+LINE 1: WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
+                      ^
+SET ivorysql.compatible_mode = oracle;
+-- E05: Syntax error in function body — expect error
+WITH FUNCTION broken_body(n NUMBER) RETURN NUMBER IS
+BEGIN RETRUN n; END;
+SELECT broken_body(1) FROM dual;
+ERROR:  syntax error at or near "RETRUN"
+LINE 1: BEGIN RETRUN n; END
+              ^
+QUERY:  BEGIN RETRUN n; END
+-- E06: WITH function used as a table function — expect clear error
+WITH FUNCTION as_table(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT * FROM as_table(5);
+ERROR:  WITH clause function cannot be used as a table or set-returning function
+HINT:  WITH FUNCTION/PROCEDURE definitions can only be invoked from scalar expression contexts.
+-- T20: Nested BEGIN…END inside WITH FUNCTION body
+-- (inner END; must not dismantle WITH-clause tracking on the client side)
+WITH FUNCTION nested_begin(n NUMBER) RETURN NUMBER IS
+BEGIN
+  BEGIN
+    RETURN n * 2;
+  END;
+END;
+SELECT nested_begin(5) FROM dual;
+ nested_begin 
+--------------
+ 10
+(1 row)
+
+-- E07: Qualified name in WITH FUNCTION declaration — expect clear error
+WITH FUNCTION public.qual_func(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT public.qual_func(5) FROM dual;
+ERROR:  qualified name is not allowed in WITH FUNCTION declaration
+LINE 1: WITH FUNCTION public.qual_func(n NUMBER) RETURN NUMBER IS
+                      ^
+-- E08: Qualified name in WITH PROCEDURE declaration — expect clear error
+WITH PROCEDURE public.qual_proc IS
+BEGIN NULL; END;
+SELECT 'unused' FROM dual;
+ERROR:  qualified name is not allowed in WITH PROCEDURE declaration
+LINE 1: WITH PROCEDURE public.qual_proc IS
+                       ^
+-- E09: WITH-clause names must NOT leak into catalog functions called from
+-- within the WITH execution frame.  catalog_caller is a regular PL/iSQL
+-- function whose body references _wf_leak_target.  When invoked from inside
+-- a WITH FUNCTION body, the WITH-clause name must remain invisible to the
+-- catalog function's lexical scope.
+CREATE OR REPLACE FUNCTION catalog_caller(n NUMBER) RETURN NUMBER IS
+  result NUMBER;
+BEGIN
+  result := _wf_leak_target(n);
+  RETURN result;
+END;
+/
+WITH
+  FUNCTION _wf_leak_target(x NUMBER) RETURN NUMBER IS
+  BEGIN RETURN x + 1000; END;
+  FUNCTION calls_catalog(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN catalog_caller(n); END;
+SELECT calls_catalog(5) FROM dual;
+ERROR:  function _wf_leak_target(number) does not exist
+LINE 1: result := _wf_leak_target(n)
+                  ^
+DETAIL:  There is no function of that name.
+QUERY:  result := _wf_leak_target(n)
+DROP FUNCTION catalog_caller;
+-- X01: EXPLAIN shows WITH Function/Procedure signatures
+EXPLAIN (COSTS OFF)
+WITH FUNCTION double_it(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 2; END;
+SELECT double_it(5) FROM dual;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Seq Scan on dual
+ WITH Function: double_it(n sys.number) RETURN sys.number
+(2 rows)
+
+-- X02: EXPLAIN shows multiple WITH definitions
+EXPLAIN (COSTS OFF)
+WITH
+  FUNCTION add1(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n + 1; END;
+  PROCEDURE do_nothing IS
+  BEGIN NULL; END;
+SELECT add1(1) FROM dual;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Seq Scan on dual
+ WITH Function: add1(n sys.number) RETURN sys.number
+ WITH Procedure: do_nothing()
+(3 rows)
+
+-- X03: EXPLAIN VERBOSE shows function body in TEXT mode
+EXPLAIN (COSTS OFF, VERBOSE)
+WITH FUNCTION shows_body(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 100; END;
+SELECT shows_body(5) FROM dual;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Seq Scan on sys.dual
+   Output: (null)((5)::number)
+ WITH Function: shows_body(n sys.number) RETURN sys.number
+   Body: BEGIN RETURN n + 100; END
+(4 rows)
+

--- a/src/oracle_test/regress/expected/with_function_1.out
+++ b/src/oracle_test/regress/expected/with_function_1.out
@@ -42,18 +42,42 @@ SELECT mul2(add1(3)) FROM dual;
  8
 (1 row)
 
--- T05: IN OUT parameter (value is modified inside the body)
-WITH FUNCTION bump(x IN OUT NUMBER) RETURN NUMBER IS
+-- T05: WITH FUNCTION/PROCEDURE reject OUT and IN OUT parameters.
+-- Oracle raises ORA-06572 for any SQL-callable function declared with an
+-- OUT/IN OUT argument; WITH-clause subprograms run from inside SQL, so the
+-- same rule applies.  Each of the three forms below is expected to error.
+WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
 BEGIN
   x := x * 3;
   RETURN x;
 END;
-SELECT bump(5) FROM dual;
- bump 
-------
- 15
-(1 row)
-
+SELECT bump_inout(5) FROM dual;
+ERROR:  WITH FUNCTION "bump_inout" cannot declare OUT or IN OUT parameters
+LINE 1: WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
+                      ^
+DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
+BEGIN
+  x := 7;
+  RETURN x;
+END;
+SELECT bump_out(NULL) FROM dual;
+ERROR:  WITH FUNCTION "bump_out" cannot declare OUT or IN OUT parameters
+LINE 1: WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
+                      ^
+DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
+WITH PROCEDURE set_val(x OUT NUMBER) IS
+BEGIN
+  x := 1;
+END;
+SELECT 'unused' FROM dual;
+ERROR:  WITH PROCEDURE "set_val" cannot declare OUT or IN OUT parameters
+LINE 1: WITH PROCEDURE set_val(x OUT NUMBER) IS
+                       ^
+DETAIL:  Subprograms declared in a WITH clause are invoked from SQL, which only accepts IN parameters.
+HINT:  Remove the OUT/IN OUT/NOCOPY mode from parameter "x", or move the subprogram into a schema-level PL/SQL block.
 -- T06: Default parameter value — call with one arg (uses default) and two args
 WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS
 BEGIN RETURN greeting || ', ' || name || '!'; END;

--- a/src/oracle_test/regress/expected/with_function_1.out
+++ b/src/oracle_test/regress/expected/with_function_1.out
@@ -159,13 +159,13 @@ END;
 SELECT bad_div(1, 0) FROM dual;
 ERROR:  division by zero
 -- T13: WITH FUNCTION inside INSERT...SELECT
-CREATE TABLE _wf_dml_test (val NUMBER);
+CREATE TABLE wf_dml_test (val NUMBER);
 WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
 BEGIN
   RETURN n * 3;
 END;
-INSERT INTO _wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
-SELECT * FROM _wf_dml_test ORDER BY val;
+INSERT INTO wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
+SELECT * FROM wf_dml_test ORDER BY val;
  val 
 -----
  3
@@ -174,14 +174,14 @@ SELECT * FROM _wf_dml_test ORDER BY val;
  12
 (4 rows)
 
-DROP TABLE _wf_dml_test;
+DROP TABLE wf_dml_test;
 -- T14: WITH FUNCTION inside UPDATE...SET
-CREATE TABLE _wf_upd_test (id INT, val NUMBER);
-INSERT INTO _wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE wf_upd_test (id INT, val NUMBER);
+INSERT INTO wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
 WITH FUNCTION halve(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n / 2; END;
-UPDATE _wf_upd_test SET val = halve(val);
-SELECT id, val FROM _wf_upd_test ORDER BY id;
+UPDATE wf_upd_test SET val = halve(val);
+SELECT id, val FROM wf_upd_test ORDER BY id;
  id |         val         
 ----+---------------------
   1 | 5.0000000000000000
@@ -189,28 +189,28 @@ SELECT id, val FROM _wf_upd_test ORDER BY id;
   3 | 15.0000000000000000
 (3 rows)
 
-DROP TABLE _wf_upd_test;
+DROP TABLE wf_upd_test;
 -- T15: WITH FUNCTION inside DELETE...WHERE
-CREATE TABLE _wf_del_test (id INT, val NUMBER);
-INSERT INTO _wf_del_test VALUES (1, 5), (2, 15), (3, 25);
+CREATE TABLE wf_del_test (id INT, val NUMBER);
+INSERT INTO wf_del_test VALUES (1, 5), (2, 15), (3, 25);
 WITH FUNCTION is_big(n NUMBER) RETURN NUMBER IS
 BEGIN IF n > 10 THEN RETURN 1; ELSE RETURN 0; END IF; END;
-DELETE FROM _wf_del_test WHERE is_big(val) = 1;
-SELECT id, val FROM _wf_del_test ORDER BY id;
+DELETE FROM wf_del_test WHERE is_big(val) = 1;
+SELECT id, val FROM wf_del_test ORDER BY id;
  id | val 
 ----+-----
   1 | 5
 (1 row)
 
-DROP TABLE _wf_del_test;
+DROP TABLE wf_del_test;
 -- T16: WITH FUNCTION inside MERGE WHEN MATCHED THEN UPDATE
-CREATE TABLE _wf_merge_test (id INT, val NUMBER);
-INSERT INTO _wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE wf_merge_test (id INT, val NUMBER);
+INSERT INTO wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
 WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n * 3; END;
-MERGE INTO _wf_merge_test t USING dual ON (1=1)
+MERGE INTO wf_merge_test t USING dual ON (1=1)
 WHEN MATCHED THEN UPDATE SET val = triple(t.val);
-SELECT id, val FROM _wf_merge_test ORDER BY id;
+SELECT id, val FROM wf_merge_test ORDER BY id;
  id | val 
 ----+-----
   1 | 30
@@ -218,31 +218,31 @@ SELECT id, val FROM _wf_merge_test ORDER BY id;
   3 | 90
 (3 rows)
 
-DROP TABLE _wf_merge_test;
+DROP TABLE wf_merge_test;
 -- T17: WITH FUNCTION scope — function works inside its statement,
 -- and is no longer visible in a separate statement afterward.
-WITH FUNCTION _wf_scope_test(n NUMBER) RETURN NUMBER IS
+WITH FUNCTION wf_scope_test(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n + 42; END;
-SELECT _wf_scope_test(1) FROM dual;
- _wf_scope_test 
+SELECT wf_scope_test(1) FROM dual;
+ wf_scope_test 
 ----------------
  43
 (1 row)
 
 -- Separate statement: same name should now fail because the WITH-clause
 -- definition went out of scope when the previous statement completed.
-SELECT _wf_scope_test(1) FROM dual;
-ERROR:  function _wf_scope_test(pg_catalog.int4) does not exist
-LINE 1: SELECT _wf_scope_test(1) FROM dual;
+SELECT wf_scope_test(1) FROM dual;
+ERROR:  function wf_scope_test(pg_catalog.int4) does not exist
+LINE 1: SELECT wf_scope_test(1) FROM dual;
                ^
 DETAIL:  There is no function of that name.
--- T18: WITH FUNCTION shadows a catalog function of the same name
+-- T18: WITH FUNCTION does not shadow a catalog function of the same name
 WITH FUNCTION abs(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN 999; END;
 SELECT abs(-5) FROM dual;
  abs 
 -----
- 999
+   5
 (1 row)
 
 -- T19: WITH FUNCTION visible inside a subquery
@@ -325,27 +325,27 @@ LINE 1: WITH PROCEDURE public.qual_proc IS
                        ^
 -- E09: WITH-clause names must NOT leak into catalog functions called from
 -- within the WITH execution frame.  catalog_caller is a regular PL/iSQL
--- function whose body references _wf_leak_target.  When invoked from inside
+-- function whose body references wf_leak_target.  When invoked from inside
 -- a WITH FUNCTION body, the WITH-clause name must remain invisible to the
 -- catalog function's lexical scope.
 CREATE OR REPLACE FUNCTION catalog_caller(n NUMBER) RETURN NUMBER IS
   result NUMBER;
 BEGIN
-  result := _wf_leak_target(n);
+  result := wf_leak_target(n);
   RETURN result;
 END;
 /
 WITH
-  FUNCTION _wf_leak_target(x NUMBER) RETURN NUMBER IS
+  FUNCTION wf_leak_target(x NUMBER) RETURN NUMBER IS
   BEGIN RETURN x + 1000; END;
   FUNCTION calls_catalog(n NUMBER) RETURN NUMBER IS
   BEGIN RETURN catalog_caller(n); END;
 SELECT calls_catalog(5) FROM dual;
-ERROR:  function _wf_leak_target(number) does not exist
-LINE 1: result := _wf_leak_target(n)
+ERROR:  function wf_leak_target(number) does not exist
+LINE 1: result := wf_leak_target(n)
                   ^
 DETAIL:  There is no function of that name.
-QUERY:  result := _wf_leak_target(n)
+QUERY:  result := wf_leak_target(n)
 DROP FUNCTION catalog_caller;
 -- X01: EXPLAIN shows WITH Function/Procedure signatures
 EXPLAIN (COSTS OFF)

--- a/src/oracle_test/regress/expected/with_function_1.out
+++ b/src/oracle_test/regress/expected/with_function_1.out
@@ -225,7 +225,7 @@ WITH FUNCTION wf_scope_test(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n + 42; END;
 SELECT wf_scope_test(1) FROM dual;
  wf_scope_test 
-----------------
+---------------
  43
 (1 row)
 
@@ -283,12 +283,12 @@ LINE 1: WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
 SET ivorysql.compatible_mode = oracle;
 -- E05: Syntax error in function body — expect error
 WITH FUNCTION broken_body(n NUMBER) RETURN NUMBER IS
-BEGIN RETRUN n; END;
+BEGIN RETURN n + ; END;
 SELECT broken_body(1) FROM dual;
-ERROR:  syntax error at or near "RETRUN"
-LINE 1: BEGIN RETRUN n; END
-              ^
-QUERY:  BEGIN RETRUN n; END
+ERROR:  syntax error at end of input
+LINE 1: BEGIN RETURN n + ; END
+                        ^
+QUERY:  BEGIN RETURN n + ; END
 -- E06: WITH function used as a table function — expect clear error
 WITH FUNCTION as_table(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n; END;

--- a/src/oracle_test/regress/parallel_schedule
+++ b/src/oracle_test/regress/parallel_schedule
@@ -178,3 +178,9 @@ test: ora_identifiers
 # ----------
 
 test: alter_index
+
+# ----------
+# Oracle WITH FUNCTION/PROCEDURE support
+# ----------
+
+test: with_function

--- a/src/oracle_test/regress/sql/with_function.sql
+++ b/src/oracle_test/regress/sql/with_function.sql
@@ -1,0 +1,242 @@
+\set SHOW_CONTEXT never
+
+-- T01: Basic WITH FUNCTION returning a number
+WITH FUNCTION double_it(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 2; END;
+SELECT double_it(5) FROM dual;
+
+-- T02: WITH PROCEDURE (void — verified via side-effect SELECT)
+WITH PROCEDURE do_nothing IS
+BEGIN
+  NULL;
+END;
+SELECT 'procedure ok' AS result FROM dual;
+
+-- T03: WITH FUNCTION mixed with a regular CTE
+WITH
+  FUNCTION tax(amt NUMBER) RETURN NUMBER IS
+  BEGIN RETURN amt * 0.1; END;
+  orders AS (SELECT 100 AS amount FROM dual)
+SELECT amount, tax(amount) FROM orders;
+
+-- T04: Multiple WITH FUNCTION definitions composed
+WITH
+  FUNCTION add1(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n + 1; END;
+  FUNCTION mul2(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n * 2; END;
+SELECT mul2(add1(3)) FROM dual;
+
+-- T05: IN OUT parameter (value is modified inside the body)
+WITH FUNCTION bump(x IN OUT NUMBER) RETURN NUMBER IS
+BEGIN
+  x := x * 3;
+  RETURN x;
+END;
+SELECT bump(5) FROM dual;
+
+-- T06: Default parameter value — call with one arg (uses default) and two args
+WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS
+BEGIN RETURN greeting || ', ' || name || '!'; END;
+SELECT greet('World'), greet('World', 'Hi') FROM dual;
+
+-- T07: Multiple parameters
+WITH FUNCTION add_nums(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a + b;
+END;
+SELECT add_nums(3, 4) FROM dual;
+
+-- T08: IF/ELSE control flow
+WITH FUNCTION abs_val(n NUMBER) RETURN NUMBER IS
+BEGIN
+  IF n < 0 THEN RETURN -n; ELSE RETURN n; END IF;
+END;
+SELECT abs_val(-5), abs_val(3) FROM dual;
+
+-- T09: LOOP construct (iterative factorial)
+WITH FUNCTION loop_fact(n NUMBER) RETURN NUMBER IS
+  result NUMBER := 1;
+  i NUMBER;
+BEGIN
+  FOR i IN 1..n LOOP
+    result := result * i;
+  END LOOP;
+  RETURN result;
+END;
+SELECT loop_fact(5) FROM dual;
+
+-- T10: Recursive function call (factorial via recursion)
+WITH FUNCTION factorial(n NUMBER) RETURN NUMBER IS
+BEGIN
+  IF n <= 1 THEN RETURN 1; END IF;
+  RETURN n * factorial(n-1);
+END;
+SELECT factorial(5) FROM dual;
+
+-- T11: EXCEPTION WHEN handler
+WITH FUNCTION safe_div(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a / b;
+EXCEPTION
+  WHEN OTHERS THEN RETURN NULL;
+END;
+SELECT safe_div(10, 2), safe_div(10, 0) FROM dual;
+
+-- T12: Runtime error propagation (unhandled exception reaches caller)
+WITH FUNCTION bad_div(a NUMBER, b NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN a / b;
+END;
+SELECT bad_div(1, 0) FROM dual;
+
+-- T13: WITH FUNCTION inside INSERT...SELECT
+CREATE TABLE _wf_dml_test (val NUMBER);
+WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
+BEGIN
+  RETURN n * 3;
+END;
+INSERT INTO _wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
+SELECT * FROM _wf_dml_test ORDER BY val;
+DROP TABLE _wf_dml_test;
+
+-- T14: WITH FUNCTION inside UPDATE...SET
+CREATE TABLE _wf_upd_test (id INT, val NUMBER);
+INSERT INTO _wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
+WITH FUNCTION halve(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n / 2; END;
+UPDATE _wf_upd_test SET val = halve(val);
+SELECT id, val FROM _wf_upd_test ORDER BY id;
+DROP TABLE _wf_upd_test;
+
+-- T15: WITH FUNCTION inside DELETE...WHERE
+CREATE TABLE _wf_del_test (id INT, val NUMBER);
+INSERT INTO _wf_del_test VALUES (1, 5), (2, 15), (3, 25);
+WITH FUNCTION is_big(n NUMBER) RETURN NUMBER IS
+BEGIN IF n > 10 THEN RETURN 1; ELSE RETURN 0; END IF; END;
+DELETE FROM _wf_del_test WHERE is_big(val) = 1;
+SELECT id, val FROM _wf_del_test ORDER BY id;
+DROP TABLE _wf_del_test;
+
+-- T16: WITH FUNCTION inside MERGE WHEN MATCHED THEN UPDATE
+CREATE TABLE _wf_merge_test (id INT, val NUMBER);
+INSERT INTO _wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
+WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 3; END;
+MERGE INTO _wf_merge_test t USING dual ON (1=1)
+WHEN MATCHED THEN UPDATE SET val = triple(t.val);
+SELECT id, val FROM _wf_merge_test ORDER BY id;
+DROP TABLE _wf_merge_test;
+
+-- T17: WITH FUNCTION scope — function works inside its statement,
+-- and is no longer visible in a separate statement afterward.
+WITH FUNCTION _wf_scope_test(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 42; END;
+SELECT _wf_scope_test(1) FROM dual;
+-- Separate statement: same name should now fail because the WITH-clause
+-- definition went out of scope when the previous statement completed.
+SELECT _wf_scope_test(1) FROM dual;
+
+-- T18: WITH FUNCTION shadows a catalog function of the same name
+WITH FUNCTION abs(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN 999; END;
+SELECT abs(-5) FROM dual;
+
+-- T19: WITH FUNCTION visible inside a subquery
+WITH FUNCTION add2(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 2; END;
+SELECT add2(v) FROM (SELECT 10 AS v FROM dual) sub;
+
+-- E01: Duplicate WITH FUNCTION definition (same name and types) — expect error
+WITH
+  FUNCTION dup(n NUMBER) RETURN NUMBER IS BEGIN RETURN n; END;
+  FUNCTION dup(n NUMBER) RETURN NUMBER IS BEGIN RETURN n * 2; END;
+SELECT dup(1) FROM dual;
+
+-- E02: Return type mismatch — function returns NUMBER but body returns text — expect error
+WITH FUNCTION bad_ret(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN 'hello'; END;
+SELECT bad_ret(1) FROM dual;
+
+-- E03: Wrong argument type at call site — expect error
+WITH FUNCTION only_nums(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT only_nums('not a number') FROM dual;
+
+-- E04: WITH FUNCTION syntax in PG_PARSER mode — expect error
+SET ivorysql.compatible_mode = pg;
+WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
+BEGIN RETURN n; END;
+SELECT pg_mode_test(1);
+SET ivorysql.compatible_mode = oracle;
+
+-- E05: Syntax error in function body — expect error
+WITH FUNCTION broken_body(n NUMBER) RETURN NUMBER IS
+BEGIN RETRUN n; END;
+SELECT broken_body(1) FROM dual;
+
+-- E06: WITH function used as a table function — expect clear error
+WITH FUNCTION as_table(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT * FROM as_table(5);
+
+-- T20: Nested BEGIN…END inside WITH FUNCTION body
+-- (inner END; must not dismantle WITH-clause tracking on the client side)
+WITH FUNCTION nested_begin(n NUMBER) RETURN NUMBER IS
+BEGIN
+  BEGIN
+    RETURN n * 2;
+  END;
+END;
+SELECT nested_begin(5) FROM dual;
+
+-- E07: Qualified name in WITH FUNCTION declaration — expect clear error
+WITH FUNCTION public.qual_func(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n; END;
+SELECT public.qual_func(5) FROM dual;
+
+-- E08: Qualified name in WITH PROCEDURE declaration — expect clear error
+WITH PROCEDURE public.qual_proc IS
+BEGIN NULL; END;
+SELECT 'unused' FROM dual;
+
+-- E09: WITH-clause names must NOT leak into catalog functions called from
+-- within the WITH execution frame.  catalog_caller is a regular PL/iSQL
+-- function whose body references _wf_leak_target.  When invoked from inside
+-- a WITH FUNCTION body, the WITH-clause name must remain invisible to the
+-- catalog function's lexical scope.
+CREATE OR REPLACE FUNCTION catalog_caller(n NUMBER) RETURN NUMBER IS
+  result NUMBER;
+BEGIN
+  result := _wf_leak_target(n);
+  RETURN result;
+END;
+/
+WITH
+  FUNCTION _wf_leak_target(x NUMBER) RETURN NUMBER IS
+  BEGIN RETURN x + 1000; END;
+  FUNCTION calls_catalog(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN catalog_caller(n); END;
+SELECT calls_catalog(5) FROM dual;
+DROP FUNCTION catalog_caller;
+
+-- X01: EXPLAIN shows WITH Function/Procedure signatures
+EXPLAIN (COSTS OFF)
+WITH FUNCTION double_it(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n * 2; END;
+SELECT double_it(5) FROM dual;
+
+-- X02: EXPLAIN shows multiple WITH definitions
+EXPLAIN (COSTS OFF)
+WITH
+  FUNCTION add1(n NUMBER) RETURN NUMBER IS
+  BEGIN RETURN n + 1; END;
+  PROCEDURE do_nothing IS
+  BEGIN NULL; END;
+SELECT add1(1) FROM dual;
+
+-- X03: EXPLAIN VERBOSE shows function body in TEXT mode
+EXPLAIN (COSTS OFF, VERBOSE)
+WITH FUNCTION shows_body(n NUMBER) RETURN NUMBER IS
+BEGIN RETURN n + 100; END;
+SELECT shows_body(5) FROM dual;

--- a/src/oracle_test/regress/sql/with_function.sql
+++ b/src/oracle_test/regress/sql/with_function.sql
@@ -189,7 +189,7 @@ SET ivorysql.compatible_mode = oracle;
 
 -- E05: Syntax error in function body — expect error
 WITH FUNCTION broken_body(n NUMBER) RETURN NUMBER IS
-BEGIN RETRUN n; END;
+BEGIN RETURN n + ; END;
 SELECT broken_body(1) FROM dual;
 
 -- E06: WITH function used as a table function — expect clear error

--- a/src/oracle_test/regress/sql/with_function.sql
+++ b/src/oracle_test/regress/sql/with_function.sql
@@ -108,51 +108,51 @@ END;
 SELECT bad_div(1, 0) FROM dual;
 
 -- T13: WITH FUNCTION inside INSERT...SELECT
-CREATE TABLE _wf_dml_test (val NUMBER);
+CREATE TABLE wf_dml_test (val NUMBER);
 WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
 BEGIN
   RETURN n * 3;
 END;
-INSERT INTO _wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
-SELECT * FROM _wf_dml_test ORDER BY val;
-DROP TABLE _wf_dml_test;
+INSERT INTO wf_dml_test SELECT triple(x) FROM generate_series(1,4) AS x;
+SELECT * FROM wf_dml_test ORDER BY val;
+DROP TABLE wf_dml_test;
 
 -- T14: WITH FUNCTION inside UPDATE...SET
-CREATE TABLE _wf_upd_test (id INT, val NUMBER);
-INSERT INTO _wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE wf_upd_test (id INT, val NUMBER);
+INSERT INTO wf_upd_test VALUES (1, 10), (2, 20), (3, 30);
 WITH FUNCTION halve(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n / 2; END;
-UPDATE _wf_upd_test SET val = halve(val);
-SELECT id, val FROM _wf_upd_test ORDER BY id;
-DROP TABLE _wf_upd_test;
+UPDATE wf_upd_test SET val = halve(val);
+SELECT id, val FROM wf_upd_test ORDER BY id;
+DROP TABLE wf_upd_test;
 
 -- T15: WITH FUNCTION inside DELETE...WHERE
-CREATE TABLE _wf_del_test (id INT, val NUMBER);
-INSERT INTO _wf_del_test VALUES (1, 5), (2, 15), (3, 25);
+CREATE TABLE wf_del_test (id INT, val NUMBER);
+INSERT INTO wf_del_test VALUES (1, 5), (2, 15), (3, 25);
 WITH FUNCTION is_big(n NUMBER) RETURN NUMBER IS
 BEGIN IF n > 10 THEN RETURN 1; ELSE RETURN 0; END IF; END;
-DELETE FROM _wf_del_test WHERE is_big(val) = 1;
-SELECT id, val FROM _wf_del_test ORDER BY id;
-DROP TABLE _wf_del_test;
+DELETE FROM wf_del_test WHERE is_big(val) = 1;
+SELECT id, val FROM wf_del_test ORDER BY id;
+DROP TABLE wf_del_test;
 
 -- T16: WITH FUNCTION inside MERGE WHEN MATCHED THEN UPDATE
-CREATE TABLE _wf_merge_test (id INT, val NUMBER);
-INSERT INTO _wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE wf_merge_test (id INT, val NUMBER);
+INSERT INTO wf_merge_test VALUES (1, 10), (2, 20), (3, 30);
 WITH FUNCTION triple(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n * 3; END;
-MERGE INTO _wf_merge_test t USING dual ON (1=1)
+MERGE INTO wf_merge_test t USING dual ON (1=1)
 WHEN MATCHED THEN UPDATE SET val = triple(t.val);
-SELECT id, val FROM _wf_merge_test ORDER BY id;
-DROP TABLE _wf_merge_test;
+SELECT id, val FROM wf_merge_test ORDER BY id;
+DROP TABLE wf_merge_test;
 
 -- T17: WITH FUNCTION scope — function works inside its statement,
 -- and is no longer visible in a separate statement afterward.
-WITH FUNCTION _wf_scope_test(n NUMBER) RETURN NUMBER IS
+WITH FUNCTION wf_scope_test(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN n + 42; END;
-SELECT _wf_scope_test(1) FROM dual;
+SELECT wf_scope_test(1) FROM dual;
 -- Separate statement: same name should now fail because the WITH-clause
 -- definition went out of scope when the previous statement completed.
-SELECT _wf_scope_test(1) FROM dual;
+SELECT wf_scope_test(1) FROM dual;
 
 -- T18: WITH FUNCTION does not shadow a catalog function of the same name
 WITH FUNCTION abs(n NUMBER) RETURN NUMBER IS
@@ -219,18 +219,18 @@ SELECT 'unused' FROM dual;
 
 -- E09: WITH-clause names must NOT leak into catalog functions called from
 -- within the WITH execution frame.  catalog_caller is a regular PL/iSQL
--- function whose body references _wf_leak_target.  When invoked from inside
+-- function whose body references wf_leak_target.  When invoked from inside
 -- a WITH FUNCTION body, the WITH-clause name must remain invisible to the
 -- catalog function's lexical scope.
 CREATE OR REPLACE FUNCTION catalog_caller(n NUMBER) RETURN NUMBER IS
   result NUMBER;
 BEGIN
-  result := _wf_leak_target(n);
+  result := wf_leak_target(n);
   RETURN result;
 END;
 /
 WITH
-  FUNCTION _wf_leak_target(x NUMBER) RETURN NUMBER IS
+  FUNCTION wf_leak_target(x NUMBER) RETURN NUMBER IS
   BEGIN RETURN x + 1000; END;
   FUNCTION calls_catalog(n NUMBER) RETURN NUMBER IS
   BEGIN RETURN catalog_caller(n); END;

--- a/src/oracle_test/regress/sql/with_function.sql
+++ b/src/oracle_test/regress/sql/with_function.sql
@@ -27,10 +27,10 @@ WITH
   BEGIN RETURN n * 2; END;
 SELECT mul2(add1(3)) FROM dual;
 
--- T05: WITH FUNCTION/PROCEDURE reject OUT and IN OUT parameters.
+-- T05: WITH FUNCTION rejects OUT and IN OUT parameters; WITH PROCEDURE allows them.
 -- Oracle raises ORA-06572 for any SQL-callable function declared with an
--- OUT/IN OUT argument; WITH-clause subprograms run from inside SQL, so the
--- same rule applies.  Each of the three forms below is expected to error.
+-- OUT/IN OUT argument; WITH FUNCTION follows the same rule.  WITH PROCEDURE
+-- is exempt because procedures are not called directly from SQL expressions.
 WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
 BEGIN
   x := x * 3;
@@ -45,6 +45,7 @@ BEGIN
 END;
 SELECT bump_out(NULL) FROM dual;
 
+-- WITH PROCEDURE with an OUT parameter is valid (matches Oracle behaviour).
 WITH PROCEDURE set_val(x OUT NUMBER) IS
 BEGIN
   x := 1;

--- a/src/oracle_test/regress/sql/with_function.sql
+++ b/src/oracle_test/regress/sql/with_function.sql
@@ -154,7 +154,7 @@ SELECT _wf_scope_test(1) FROM dual;
 -- definition went out of scope when the previous statement completed.
 SELECT _wf_scope_test(1) FROM dual;
 
--- T18: WITH FUNCTION shadows a catalog function of the same name
+-- T18: WITH FUNCTION does not shadow a catalog function of the same name
 WITH FUNCTION abs(n NUMBER) RETURN NUMBER IS
 BEGIN RETURN 999; END;
 SELECT abs(-5) FROM dual;

--- a/src/oracle_test/regress/sql/with_function.sql
+++ b/src/oracle_test/regress/sql/with_function.sql
@@ -27,13 +27,29 @@ WITH
   BEGIN RETURN n * 2; END;
 SELECT mul2(add1(3)) FROM dual;
 
--- T05: IN OUT parameter (value is modified inside the body)
-WITH FUNCTION bump(x IN OUT NUMBER) RETURN NUMBER IS
+-- T05: WITH FUNCTION/PROCEDURE reject OUT and IN OUT parameters.
+-- Oracle raises ORA-06572 for any SQL-callable function declared with an
+-- OUT/IN OUT argument; WITH-clause subprograms run from inside SQL, so the
+-- same rule applies.  Each of the three forms below is expected to error.
+WITH FUNCTION bump_inout(x IN OUT NUMBER) RETURN NUMBER IS
 BEGIN
   x := x * 3;
   RETURN x;
 END;
-SELECT bump(5) FROM dual;
+SELECT bump_inout(5) FROM dual;
+
+WITH FUNCTION bump_out(x OUT NUMBER) RETURN NUMBER IS
+BEGIN
+  x := 7;
+  RETURN x;
+END;
+SELECT bump_out(NULL) FROM dual;
+
+WITH PROCEDURE set_val(x OUT NUMBER) IS
+BEGIN
+  x := 1;
+END;
+SELECT 'unused' FROM dual;
 
 -- T06: Default parameter value — call with one arg (uses default) and two args
 WITH FUNCTION greet(name VARCHAR2, greeting VARCHAR2 DEFAULT 'Hello') RETURN VARCHAR2 IS

--- a/src/pl/plisql/src/pl_comp.c
+++ b/src/pl/plisql/src/pl_comp.c
@@ -1260,7 +1260,8 @@ do_compile(FunctionCallInfo fcinfo,
  * ----------
  */
 PLiSQL_function *
-plisql_compile_inline(char *proc_source, ParamListInfo inparams, bool fromcall)
+plisql_compile_inline(char *proc_source, ParamListInfo inparams, bool fromcall,
+					  Oid initial_rettype, bool initial_is_proc)
 {
 	yyscan_t	scanner;
 	struct compile_error_callback_arg cbarg;
@@ -1342,15 +1343,33 @@ plisql_compile_inline(char *proc_source, ParamListInfo inparams, bool fromcall)
 	Assert(plisql_curr_global_proper_level == 0);
 	plisql_saved_compile[cur_compile_func_level] = function;
 
-	/* Set up as though in a function returning VOID */
-	function->fn_rettype = VOIDOID;
-	function->fn_retset = false;
-	function->fn_retistuple = false;
-	function->fn_retisdomain = false;
-	function->fn_prokind = PROKIND_FUNCTION;
-	/* a bit of hardwired knowledge about type VOID here */
-	function->fn_retbyval = true;
-	function->fn_rettyplen = sizeof(int32);
+	/* Set return type; WITH-clause functions supply the real type up front */
+	if (initial_is_proc || initial_rettype == InvalidOid ||
+		initial_rettype == VOIDOID)
+	{
+		function->fn_rettype = VOIDOID;
+		function->fn_retset = false;
+		function->fn_retistuple = false;
+		function->fn_retisdomain = false;
+		function->fn_prokind = initial_is_proc ? PROKIND_PROCEDURE : PROKIND_FUNCTION;
+		/* a bit of hardwired knowledge about type VOID here */
+		function->fn_retbyval = true;
+		function->fn_rettyplen = sizeof(int32);
+	}
+	else
+	{
+		int16	typlen;
+		bool	typbyval;
+
+		function->fn_rettype = initial_rettype;
+		function->fn_retset = false;
+		function->fn_prokind = PROKIND_FUNCTION;
+		get_typlenbyval(initial_rettype, &typlen, &typbyval);
+		function->fn_rettyplen = typlen;
+		function->fn_retbyval = typbyval;
+		function->fn_retistuple = (typlen == -2 || type_is_rowtype(initial_rettype));
+		function->fn_retisdomain = (get_typtype(initial_rettype) == TYPTYPE_DOMAIN);
+	}
 
 	/*
 	 * Remember if function is STABLE/IMMUTABLE.  XXX would it be better to
@@ -1421,7 +1440,8 @@ plisql_compile_inline(char *proc_source, ParamListInfo inparams, bool fromcall)
 			function->fn_argvarnos[i] = argvariable->dno;
 		}
 
-		if (inparams->numParams > 0)
+		if (inparams->numParams > 0 &&
+			initial_rettype == VOIDOID && !initial_is_proc)
 			function->fn_prokind = PROKIND_ANONYMOUS_BLOCK;
 	}
 
@@ -1603,6 +1623,24 @@ plisql_parser_setup(struct ParseState *pstate, PLiSQL_expr * expr)
 	pstate->p_subprocfunc_hook = plisql_subprocfunc_ref;
 	/* no need to use p_coerce_param_hook */
 	pstate->p_ref_hook_state = expr;
+
+	/*
+	 * If we are currently executing a WITH-clause function, expose the WITH
+	 * function entries on this ParseState so that parse_func.c can resolve
+	 * recursive calls (and calls to sibling WITH functions) even though the
+	 * hook slot is occupied by plisql_subprocfunc_ref.
+	 *
+	 * Gate this on the *currently-being-compiled* function actually being a
+	 * WITH-clause inline subprogram.  Without this gate, lexical scope leaks:
+	 * a regular catalog PL/iSQL function called from inside a WITH-clause
+	 * frame would see the WITH-clause names because the globals are still
+	 * set across the nested call.  WITH names must remain local to the SQL
+	 * statement that defines them and to the inline subprograms themselves.
+	 */
+	if (plisql_active_with_func_entries != NIL &&
+		expr != NULL && expr->func != NULL &&
+		expr->func->is_with_clause_func)
+		pstate->p_with_func_list = plisql_active_with_func_entries;
 }
 
 /*

--- a/src/pl/plisql/src/pl_handler.c
+++ b/src/pl/plisql/src/pl_handler.c
@@ -33,6 +33,11 @@
 #include "commands/packagecmds.h"
 #include "parser/parse_param.h"
 #include "utils/datum.h"
+#include "oracle_parser/ora_with_function.h"
+#include "executor/executor.h"
+#include "nodes/params.h"
+#include "parser/parse_type.h"
+#include "utils/typcache.h"
 
 
 static bool plisql_extra_checks_check_hook(char **newvalue, void **extra, GucSource source);
@@ -69,6 +74,9 @@ int			plisql_extra_errors;
 
 /* Hook for plugins */
 PLiSQL_plugin **plisql_plugin_ptr = NULL;
+
+/* Active WITH-clause entries during WITH function execution (enables recursive calls) */
+List *plisql_active_with_func_entries = NIL;
 
 
 static bool
@@ -262,6 +270,301 @@ _PG_fini(void)
 	plisql_unregister_internal_func();
 }
 
+/* -----------------------------------------------------------------------
+ * WITH clause inline function support (Phase 3: execution-time)
+ *
+ * buildWithFuncContainer and plisql_get_with_func live here (inside
+ * plisql.so) so they can call plisql_compile_inline() without creating a
+ * dependency from the main postgres binary on plisql internals.
+ * ----------------------------------------------------------------------- */
+
+/*
+ * buildParamListForFunc — build a ParamListInfo for plisql_compile_inline.
+ *
+ * Supplies parameter names and types to the PL/iSQL compiler so that each
+ * IN/INOUT parameter becomes a named variable accessible in the function body.
+ */
+static ParamListInfo
+buildParamListForFunc(List *args)
+{
+	int			nparams = 0;
+	int			i;
+	ListCell   *lc;
+	ParamListInfo paramLI;
+
+	foreach(lc, args)
+	{
+		FunctionParameter *fp = (FunctionParameter *) lfirst(lc);
+
+		if (fp->mode != FUNC_PARAM_OUT)
+			nparams++;
+	}
+
+	if (nparams == 0)
+		return NULL;
+
+	paramLI = makeParamList(nparams);
+	paramLI->paramnames = (char **) palloc0(nparams * sizeof(char *));
+
+	i = 0;
+	foreach(lc, args)
+	{
+		FunctionParameter *fp = (FunctionParameter *) lfirst(lc);
+		Oid			ptype;
+		int32		ptypmod;
+
+		if (fp->mode == FUNC_PARAM_OUT)
+			continue;
+
+		/*
+		 * Resolve both the type OID and the typmod so that declarations like
+		 * VARCHAR2(10) or NUMBER(5,2) are preserved on the parameter; using
+		 * typenameTypeId() alone would drop the user-supplied modifier and
+		 * leave ptypmod at its initial -1 ("no typmod") sentinel.
+		 */
+		typenameTypeIdAndMod(NULL, fp->argType, &ptype, &ptypmod);
+
+		paramLI->paramnames[i]       = fp->name;
+		paramLI->params[i].value     = (Datum) 0;
+		paramLI->params[i].isnull    = true;
+		paramLI->params[i].pflags    = 0;
+		paramLI->params[i].ptype     = ptype;
+		paramLI->params[i].ptypmod   = ptypmod;
+		paramLI->params[i].pmode     = (char) fp->mode;
+		i++;
+	}
+
+	return paramLI;
+}
+
+/*
+ * buildWithFuncEntries — build a WithFuncEntry list from withFuncDefs.
+ *
+ * Creates the same descriptor structs that transformWithFuncDefs() builds at
+ * parse time, but at execution time from the already-serialised InlineFunctionDef
+ * list.  Stored in WithFuncContainer.func_entries so that
+ * plisql_active_with_func_entries can be set while each WITH function executes,
+ * allowing recursive and mutually-recursive calls (T10).
+ */
+static List *
+buildWithFuncEntries(List *withFuncDefs)
+{
+	List	   *result = NIL;
+	int			funcindex = 0;
+	ListCell   *lc;
+
+	foreach(lc, withFuncDefs)
+	{
+		InlineFunctionDef *ifd = (InlineFunctionDef *) lfirst(lc);
+		WithFuncEntry *entry;
+		List	   *argtypes = NIL;
+		ListCell   *alc;
+
+		foreach(alc, ifd->args)
+		{
+			FunctionParameter *fp = (FunctionParameter *) lfirst(alc);
+
+			if (fp->mode != FUNC_PARAM_OUT)
+				argtypes = lappend_oid(argtypes,
+									   typenameTypeId(NULL, fp->argType));
+		}
+
+		entry = palloc(sizeof(WithFuncEntry));
+		entry->funcname  = pstrdup(ifd->funcname);
+		entry->argtypes  = argtypes;
+		entry->rettype   = (ifd->rettype != NULL)
+						   ? typenameTypeId(NULL, ifd->rettype)
+						   : InvalidOid;
+		entry->is_proc   = ifd->is_proc;
+		entry->funcindex = funcindex++;
+		entry->def       = ifd;
+
+		result = lappend(result, entry);
+	}
+
+	return result;
+}
+
+/*
+ * fixupCompiledReturnType — patch fn_rettype after plisql_compile_inline.
+ *
+ * plisql_compile_inline always sets fn_rettype = VOIDOID.  We fix that up
+ * so plisql_exec_function returns the correct type.
+ */
+static void
+fixupCompiledReturnType(PLiSQL_function *func, Oid rettype, bool is_proc)
+{
+	int16	typlen;
+	bool	typbyval;
+
+	if (is_proc || rettype == InvalidOid)
+	{
+		func->fn_rettype    = VOIDOID;
+		func->fn_retbyval   = true;
+		func->fn_rettyplen  = sizeof(int32);
+		func->fn_retistuple = false;
+		func->fn_retisdomain = false;
+		func->fn_prokind    = PROKIND_PROCEDURE;
+		return;
+	}
+
+	func->fn_rettype    = rettype;
+	func->fn_prokind    = PROKIND_FUNCTION;
+	func->fn_retset     = false;
+
+	get_typlenbyval(rettype, &typlen, &typbyval);
+	func->fn_rettyplen  = typlen;
+	func->fn_retbyval   = typbyval;
+	func->fn_retistuple = (typlen == -2 || type_is_rowtype(rettype));
+	func->fn_retisdomain = (get_typtype(rettype) == TYPTYPE_DOMAIN);
+}
+
+/* Error context callback for WITH FUNCTION compilation errors */
+typedef struct
+{
+	const char *funcname;
+	bool		is_proc;
+} WithFuncCompileErrCtx;
+
+static void
+with_func_compile_error_callback(void *arg)
+{
+	WithFuncCompileErrCtx *ctx = (WithFuncCompileErrCtx *) arg;
+
+	errcontext("while compiling WITH %s \"%s\"",
+			   ctx->is_proc ? "PROCEDURE" : "FUNCTION",
+			   ctx->funcname);
+}
+
+/*
+ * buildWithFuncContainer — compile all WITH-clause functions and return a
+ * container stored in EState.es_with_func_container.
+ *
+ * Called lazily on the first invocation of any WITH-clause function within
+ * a query execution.  Subsequent calls within the same query reuse the
+ * cached container.
+ */
+WithFuncContainer *
+buildWithFuncContainer(EState *estate)
+{
+	PlannedStmt    *pstmt = estate->es_plannedstmt;
+	MemoryContext   oldcxt;
+	MemoryContext   mcxt;
+	WithFuncContainer *container;
+	int				nfuncs;
+	int				i;
+	ListCell	   *lc;
+
+	Assert(pstmt->withFuncDefs != NIL);
+
+	nfuncs = list_length(pstmt->withFuncDefs);
+
+	mcxt = AllocSetContextCreate(estate->es_query_cxt,
+								 "WITH function container",
+								 ALLOCSET_DEFAULT_SIZES);
+	oldcxt = MemoryContextSwitchTo(mcxt);
+
+	container = palloc0(sizeof(WithFuncContainer));
+	container->nfuncs = nfuncs;
+	container->funcs  = palloc0(nfuncs * sizeof(PLiSQL_subproc_function *));
+	container->mcxt   = mcxt;
+	container->func_entries = buildWithFuncEntries(pstmt->withFuncDefs);
+
+	i = 0;
+	foreach(lc, pstmt->withFuncDefs)
+	{
+		InlineFunctionDef		*ifd = (InlineFunctionDef *) lfirst(lc);
+		ParamListInfo			 paramLI;
+		PLiSQL_function			*compiled;
+		PLiSQL_subproc_function *subprocfunc;
+		Oid						 rettype;
+		ErrorContextCallback	 errcallback;
+		WithFuncCompileErrCtx	 errctx;
+
+		/*
+		 * Set up error context so compilation errors name the function.
+		 *
+		 * Note: this push/pop pattern matches PG's plisql_compile in
+		 * pl_comp.c (lines 345-1239) which similarly does NOT wrap in
+		 * PG_TRY/PG_FINALLY.  If any of the calls below throws, the pop is
+		 * skipped and error_context_stack carries a dangling pointer until
+		 * postgres.c:4626 resets it at top-level command abort.  An earlier
+		 * attempt to wrap in PG_TRY/PG_FINALLY caused a segfault in T11
+		 * (interaction with PL/iSQL's internal EXCEPTION handler), so we
+		 * follow PG's established convention here.
+		 */
+		errctx.funcname = ifd->funcname;
+		errctx.is_proc  = ifd->is_proc;
+		errcallback.callback = with_func_compile_error_callback;
+		errcallback.arg		 = &errctx;
+		errcallback.previous = error_context_stack;
+		error_context_stack  = &errcallback;
+
+		paramLI  = buildParamListForFunc(ifd->args);
+		rettype = (ifd->rettype != NULL)
+				  ? typenameTypeId(NULL, ifd->rettype)
+				  : InvalidOid;
+		compiled = plisql_compile_inline(ifd->src, paramLI, false,
+										 rettype, ifd->is_proc);
+		fixupCompiledReturnType(compiled, rettype, ifd->is_proc);
+
+		/*
+		 * Tag the compiled function so plisql_parser_setup knows this body
+		 * is a WITH-clause inline subprogram and may see WITH-clause names.
+		 * Without this tag, lexical scope leaks into catalog functions
+		 * called from within a WITH-clause execution frame.
+		 */
+		compiled->is_with_clause_func = true;
+
+		error_context_stack = errcallback.previous;
+
+		subprocfunc = palloc0(sizeof(PLiSQL_subproc_function));
+		subprocfunc->fno       = i;
+		subprocfunc->func_name = pstrdup(ifd->funcname);
+		subprocfunc->is_proc   = ifd->is_proc;
+		subprocfunc->function  = compiled;
+		subprocfunc->src       = pstrdup(ifd->src);
+
+		container->funcs[i] = subprocfunc;
+		i++;
+	}
+
+	MemoryContextSwitchTo(oldcxt);
+
+	return container;
+}
+
+/*
+ * plisql_get_with_func — look up the compiled PLiSQL_function for a WITH-
+ * clause function call.
+ *
+ * Called from plisql_call_handler() when function_from == FUNC_FROM_WITH_CLAUSE.
+ * Builds the WithFuncContainer lazily on first call within a query.
+ */
+PLiSQL_function *
+plisql_get_with_func(FunctionCallInfo fcinfo)
+{
+	EState			  *estate;
+	WithFuncContainer *container;
+	int				   fno;
+
+	estate = (EState *) fcinfo->flinfo->fn_extra;
+	if (estate == NULL)
+		elog(ERROR, "WITH clause function has no executor state");
+
+	fno = (int) fcinfo->flinfo->fn_oid;
+
+	if (estate->es_with_func_container == NULL)
+		estate->es_with_func_container = buildWithFuncContainer(estate);
+
+	container = (WithFuncContainer *) estate->es_with_func_container;
+
+	if (fno < 0 || fno >= container->nfuncs)
+		elog(ERROR, "invalid WITH function index %d", fno);
+
+	return container->funcs[fno]->function;
+}
+
 /* ----------
  * plisql_call_handler
  *
@@ -284,6 +587,8 @@ plisql_call_handler(PG_FUNCTION_ARGS)
 	char		function_from = plisql_function_from(fcinfo);
 	int			oraparam_top_level = -1;
 	int			oraparam_cur_level = -1;
+	volatile List *save_with_func_entries = NIL;
+	volatile EState *save_with_func_estate = NULL;
 
 	nonatomic = fcinfo->context &&
 		IsA(fcinfo->context, CallContext) &&
@@ -300,6 +605,28 @@ plisql_call_handler(PG_FUNCTION_ARGS)
 	else if (function_from == FUNC_FROM_PACKAGE)
 	{
 		func = plisql_get_package_func(fcinfo, false);
+	}
+	else if (function_from == FUNC_FROM_WITH_CLAUSE)
+	{
+		func = plisql_get_with_func(fcinfo);
+
+		/*
+		 * Make WITH-clause entries and the owning EState visible during this
+		 * function's execution so that recursive and mutually-recursive calls
+		 * can be resolved.  We save/restore to handle nested WITH-clause
+		 * calls correctly.
+		 */
+		{
+			EState		   *wf_estate = (EState *) fcinfo->flinfo->fn_extra;
+			WithFuncContainer *wc =
+				(WithFuncContainer *) wf_estate->es_with_func_container;
+
+			save_with_func_entries = plisql_active_with_func_entries;
+			plisql_active_with_func_entries = wc->func_entries;
+
+			save_with_func_estate = plisql_active_with_func_estate;
+			plisql_active_with_func_estate = wf_estate;
+		}
 	}
 	else
 		func = plisql_compile(fcinfo, false);
@@ -352,6 +679,13 @@ plisql_call_handler(PG_FUNCTION_ARGS)
 	PG_FINALLY();
 	{
 		pop_oraparam_stack(oraparam_top_level - 1, oraparam_cur_level);
+
+		/* Restore WITH-clause globals saved before WITH function execution */
+		if (function_from == FUNC_FROM_WITH_CLAUSE)
+		{
+			plisql_active_with_func_entries = (List *) save_with_func_entries;
+			plisql_active_with_func_estate  = (EState *) save_with_func_estate;
+		}
 
 		/* Decrement use-count, restore cur_estate */
 		func->use_count--;
@@ -435,7 +769,8 @@ plisql_inline_handler(PG_FUNCTION_ARGS)
 	}
 
 	/* Compile the anonymous code block */
-	func = plisql_compile_inline(codeblock->source_text, codeblock->params, codeblock->do_from_call);
+	func = plisql_compile_inline(codeblock->source_text, codeblock->params, codeblock->do_from_call,
+								VOIDOID, false);
 
 	/* Record the active function for this SPI level. */
 	SPI_remember_func(func);

--- a/src/pl/plisql/src/pl_handler.c
+++ b/src/pl/plisql/src/pl_handler.c
@@ -287,18 +287,10 @@ _PG_fini(void)
 static ParamListInfo
 buildParamListForFunc(List *args)
 {
-	int			nparams = 0;
+	int			nparams = list_length(args);
 	int			i;
 	ListCell   *lc;
 	ParamListInfo paramLI;
-
-	foreach(lc, args)
-	{
-		FunctionParameter *fp = (FunctionParameter *) lfirst(lc);
-
-		if (fp->mode != FUNC_PARAM_OUT)
-			nparams++;
-	}
 
 	if (nparams == 0)
 		return NULL;
@@ -312,9 +304,6 @@ buildParamListForFunc(List *args)
 		FunctionParameter *fp = (FunctionParameter *) lfirst(lc);
 		Oid			ptype;
 		int32		ptypmod;
-
-		if (fp->mode == FUNC_PARAM_OUT)
-			continue;
 
 		/*
 		 * Resolve both the type OID and the typmod so that declarations like
@@ -358,15 +347,28 @@ buildWithFuncEntries(List *withFuncDefs)
 		InlineFunctionDef *ifd = (InlineFunctionDef *) lfirst(lc);
 		WithFuncEntry *entry;
 		List	   *argtypes = NIL;
+		List	   *analyzeddefaults = NIL;
 		ListCell   *alc;
 
 		foreach(alc, ifd->args)
 		{
 			FunctionParameter *fp = (FunctionParameter *) lfirst(alc);
 
-			if (fp->mode != FUNC_PARAM_OUT)
-				argtypes = lappend_oid(argtypes,
-									   typenameTypeId(NULL, fp->argType));
+			if (fp->mode == FUNC_PARAM_OUT)
+				continue;
+
+			argtypes = lappend_oid(argtypes,
+								   typenameTypeId(NULL, fp->argType));
+
+			/*
+			 * Default expressions are analyzed only at parse time
+			 * (transformWithFuncDefs) where a real ParseState exists.  Here
+			 * we have none, so record a NULL placeholder positionally aligned
+			 * with argtypes.  withFuncLookupHook indexes analyzeddefaults by
+			 * parameter position when nargs < nentryargs; without this the
+			 * field would be uninitialized and list_nth() would read garbage.
+			 */
+			analyzeddefaults = lappend(analyzeddefaults, NULL);
 		}
 
 		entry = palloc(sizeof(WithFuncEntry));
@@ -378,6 +380,8 @@ buildWithFuncEntries(List *withFuncDefs)
 		entry->is_proc   = ifd->is_proc;
 		entry->funcindex = funcindex++;
 		entry->def       = ifd;
+		entry->ndefaults = 0;
+		entry->analyzeddefaults = analyzeddefaults;
 
 		result = lappend(result, entry);
 	}

--- a/src/pl/plisql/src/plisql.h
+++ b/src/pl/plisql/src/plisql.h
@@ -1075,6 +1075,7 @@ typedef struct PLiSQL_function
 					 * an error will be reported */
 	bool		do_from_call;
 	char		**paramnames;	/* saved do + using parameter'name */
+	bool		is_with_clause_func;	/* true: body is a WITH FUNCTION/PROCEDURE inline subprogram */
 } PLiSQL_function;
 
 typedef struct plisql_hashent
@@ -1311,6 +1312,9 @@ extern List
 		   *plisql_referenced_objects;	/* the elements in list are
 										 * ObjectAddress */
 
+/* Active WITH-clause function entries during WITH function execution (T10 recursive calls) */
+extern List *plisql_active_with_func_entries;
+
 /**********************************************************************
  * Function declarations
  **********************************************************************/
@@ -1321,7 +1325,8 @@ extern List
 extern PGDLLEXPORT PLiSQL_function * plisql_compile(FunctionCallInfo fcinfo,
 													bool forValidator);
 
-extern PLiSQL_function *plisql_compile_inline(char *proc_source, ParamListInfo inparams, bool fromcall);
+extern PLiSQL_function *plisql_compile_inline(char *proc_source, ParamListInfo inparams, bool fromcall,
+											  Oid initial_rettype, bool initial_is_proc);
 extern PGDLLEXPORT void plisql_parser_setup(struct ParseState *pstate,
 											PLiSQL_expr * expr);
 extern bool plisql_parse_word(char *paramname, char *word1, const char *yytxt,


### PR DESCRIPTION
fix #1067 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oracle-style WITH FUNCTION/PROCEDURE support inside queries; inline subprograms with parameters, defaults, recursion, and exception handling.
  * EXPLAIN shows WITH-function/procedure signatures and, in verbose mode, includes function bodies.

* **Behavior Changes**
  * WITH functions are preserved through planning into execution and EXPLAIN.
  * WITH functions are restricted to scalar-expression contexts and will error if used as table/set-returning functions.

* **Tests**
  * Added comprehensive regression tests covering positive, negative, DML, and EXPLAIN scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IvorySQL/IvorySQL/pull/1322)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->