### PR TITLE
[Oracle compatibility] Create index online

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -726,12 +726,17 @@ DefineIndex(Oid tableId,
 	if (partitioned)
 	{
 		/*
-		 * Note: we check 'stmt->concurrent' rather than 'concurrent', so that
-		 * the error is thrown also for temporary tables.  Seems better to be
-		 * consistent, even though we could do it on temporary table because
-		 * we're not actually doing it concurrently.
+		 * For ONLINE keyword (Oracle-compatible mode), silently degrade to a
+		 * non-concurrent build on partitioned tables.  Oracle succeeds with
+		 * CREATE INDEX ... ONLINE on partitioned tables (creates a global
+		 * non-partitioned index, PAR=NO).  Preserve the error for
+		 * CONCURRENTLY so existing PostgreSQL behavior is unchanged.
+		 *
+		 * Note: we check stmt->online_keyword to distinguish the two paths.
 		 */
-		if (stmt->concurrent)
+		if (stmt->concurrent && stmt->online_keyword)
+			concurrent = false;
+		else if (stmt->concurrent)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot create index on partitioned table \"%s\" concurrently",

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -735,7 +735,13 @@ DefineIndex(Oid tableId,
 		 * Note: we check stmt->online_keyword to distinguish the two paths.
 		 */
 		if (stmt->concurrent && stmt->online_keyword)
+		{
 			concurrent = false;
+			/* Correct the progress command reported before this downgrade. */
+			if (!OidIsValid(parentIndexId))
+				pgstat_progress_update_param(PROGRESS_CREATEIDX_COMMAND,
+											 PROGRESS_CREATEIDX_COMMAND_CREATE);
+		}
 		else if (stmt->concurrent)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -8843,7 +8843,7 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 						}
 					}
 
-					/* FR-005: CONCURRENTLY and ONLINE are mutually exclusive */
+					/* CONCURRENTLY and ONLINE are mutually exclusive */
 					if ($4 && online)
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
@@ -8913,7 +8913,7 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 						}
 					}
 
-					/* FR-005: CONCURRENTLY and ONLINE are mutually exclusive */
+					/* CONCURRENTLY and ONLINE are mutually exclusive */
 					if ($4 && online)
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -337,6 +337,8 @@ static void determineLanguage(List *options);
 	   replica_identity partition_cmd index_partition_cmd
 %type <list>	rebuild_index_opt_list
 %type <defelt>	rebuild_index_opt
+%type <list>	create_index_opt_list
+%type <defelt>	create_index_opt
 %type <list>	alter_table_cmds alter_type_cmds
 %type <list>    alter_identity_column_option_list
 %type <defelt>  alter_identity_column_option
@@ -2632,6 +2634,31 @@ index_partition_cmd:
 					$$ = (Node *) n;
 				}
 		;
