### PR TITLE
feat: implement Oracle-compatible UTL_ENCODE package

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -31,7 +31,8 @@ OBJS = \
 	src/sysview/sysview_functions.o \
 	src/xml_functions/ora_xml_functions.o \
 	src/builtin_packages/dbms_utility/dbms_utility.o \
-	src/builtin_packages/dbms_lock/dbms_lock.o	
+	src/builtin_packages/dbms_lock/dbms_lock.o \
+	src/builtin_packages/utl_encode/utl_encode.o
 
 EXTENSION = ivorysql_ora
 
@@ -78,7 +79,8 @@ ORA_REGRESS = \
 	ora_dbms_output \
 	ora_ascii \
 	dbms_lock \
-	utl_file
+	utl_file \
+	utl_encode
 
 SHLIB_LINK += -lxml2
 

--- a/contrib/ivorysql_ora/expected/utl_encode.out
+++ b/contrib/ivorysql_ora/expected/utl_encode.out
@@ -1,0 +1,124 @@
+--
+-- utl_encode.sql
+--
+-- Tests for UTL_ENCODE package (BASE64_ENCODE and BASE64_DECODE functions)
+--
+-- ============================================================
+-- Tests for UTL_ENCODE.BASE64_ENCODE
+-- ============================================================
+-- NULL input returns NULL (STRICT modifier)
+SELECT utl_encode.base64_encode(NULL) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Basic encoding: hextoraw('48656C6C6F') = 'Hello' bytes
+-- Expected: 'SGVsbG8=\n' = hextoraw('534756736247383D0A')
+SELECT rawtohex(utl_encode.base64_encode(hextoraw('48656C6C6F'))) = '534756736247383D0A';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Round-trip at line-break boundary: 48 bytes (exactly 1 line of 64 base64 chars)
+-- hextoraw(rpad('0',96,'0')) produces 48 zero bytes
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw(rpad('0', 96, '0'))
+)) = hextoraw(rpad('0', 96, '0'));
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Round-trip at line-break boundary: 49 bytes (spans 2 lines)
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw(rpad('0', 98, '0'))
+)) = hextoraw(rpad('0', 98, '0'));
+ ?column? 
+----------
+ t
+(1 row)
+
+-- PL/iSQL package interface test for encode
+DECLARE
+    v_src     RAW(100) := hextoraw('48656C6C6F');
+    v_encoded RAW(200);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    v_encoded := utl_encode.base64_encode(v_src);
+    dbms_output.enable();
+    dbms_output.put_line('encoded=' || rawtohex(v_encoded));
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+NOTICE:  encoded=534756736247383D0A
+-- ============================================================
+-- Tests for UTL_ENCODE.BASE64_DECODE
+-- ============================================================
+-- NULL input returns NULL (STRICT modifier)
+SELECT utl_encode.base64_decode(NULL) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Decode known base64 string: 'SGVsbG8=\n' -> 'Hello' bytes
+-- hextoraw('534756736247383D0A') = 'SGVsbG8=\n', hextoraw('48656C6C6F') = 'Hello'
+SELECT rawtohex(utl_encode.base64_decode(hextoraw('534756736247383D0A'))) = '48656C6C6F';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Round-trip: base64_decode(base64_encode(x)) = x for 'Hello'
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw('48656C6C6F')
+)) = hextoraw('48656C6C6F');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Round-trip: large input (200 bytes, multiple lines of encoded output)
+-- hextoraw(rpad('AB',400,'AB')) produces 200 bytes of 0xAB
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw(rpad('AB', 400, 'AB'))
+)) = hextoraw(rpad('AB', 400, 'AB'));
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Whitespace-only input returns empty RAW
+-- hextoraw('0A0D200A') = LF CR SP LF; rawtohex of empty RAW returns NULL in Oracle mode
+SELECT rawtohex(utl_encode.base64_decode(hextoraw('0A0D200A'))) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Invalid base64 characters raise ERROR
+-- hextoraw('5A5A5A21') = 'ZZZ!' where '!' is not a valid base64 character
+SELECT utl_encode.base64_decode(hextoraw('5A5A5A21'));
+ERROR:  UTL_ENCODE.BASE64_DECODE: invalid base64 input
+CONTEXT:  PL/iSQL function base64_decode line 8 at RETURN
+-- PL/iSQL package interface test for decode
+DECLARE
+    v_src     RAW(100) := hextoraw('48656C6C6F');
+    v_encoded RAW(200);
+    v_decoded RAW(200);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    v_encoded := utl_encode.base64_encode(v_src);
+    v_decoded := utl_encode.base64_decode(v_encoded);
+    dbms_output.enable();
+    dbms_output.put_line('round_trip_match=' || CASE WHEN v_decoded = v_src THEN 't' ELSE 'f' END);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+NOTICE:  round_trip_match=t

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -6,3 +6,4 @@ src/sysview/sysview
 src/xml_functions/xml_functions
 src/builtin_packages/dbms_utility/dbms_utility
 src/builtin_packages/dbms_lock/dbms_lock
