### PR TITLE
psql: add %o prompt escape for Oracle compatibility mode

### DIFF
--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -5092,6 +5092,27 @@ testdb=&gt; <userinput>INSERT INTO my_table VALUES (:'content');</userinput>
         </listitem>
       </varlistentry>
 
+      <varlistentry id="app-psql-prompting-o">
+        <term><literal>%o</literal></term>
+        <listitem>
+        <para>
+        <literal>[ORA]</literal> when the connected
+        <productname>IvorySQL</productname> server reports the current
+        session compatibility mode
+        (<varname>ivorysql.compatible_mode</varname>) as
+        <literal>oracle</literal>, and empty otherwise. The indicator
+        follows in-session mode changes, so it appears, for example,
+        after connecting to an IvorySQL listener port that selects
+        Oracle mode or after running <command>SET ivorysql.compatible_mode
+        = 'oracle'</command>, and disappears when the mode is switched
+        back to <literal>pg</literal>. Connections to a plain
+        <productname>PostgreSQL</productname> server, or to an
+        <productname>IvorySQL</productname> server whose compatibility
+        mode is <literal>pg</literal>, produce nothing.
+        </para>
+        </listitem>
+      </varlistentry>
+
       <varlistentry id="app-psql-prompting-x">
         <term><literal>%x</literal></term>
         <listitem>
@@ -5183,7 +5204,7 @@ testdb=&gt; \set PROMPT1 '%[%033[1;33;40m%]%n@%/%R%[%033[0m%]%# '
 
     To insert a percent sign into your prompt, write
     <literal>%%</literal>. The default prompts are
-    <literal>'%/%R%x%# '</literal> for prompts 1 and 2, and
+    <literal>'%o%/%R%x%# '</literal> for prompts 1 and 2, and
     <literal>'&gt;&gt; '</literal> for prompt 3.
     </para>
 

--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1369,7 +1369,7 @@
 
 { name => 'ivorysql.compatible_mode', type => 'enum', context => 'PGC_USERSET', group => 'CLIENT_CONN_STATEMENT',
   short_desc => 'Set default sql parser compatibility mode',
-  flags => 'GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING',
+  flags => 'GUC_REPORT | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING',
   variable => 'compatible_db',
   boot_val => 'PG_PARSER',
   options => 'db_parser_options',

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -401,7 +401,7 @@ static struct config_enum Ivy_ConfigureNamesEnum[] =
 		{"ivorysql.compatible_mode", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Set default sql parser compatibility mode"),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING
+			GUC_REPORT | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING
 		},
 		&compatible_db,
 		PG_PARSER, db_parser_options,

--- a/src/bin/psql/ora_prompt.c
+++ b/src/bin/psql/ora_prompt.c
@@ -46,6 +46,8 @@
  *		in prompt3 nothing
  * %i - "standby" or "primary" depending on the server's in_hot_standby
  *      status, or "?" if unavailable (empty if unknown)
+ * %o - "[ORA]" when the session is in Oracle compatibility mode
+ *      (ivorysql.compatible_mode = oracle), empty otherwise
  * %x - transaction status: empty, *, !, ? (unknown or no connection)
  * %l - The line number inside the current statement, starting from 1.
  * %? - the error code of the last query (not yet implemented)
@@ -268,6 +270,15 @@ ora_get_prompt(Ora_promptStatus_t status, ConditionalStack cstack)
 					}
 					break;
 
+				case 'o':
+					if (pset.db)
+					{
+						const char *cm = PQparameterStatus(pset.db, "ivorysql.compatible_mode");
+
+						if (cm && strcmp(cm, "oracle") == 0)
+							strlcpy(buf, "[ORA]", sizeof(buf));
+					}
+					break;
 				case 'x':
 					if (!pset.db)
 						buf[0] = '?';