+
+/*
+ * create_index_opt_list / create_index_opt
+ *
+ * Options following CREATE INDEX column list.
+ * ONLINE and TABLESPACE may appear in any order (Oracle-compatible).
+ * Duplicate options are rejected immediately.
+ */
+create_index_opt_list:
+		create_index_opt_list create_index_opt
+				{ $$ = lappend($1, $2); }
+		| /* EMPTY */
+				{ $$ = NIL; }
+	;
+
+create_index_opt:
+		ONLINE
+				{
+					$$ = makeDefElem("online", (Node *) makeBoolean(true), @1);
+				}
+		| TABLESPACE name
+				{
+					$$ = makeDefElem("tablespace", (Node *) makeString($2), @1);
+				}
+	;
 
 /*
  * rebuild_index_opt_list / rebuild_index_opt
@@ -8782,12 +8809,50 @@ defacl_privilege_target:
 
 IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 			ON relation_expr access_method_clause '(' index_params ')'
-			opt_include opt_unique_null_treatment opt_reloptions OptTableSpace where_clause
+			opt_include opt_unique_null_treatment opt_reloptions
+			create_index_opt_list where_clause
 				{
-					IndexStmt *n = makeNode(IndexStmt);
+					IndexStmt  *n = makeNode(IndexStmt);
+					bool		online = false;
+					bool		online_seen = false;
+					char	   *tablespace = NULL;
+					ListCell   *lc;
+
+					foreach(lc, $15)
+					{
+						DefElem *opt = (DefElem *) lfirst(lc);
+
+						if (strcmp(opt->defname, "online") == 0)
+						{
+							if (online_seen)
+								ereport(ERROR,
+										(errcode(ERRCODE_SYNTAX_ERROR),
+										 errmsg("ONLINE specified multiple times"),
+										 parser_errposition(opt->location)));
+							online = defGetBoolean(opt);
+							online_seen = true;
+						}
+						else if (strcmp(opt->defname, "tablespace") == 0)
+						{
+							if (tablespace != NULL)
+								ereport(ERROR,
+										(errcode(ERRCODE_SYNTAX_ERROR),
+										 errmsg("TABLESPACE specified multiple times"),
+										 parser_errposition(opt->location)));
+							tablespace = defGetString(opt);
+						}
+					}
+
+					/* FR-005: CONCURRENTLY and ONLINE are mutually exclusive */
+					if ($4 && online)
+						ereport(ERROR,
+								(errcode(ERRCODE_SYNTAX_ERROR),
+								 errmsg("cannot use both CONCURRENTLY and ONLINE"),
+								 parser_errposition(@4)));
 
 					n->unique = $2;
-					n->concurrent = $4;
+					n->concurrent = $4 || online;
+					n->online_keyword = online;
 					n->idxname = $5;
 					n->relation = $7;
 					n->accessMethod = $8;
@@ -8795,7 +8860,7 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 					n->indexIncludingParams = $12;
 					n->nulls_not_distinct = !$13;
 					n->options = $14;
-					n->tableSpace = $15;
+					n->tableSpace = tablespace;
 					n->whereClause = $16;
 					n->excludeOpNames = NIL;
 					n->idxcomment = NULL;
@@ -8814,12 +8879,50 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 				}
 			| CREATE opt_unique INDEX opt_concurrently IF_P NOT EXISTS name
 			ON relation_expr access_method_clause '(' index_params ')'
