### PR TITLE
Fix json gb18030 encoding

### DIFF
--- a/contrib/gb18030_2022/Makefile
+++ b/contrib/gb18030_2022/Makefile
@@ -10,7 +10,8 @@ EXTENSION = gb18030_2022
 PGFILEDESC = "gb18030_2022,support gb18030 2022 with extension"
 DATA = gb18030_2022--1.0.sql
 REGRESS = gb18030_2022_and_utf8 \
-		copy
+		copy \
+		json_gb18030
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/gb18030_2022/expected/json_gb18030.out
+++ b/contrib/gb18030_2022/expected/json_gb18030.out
@@ -1,0 +1,261 @@
+-- Test JSON/JSONB parsing with GB18030 encoding
+--
+-- This test verifies that the JSON parser correctly handles multi-byte
+-- characters in GB18030 encoding, specifically characters where the second
+-- byte is 0x5C (backslash) which could be misinterpreted as a JSON escape
+-- character if the parser scans byte-by-byte instead of character-by-character.
+--
+-- In GB18030 two-byte encoding, the second byte ranges from 0x40-0x7E and
+-- 0x80-0xFE. The byte 0x5C (backslash) falls in the 0x40-0x7E range, so it
+-- can appear as the second byte of a two-byte character (e.g., 0x81 0x5C
+-- encodes 倄 U+5014). Without the fix, the JSON parser would incorrectly
+-- interpret this 0x5C as a JSON backslash escape character.
+
+-- Setup: create GB18030 database and configure encoding
+create database json_gb18030_test encoding='gb18030' LC_COLLATE='C' LC_CTYPE='C' TEMPLATE=template0;
+\c json_gb18030_test
+load 'gb18030_2022';
+show server_encoding;
+ server_encoding 
+-----------------
+ GB18030
+(1 row)
+
+set client_encoding = 'UTF8';
+show client_encoding;
+ client_encoding 
+-----------------
+ UTF8
+(1 row)
+
+-- ===================================================================
+-- Test 1: Basic JSON parsing with GB18030 characters containing 0x5C
+--         as second byte
+-- ===================================================================
+
+-- 0x81 0x5C = 倄 (U+5014), second byte is 0x5C (backslash)
+-- Without fix: ERROR: invalid input syntax for type json
+-- Detail: Escape sequence "\" is invalid
+SELECT ('{"name": "' || convert_from('\x815C', 'GB18030') || '"}')::json;
+    ?column?     
+-----------------
+ {"name": "乘"}
+(1 row)
+
+-- Same test with jsonb
+SELECT ('{"name": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb;
+    ?column?     
+------------------
+ {"name": "乘"}
+(1 row)
+
+-- ===================================================================
+-- Test 2: Multiple characters with 0x5C as second byte in a single
+--         JSON string value
+-- ===================================================================
+
+-- 0x82 0x5C also has 0x5C as second byte
+SELECT ('{"city": "' || convert_from('\x815C', 'GB18030') || ' and ' || convert_from('\x825C', 'GB18030') || '"}')::json;
+       ?column?       
+-----------------------
+ {"city": "乘 and 俓"}
+(1 row)
+
+SELECT ('{"city": "' || convert_from('\x815C', 'GB18030') || ' and ' || convert_from('\x825C', 'GB18030') || '"}')::jsonb;
+        ?column?        
+------------------------
+ {"city": "乘 and 俓"}
+(1 row)
+
+-- ===================================================================
+-- Test 3: JSON with GB18030 characters in keys
+-- ===================================================================
+
+SELECT ('{"' || convert_from('\x815C', 'GB18030') || '": "value"}')::json;
+   ?column?    
+----------------
+ {"乘": "value"}
+(1 row)
+
+SELECT ('{"' || convert_from('\x815C', 'GB18030') || '": "value"}')::jsonb;
+    ?column?     
+------------------
+ {"乘": "value"}
+(1 row)
+
+-- ===================================================================
+-- Test 4: Nested JSON objects and arrays with GB18030 characters
+-- ===================================================================
+
+SELECT ('{"outer": {"inner": "' || convert_from('\x815C', 'GB18030') || '"}}')::json;
+         ?column?         
+--------------------------
+ {"outer": {"inner": "乘"}}
+(1 row)
+
+SELECT ('{"array": ["' || convert_from('\x815C', 'GB18030') || '", "normal"]}')::jsonb;
+         ?column?         
+--------------------------
+ {"array": ["乘", "normal"]}
+(1 row)
+
+-- ===================================================================
+-- Test 5: GB18030 characters at string boundaries (start and end)
+-- ===================================================================
+
+-- Character at the start of a JSON string value
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || 'end"}')::json;
+  ?column?   
+--------------
+ {"k": "乘end"}
+(1 row)
+
+-- Character at the end of a JSON string value
+SELECT ('{"k": "start' || convert_from('\x815C', 'GB18030') || '"}')::json;
+   ?column?    
+----------------
+ {"k": "start乘"}
+(1 row)
+
+-- Character as the entire JSON string value
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb;
+   ?column?   
+----------------
+ {"k": "乘"}
+(1 row)
+
+-- ===================================================================
+-- Test 6: Table operations with JSONB and GB18030 characters
+-- ===================================================================
+
+CREATE TABLE json_gb18030_test(id int, data jsonb);
+INSERT INTO json_gb18030_test VALUES (1, ('{"name": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb);
+INSERT INTO json_gb18030_test VALUES (2, ('{"desc": "hello ' || convert_from('\x815C', 'GB18030') || ' world"}')::jsonb);
+INSERT INTO json_gb18030_test VALUES (3, ('{"items": ["' || convert_from('\x815C', 'GB18030') || '", "test"]}')::jsonb);
+-- Query the data
+SELECT id, data FROM json_gb18030_test ORDER BY id;
+ id |           data           
+----+--------------------------
+  1 | {"name": "乘"}
+  2 | {"desc": "hello 乘 world"}
+  3 | {"items": ["乘", "test"]}
+(3 rows)
+
+-- JSONB operators
+SELECT id, data->>'name' FROM json_gb18030_test WHERE data ? 'name';
+ id | ?column? 
+----+----------
+  1 | 乘
+(1 row)
+
+SELECT id, data->>'desc' FROM json_gb18030_test WHERE data ? 'desc';
+ id | ?column?  
+----+------------
+  2 | hello 乘 world
+(1 row)
+
+SELECT id, data->'items' FROM json_gb18030_test WHERE data ? 'items';
+ id |     data->'items'     
+----+-----------------------
+  3 | ["乘", "test"]
+(1 row)
+
+-- ===================================================================
+-- Test 7: JSON type (not JSONB) with table operations
+-- ===================================================================
+
+CREATE TABLE json_gb18030_json_test(id int, data json);
+INSERT INTO json_gb18030_json_test VALUES (1, ('{"key": "' || convert_from('\x815C', 'GB18030') || '"}')::json);
+INSERT INTO json_gb18030_json_test VALUES (2, ('{"a": "' || convert_from('\x815C', 'GB18030') || '", "b": "' || convert_from('\x825C', 'GB18030') || '"}')::json);
+SELECT id, data FROM json_gb18030_json_test ORDER BY id;
+ id |            data             
+----+-----------------------------
+  1 | {"key": "乘"}
+  2 | {"a": "乘", "b": "俓"}
+(2 rows)
+
+-- ===================================================================
+-- Test 8: JSON with legitimate escape sequences alongside GB18030
+--         characters (ensure real escapes still work)
+-- ===================================================================
+
+-- Real backslash escape followed by GB18030 character with 0x5C
+SELECT ('{"k": "line1\n' || convert_from('\x815C', 'GB18030') || '"}')::json;
+     ?column?      
+-------------------
+ {"k": "line1\n乘"}
+(1 row)
+
+-- GB18030 character followed by real backslash escape
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || '\nline2"}')::json;
+      ?column?       
+----------------------
+ {"k": "乘\nline2"}
+(1 row)
+
+-- Tab escape with GB18030 character
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || '\tvalue"}')::jsonb;
+      ?column?       
+----------------------
+ {"k": "乘\tvalue"}
+(1 row)
+
+-- ===================================================================
+-- Test 9: Four-byte GB18030 characters in JSON
+-- ===================================================================
+
+-- Four-byte GB18030 characters (0x8135F437 etc.)
+-- These don't contain 0x5C/0x22 internally but test the multi-byte
+-- skip path for 4-byte characters
+SELECT ('{"char": "' || convert_from('\x8135F437', 'GB18030') || '"}')::json;
+     ?column?      
+-------------------
+ {"char": ""}
+(1 row)
+
+SELECT ('{"char": "' || convert_from('\x8135F437', 'GB18030') || '"}')::jsonb;
+      ?column?      
+---------------------
+ {"char": ""}
+(1 row)
+
+-- ===================================================================
+-- Test 10: Various JSON functions with GB18030 characters
+-- ===================================================================
+
+-- json_typeof
+SELECT json_typeof(('{"k": "' || convert_from('\x815C', 'GB18030') || '"}')::json);
+ json_typeof 
+-------------
+ object
+(1 row)
+
+-- json_array_length
+SELECT json_array_length(('["' || convert_from('\x815C', 'GB18030') || '", "a", "b"]')::json);
+ json_array_length 
+--------------------
+                  3
+(1 row)
+
+-- jsonb_pretty
+SELECT jsonb_pretty(('{"key": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb);
+   jsonb_pretty   
+------------------
+ {                +
+     "key": "乘"  +
+ }
+(1 row)
+
+-- jsonb_build_object
+SELECT jsonb_build_object('name', convert_from('\x815C', 'GB18030'));
+ jsonb_build_object 
+---------------------
+ {"name": "乘"}
+(1 row)
+
+-- Cleanup
+DROP TABLE json_gb18030_test;
+DROP TABLE json_gb18030_json_test;
+-- Disconnect and drop test database
+\c postgres
+drop database json_gb18030_test;

--- a/contrib/gb18030_2022/meson.build
+++ b/contrib/gb18030_2022/meson.build
@@ -45,6 +45,7 @@ tests += {
     'sql': [
       'gb18030_2022_and_utf8',
       'copy',
+      'json_gb18030',
     ],
   },
 }

--- a/contrib/gb18030_2022/sql/json_gb18030.sql
+++ b/contrib/gb18030_2022/sql/json_gb18030.sql
@@ -1,0 +1,153 @@
+-- Test JSON/JSONB parsing with GB18030 encoding
+--
+-- This test verifies that the JSON parser correctly handles multi-byte
+-- characters in GB18030 encoding, specifically characters where the second
+-- byte is 0x5C (backslash) which could be misinterpreted as a JSON escape
+-- character if the parser scans byte-by-byte instead of character-by-character.
+--
+-- In GB18030 two-byte encoding, the second byte ranges from 0x40-0x7E and
+-- 0x80-0xFE. The byte 0x5C (backslash) falls in the 0x40-0x7E range, so it
+-- can appear as the second byte of a two-byte character (e.g., 0x81 0x5C
+-- encodes 倄 U+5014). Without the fix, the JSON parser would incorrectly
+-- interpret this 0x5C as a JSON backslash escape character.
+
+-- Setup: create GB18030 database and configure encoding
+create database json_gb18030_test encoding='gb18030' LC_COLLATE='C' LC_CTYPE='C' TEMPLATE=template0;
+\c json_gb18030_test
+
+load 'gb18030_2022';
+
+show server_encoding;
+set client_encoding = 'UTF8';
+show client_encoding;
+
+-- ===================================================================
+-- Test 1: Basic JSON parsing with GB18030 characters containing 0x5C
+--         as second byte
+-- ===================================================================
+
+-- 0x81 0x5C = 倄 (U+5014), second byte is 0x5C (backslash)
+-- Without fix: ERROR: invalid input syntax for type json
+-- Detail: Escape sequence "\" is invalid
+SELECT ('{"name": "' || convert_from('\x815C', 'GB18030') || '"}')::json;
+
+-- Same test with jsonb
+SELECT ('{"name": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb;
+
+-- ===================================================================
+-- Test 2: Multiple characters with 0x5C as second byte in a single
+--         JSON string value
+-- ===================================================================
+
+-- 0x82 0x5C also has 0x5C as second byte
+SELECT ('{"city": "' || convert_from('\x815C', 'GB18030') || ' and ' || convert_from('\x825C', 'GB18030') || '"}')::json;
+
+SELECT ('{"city": "' || convert_from('\x815C', 'GB18030') || ' and ' || convert_from('\x825C', 'GB18030') || '"}')::jsonb;
+
+-- ===================================================================
+-- Test 3: JSON with GB18030 characters in keys
+-- ===================================================================
+
+SELECT ('{"' || convert_from('\x815C', 'GB18030') || '": "value"}')::json;
+
+SELECT ('{"' || convert_from('\x815C', 'GB18030') || '": "value"}')::jsonb;
+
+-- ===================================================================
+-- Test 4: Nested JSON objects and arrays with GB18030 characters
+-- ===================================================================
+
+SELECT ('{"outer": {"inner": "' || convert_from('\x815C', 'GB18030') || '"}}')::json;
+
+SELECT ('{"array": ["' || convert_from('\x815C', 'GB18030') || '", "normal"]}')::jsonb;
+
+-- ===================================================================
+-- Test 5: GB18030 characters at string boundaries (start and end)
+-- ===================================================================
+
+-- Character at the start of a JSON string value
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || 'end"}')::json;
+
+-- Character at the end of a JSON string value
+SELECT ('{"k": "start' || convert_from('\x815C', 'GB18030') || '"}')::json;
+
+-- Character as the entire JSON string value
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb;
+
+-- ===================================================================
+-- Test 6: Table operations with JSONB and GB18030 characters
+-- ===================================================================
+
+CREATE TABLE json_gb18030_test(id int, data jsonb);
+
+-- Insert JSONB data containing characters with 0x5C as second byte
+INSERT INTO json_gb18030_test VALUES (1, ('{"name": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb);
+INSERT INTO json_gb18030_test VALUES (2, ('{"desc": "hello ' || convert_from('\x815C', 'GB18030') || ' world"}')::jsonb);
+INSERT INTO json_gb18030_test VALUES (3, ('{"items": ["' || convert_from('\x815C', 'GB18030') || '", "test"]}')::jsonb);
+
+-- Query the data
+SELECT id, data FROM json_gb18030_test ORDER BY id;
+
+-- JSONB operators
+SELECT id, data->>'name' FROM json_gb18030_test WHERE data ? 'name';
+SELECT id, data->>'desc' FROM json_gb18030_test WHERE data ? 'desc';
+SELECT id, data->'items' FROM json_gb18030_test WHERE data ? 'items';
+
+-- ===================================================================
+-- Test 7: JSON type (not JSONB) with table operations
+-- ===================================================================
+
+CREATE TABLE json_gb18030_json_test(id int, data json);
+
+INSERT INTO json_gb18030_json_test VALUES (1, ('{"key": "' || convert_from('\x815C', 'GB18030') || '"}')::json);
+INSERT INTO json_gb18030_json_test VALUES (2, ('{"a": "' || convert_from('\x815C', 'GB18030') || '", "b": "' || convert_from('\x825C', 'GB18030') || '"}')::json);
+
+SELECT id, data FROM json_gb18030_json_test ORDER BY id;
+
+-- ===================================================================
+-- Test 8: JSON with legitimate escape sequences alongside GB18030
+--         characters (ensure real escapes still work)
+-- ===================================================================
+
+-- Real backslash escape followed by GB18030 character with 0x5C
+SELECT ('{"k": "line1\n' || convert_from('\x815C', 'GB18030') || '"}')::json;
+
+-- GB18030 character followed by real backslash escape
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || '\nline2"}')::json;
+
+-- Tab escape with GB18030 character
+SELECT ('{"k": "' || convert_from('\x815C', 'GB18030') || '\tvalue"}')::jsonb;
+
+-- ===================================================================
+-- Test 9: Four-byte GB18030 characters in JSON
+-- ===================================================================
+
+-- Four-byte GB18030 characters (0x8135F437 etc.)
+-- These don't contain 0x5C/0x22 internally but test the multi-byte
+-- skip path for 4-byte characters
+SELECT ('{"char": "' || convert_from('\x8135F437', 'GB18030') || '"}')::json;
+
+SELECT ('{"char": "' || convert_from('\x8135F437', 'GB18030') || '"}')::jsonb;
+
+-- ===================================================================
+-- Test 10: Various JSON functions with GB18030 characters
+-- ===================================================================
+
+-- json_typeof
+SELECT json_typeof(('{"k": "' || convert_from('\x815C', 'GB18030') || '"}')::json);
+
+-- json_array_length
+SELECT json_array_length(('["' || convert_from('\x815C', 'GB18030') || '", "a", "b"]')::json);
+
+-- jsonb_pretty
+SELECT jsonb_pretty(('{"key": "' || convert_from('\x815C', 'GB18030') || '"}')::jsonb);
+
+-- jsonb_build_object
+SELECT jsonb_build_object('name', convert_from('\x815C', 'GB18030'));
+
+-- Cleanup
+DROP TABLE json_gb18030_test;
+DROP TABLE json_gb18030_json_test;
+
+-- Disconnect and drop test database
+\c postgres
+drop database json_gb18030_test;

--- a/src/common/jsonapi.c
+++ b/src/common/jsonapi.c
@@ -1637,18 +1637,91 @@ json_lex(JsonLexContext *lex)
 			 */
 			int			escapes = 0;
 
-			for (int i = ptok->len - 1; i > 0; i--)
+			/*
+			 * Count the trailing backslashes on the partial token.
+			 *
+			 * In multi-byte encodings other than UTF-8, an ASCII byte
+			 * like 0x5C (backslash) can appear as a non-leading byte
+			 * of a multi-byte character.  We must scan forward through
+			 * the partial token to properly identify real backslash
+			 * characters and avoid miscounting bytes that are part of
+			 * multi-byte characters.
+			 */
+			if (lex->input_encoding == PG_UTF8 ||
+				pg_encoding_max_length(lex->input_encoding) <= 1)
 			{
-				/* count the trailing backslashes on the partial token */
-				if (ptok->data[i] == '\\')
-					escapes++;
-				else
-					break;
+				/* UTF-8 and single-byte: simple backward scan is safe */
+				for (int i = ptok->len - 1; i > 0; i--)
+				{
+					if (ptok->data[i] == '\\')
+						escapes++;
+					else
+						break;
+				}
+			}
+			else
+			{
+				/*
+				 * Multi-byte encoding: forward scan to properly track
+				 * trailing backslashes, skipping multi-byte characters.
+				 */
+				for (int i = 1; i < ptok->len; )
+				{
+					if (IS_HIGHBIT_SET(ptok->data[i]))
+					{
+						int			charlen;
+
+						charlen = pg_encoding_mblen_or_incomplete(
+							lex->input_encoding,
+							&ptok->data[i],
+							ptok->len - i);
+						if (charlen > 1)
+							i += charlen;
+						else
+							i++;
+						escapes = 0;
+					}
+					else if (ptok->data[i] == '\\')
+					{
+						escapes++;
+						i++;
+					}
+					else
+					{
+						escapes = 0;
+						i++;
+					}
+				}
 			}
 
-			for (size_t i = 0; i < lex->input_length; i++)
+			for (size_t i = 0; i < lex->input_length; )
 			{
 				char		c = lex->input[i];
+
+				/*
+				 * In multi-byte encodings other than UTF-8, skip over
+				 * multi-byte characters to avoid misinterpreting their
+				 * internal bytes as backslash or double-quote.
+				 */
+				if (IS_HIGHBIT_SET(c))
+				{
+					int			charlen;
+
+					charlen = pg_encoding_mblen_or_incomplete(
+						lex->input_encoding,
+						&lex->input[i],
+						lex->input_length - i);
+					if (charlen > 1)
+					{
+						jsonapi_appendBinaryStringInfo(ptok,
+											   &lex->input[i],
+										   charlen);
+						added += charlen;
+						i += charlen;
+						escapes = 0;
+						continue;
+					}
+				}
 
 				jsonapi_appendStringInfoCharMacro(ptok, c);
 				added++;
@@ -1661,6 +1734,7 @@ json_lex(JsonLexContext *lex)
 					escapes++;
 				else
 					escapes = 0;
+				i++;
 			}
 		}
 		else
@@ -2008,7 +2082,38 @@ json_lex_string(JsonLexContext *lex)
 		/* Premature end of the string. */
 		if (s >= end)
 			FAIL_OR_INCOMPLETE_AT_CHAR_START(JSON_INVALID_TOKEN);
-		else if (*s == '"')
+
+		/*
+		 * In multi-byte encodings other than UTF-8, an ASCII byte
+		 * (e.g. 0x5C backslash, 0x22 double quote) can appear as a
+		 * non-leading byte of a multi-byte character.  We must skip
+		 * over such characters as a whole to avoid misinterpreting
+		 * their internal bytes.
+		 */
+		if (IS_HIGHBIT_SET(*s))
+		{
+			int			charlen;
+
+			charlen = pg_encoding_mblen_or_incomplete(lex->input_encoding,
+													  s, end - s);
+			if (charlen > 1)
+			{
+				/*
+				 * We need to check that there are enough bytes left
+				 * for this multi-byte character.
+				 */
+				if (s + charlen > end)
+					FAIL_OR_INCOMPLETE_AT_CHAR_START(JSON_INVALID_TOKEN);
+
+				if (lex->need_escapes)
+					jsonapi_appendBinaryStringInfo(lex->strval, s, charlen);
+
+				s += charlen - 1;	/* loop increment will add 1 more */
+				continue;
+			}
+		}
+
+		if (*s == '"')
 			break;
 		else if (*s == '\\')
 		{
@@ -2165,26 +2270,73 @@ json_lex_string(JsonLexContext *lex)
 			/*
 			 * Skip to the first byte that requires special handling, so we
 			 * can batch calls to jsonapi_appendBinaryStringInfo.
+			 *
+			 * In UTF-8 and single-byte encodings, ASCII bytes (like
+			 * backslash and double-quote) cannot appear as non-leading
+			 * bytes of multi-byte characters, so a simple byte-by-byte
+			 * scan is safe.  In other multi-byte encodings (e.g.
+			 * GB18030), ASCII bytes can appear inside multi-byte
+			 * characters, so we must scan character-by-character to
+			 * avoid false matches.
 			 */
-			while (p < end - sizeof(Vector8) &&
-				   !pg_lfind8('\\', (uint8 *) p, sizeof(Vector8)) &&
-				   !pg_lfind8('"', (uint8 *) p, sizeof(Vector8)) &&
-				   !pg_lfind8_le(31, (uint8 *) p, sizeof(Vector8)))
-				p += sizeof(Vector8);
-
-			for (; p < end; p++)
+			if (lex->input_encoding == PG_UTF8 ||
+				pg_encoding_max_length(lex->input_encoding) <= 1)
 			{
-				if (*p == '\\' || *p == '"')
-					break;
-				else if ((unsigned char) *p <= 31)
+				while (p < end - sizeof(Vector8) &&
+					   !pg_lfind8('\\', (uint8 *) p, sizeof(Vector8)) &&
+					   !pg_lfind8('"', (uint8 *) p, sizeof(Vector8)) &&
+					   !pg_lfind8_le(31, (uint8 *) p, sizeof(Vector8)))
+					p += sizeof(Vector8);
+
+				for (; p < end; p++)
 				{
-					/* Per RFC4627, these characters MUST be escaped. */
-					/*
-					 * Since *p isn't printable, exclude it from the context
-					 * string
-					 */
-					lex->token_terminator = p;
-					return JSON_ESCAPING_REQUIRED;
+					if (*p == '\\' || *p == '"')
+						break;
+					else if ((unsigned char) *p <= 31)
+					{
+						/* Per RFC4627, these characters MUST be escaped. */
+						/*
+						 * Since *p isn't printable, exclude it from the context
+						 * string
+						 */
+						lex->token_terminator = p;
+						return JSON_ESCAPING_REQUIRED;
+					}
+				}
+			}
+			else
+			{
+				/*
+				 * Multi-byte encoding where ASCII bytes can appear inside
+				 * multi-byte characters: scan character-by-character.
+				 */
+				while (p < end)
+				{
+					if (*p == '"' || *p == '\\')
+						break;
+					else if ((unsigned char) *p <= 31)
+					{
+						lex->token_terminator = p;
+						return JSON_ESCAPING_REQUIRED;
+					}
+					else if (IS_HIGHBIT_SET(*p))
+					{
+						int			charlen;
+
+						charlen = pg_encoding_mblen_or_incomplete(
+							lex->input_encoding, p, end - p);
+						if (charlen > 1)
+						{
+							if (p + charlen > end)
+							{
+								p = end;
+								break;
+							}
+							p += charlen;
+							continue;
+						}
+					}
+					p++;
 				}
 			}
 


### PR DESCRIPTION
This patch fixes misparsing issues of JSON/JSONB text under GB18030 and similar multi-byte encodings.
The root cause is that ASCII special bytes like backslash can exist as trailing bytes of multi-byte characters, while the original lexer scans byte by byte without encoding awareness.
We adjust json_lex_string and incremental lexing logic to consume complete multibyte characters via libpg encoding utilities for non-UTF8 encodings. Optimized fast paths for UTF-8 are untouched. Comprehensive regression tests are added in gb18030_2022 extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON and JSONB parsing for non-UTF-8 multibyte encodings, including GB18030.
  - Prevented valid multibyte characters from being misinterpreted as quotation marks or backslashes.
  - Improved handling of incremental JSON parsing and escaped characters.

- **Tests**
  - Added comprehensive regression coverage for GB18030-2022 JSON and JSONB behavior, including nested structures, Unicode characters, escapes, and JSON functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->