--- a/src/bin/psql/prompt.c
+++ b/src/bin/psql/prompt.c
@@ -46,6 +46,8 @@
  *		in prompt3 nothing
  * %i - "standby" or "primary" depending on the server's in_hot_standby
  *      status, or "?" if unavailable (empty if unknown)
+ * %o - "[ORA]" when the session is in Oracle compatibility mode
+ *      (ivorysql.compatible_mode = oracle), empty otherwise
  * %x - transaction status: empty, *, !, ? (unknown or no connection)
  * %l - The line number inside the current statement, starting from 1.
  * %? - the error code of the last query (not yet implemented)
@@ -275,6 +277,15 @@ get_prompt(promptStatus_t status, ConditionalStack cstack)
 						/* Use ? for versions that don't report in_hot_standby */
 						else
 							buf[0] = '?';
+					}
+					break;
+				case 'o':
+					if (pset.db)
+					{
+						const char *cm = PQparameterStatus(pset.db, "ivorysql.compatible_mode");
+
+						if (cm && strcmp(cm, "oracle") == 0)
+							strlcpy(buf, "[ORA]", sizeof(buf));
 					}
 					break;
 				case 'x':

--- a/src/bin/psql/settings.h
+++ b/src/bin/psql/settings.h
@@ -23,8 +23,8 @@
 #define DEFAULT_EDITOR_LINENUMBER_ARG "+"
 #endif
 
-#define DEFAULT_PROMPT1 "%/%R%x%# "
-#define DEFAULT_PROMPT2 "%/%R%x%# "
+#define DEFAULT_PROMPT1 "%o%/%R%x%# "
+#define DEFAULT_PROMPT2 "%o%/%R%x%# "
 #define DEFAULT_PROMPT3 ">> "
 
 #define DEFAULT_WATCH_INTERVAL "2"

--- a/src/bin/psql/t/040_prompt.pl
+++ b/src/bin/psql/t/040_prompt.pl
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2026, PostgreSQL Global Development Group
+# Copyright (c) 2021-2026, PostgreSQL Global Development Group
 
 # Test psql's %o prompt escape.  The escape prints "[ORA]" when the connected
 # IvorySQL server reports the session's compatibility mode

--- a/src/bin/psql/t/040_prompt.pl
+++ b/src/bin/psql/t/040_prompt.pl
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2021-2026, PostgreSQL Global Development Group
+# Copyright (c) 2021-2026, IvorySQL Global Development Group
 
 # Test psql's %o prompt escape.  The escape prints "[ORA]" when the connected
 # IvorySQL server reports the session's compatibility mode

--- a/src/bin/psql/t/040_prompt.pl
+++ b/src/bin/psql/t/040_prompt.pl
@@ -5,11 +5,11 @@
 # IvorySQL server reports the session's compatibility mode
 # (ivorysql.compatible_mode) as "oracle", and expands to nothing otherwise.
 #
-# The default regression cluster is initialized in "pg" database mode, so
-# compatible_mode is "pg" here and %o must expand to nothing.  The full
-# "[ORA]" path is exercised against Oracle-mode clusters by the oracle
-# regression suite; this test guards the client-side escape handling in the
-# standard (pg-mode) test environment.
+# Both paths are exercised here against real IvorySQL clusters started by the
+# TAP harness:
+#   * a default pg-mode cluster, where %o must expand to nothing;
+#   * an Oracle-mode cluster where compatible_mode is switched to oracle
+#     in-session, where %o must expand to "[ORA]".
 
 use strict;
 use warnings FATAL => 'all';
@@ -25,8 +25,11 @@ if ($@)
 	plan skip_all => 'IO::Pty is needed to run this test';
 }
 
