### PR TITLE
remove the libxml lib dependency from ivorysql_ora

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -84,7 +84,9 @@ ORA_REGRESS = \
 	utl_raw \
 	utl_encode
 
-#SHLIB_LINK += -lxml2
+ifeq ($(with_libxml),yes) 
+SHLIB_LINK += -lxml2
+endif
 
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src

--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -84,7 +84,7 @@ ORA_REGRESS = \
 	utl_raw \
 	utl_encode
 
-SHLIB_LINK += -lxml2
+#SHLIB_LINK += -lxml2
 
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src


### PR DESCRIPTION
Fix issue #1353 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration so the XML library is linked only when XML support is enabled, instead of being linked unconditionally.
  * Expected to have no impact on end-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->