### PR TITLE
Fix package datum misresolution in plisql_param_compile

### DIFF
--- a/src/oracle_test/regress/expected/ora_package.out
+++ b/src/oracle_test/regress/expected/ora_package.out
@@ -6321,6 +6321,61 @@ SELECT * FROM test_nested_commit ORDER BY id;
 
 DROP PACKAGE pkg_commit_test;
 DROP TABLE test_nested_commit;
+-- Test that a package CONSTANT referenced more than once while evaluating a
+-- simple expression always yields its own value, even when the reference is
+-- the RHS of an assignment to a variable that was already assigned earlier
+-- in the same block.  (Previously, plisql_param_compile rebound dno to the
+-- resolved datum's own dno within the package's namespace, and
+-- plisql_param_eval_var_check compared that against expr->target_param -- a
+-- dno in the *calling* function's namespace -- without accounting for
+-- pkgoid.  A coincidental numeric match caused it to read an unrelated local
+-- variable's value instead of the package constant.)
+CREATE OR REPLACE PACKAGE pkg_const_repeat_test IS
+  my_const CONSTANT VARCHAR2(2) := chr(13) || chr(10);
+  my_var VARCHAR2(20) := 'pkgvar-init';
+END pkg_const_repeat_test;
+/
+DO $$
+DECLARE
+  l_message VARCHAR2(100);
+  v_local   VARCHAR2(2) := pkg_const_repeat_test.my_const;
+BEGIN
+  IF v_local != chr(13) || chr(10) THEN
+    RAISE EXCEPTION 'unexpected v_local value';
+  END IF;
+
+  l_message := 'Line 1' || v_local || 'Line 2';
+  IF l_message != 'Line 1' || chr(13) || chr(10) || 'Line 2' THEN
+    RAISE EXCEPTION 'unexpected l_message value (first assignment): %', l_message;
+  END IF;
+
+  l_message := 'Line 3' || pkg_const_repeat_test.my_const || 'Line 4';
+  IF l_message != 'Line 3' || chr(13) || chr(10) || 'Line 4' THEN
+    RAISE EXCEPTION 'unexpected l_message value (second assignment): %', l_message;
+  END IF;
+
+  -- Same failure pattern, but for a mutable (non-CONSTANT) package variable,
+  -- including a reassignment of the package variable itself in between.
+  IF pkg_const_repeat_test.my_var != 'pkgvar-init' THEN
+    RAISE EXCEPTION 'unexpected initial my_var value: %', pkg_const_repeat_test.my_var;
+  END IF;
+
+  l_message := 'Line 1' || pkg_const_repeat_test.my_var || 'Line 2';
+  IF l_message != 'Line 1' || 'pkgvar-init' || 'Line 2' THEN
+    RAISE EXCEPTION 'unexpected l_message value (var, first assignment): %', l_message;
+  END IF;
+
+  pkg_const_repeat_test.my_var := 'pkgvar-updated';
+  l_message := 'Line 3' || pkg_const_repeat_test.my_var || 'Line 4';
+  IF l_message != 'Line 3' || 'pkgvar-updated' || 'Line 4' THEN
+    RAISE EXCEPTION 'unexpected l_message value (var, second assignment): %', l_message;
+  END IF;
+
+  RAISE NOTICE 'pkg_const_repeat_test: all checks passed';
+END;
+$$;
+NOTICE:  pkg_const_repeat_test: all checks passed
+DROP PACKAGE pkg_const_repeat_test;
 --clean data
 RESET ivorysql.allow_out_parameter_const;
 DROP FUNCTION test_event_trigger;

--- a/src/oracle_test/regress/sql/ora_package.sql
+++ b/src/oracle_test/regress/sql/ora_package.sql
@@ -6130,6 +6130,63 @@ SELECT * FROM test_nested_commit ORDER BY id;
 DROP PACKAGE pkg_commit_test;
 DROP TABLE test_nested_commit;
 
+-- Test that a package CONSTANT referenced more than once while evaluating a
+-- simple expression always yields its own value, even when the reference is
+-- the RHS of an assignment to a variable that was already assigned earlier
+-- in the same block.  (Previously, plisql_param_compile rebound dno to the
+-- resolved datum's own dno within the package's namespace, and
+-- plisql_param_eval_var_check compared that against expr->target_param -- a
+-- dno in the *calling* function's namespace -- without accounting for
+-- pkgoid.  A coincidental numeric match caused it to read an unrelated local
+-- variable's value instead of the package constant.)
+CREATE OR REPLACE PACKAGE pkg_const_repeat_test IS
+  my_const CONSTANT VARCHAR2(2) := chr(13) || chr(10);
+  my_var VARCHAR2(20) := 'pkgvar-init';
+END pkg_const_repeat_test;
+/
+
+DO $$
+DECLARE
+  l_message VARCHAR2(100);
+  v_local   VARCHAR2(2) := pkg_const_repeat_test.my_const;
+BEGIN
+  IF v_local != chr(13) || chr(10) THEN
+    RAISE EXCEPTION 'unexpected v_local value';
+  END IF;
+
+  l_message := 'Line 1' || v_local || 'Line 2';
+  IF l_message != 'Line 1' || chr(13) || chr(10) || 'Line 2' THEN
+    RAISE EXCEPTION 'unexpected l_message value (first assignment): %', l_message;
+  END IF;
+
+  l_message := 'Line 3' || pkg_const_repeat_test.my_const || 'Line 4';
+  IF l_message != 'Line 3' || chr(13) || chr(10) || 'Line 4' THEN
+    RAISE EXCEPTION 'unexpected l_message value (second assignment): %', l_message;
+  END IF;
+
+  -- Same failure pattern, but for a mutable (non-CONSTANT) package variable,
+  -- including a reassignment of the package variable itself in between.
+  IF pkg_const_repeat_test.my_var != 'pkgvar-init' THEN
+    RAISE EXCEPTION 'unexpected initial my_var value: %', pkg_const_repeat_test.my_var;
+  END IF;
+
+  l_message := 'Line 1' || pkg_const_repeat_test.my_var || 'Line 2';
+  IF l_message != 'Line 1' || 'pkgvar-init' || 'Line 2' THEN
+    RAISE EXCEPTION 'unexpected l_message value (var, first assignment): %', l_message;
+  END IF;
+
+  pkg_const_repeat_test.my_var := 'pkgvar-updated';
+  l_message := 'Line 3' || pkg_const_repeat_test.my_var || 'Line 4';
+  IF l_message != 'Line 3' || 'pkgvar-updated' || 'Line 4' THEN
+    RAISE EXCEPTION 'unexpected l_message value (var, second assignment): %', l_message;
+  END IF;
+
+  RAISE NOTICE 'pkg_const_repeat_test: all checks passed';
+END;
+$$;
+
+DROP PACKAGE pkg_const_repeat_test;
+
 --clean data
 RESET ivorysql.allow_out_parameter_const;
 DROP FUNCTION test_event_trigger;

--- a/src/pl/plisql/src/pl_exec.c
+++ b/src/pl/plisql/src/pl_exec.c
@@ -7098,7 +7098,18 @@ plisql_param_compile(ParamListInfo params, Param *param,
 	{
 		bool		isvarlena = (((PLiSQL_var *) datum)->datatype->typlen == -1);
 
-		if (isvarlena && dno == expr->target_param && expr->expr_simple_expr)
+		/*
+		 * dno has just been rebound to the resolved datum's own dno, which
+		 * for a package-qualified reference lives in the package's datum
+		 * namespace, not the calling function's.  plisql_param_eval_var_check
+		 * (below) indexes estate->datums[dno] directly without regard to
+		 * pkgoid, so comparing this dno against expr->target_param (a dno in
+		 * the calling function's namespace) is only meaningful when the
+		 * datum isn't package-qualified; otherwise a coincidental numeric
+		 * match causes it to read an unrelated local variable at runtime.
+		 */
+		if (isvarlena && dno == expr->target_param && expr->expr_simple_expr &&
+			!OidIsValid(((PLiSQL_var *) datum)->pkgoid))
 			scratch.d.cparam.paramfunc = plisql_param_eval_var_check;
 		else if (isvarlena)
 			scratch.d.cparam.paramfunc = plisql_param_eval_var_ro;


### PR DESCRIPTION
Fixes #1382

plisql_param_compile rebinds dno to the resolved datum's own dno, which for a package-qualified reference lives in the package's datum namespace rather than the calling function's. That dno was then compared against expr->target_param (a dno in the calling function's namespace to decide whether to install the plisql_param_eval_var_check fast path. Unlike its siblings plisql_param_eval_var/_ro, that path indexes estate->datums[dno] directly with no pkgoid awareness, so a coincidental numeric match between the two namespaces (common for small packages/blocks, e.g. both being dno 0) made it read and return an unrelated local variable's value instead of the package datum.

Symptom: referencing a package CONSTANT/variable more than once while evaluating a simple expression could silently return the wrong value
- either empty (uninitialized target) or the stale value of whatever variable happened to share that dno in the calling block.

Skip that fast path for package-qualified datums so they fall through to plisql_param_eval_var_ro, which already resolves package datums correctly via get_package_datum_bydno(). Adds a regression case to ora_package.sql reproducing the exact failure pattern.

Reported-by: Yasir Hussain Shah <yasir.hussain.shah@data-bene.io>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved inconsistent behavior when repeatedly evaluating package constants in expressions, especially for CRLF/newline-containing strings.
  * Improved evaluation for simple expressions involving package-qualified references to ensure correct variable handling.

* **Tests**
  * Added a new regression test that exercises repeated expression building using both a package constant and a mutable package variable, including validation of CRLF/newline results and expected pass/fail checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->