### PR TITLE
don't allow setting ivorysql.compatible_mode via ALTER USER/DATABASE SET

### DIFF
--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -19,6 +19,7 @@
 #include "catalog/pg_db_role_setting.h"
 #include "utils/fmgroids.h"
 #include "utils/rel.h"
+#include "utils/guc_tables.h"   /* for find_option */
 
 void
 AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
@@ -30,6 +31,19 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 	SysScanDesc scan;
 
 	valuestr = ExtractSetVariableArgs(setstmt);
+
+	if (valuestr != NULL)
+	{
+		struct config_generic *record;
+
+		record = find_option(setstmt->name, false, true, WARNING);
+		if (record && (record->flags & GUC_DISALLOW_IN_DB_ROLE_SETTING))
+		ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("cannot set parameter \"%s\" via ALTER USER/ROLE/DATABASE SET",
+				setstmt->name),
+			 errhint("Use SET command in session instead.")));
+	}
 
 	/* Get the old tuple, if any. */
 

--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1368,7 +1368,7 @@
 
 { name => 'ivorysql.compatible_mode', type => 'enum', context => 'PGC_USERSET', group => 'CLIENT_CONN_STATEMENT',
   short_desc => 'Set default sql parser compatibility mode',
-  flags => 'GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE',
+  flags => 'GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING',
   variable => 'compatible_db',
   boot_val => 'PG_PARSER',
   options => 'db_parser_options',

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -401,7 +401,7 @@ static struct config_enum Ivy_ConfigureNamesEnum[] =
 		{"ivorysql.compatible_mode", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Set default sql parser compatibility mode"),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING
 		},
 		&compatible_db,
 		PG_PARSER, db_parser_options,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -230,6 +230,8 @@ typedef enum
 #define GUC_RUNTIME_COMPUTED   0x004000 /* delay processing in 'postgres -C' */
 #define GUC_ALLOW_IN_PARALLEL  0x008000 /* allow setting in parallel mode */
 
+#define GUC_DISALLOW_IN_DB_ROLE_SETTING  0x800000 /* IvorySQL: can't set via ALTER USER/DATABASE SET */
+
 #define GUC_UNIT_KB			 0x01000000 /* value is in kilobytes */
 #define GUC_UNIT_BLOCKS		 0x02000000 /* value is in blocks */
 #define GUC_UNIT_XBLOCKS	 0x03000000 /* value is in xlog blocks */


### PR DESCRIPTION
fix issue #1357 

The value of ivorysql.compatible_mode is determined by port or can be set using SET command in session. 
But it cannot be set via ALTER USER/DATABASE SET.