### PR TITLE
gitignore: ignore in-tree build generated files

### DIFF
--- a/contrib/ivorysql_ora/.gitignore
+++ b/contrib/ivorysql_ora/.gitignore
@@ -1,0 +1,1 @@
+/ivorysql_ora--1.0.sql

--- a/src/bin/psql/.gitignore
+++ b/src/bin/psql/.gitignore
@@ -4,3 +4,7 @@
 /sql_help.c
 /psql
 /tmp_check/
+/ora_psqlscanslash.c
+/psqlplusparse.c
+/psqlplusparse.h
+/psqlplusscan.c

--- a/src/fe_utils/.gitignore
+++ b/src/fe_utils/.gitignore
@@ -1,1 +1,3 @@
 /psqlscan.c
+/ora_keywords.c
+/ora_kwlist_d.h

--- a/src/include/catalog/.gitignore
+++ b/src/include/catalog/.gitignore
@@ -6,3 +6,4 @@
 /system_constraints.sql
 /pg_*_d.h
 /bki-stamp
+/postgres_oracle.bki

--- a/src/oracle_fe_utils/.gitignore
+++ b/src/oracle_fe_utils/.gitignore
@@ -1,0 +1,1 @@
+/ora_psqlscan.c

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -1,5 +1,6 @@
 # Local binaries
 /pg_regress
+/ora_pg_regress
 
 # Generated subdirectories
 /tmp_check/


### PR DESCRIPTION
## Summary

Fixes #1387.

After an in-tree build, several IvorySQL-generated files show up as untracked under `git status`, because they are not covered by any `.gitignore` — unlike their upstream PostgreSQL counterparts.

This mirrors upstream PostgreSQL's convention: per-directory `.gitignore` files with anchored entries, placing each generated file next to its non-Oracle sibling. The ten files reported in the issue are now ignored:

| Generated file | `.gitignore` | Existing sibling entry |
| --- | --- | --- |
| `src/bin/psql/ora_psqlscanslash.c` | `src/bin/psql/.gitignore` | `/psqlscanslash.c` |
| `src/bin/psql/psqlplusparse.c` | `src/bin/psql/.gitignore` | (parser output) |
| `src/bin/psql/psqlplusparse.h` | `src/bin/psql/.gitignore` | (parser output) |
| `src/bin/psql/psqlplusscan.c` | `src/bin/psql/.gitignore` | (scanner output) |
| `src/fe_utils/ora_keywords.c` | `src/fe_utils/.gitignore` | `/psqlscan.c` |
| `src/fe_utils/ora_kwlist_d.h` | `src/fe_utils/.gitignore` | `/psqlscan.c` |
| `src/include/catalog/postgres_oracle.bki` | `src/include/catalog/.gitignore` | `/postgres.bki` |
| `src/oracle_fe_utils/ora_psqlscan.c` | `src/oracle_fe_utils/.gitignore` (new) | — |
| `src/test/regress/ora_pg_regress` | `src/test/regress/.gitignore` | `/pg_regress` |
| `contrib/ivorysql_ora/ivorysql_ora--1.0.sql` | `contrib/ivorysql_ora/.gitignore` (new) | — |

## Verification

After the change, `git status` reports only the six `.gitignore` changes and no longer lists the generated files. Confirmed with `git check-ignore -v` that each generated file is matched by the rule added in its directory:

```
contrib/ivorysql_ora/.gitignore:1:/ivorysql_ora--1.0.sql    contrib/ivorysql_ora/ivorysql_ora--1.0.sql
src/bin/psql/.gitignore:7:/ora_psqlscanslash.c              src/bin/psql/ora_psqlscanslash.c
src/bin/psql/.gitignore:8:/psqlplusparse.c                  src/bin/psql/psqlplusparse.c
src/bin/psql/.gitignore:9:/psqlplusparse.h                  src/bin/psql/psqlplusparse.h
src/bin/psql/.gitignore:10:/psqlplusscan.c                  src/bin/psql/psqlplusscan.c
src/fe_utils/.gitignore:2:/ora_keywords.c                   src/fe_utils/ora_keywords.c
src/fe_utils/.gitignore:3:/ora_kwlist_d.h                   src/fe_utils/ora_kwlist_d.h
src/include/catalog/.gitignore:9:/postgres_oracle.bki       src/include/catalog/postgres_oracle.bki
src/oracle_fe_utils/.gitignore:1:/ora_psqlscan.c            src/oracle_fe_utils/ora_psqlscan.c
src/test/regress/.gitignore:3:/ora_pg_regress               src/test/regress/ora_pg_regress
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude additional generated artifacts, including alternate parser-related files, Oracle-related keyword lists, catalog artifacts, regression test output, and SQL build artifacts.
  * Reduces noise from untracked build/test outputs and keeps the working directory cleaner during development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->