+src/builtin_packages/utl_encode/utl_encode

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -29,7 +29,8 @@ ivorysql_ora_sources = files(
   'src/sysview/sysview_functions.c',
   'src/xml_functions/ora_xml_functions.c',
   'src/builtin_packages/dbms_utility/dbms_utility.c',
-  'src/builtin_packages/dbms_lock/dbms_lock.c'
+  'src/builtin_packages/dbms_lock/dbms_lock.c',
+  'src/builtin_packages/utl_encode/utl_encode.c'
 )
 
 if host_system == 'windows'

--- a/contrib/ivorysql_ora/sql/utl_encode.sql
+++ b/contrib/ivorysql_ora/sql/utl_encode.sql
@@ -1,0 +1,89 @@
+--
+-- utl_encode.sql
+--
+-- Tests for UTL_ENCODE package (BASE64_ENCODE and BASE64_DECODE functions)
+--
+
+-- ============================================================
+-- Tests for UTL_ENCODE.BASE64_ENCODE
+-- ============================================================
+
+-- NULL input returns NULL (STRICT modifier)
+SELECT utl_encode.base64_encode(NULL) IS NULL;
+
+-- Basic encoding: hextoraw('48656C6C6F') = 'Hello' bytes
+-- Expected: 'SGVsbG8=\n' = hextoraw('534756736247383D0A')
+SELECT rawtohex(utl_encode.base64_encode(hextoraw('48656C6C6F'))) = '534756736247383D0A';
+
+-- Round-trip at line-break boundary: 48 bytes (exactly 1 line of 64 base64 chars)
+-- hextoraw(rpad('0',96,'0')) produces 48 zero bytes
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw(rpad('0', 96, '0'))
+)) = hextoraw(rpad('0', 96, '0'));
+
+-- Round-trip at line-break boundary: 49 bytes (spans 2 lines)
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw(rpad('0', 98, '0'))
+)) = hextoraw(rpad('0', 98, '0'));
+
+-- PL/iSQL package interface test for encode
+DECLARE
+    v_src     RAW(100) := hextoraw('48656C6C6F');
+    v_encoded RAW(200);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    v_encoded := utl_encode.base64_encode(v_src);
+    dbms_output.enable();
+    dbms_output.put_line('encoded=' || rawtohex(v_encoded));
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+
+-- ============================================================
+-- Tests for UTL_ENCODE.BASE64_DECODE
+-- ============================================================
+
+-- NULL input returns NULL (STRICT modifier)
+SELECT utl_encode.base64_decode(NULL) IS NULL;
+
+-- Decode known base64 string: 'SGVsbG8=\n' -> 'Hello' bytes
+-- hextoraw('534756736247383D0A') = 'SGVsbG8=\n', hextoraw('48656C6C6F') = 'Hello'
+SELECT rawtohex(utl_encode.base64_decode(hextoraw('534756736247383D0A'))) = '48656C6C6F';
+
+-- Round-trip: base64_decode(base64_encode(x)) = x for 'Hello'
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw('48656C6C6F')
+)) = hextoraw('48656C6C6F');
+
+-- Round-trip: large input (200 bytes, multiple lines of encoded output)
+-- hextoraw(rpad('AB',400,'AB')) produces 200 bytes of 0xAB
+SELECT utl_encode.base64_decode(utl_encode.base64_encode(
+    hextoraw(rpad('AB', 400, 'AB'))
+)) = hextoraw(rpad('AB', 400, 'AB'));
+
+-- Whitespace-only input returns empty RAW
+-- hextoraw('0A0D200A') = LF CR SP LF; rawtohex of empty RAW returns NULL in Oracle mode
+SELECT rawtohex(utl_encode.base64_decode(hextoraw('0A0D200A'))) IS NULL;
+
+-- Invalid base64 characters raise ERROR
+-- hextoraw('5A5A5A21') = 'ZZZ!' where '!' is not a valid base64 character
+SELECT utl_encode.base64_decode(hextoraw('5A5A5A21'));
+
+-- PL/iSQL package interface test for decode
+DECLARE
+    v_src     RAW(100) := hextoraw('48656C6C6F');
+    v_encoded RAW(200);
+    v_decoded RAW(200);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    v_encoded := utl_encode.base64_encode(v_src);
+    v_decoded := utl_encode.base64_decode(v_encoded);
+    dbms_output.enable();
+    dbms_output.put_line('round_trip_match=' || CASE WHEN v_decoded = v_src THEN 't' ELSE 'f' END);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_encode/utl_encode--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_encode/utl_encode--1.0.sql
@@ -1,0 +1,66 @@
+/***************************************************************
+ *
+ * UTL_ENCODE Package
+ *
+ * Oracle-compatible encoding/decoding utilities.
+ *
+ ***************************************************************
+*/
+
+/*
+ * Register the C implementation in the sys schema.
+ * Input/output use bytea (RAW maps to bytea in IvorySQL).
+ * STRICT: returns NULL automatically when input is NULL.
+ */
+CREATE FUNCTION sys.utl_encode_base64_encode(bytea)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'ivorysql_utl_encode_base64_encode'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.utl_encode_base64_decode(bytea)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'ivorysql_utl_encode_base64_decode'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+-- PL/iSQL package declaration
+CREATE PACKAGE utl_encode AS
+
+    /*
+     * BASE64_ENCODE
+     * Encodes binary RAW data to base64 format.
+     * Each output line is 64 characters followed by a newline (RFC 1521).
+     *
+     * Parameters:
+     *   r  IN RAW  - binary data to encode
+     * Returns:
+     *   RAW  - base64-encoded data as ASCII bytes with embedded newlines
+     */
+    FUNCTION base64_encode(r IN RAW) RETURN RAW;
+
+    /*
+     * BASE64_DECODE
+     * Decodes base64-encoded RAW data back to binary.
+     * Embedded whitespace (LF, CRLF, tab, space) is stripped before decoding.
+     *
+     * Parameters:
+     *   r  IN RAW  - base64-encoded data to decode
+     * Returns:
+     *   RAW  - decoded binary data
+     */
+    FUNCTION base64_decode(r IN RAW) RETURN RAW;
+
+END utl_encode;
+
+CREATE PACKAGE BODY utl_encode AS
+
+    FUNCTION base64_encode(r IN RAW) RETURN RAW IS
+    BEGIN
+        RETURN utl_encode_base64_encode(r);
+    END;
+
+    FUNCTION base64_decode(r IN RAW) RETURN RAW IS
+    BEGIN
+        RETURN utl_encode_base64_decode(r);
+    END;
+
+END utl_encode;

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_encode/utl_encode.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_encode/utl_encode.c
@@ -1,0 +1,196 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Implementation of Oracle's UTL_ENCODE package.
+ * This module is part of ivorysql_ora extension.
+ *
+ * Portions Copyright (c) 2025-2026, IvorySQL Global Development Team
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_encode/utl_encode.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+#include "fmgr.h"
+#include "varatt.h"
+#include "utils/builtins.h"
+#include "common/base64.h"
+
+/*
+ * Oracle UTL_ENCODE.BASE64_ENCODE uses 64-character lines (RFC 1521 MIME format).
+ * PostgreSQL's built-in encode(bytea, 'base64') uses 76-character lines (RFC 2045),
+ * so we implement our own wrapper to match Oracle's line-break convention.
+ */
+#define UTL_ENCODE_B64_LINE_LEN 64
+
+/*
+ * ivorysql_utl_encode_base64_encode
+ *
+ * Oracle-compatible BASE64_ENCODE implementation:
+ *   - Encodes binary (RAW/bytea) input to base64 ASCII bytes
+ *   - Inserts a LF (\n) after every 64-character line, including the last
+ *   - Empty input returns empty bytea
+ *   - NULL input: handled by STRICT modifier in SQL registration
+ *
+ * Oracle signature: UTL_ENCODE.BASE64_ENCODE(r IN RAW) RETURN RAW
+ * Maps to: bytea -> bytea  (RAW is bytea in IvorySQL)
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_encode_base64_encode);
+Datum
+ivorysql_utl_encode_base64_encode(PG_FUNCTION_ARGS)
+{
+	bytea	   *src = PG_GETARG_BYTEA_PP(0);
+	int			src_len = VARSIZE_ANY_EXHDR(src);
+	uint8	   *src_data = (uint8 *) VARDATA_ANY(src);
+	int			b64_len;
+	int			num_lines;
+	int			result_len;
+	char	   *raw_b64;
+	int			encoded_len;
+	bytea	   *result;
+	char	   *dst;
+	char	   *p;
+	int			remaining;
+	int			chunk;
+
+	/* Empty input: return empty bytea */
+	if (src_len == 0)
+	{
+		result = (bytea *) palloc(VARHDRSZ);
+		SET_VARSIZE(result, VARHDRSZ);
+		PG_RETURN_BYTEA_P(result);
+	}
+
+	/* Calculate raw base64 encoded length (no newlines) */
+	b64_len = pg_b64_enc_len(src_len);
+
+	/* Number of output lines: ceil(b64_len / 64) */
+	num_lines = (b64_len + UTL_ENCODE_B64_LINE_LEN - 1) / UTL_ENCODE_B64_LINE_LEN;
+
+	/* Total buffer: base64 characters + one LF per line */
+	result_len = b64_len + num_lines;
+
+	/* Encode input to raw base64 (no line breaks) */
+	raw_b64 = palloc(b64_len + 1);
+	encoded_len = pg_b64_encode(src_data, src_len, raw_b64, b64_len);
+	if (encoded_len < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("UTL_ENCODE.BASE64_ENCODE: encoding failed")));
+
+	/* Build output: copy 64-char chunks with LF terminator after each */
+	result = (bytea *) palloc(VARHDRSZ + result_len);
+	dst = VARDATA(result);
+	p = raw_b64;
+	remaining = encoded_len;
+
+	while (remaining > 0)
+	{
+		chunk = (remaining >= UTL_ENCODE_B64_LINE_LEN) ?
+				UTL_ENCODE_B64_LINE_LEN : remaining;
+		memcpy(dst, p, chunk);
+		dst += chunk;
+		p += chunk;
+		remaining -= chunk;
+		*dst++ = '\n';
+	}
+
+	SET_VARSIZE(result, VARHDRSZ + (dst - VARDATA(result)));
+	pfree(raw_b64);
+
+	PG_RETURN_BYTEA_P(result);
+}
+
+/*
+ * ivorysql_utl_encode_base64_decode
+ *
+ * Oracle-compatible BASE64_DECODE implementation:
+ *   - Decodes base64 ASCII bytes (RAW/bytea) back to binary
+ *   - Strips embedded whitespace (\n, \r, \t, space) before decoding,
+ *     because Oracle's BASE64_ENCODE inserts LF every 64 chars and
+ *     pg_b64_decode() rejects all whitespace characters
+ *   - Whitespace-only input returns empty bytea
+ *   - Empty input returns empty bytea
+ *   - NULL input: handled by STRICT modifier in SQL registration
+ *   - Invalid base64 characters (after whitespace stripping) raise ERROR
+ *
+ * Oracle signature: UTL_ENCODE.BASE64_DECODE(r IN RAW) RETURN RAW
+ * Maps to: bytea -> bytea  (RAW is bytea in IvorySQL)
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_encode_base64_decode);
+Datum
+ivorysql_utl_encode_base64_decode(PG_FUNCTION_ARGS)
+{
+	bytea	   *src = PG_GETARG_BYTEA_PP(0);
+	int			src_len = VARSIZE_ANY_EXHDR(src);
+	char	   *src_data = VARDATA_ANY(src);
+	char	   *clean_buf;
+	int			clean_len;
+	int			i;
+	int			dec_buf_len;
+	int			decoded_len;
+	bytea	   *result;
+	uint8	   *dst;
+
+	/* Empty input: return empty bytea */
+	if (src_len == 0)
+	{
+		result = (bytea *) palloc(VARHDRSZ);
+		SET_VARSIZE(result, VARHDRSZ);
+		PG_RETURN_BYTEA_P(result);
+	}
+
+	/*
+	 * Strip whitespace pass: copy only non-whitespace bytes into clean_buf.
+	 * pg_b64_decode() rejects whitespace characters, but Oracle's BASE64_ENCODE
+	 * inserts LF (\n) after every 64-character line.  We accept \n, \r, \t,
+	 * and plain space as legitimate padding whitespace.
+	 */
+	clean_buf = palloc(src_len);
+	clean_len = 0;
+	for (i = 0; i < src_len; i++)
+	{
+		unsigned char c = (unsigned char) src_data[i];
+
+		if (c != '\n' && c != '\r' && c != '\t' && c != ' ')
+			clean_buf[clean_len++] = src_data[i];
+	}
+
+	/* Whitespace-only input: return empty bytea */
+	if (clean_len == 0)
+	{
+		pfree(clean_buf);
+		result = (bytea *) palloc(VARHDRSZ);
+		SET_VARSIZE(result, VARHDRSZ);
+		PG_RETURN_BYTEA_P(result);
+	}
+
+	/* Allocate output buffer (pg_b64_dec_len gives an upper bound) */
+	dec_buf_len = pg_b64_dec_len(clean_len);
+	result = (bytea *) palloc(VARHDRSZ + dec_buf_len);
+	dst = (uint8 *) VARDATA(result);
+
+	decoded_len = pg_b64_decode(clean_buf, clean_len, dst, dec_buf_len);
+	pfree(clean_buf);
+
+	if (decoded_len < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("UTL_ENCODE.BASE64_DECODE: invalid base64 input")));
+
+	SET_VARSIZE(result, VARHDRSZ + decoded_len);
+
+	PG_RETURN_BYTEA_P(result);
+}


