### PR TITLE
docs: fix inaccurate GUC name in README for 5.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 English | [中文](README_CN.md)
 
 IvorySQL is developed based on [PostgreSQL](https://github.com/postgres/postgres). 
-IvorySQL is advanced, fully featured, open-source Oracle-compatible PostgreSQL with a firm commitment to always remain 100% compatible and a drop-in replacement for the latest PostgreSQL. IvorySQL adds the `compatible_mode` GUC parameter to switch between Oracle and PostgreSQL compatibility modes.
+IvorySQL is advanced, fully featured, open-source Oracle-compatible PostgreSQL with a firm commitment to always remain 100% compatible and a drop-in replacement for the latest PostgreSQL. IvorySQL adds the `ivorysql.compatible_mode` GUC parameter to switch between Oracle and PostgreSQL compatibility modes.
 One of the highlights of IvorySQL is PL/iSQL procedural language that supports oracle’s PL/SQL syntax and Oracle style Packages.
 
 The IvorySQL project is released under the Apache 2 license and encourages all types of contributions. For IvorySQL community no contribution is too small, and we want to thank all our community contributors.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 English | [中文](README_CN.md)
 
 IvorySQL is developed based on [PostgreSQL](https://github.com/postgres/postgres). 
-IvorySQL is advanced, fully featured, open source Oracle compatible PostgreSQL with a firm commitment to always remain 100% compatible and a Drop-in replacement of the latest PostgreSQL. IvorySQL adds a “compatible_db” toggle switch to switch between Oracle and PostgreSQL compatibility modes.
+IvorySQL is advanced, fully featured, open source Oracle compatible PostgreSQL with a firm commitment to always remain 100% compatible and a Drop-in replacement of the latest PostgreSQL. IvorySQL adds the `compatible_mode` GUC parameter to switch between Oracle and PostgreSQL compatibility modes.
 One of the highlights of IvorySQL is PL/iSQL procedural language that supports oracle’s PL/SQL syntax and Oracle style Packages.
 
 The IvorySQL project is released under the Apache 2 license and encourages all types of contributions. For IvorySQL community no contribution is too small, and we want to thank all our community contributors.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 English | [中文](README_CN.md)
 
 IvorySQL is developed based on [PostgreSQL](https://github.com/postgres/postgres). 
-IvorySQL is advanced, fully featured, open source Oracle compatible PostgreSQL with a firm commitment to always remain 100% compatible and a Drop-in replacement of the latest PostgreSQL. IvorySQL adds the `compatible_mode` GUC parameter to switch between Oracle and PostgreSQL compatibility modes.
+IvorySQL is advanced, fully featured, open-source Oracle compatible PostgreSQL with a firm commitment to always remain 100% compatible and a drop-in replacement of the latest PostgreSQL. IvorySQL adds the `compatible_mode` GUC parameter to switch between Oracle and PostgreSQL compatibility modes.
 One of the highlights of IvorySQL is PL/iSQL procedural language that supports oracle’s PL/SQL syntax and Oracle style Packages.
 
 The IvorySQL project is released under the Apache 2 license and encourages all types of contributions. For IvorySQL community no contribution is too small, and we want to thank all our community contributors.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 English | [中文](README_CN.md)
 
 IvorySQL is developed based on [PostgreSQL](https://github.com/postgres/postgres). 
-IvorySQL is advanced, fully featured, open-source Oracle compatible PostgreSQL with a firm commitment to always remain 100% compatible and a drop-in replacement of the latest PostgreSQL. IvorySQL adds the `compatible_mode` GUC parameter to switch between Oracle and PostgreSQL compatibility modes.
+IvorySQL is advanced, fully featured, open-source Oracle-compatible PostgreSQL with a firm commitment to always remain 100% compatible and a drop-in replacement for the latest PostgreSQL. IvorySQL adds the `compatible_mode` GUC parameter to switch between Oracle and PostgreSQL compatibility modes.
 One of the highlights of IvorySQL is PL/iSQL procedural language that supports oracle’s PL/SQL syntax and Oracle style Packages.
 
 The IvorySQL project is released under the Apache 2 license and encourages all types of contributions. For IvorySQL community no contribution is too small, and we want to thank all our community contributors.

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,7 +10,7 @@
 
 [English](README.md) | 中文
 
-IvorySQL 基于开源[PostgreSQL](https://github.com/postgres/postgres)数据库。是一款先进、功能全面的开源 Oracle 兼容 PostgreSQL，始终承诺100% 兼容最新版本的 PostgreSQL，并可作为其无缝替代方案。IvorySQL 增加了一个 “compatible_db” 开关，支持在 Oracle 和 PostgreSQL 兼容模式之间自由切换。IvorySQL 的一大亮点是 PL/iSQL 过程式语言，它兼容 Oracle 的 PL/SQL 语法并支持 Oracle 风格的 Package。
+IvorySQL 基于开源[PostgreSQL](https://github.com/postgres/postgres)数据库。是一款先进、功能全面的开源 Oracle 兼容 PostgreSQL，始终承诺100% 兼容最新版本的 PostgreSQL，并可作为其无缝替代方案。IvorySQL 增加了 `compatible_mode` GUC 参数，支持在 Oracle 和 PostgreSQL 兼容模式之间自由切换。IvorySQL 的一大亮点是 PL/iSQL 过程式语言，它兼容 Oracle 的 PL/SQL 语法并支持 Oracle 风格的 Package。
 
 IvorySQL 项目采用 Apache 2.0 许可协议发布，并鼓励各种形式的社区贡献。在 IvorySQL 社区中，每一份贡献都至关重要，我们由衷感谢所有社区贡献者的支持！
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,7 +10,7 @@
 
 [English](README.md) | 中文
 
-IvorySQL 基于开源[PostgreSQL](https://github.com/postgres/postgres)数据库。是一款先进、功能全面的开源 Oracle 兼容 PostgreSQL，始终承诺100% 兼容最新版本的 PostgreSQL，并可作为其无缝替代方案。IvorySQL 增加了 `compatible_mode` GUC 参数，支持在 Oracle 和 PostgreSQL 兼容模式之间自由切换。IvorySQL 的一大亮点是 PL/iSQL 过程式语言，它兼容 Oracle 的 PL/SQL 语法并支持 Oracle 风格的 Package。
+IvorySQL 基于开源[PostgreSQL](https://github.com/postgres/postgres)数据库。是一款先进、功能全面的开源 Oracle 兼容 PostgreSQL，始终承诺100% 兼容最新版本的 PostgreSQL，并可作为其无缝替代方案。IvorySQL 增加了 `ivorysql.compatible_mode` GUC 参数，支持在 Oracle 和 PostgreSQL 兼容模式之间自由切换。IvorySQL 的一大亮点是 PL/iSQL 过程式语言，它兼容 Oracle 的 PL/SQL 语法并支持 Oracle 风格的 Package。
 
 IvorySQL 项目采用 Apache 2.0 许可协议发布，并鼓励各种形式的社区贡献。在 IvorySQL 社区中，每一份贡献都至关重要，我们由衷感谢所有社区贡献者的支持！
 


### PR DESCRIPTION
### Related Issue
Closes #1358

### Motivation
Issue #1358 asks to update the README for the 5.4 release. The installation links were already bumped from v5.3 to v5.4 in commit `fa976fed`, but the README still contained an **inaccurate GUC parameter name**. The README described the Oracle/PostgreSQL compatibility switch as a `compatible_db` toggle switch, while the actual configuration parameter is named **`compatible_mode`** (full name `ivorysql.compatible_mode`, accepting values `oracle` / `pg`).

This was verified against the source tree — the GUC is referenced as `ivorysql.compatible_mode` throughout the regression test suite (e.g. `contrib/ivorysql_ora/sql/ora_sysview.sql`, `contrib/ivorysql_ora/sql/ora_like_operator.sql`).

### Changes
- **README.md**: `compatible_db` toggle switch → `compatible_mode` GUC parameter
- **README_CN.md**: `compatible_db` 开关 → `compatible_mode` GUC 参数

Both the English and Chinese READMEs are updated to keep them in sync.

### How Verified
- Documentation-only change, no code or build impact.
- Confirmed the GUC name `ivorysql.compatible_mode` via grep across the codebase (test SQL files and expected output).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the English README to describe Oracle/PostgreSQL compatibility switching using the `compatible_mode` GUC parameter (replacing the previously documented toggle name).
  * Updated the Chinese README to match the same `compatible_mode`-based compatibility mechanism.
  * Clarified the new control name to reflect current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->