-# start a new server
-my $node = PostgreSQL::Test::Cluster->new('main');
+# ---------------------------------------------------------------------------
+# pg-mode cluster: %o expands to nothing.
+# ---------------------------------------------------------------------------
+{
+my $node = PostgreSQL::Test::Cluster->new('pgmode');
 $node->init;
 $node->start;
 
@@ -73,6 +76,48 @@ like($mode, qr/^pg\r?$/m, "compatible_mode is pg in a pg-mode cluster");
 # send psql an explicit \q to shut it down, else pty won't close properly
 $h->quit or die "psql returned $?";
 
-# done
 $node->stop;
+}
+
+# ---------------------------------------------------------------------------
+# Oracle-mode cluster: %o expands to "[ORA]".
+# ---------------------------------------------------------------------------
+{
+# Cluster.pm initializes clusters with `initdb -m pg`; appending `-m oracle`
+# creates an Oracle-mode (database_mode = DB_ORACLE) cluster, the only mode in
+# which compatible_mode may be switched to oracle.
+local $ENV{PG_TEST_INITDB_EXTRA_OPTS} = '-m oracle';
+
+my $node = PostgreSQL::Test::Cluster->new('oraclemode');
+$node->init;
+$node->start;
+
+my $h = $node->interactive_psql('postgres');
+
+# Switch the session to oracle compatibility, then isolate %o with markers.
+# After the SET, the server reports compatible_mode = oracle, so the rendered
+# prompt must become "BEFORE[ORA]AFTER".
+$h->query_until(
+	qr/^ok2\r?$/m,
+	"SET ivorysql.compatible_mode = oracle;\n"
+	  . "\\set PROMPT1 'BEFORE[%o]AFTER'\n"
+	  . "select 'p4' as p;\nselect 'ok2' as r;\n");
+my $out = $h->query_until(
+	qr/^res3\r?$/m,
+	"select 'p5' as p;\nselect 'res3' as r;\n");
+like(
+	$out,
+	qr/BEFORE\[ORA\]AFTER/,
+	"%o expands to [ORA] when compatible_mode is oracle");
+
+# Confirm the value %o keys off of.
+my $mode = $h->query_until(qr/^oracle\r?$/m, "show ivorysql.compatible_mode;\n");
+like($mode, qr/^oracle\r?$/m,
+	"compatible_mode is oracle in an oracle-mode session");
+
+$h->quit or die "psql returned $?";
+
+$node->stop;
+}
+
 done_testing();