### PR DESCRIPTION
 (BASE64_ENCODE and BASE64_DECODE)

Add UTL_ENCODE built-in package to ivorysql_ora extension, providing Oracle-compatible base64 encoding and decoding via RAW (bytea) input/output.

BASE64_ENCODE:
- Encodes binary data to base64 ASCII using 64-character lines with LF terminator after each line (RFC 1521 MIME format, matching Oracle's convention)
- Empty input returns empty RAW; NULL input returns NULL (STRICT)

BASE64_DECODE:
- Decodes base64-encoded RAW data back to binary
- Strips embedded whitespace (\n, \r, \t, space) before decoding so that output from BASE64_ENCODE (which inserts LF every 64 chars) round-trips correctly
- Whitespace-only input returns empty RAW; NULL input returns NULL (STRICT)
- Invalid base64 characters raise ERRCODE_INVALID_PARAMETER_VALUE

Implementation:
- C functions ivorysql_utl_encode_base64_encode / _base64_decode in utl_encode.c
- PL/iSQL package spec and body wrap the C functions as utl_encode.base64_encode / utl_encode.base64_decode with RAW parameter types
- Build system wired in Makefile, meson.build, and ivorysql_ora_merge_sqls
- Regression tests cover: NULL, empty, known values, round-trips at line-break boundaries (48 / 49 / 200 bytes), CRLF handling, whitespace-only input, and PL/iSQL package interface

resolve #1053 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `UTL_ENCODE` package for Oracle compatibility with `BASE64_ENCODE` and `BASE64_DECODE` functions, supporting encoding and decoding of binary data with proper whitespace handling and error detection for invalid input.

* **Tests**
  * Added comprehensive test suite for `UTL_ENCODE` functionality including NULL handling, round-trip verification, boundary cases, and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IvorySQL/IvorySQL/pull/1338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->