### PR TITLE
Make libxml support mandatory for building IvorySQL

### DIFF
--- a/configure
+++ b/configure
@@ -9240,7 +9240,7 @@ $as_echo "#define USE_LIBXML 1" >>confdefs.h
 
       ;;
     no)
-      :
+      as_fn_error $? "--without-libxml is not supported. The ivorysql_ora plugin depends on the libxml library." "$LINENO" 5
       ;;
     *)
       as_fn_error $? "no argument expected for --with-libxml option" "$LINENO" 5
@@ -9248,7 +9248,9 @@ $as_echo "#define USE_LIBXML 1" >>confdefs.h
   esac
 
 else
-  with_libxml=no
+  with_libxml=yes
+
+$as_echo "#define USE_LIBXML 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1159,8 +1159,9 @@ fi
 # XML
 #
 AC_MSG_CHECKING([whether to build with XML support])
-PGAC_ARG_BOOL(with, libxml, no, [build with XML support],
-              [AC_DEFINE([USE_LIBXML], 1, [Define to 1 to build with XML support. (--with-libxml)])])
+PGAC_ARG_BOOL(with, libxml, yes, [build with XML support],
+              [AC_DEFINE([USE_LIBXML], 1, [Define to 1 to build with XML support. (--with-libxml)])],
+              [AC_MSG_ERROR([--without-libxml is not supported. The ivorysql_ora plugin depends on the libxml library.])])
 AC_MSG_RESULT([$with_libxml])
 AC_SUBST(with_libxml)
 


### PR DESCRIPTION
Fix issue #1353 

The ivorysql_ora plugin depends on libxml, so enable it by default and reject --without-libxml at configure time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enable XML support (libxml) by default. libxml is now a required dependency for the ivorysql_ora plugin and cannot be disabled during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->