-			opt_include opt_unique_null_treatment opt_reloptions OptTableSpace where_clause
+			opt_include opt_unique_null_treatment opt_reloptions
+			create_index_opt_list where_clause
 				{
-					IndexStmt *n = makeNode(IndexStmt);
+					IndexStmt  *n = makeNode(IndexStmt);
+					bool		online = false;
+					bool		online_seen = false;
+					char	   *tablespace = NULL;
+					ListCell   *lc;
+
+					foreach(lc, $18)
+					{
+						DefElem *opt = (DefElem *) lfirst(lc);
+
+						if (strcmp(opt->defname, "online") == 0)
+						{
+							if (online_seen)
+								ereport(ERROR,
+										(errcode(ERRCODE_SYNTAX_ERROR),
+										 errmsg("ONLINE specified multiple times"),
+										 parser_errposition(opt->location)));
+							online = defGetBoolean(opt);
+							online_seen = true;
+						}
+						else if (strcmp(opt->defname, "tablespace") == 0)
+						{
+							if (tablespace != NULL)
+								ereport(ERROR,
+										(errcode(ERRCODE_SYNTAX_ERROR),
+										 errmsg("TABLESPACE specified multiple times"),
+										 parser_errposition(opt->location)));
+							tablespace = defGetString(opt);
+						}
+					}
+
+					/* FR-005: CONCURRENTLY and ONLINE are mutually exclusive */
+					if ($4 && online)
+						ereport(ERROR,
+								(errcode(ERRCODE_SYNTAX_ERROR),
+								 errmsg("cannot use both CONCURRENTLY and ONLINE"),
+								 parser_errposition(@4)));
 
 					n->unique = $2;
-					n->concurrent = $4;
+					n->concurrent = $4 || online;
+					n->online_keyword = online;
 					n->idxname = $8;
 					n->relation = $10;
 					n->accessMethod = $11;
@@ -8827,7 +8930,7 @@ IndexStmt:	CREATE opt_unique INDEX opt_concurrently opt_single_name
 					n->indexIncludingParams = $15;
 					n->nulls_not_distinct = !$16;
 					n->options = $17;
-					n->tableSpace = $18;
+					n->tableSpace = tablespace;
 					n->whereClause = $19;
 					n->excludeOpNames = NIL;
 					n->idxcomment = NULL;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3596,6 +3596,7 @@ typedef struct IndexStmt
 	bool		initdeferred;	/* is the constraint INITIALLY DEFERRED? */
 	bool		transformed;	/* true when transformIndexStmt is finished */
 	bool		concurrent;		/* should this be a concurrent index build? */
+	bool		online_keyword; /* was ONLINE keyword used (not CONCURRENTLY)? */
 	bool		if_not_exists;	/* just do nothing if index already exists? */
 	bool		reset_default_tblspc;	/* reset default_tablespace prior to
 										 * executing */

--- a/src/oracle_test/regress/expected/create_index_online.out
+++ b/src/oracle_test/regress/expected/create_index_online.out
@@ -1,7 +1,6 @@
 --
 -- CREATE_INDEX_ONLINE
 -- Test Oracle-compatible CREATE INDEX ... ONLINE syntax
--- Feature: IvorySQL-FEAT-XXXX
 --
 SET ivorysql.compatible_mode = oracle;
 SET client_min_messages TO 'warning';
@@ -85,7 +84,7 @@ NOTICE:  relation "idx_online_email" already exists, skipping
 -- GROUP 5: Partitioned table with ONLINE
 -- ============================================================
 -- T15: Partitioned table parent index ONLINE
--- ONLINE on partitioned table silently degrades to non-concurrent build (FR-009)
+-- ONLINE on partitioned table silently degrades to non-concurrent build 
 CREATE INDEX idx_part_online ON tbl_ci_part (id) ONLINE;
 -- T16: Verify parent index and its partition child indexes are all valid
 SELECT c.relname, i.indisvalid

--- a/src/oracle_test/regress/expected/create_index_online.out
+++ b/src/oracle_test/regress/expected/create_index_online.out
@@ -1,0 +1,149 @@
+--
+-- CREATE_INDEX_ONLINE
+-- Test Oracle-compatible CREATE INDEX ... ONLINE syntax
+-- Feature: IvorySQL-FEAT-XXXX
+--
+SET ivorysql.compatible_mode = oracle;
+SET client_min_messages TO 'warning';
+DROP TABLE IF EXISTS tbl_ci_online    CASCADE;
+DROP TABLE IF EXISTS tbl_ci_part      CASCADE;
+DROP TABLE IF EXISTS tbl_ci_unique    CASCADE;
+RESET client_min_messages;
+-- Base test table
+CREATE TABLE tbl_ci_online (
+    id      NUMBER(10)    PRIMARY KEY,
+    name    VARCHAR2(100),
+    dept_id NUMBER(10),
+    salary  NUMBER(10,2),
+    status  VARCHAR2(20)
+);
+INSERT INTO tbl_ci_online
+    SELECT g, 'name'||g, MOD(g,20), g*100.0, CASE WHEN MOD(g,2)=0 THEN 'ACTIVE' ELSE 'INACTIVE' END
+    FROM generate_series(1, 1000) g;
+-- Unique index test table
+CREATE TABLE tbl_ci_unique (
+    id    NUMBER(10)    PRIMARY KEY,
+    email VARCHAR2(200) NOT NULL
+);
+INSERT INTO tbl_ci_unique SELECT g, 'user'||g||'@example.com' FROM generate_series(1, 200) g;
+-- Partitioned table
+CREATE TABLE tbl_ci_part (
+    id     NUMBER(10),
+    region VARCHAR2(20)
+) PARTITION BY RANGE (id);
+CREATE TABLE tbl_ci_part_p1 PARTITION OF tbl_ci_part FOR VALUES FROM (1)   TO (501);
+CREATE TABLE tbl_ci_part_p2 PARTITION OF tbl_ci_part FOR VALUES FROM (501) TO (1001);
+INSERT INTO tbl_ci_part SELECT g, CASE WHEN g<=500 THEN 'east' ELSE 'west' END
+    FROM generate_series(1, 1000) g;
+-- ============================================================
+-- GROUP 1: Basic CREATE INDEX ... ONLINE
+-- ============================================================
+-- T01: Simplest form
+CREATE INDEX idx_online_name ON tbl_ci_online (name) ONLINE;
+-- T02: Verify index is valid
+SELECT indisvalid FROM pg_index
+  WHERE indexrelid = 'idx_online_name'::regclass;
+ indisvalid 
+------------
+ t
+(1 row)
+
+-- T03: Multi-column index
+CREATE INDEX idx_online_multi ON tbl_ci_online (dept_id, salary) ONLINE;
+-- T04: Expression index
+CREATE INDEX idx_online_expr ON tbl_ci_online (lower(name)) ONLINE;
+-- ============================================================
+-- GROUP 2: CREATE UNIQUE INDEX ... ONLINE
+-- ============================================================
+-- T07: Unique index
+CREATE UNIQUE INDEX idx_online_email ON tbl_ci_unique (email) ONLINE;
+-- T08: Verify uniqueness (duplicate email should fail)
+INSERT INTO tbl_ci_unique VALUES (999, 'user1@example.com');
+ERROR:  duplicate key value violates unique constraint "idx_online_email"
+DETAIL:  Key (email)=(user1@example.com) already exists.
+-- ============================================================
+-- GROUP 3: ONLINE and TABLESPACE in any order
+-- ============================================================
+-- T09: ONLINE before TABLESPACE
+CREATE INDEX idx_online_tbs_a ON tbl_ci_online (dept_id) ONLINE TABLESPACE pg_default;
+-- T10: ONLINE after TABLESPACE (Oracle-compatible: any order)
+CREATE INDEX idx_online_tbs_b ON tbl_ci_online (dept_id) TABLESPACE pg_default ONLINE;
+-- T11: TABLESPACE only (control: ensure existing behavior unchanged)
+CREATE INDEX idx_tbs_only ON tbl_ci_online (salary) TABLESPACE pg_default;
+-- ============================================================
+-- GROUP 4: IF NOT EXISTS with ONLINE
+-- ============================================================
+-- T12: Normal case (index does not exist)
+CREATE INDEX IF NOT EXISTS idx_online_ifne ON tbl_ci_online (status) ONLINE;
+-- T13: Index already exists, NOTICE instead of error
+CREATE INDEX IF NOT EXISTS idx_online_ifne ON tbl_ci_online (status) ONLINE;
+NOTICE:  relation "idx_online_ifne" already exists, skipping
+-- T14: IF NOT EXISTS + UNIQUE + ONLINE, index name already exists
+CREATE UNIQUE INDEX IF NOT EXISTS idx_online_email ON tbl_ci_unique (email) ONLINE;
+NOTICE:  relation "idx_online_email" already exists, skipping
+-- ============================================================
+-- GROUP 5: Partitioned table with ONLINE
+-- ============================================================
+-- T15: Partitioned table parent index ONLINE
+-- ONLINE on partitioned table silently degrades to non-concurrent build (FR-009)
+CREATE INDEX idx_part_online ON tbl_ci_part (id) ONLINE;
+-- T16: Verify parent index and its partition child indexes are all valid
+SELECT c.relname, i.indisvalid
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+WHERE i.indexrelid = 'idx_part_online'::regclass
+   OR i.indexrelid IN (
+       SELECT inhrelid FROM pg_inherits
+       WHERE inhparent = 'idx_part_online'::regclass
+   )
+ORDER BY c.relname;
+        relname        | indisvalid 
+-----------------------+------------
+ idx_part_online       | t
+ tbl_ci_part_p1_id_idx | t
+ tbl_ci_part_p2_id_idx | t
+(3 rows)
+
+-- T17: Partitioned table ONLINE (no explicit tablespace — pg_default cannot be
+--      specified explicitly for partitioned relations in PostgreSQL)
+CREATE INDEX idx_part_online_tbs ON tbl_ci_part (region) ONLINE;
+-- ============================================================
+-- GROUP 6: CONCURRENTLY and ONLINE are mutually exclusive
+-- ============================================================
+-- T18: CONCURRENTLY before ONLINE (should error)
+CREATE INDEX CONCURRENTLY idx_both ON tbl_ci_online (name) ONLINE;
+ERROR:  cannot use both CONCURRENTLY and ONLINE
+LINE 1: CREATE INDEX CONCURRENTLY idx_both ON tbl_ci_online (name) O...
+                     ^
+-- T19: Verify existing CONCURRENTLY syntax is unaffected
+CREATE INDEX CONCURRENTLY idx_still_conc ON tbl_ci_online (dept_id);
+-- ============================================================
+-- GROUP 7: Different access methods with ONLINE
+-- ============================================================
+-- T20: HASH index ONLINE
+CREATE INDEX idx_hash_online ON tbl_ci_online USING hash (name) ONLINE;
+-- T21: Default method (btree) ONLINE
+CREATE INDEX idx_btree_online ON tbl_ci_online USING btree (dept_id) ONLINE;
+-- T22: Expression index using Oracle built-in UPPER
+CREATE INDEX idx_upper_online ON tbl_ci_online (UPPER(name)) ONLINE;
+-- ============================================================
+-- GROUP 8: PG parser mode unaffected (compatibility check)
+-- ============================================================
+-- T23: Switch to PG parser mode, ONLINE should be a syntax error
+SET ivorysql.compatible_mode = pg;
+CREATE INDEX idx_pg_mode ON tbl_ci_online (name) ONLINE;
+ERROR:  syntax error at or near "ONLINE"
+LINE 1: CREATE INDEX idx_pg_mode ON tbl_ci_online (name) ONLINE;
+                                                         ^
+-- Restore Oracle mode
+SET ivorysql.compatible_mode = oracle;
+-- T24: PG mode CONCURRENTLY still works
+SET ivorysql.compatible_mode = pg;
+CREATE INDEX CONCURRENTLY idx_pg_conc ON tbl_ci_online (salary);
+SET ivorysql.compatible_mode = oracle;
+-- ============================================================
+-- Cleanup
+-- ============================================================
+DROP TABLE IF EXISTS tbl_ci_online  CASCADE;
+DROP TABLE IF EXISTS tbl_ci_part    CASCADE;
+DROP TABLE IF EXISTS tbl_ci_unique  CASCADE;

--- a/src/oracle_test/regress/parallel_schedule
+++ b/src/oracle_test/regress/parallel_schedule
@@ -177,7 +177,7 @@ test: ora_identifiers
 # Oracle ALTER INDEX ... REBUILD syntax (#1064)
 # ----------
 
-test: alter_index
+test: alter_index create_index_online
 
 # ----------
 # Oracle WITH FUNCTION/PROCEDURE support

--- a/src/oracle_test/regress/sql/create_index_online.sql
+++ b/src/oracle_test/regress/sql/create_index_online.sql
@@ -1,7 +1,6 @@
 --
 -- CREATE_INDEX_ONLINE
 -- Test Oracle-compatible CREATE INDEX ... ONLINE syntax
--- Feature: IvorySQL-FEAT-XXXX
 --
 
 SET ivorysql.compatible_mode = oracle;
@@ -98,7 +97,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_online_email ON tbl_ci_unique (email) ONLI
 -- ============================================================
 
 -- T15: Partitioned table parent index ONLINE
--- ONLINE on partitioned table silently degrades to non-concurrent build (FR-009)
+-- ONLINE on partitioned table silently degrades to non-concurrent build 
 CREATE INDEX idx_part_online ON tbl_ci_part (id) ONLINE;
 
 -- T16: Verify parent index and its partition child indexes are all valid

--- a/src/oracle_test/regress/sql/create_index_online.sql
+++ b/src/oracle_test/regress/sql/create_index_online.sql
@@ -1,0 +1,163 @@
+--
+-- CREATE_INDEX_ONLINE
+-- Test Oracle-compatible CREATE INDEX ... ONLINE syntax
+-- Feature: IvorySQL-FEAT-XXXX
+--
+
+SET ivorysql.compatible_mode = oracle;
+SET client_min_messages TO 'warning';
+DROP TABLE IF EXISTS tbl_ci_online    CASCADE;
+DROP TABLE IF EXISTS tbl_ci_part      CASCADE;
+DROP TABLE IF EXISTS tbl_ci_unique    CASCADE;
+RESET client_min_messages;
+
+-- Base test table
+CREATE TABLE tbl_ci_online (
+    id      NUMBER(10)    PRIMARY KEY,
+    name    VARCHAR2(100),
+    dept_id NUMBER(10),
+    salary  NUMBER(10,2),
+    status  VARCHAR2(20)
+);
+INSERT INTO tbl_ci_online
+    SELECT g, 'name'||g, MOD(g,20), g*100.0, CASE WHEN MOD(g,2)=0 THEN 'ACTIVE' ELSE 'INACTIVE' END
+    FROM generate_series(1, 1000) g;
+
+-- Unique index test table
+CREATE TABLE tbl_ci_unique (
+    id    NUMBER(10)    PRIMARY KEY,
+    email VARCHAR2(200) NOT NULL
+);
+INSERT INTO tbl_ci_unique SELECT g, 'user'||g||'@example.com' FROM generate_series(1, 200) g;
+
+-- Partitioned table
+CREATE TABLE tbl_ci_part (
+    id     NUMBER(10),
+    region VARCHAR2(20)
+) PARTITION BY RANGE (id);
+CREATE TABLE tbl_ci_part_p1 PARTITION OF tbl_ci_part FOR VALUES FROM (1)   TO (501);
+CREATE TABLE tbl_ci_part_p2 PARTITION OF tbl_ci_part FOR VALUES FROM (501) TO (1001);
+INSERT INTO tbl_ci_part SELECT g, CASE WHEN g<=500 THEN 'east' ELSE 'west' END
+    FROM generate_series(1, 1000) g;
+
+-- ============================================================
+-- GROUP 1: Basic CREATE INDEX ... ONLINE
+-- ============================================================
+
+-- T01: Simplest form
+CREATE INDEX idx_online_name ON tbl_ci_online (name) ONLINE;
+
+-- T02: Verify index is valid
+SELECT indisvalid FROM pg_index
+  WHERE indexrelid = 'idx_online_name'::regclass;
+
+-- T03: Multi-column index
+CREATE INDEX idx_online_multi ON tbl_ci_online (dept_id, salary) ONLINE;
+
+-- T04: Expression index
+CREATE INDEX idx_online_expr ON tbl_ci_online (lower(name)) ONLINE;
+
+-- ============================================================
+-- GROUP 2: CREATE UNIQUE INDEX ... ONLINE
+-- ============================================================
+
+-- T07: Unique index
+CREATE UNIQUE INDEX idx_online_email ON tbl_ci_unique (email) ONLINE;
+
+-- T08: Verify uniqueness (duplicate email should fail)
+INSERT INTO tbl_ci_unique VALUES (999, 'user1@example.com');
+
+-- ============================================================
+-- GROUP 3: ONLINE and TABLESPACE in any order
+-- ============================================================
+
+-- T09: ONLINE before TABLESPACE
+CREATE INDEX idx_online_tbs_a ON tbl_ci_online (dept_id) ONLINE TABLESPACE pg_default;
+
+-- T10: ONLINE after TABLESPACE (Oracle-compatible: any order)
+CREATE INDEX idx_online_tbs_b ON tbl_ci_online (dept_id) TABLESPACE pg_default ONLINE;
+
+-- T11: TABLESPACE only (control: ensure existing behavior unchanged)
+CREATE INDEX idx_tbs_only ON tbl_ci_online (salary) TABLESPACE pg_default;
+
+-- ============================================================
+-- GROUP 4: IF NOT EXISTS with ONLINE
+-- ============================================================
+
+-- T12: Normal case (index does not exist)
+CREATE INDEX IF NOT EXISTS idx_online_ifne ON tbl_ci_online (status) ONLINE;
+
+-- T13: Index already exists, NOTICE instead of error
+CREATE INDEX IF NOT EXISTS idx_online_ifne ON tbl_ci_online (status) ONLINE;
+
+-- T14: IF NOT EXISTS + UNIQUE + ONLINE, index name already exists
+CREATE UNIQUE INDEX IF NOT EXISTS idx_online_email ON tbl_ci_unique (email) ONLINE;
+
+-- ============================================================
+-- GROUP 5: Partitioned table with ONLINE
+-- ============================================================
+
+-- T15: Partitioned table parent index ONLINE
+-- ONLINE on partitioned table silently degrades to non-concurrent build (FR-009)
+CREATE INDEX idx_part_online ON tbl_ci_part (id) ONLINE;
+
+-- T16: Verify parent index and its partition child indexes are all valid
+SELECT c.relname, i.indisvalid
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+WHERE i.indexrelid = 'idx_part_online'::regclass
+   OR i.indexrelid IN (
+       SELECT inhrelid FROM pg_inherits
+       WHERE inhparent = 'idx_part_online'::regclass
+   )
+ORDER BY c.relname;
+
+-- T17: Partitioned table ONLINE (no explicit tablespace — pg_default cannot be
+--      specified explicitly for partitioned relations in PostgreSQL)
+CREATE INDEX idx_part_online_tbs ON tbl_ci_part (region) ONLINE;
+
+-- ============================================================
+-- GROUP 6: CONCURRENTLY and ONLINE are mutually exclusive
+-- ============================================================
+
+-- T18: CONCURRENTLY before ONLINE (should error)
+CREATE INDEX CONCURRENTLY idx_both ON tbl_ci_online (name) ONLINE;
+
+-- T19: Verify existing CONCURRENTLY syntax is unaffected
+CREATE INDEX CONCURRENTLY idx_still_conc ON tbl_ci_online (dept_id);
+
+-- ============================================================
+-- GROUP 7: Different access methods with ONLINE
+-- ============================================================
+
+-- T20: HASH index ONLINE
+CREATE INDEX idx_hash_online ON tbl_ci_online USING hash (name) ONLINE;
+
+-- T21: Default method (btree) ONLINE
+CREATE INDEX idx_btree_online ON tbl_ci_online USING btree (dept_id) ONLINE;
+
+-- T22: Expression index using Oracle built-in UPPER
+CREATE INDEX idx_upper_online ON tbl_ci_online (UPPER(name)) ONLINE;
+
+-- ============================================================
+-- GROUP 8: PG parser mode unaffected (compatibility check)
+-- ============================================================
+
+-- T23: Switch to PG parser mode, ONLINE should be a syntax error
+SET ivorysql.compatible_mode = pg;
+CREATE INDEX idx_pg_mode ON tbl_ci_online (name) ONLINE;
+
+-- Restore Oracle mode
+SET ivorysql.compatible_mode = oracle;
+
+-- T24: PG mode CONCURRENTLY still works
+SET ivorysql.compatible_mode = pg;
+CREATE INDEX CONCURRENTLY idx_pg_conc ON tbl_ci_online (salary);
+SET ivorysql.compatible_mode = oracle;
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+DROP TABLE IF EXISTS tbl_ci_online  CASCADE;
+DROP TABLE IF EXISTS tbl_ci_part    CASCADE;
+DROP TABLE IF EXISTS tbl_ci_unique  CASCADE;


### PR DESCRIPTION
fix #1065 

Support ONLINE parameter when create index. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oracle-compatible support for CREATE INDEX ... ONLINE (including TABLESPACE option and IF NOT EXISTS), across btree/hash, expression, and unique indexes; works in partitioned-table scenarios.
* **Bug Fixes**
  * Improved handling when ONLINE and CONCURRENTLY are both specified (mutual exclusion enforced; partitioned-table cases now downgrade safely to non-concurrent).
* **Tests**
  * Added comprehensive regression tests and expected outputs exercising the new syntax and parser-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->