### PR TITLE
Fix build failure with GCC 14+ (C23 bool keyword and -Wint-conversion)

### DIFF
--- a/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
+++ b/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
@@ -2466,6 +2466,6 @@ Datum ivy_xmlisvalid(PG_FUNCTION_ARGS)
 	}
 #else
 	NO_XML_SUPPORT();
-	return NULL;
+	return 0;
 #endif
 }

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -20,6 +20,7 @@ extern "C"
 {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -70,18 +71,6 @@ extern "C"
 #define PG_COPYRES_TUPLES		  0x02	/* Implies PG_COPYRES_ATTRS */
 #define PG_COPYRES_EVENTS		  0x04
 #define PG_COPYRES_NOTICEHOOKS	  0x08
-
-/*
- * Assume bool has been defined if true and false are defined.  
- * This avoids duplicate-typedef errors if this file is included after c.h.
- *
- * Starting with C23, bool, true and false are keywords, so we must not
- * provide our own typedef.  C++ has bool as a keyword as well.
- */
-#if !defined(__cplusplus) && !(defined(true) && defined(false)) && \
-	!(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
-typedef unsigned char bool;
-#endif
 
 /* Application-visible enum types */
 

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -74,8 +74,12 @@ extern "C"
 /*
  * Assume bool has been defined if true and false are defined.  
  * This avoids duplicate-typedef errors if this file is included after c.h.
+ *
+ * Starting with C23, bool, true and false are keywords, so we must not
+ * provide our own typedef.  C++ has bool as a keyword as well.
  */
-#if !(defined(true) && defined(false))
+#if !defined(__cplusplus) && !(defined(true) && defined(false)) && \
+	!(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
 typedef unsigned char bool;
 #endif
 


### PR DESCRIPTION
### Related Issue
Fixes #1351

### Motivation
GCC 14 and 15 default to `-std=gnu23`, where `bool`, `true`, and `false` are C language keywords. This breaks the IvorySQL build in two places with IvorySQL-specific (non-upstream) code:

**Error 1 — `src/interfaces/libpq/libpq-fe.h:79`:**
```
libpq-fe.h:79:23: error: 'bool' cannot be defined via 'typedef'
   79 | typedef unsigned char bool;
      |                       ^~~~
libpq-fe.h:79:23: note: 'bool' is a keyword with '-std=c23' onwards
```
The existing guard `#if !(defined(true) && defined(false))` is insufficient under C23: `true`/`false` may not be defined as macros even though `bool` is a built-in keyword, so the typedef is still emitted and fails.

**Error 2 — `contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c:2469`:**
```
ora_xml_functions.c:2469:16: error: returning 'void *' from a function with return type 'Datum' {aka 'long unsigned int'} makes integer from pointer without a cast [-Wint-conversion]
 2469 |         return NULL;
      |                ^~~~
```
`ivy_xmlisvalid()` is declared `PG_FUNCTION_INFO_V1` returning `Datum`, but its `#else` (no libxml) fallback did `return NULL;`. GCC 14 promotes `-Wint-conversion` to an error by default.

> **Note:** The uuid-ossp errors also shown in the issue are tracked separately in #979 and are **not** addressed here.

### Changes

1. **`src/interfaces/libpq/libpq-fe.h`** — Extend the guard so the `typedef unsigned char bool;` is skipped under C23 (`__STDC_VERSION__ >= 202311L`) and C++ (`__cplusplus`), mirroring the pattern already used in `src/include/c.h`:
   ```c
   #if !defined(__cplusplus) && !(defined(true) && defined(false)) && \
       !(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
   typedef unsigned char bool;
   #endif
   ```

2. **`contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c`** — In `ivy_xmlisvalid()`, replace `return NULL;` with `return 0;` in the `!USE_LIBXML` fallback, matching the upstream PostgreSQL `src/backend/utils/adt/xml.c` convention for Datum-returning SQL functions.

### How Verified
- Code review confirms both changes follow established PostgreSQL/IvorySQL patterns (`c.h` C23 guard; `xml.c` `return 0` fallback).
- Cannot compile-test GCC 14+ from the current Windows environment; CI on this PR (ubuntu-latest with recent GCC) will validate. The fix is minimal and mechanical.
- The change is backward-compatible: under C11/C17 (`__STDC_VERSION__ < 202311L`) the original typedef behavior is preserved exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML validation behavior when XML support is unavailable, so validation fails consistently instead of returning an unexpected value.
  * Improved build compatibility with standard C boolean handling by relying on the standard boolean header and removing the previous custom boolean fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->