### PR TITLE
fix: ALTER ... SET ... TO DEFAULT 可绕过新限制

### DIFF
--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -39,10 +39,10 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 		record = find_option(setstmt->name, false, true, WARNING);
 		if (record && (record->flags & GUC_DISALLOW_IN_DB_ROLE_SETTING))
 		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("cannot set parameter \"%s\" via ALTER USER/ROLE/DATABASE SET",
-						setstmt->name),
-					errhint("Use SET command in session instead.")));
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("cannot set parameter \"%s\" via ALTER USER/ROLE/DATABASE SET/RESET",
+				setstmt->name),
+			 errhint("Use SET/RESET command in session instead.")));
 	}
 
 	/* Get the old tuple, if any. */

--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -32,17 +32,17 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 
 	valuestr = ExtractSetVariableArgs(setstmt);
 
-	if (valuestr != NULL)
+	if (setstmt->kind != VAR_RESET_ALL && setstmt->name != NULL)
 	{
 		struct config_generic *record;
 
 		record = find_option(setstmt->name, false, true, WARNING);
 		if (record && (record->flags & GUC_DISALLOW_IN_DB_ROLE_SETTING))
 		ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("cannot set parameter \"%s\" via ALTER USER/ROLE/DATABASE SET",
-				setstmt->name),
-			 errhint("Use SET command in session instead.")));
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("cannot set parameter \"%s\" via ALTER USER/ROLE/DATABASE SET",
+						setstmt->name),
+					errhint("Use SET command in session instead.")));
 	}
 
 	/* Get the old tuple, if any. */

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -5485,6 +5485,19 @@ show ivorysql.compatible_mode;
  oracle
 (1 row)
 
+-- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
+create role regress_psql_cm_role;
+alter role regress_psql_cm_role set ivorysql.compatible_mode = 'pg';
+ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET
+HINT:  Use SET command in session instead.
+alter role regress_psql_cm_role set ivorysql.compatible_mode to default;
+ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET
+HINT:  Use SET command in session instead.
+alter role regress_psql_cm_role reset ivorysql.compatible_mode;
+ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET
+HINT:  Use SET command in session instead.
+drop role regress_psql_cm_role;
+
 -- check \df+
 -- we have to use functions with a predictable owner name, so make a role
 create role regress_psql_user superuser;

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -5488,16 +5488,15 @@ show ivorysql.compatible_mode;
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;
 alter role regress_psql_cm_role set ivorysql.compatible_mode = 'pg';
-ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET
-HINT:  Use SET command in session instead.
+ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET/RESET
+HINT:  Use SET/RESET command in session instead.
 alter role regress_psql_cm_role set ivorysql.compatible_mode to default;
-ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET
-HINT:  Use SET command in session instead.
+ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET/RESET
+HINT:  Use SET/RESET command in session instead.
 alter role regress_psql_cm_role reset ivorysql.compatible_mode;
-ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET
-HINT:  Use SET command in session instead.
+ERROR:  cannot set parameter "ivorysql.compatible_mode" via ALTER USER/ROLE/DATABASE SET/RESET
+HINT:  Use SET/RESET command in session instead.
 drop role regress_psql_cm_role;
-
 -- check \df+
 -- we have to use functions with a predictable owner name, so make a role
 create role regress_psql_user superuser;

--- a/src/oracle_test/regress/sql/psql.sql
+++ b/src/oracle_test/regress/sql/psql.sql
@@ -1360,6 +1360,13 @@ set ivorysql.compatible_mode = 'pg';
 reset ivorysql.compatible_mode;
 show ivorysql.compatible_mode;
 
+-- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
+create role regress_psql_cm_role;
+alter role regress_psql_cm_role set ivorysql.compatible_mode = 'pg';
+alter role regress_psql_cm_role set ivorysql.compatible_mode to default;
+alter role regress_psql_cm_role reset ivorysql.compatible_mode;
+drop role regress_psql_cm_role;
+
 -- check \df+
 -- we have to use functions with a predictable owner name, so make a role
 create role regress_psql_user superuser;


### PR DESCRIPTION
fix issue #1374 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for role- and database-level setting changes so unsupported options can’t be saved with `ALTER ... SET` or `RESET`.
  * Updated error messaging to clearly reference both `SET` and `RESET`.
* **Tests**
  * Added regression coverage ensuring `ivorysql.compatible_mode` cannot be persisted or reset via role-level `ALTER ... SET/RESET`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->