--- a/src/bin/psql/t/040_prompt.pl
+++ b/src/bin/psql/t/040_prompt.pl
@@ -100,7 +100,7 @@ my $h = $node->interactive_psql('postgres');
 $h->query_until(
 	qr/^ok2\r?$/m,
 	"SET ivorysql.compatible_mode = oracle;\n"
-	  . "\\set PROMPT1 'BEFORE[%o]AFTER'\n"
+	  . "\\set PROMPT1 'BEFORE%oAFTER'\n"
 	  . "select 'p4' as p;\nselect 'ok2' as r;\n");
 my $out = $h->query_until(
 	qr/^res3\r?$/m,

--- a/src/bin/psql/t/040_prompt.pl
+++ b/src/bin/psql/t/040_prompt.pl
@@ -1,0 +1,78 @@
+
+# Copyright (c) 2026, PostgreSQL Global Development Group
+
+# Test psql's %o prompt escape.  The escape prints "[ORA]" when the connected
+# IvorySQL server reports the session's compatibility mode
+# (ivorysql.compatible_mode) as "oracle", and expands to nothing otherwise.
+#
+# The default regression cluster is initialized in "pg" database mode, so
+# compatible_mode is "pg" here and %o must expand to nothing.  The full
+# "[ORA]" path is exercised against Oracle-mode clusters by the oracle
+# regression suite; this test guards the client-side escape handling in the
+# standard (pg-mode) test environment.
+
+use strict;
+use warnings FATAL => 'all';
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# A pty is required for psql to print prompts at all.
+eval { require IO::Pty; };
+if ($@)
+{
+	plan skip_all => 'IO::Pty is needed to run this test';
+}
+
+# start a new server
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
+$node->start;
+
+my $h = $node->interactive_psql('postgres');
+
+# interactive_psql drains the startup banner, so a prompt is only observed in
+# the output captured for a *later* command.  To reliably capture the prompt
+# that is printed between two commands, send a primer command followed by a
+# real command, and match the real command's result on its own line (so the
+# pump reads well past the primer and its trailing prompt).  Note that pty
+# output uses CR/LF line endings.
+
+# Default prompt ('%o%/%R%x%# '): %o must be recognized and expand to nothing,
+# so the prompt still reads "postgres=# " with no literal "%o".
+my $out = $h->query_until(
+	qr/^res1\r?$/m,
+	"select 'primer' as p;\nselect 'res1' as r;\n");
+like(
+	$out,
+	qr/postgres/,
+	"default prompt is shown in interactive mode");
+unlike(
+	$out,
+	qr/%o/,
+	"default prompt expands %o to nothing in pg mode");
+
+# Isolate %o with recognizable markers.  In pg mode it must expand to nothing,
+# so the rendered prompt becomes "BEFORE[]AFTER".
+$h->query_until(
+	qr/^ok1\r?$/m,
+	"\\set PROMPT1 'BEFORE[%o]AFTER'\nselect 'p2' as p;\nselect 'ok1' as r;\n");
+$out = $h->query_until(
+	qr/^res2\r?$/m,
+	"select 'p3' as p;\nselect 'res2' as r;\n");
+like(
+	$out,
+	qr/BEFORE\[\]AFTER/,
+	"%o expands to nothing when compatible_mode is pg");
+
+# Confirm the value %o keys off of.
+my $mode = $h->query_until(qr/^pg\r?$/m, "show ivorysql.compatible_mode;\n");
+like($mode, qr/^pg\r?$/m, "compatible_mode is pg in a pg-mode cluster");
+
+# send psql an explicit \q to shut it down, else pty won't close properly
+$h->quit or die "psql returned $?";
+
+# done
+$node->stop;
+done_testing();


### PR DESCRIPTION
Add a new psql prompt escape `%o` that shows whether the current session is in Oracle compatibility mode, so it is easy to tell which mode psql is running in.

## Changes
- Mark `ivorysql.compatible_mode` as `GUC_REPORT` so the server pushes its value to the client, letting the prompt track in-session `SET` changes in real time.
- Add a `%o` escape in `src/bin/psql/prompt.c` and `src/bin/psql/ora_prompt.c`: it expands to `[ORA]` when `ivorysql.compatible_mode = 'oracle'`, and to empty otherwise.

## Behavior
- **Off by default** — the standard prompt is unchanged.
- Opt in with:
  ```
  \set PROMPT1 '%o%/%R%x%# '
  ```
  Then the prompt shows `[ORA]ivorysql=#` in Oracle mode and `ivorysql=#` in PostgreSQL mode, updating live as you `SET ivorysql.compatible_mode`.

## Notes
- Reads the value via `PQparameterStatus("ivorysql.compatible_mode")`, so it requires the `GUC_REPORT` change above (server recompile + restart) and safely degrades to empty against an older server that does not report it.
- Prompts are interactive-only, so scripts / CI / regression tests are unaffected.

Verified by building and running locally: in-session `SET ivorysql.compatible_mode = oracle` makes the `%o` prompt show `[ORA]` immediately, and `SET ... = pg` clears it.

Closes #1354.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `psql` prompt escape (`%o`) that expands to an `[ORA]` marker when connected to an IvorySQL server in Oracle compatibility mode; otherwise it expands to an empty string.
  * Updated the default `PROMPT1` and `PROMPT2` formats to include `%o` automatically.
* **Documentation**
  * Extended the `psql` prompt substitution reference to document `%o` behavior and the updated default prompt strings.
* **Tests**
  * Added a regression test covering `%o` prompt expansion in interactive mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->