### PR TITLE
Fix JSON/JSONB parsing for GB18030

### DIFF
--- a/src/common/jsonapi.c
+++ b/src/common/jsonapi.c
@@ -2214,26 +2214,67 @@ json_lex_string(JsonLexContext *lex)
 			/*
 			 * Skip to the first byte that requires special handling, so we
 			 * can batch calls to jsonapi_appendBinaryStringInfo.
+			 *
+			 * A GB18030 trailing byte can fall in the 7-bit ASCII range.  A
+			 * byte that continues a multibyte character must not be mistaken
+			 * for a backslash, quote, or control character, so advance by
+			 * whole characters for that encoding.
 			 */
-			while (p < end - sizeof(Vector8) &&
-				   !pg_lfind8('\\', (const uint8 *) p, sizeof(Vector8)) &&
-				   !pg_lfind8('"', (const uint8 *) p, sizeof(Vector8)) &&
-				   !pg_lfind8_le(31, (const uint8 *) p, sizeof(Vector8)))
-				p += sizeof(Vector8);
-
-			for (; p < end; p++)
+			if (lex->input_encoding == PG_GB18030)
 			{
-				if (*p == '\\' || *p == '"')
-					break;
-				else if ((unsigned char) *p <= 31)
+				while (p < end)
 				{
-					/* Per RFC4627, these characters MUST be escaped. */
-					/*
-					 * Since *p isn't printable, exclude it from the context
-					 * string
-					 */
-					lex->token_terminator = p;
-					return JSON_ESCAPING_REQUIRED;
+					if (*p == '\\' || *p == '"')
+						break;
+					else if ((unsigned char) *p <= 31)
+					{
+						/* Per RFC4627, these characters MUST be escaped. */
+						/*
+						 * Since *p isn't printable, exclude it from the
+						 * context string
+						 */
+						lex->token_terminator = p;
+						return JSON_ESCAPING_REQUIRED;
+					}
+					else if (IS_HIGHBIT_SET((unsigned char) *p))
+					{
+						ptrdiff_t	remaining = end - p;
+						int			mblen;
+
+						mblen = pg_encoding_mblen_or_incomplete(lex->input_encoding,
+																p, remaining);
+						if (mblen > remaining)
+						{
+							s = p;
+							FAIL_OR_INCOMPLETE_AT_CHAR_START(JSON_INVALID_TOKEN);
+						}
+						p += mblen - 1;
+					}
+					p++;
+				}
+			}
+			else
+			{
+				while (p < end - sizeof(Vector8) &&
+					   !pg_lfind8('\\', (const uint8 *) p, sizeof(Vector8)) &&
+					   !pg_lfind8('"', (const uint8 *) p, sizeof(Vector8)) &&
+					   !pg_lfind8_le(31, (const uint8 *) p, sizeof(Vector8)))
+					p += sizeof(Vector8);
+
+				for (; p < end; p++)
+				{
+					if (*p == '\\' || *p == '"')
+						break;
+					else if ((unsigned char) *p <= 31)
+					{
+						/* Per RFC4627, these characters MUST be escaped. */
+						/*
+						 * Since *p isn't printable, exclude it from the
+						 * context string
+						 */
+						lex->token_terminator = p;
+						return JSON_ESCAPING_REQUIRED;
+					}
 				}
 			}
 

--- a/src/test/modules/test_escape/test_escape.c
+++ b/src/test/modules/test_escape/test_escape.c
@@ -246,6 +246,101 @@ test_gb18030_json(pe_test_config *tc)
 	destroyPQExpBuffer(raw_buf);
 }
 
+/*
+ * Exercise JSON strings containing complete and truncated GB18030 multibyte
+ * characters.  A complete character whose trailing byte is 0x5C ('\') must
+ * not be mistaken for a backslash, while a truncated character must be
+ * rejected at the correct input position.
+ *
+ * The bytes below encode a JSON object whose value includes U+8846 in
+ * GB18030.  That code point is encoded as 0xD0 0x5C, so its second byte is
+ * the ASCII backslash.  Previously this raised "invalid input syntax for
+ * type json: Escape sequence ... is invalid".
+ */
+static void
+test_gb18030_json_multibyte(pe_test_config *tc)
+{
+	static const unsigned char valid_input[] = {
+		0x7b, 0x22, 0x6a, 0x61, 0x22, 0x3a, 0x22,	/* {"ja":" */
+		0xa5, 0xab, 0xa5, 0xca, 0xa5, 0xc0, 0xa1, 0xa2, /* U+30AB etc. */
+		0xa5, 0xa2, 0xa5, 0xe1, 0xa5, 0xea, 0xa5, 0xab, /* U+30A2 etc. */
+		0xba, 0xcf,				/* U+5408 */
+		0xd0, 0x5c,				/* U+8846; second byte is '\' */
+		0xb9, 0xfa,				/* U+56FD */
+		0x22, 0x7d				/* "} */
+	};
+	static const unsigned char truncated_input[] = {
+		0x7b, 0x22, 0x6a, 0x61, 0x22, 0x3a, 0x22,	/* {"ja":" */
+		0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,	/* ABCDEFG */
+		0xd0,					/* truncated GB18030 lead byte */
+	};
+	size_t		input_len = sizeof(valid_input);
+	PQExpBuffer raw_buf;
+	JsonLexContext *lex;
+	JsonSemAction sem = {0};	/* no callbacks */
+	JsonParseErrorType json_error;
+	bool		ok;
+
+	/* Catch any attempt to read beyond the supplied JSON text. */
+	raw_buf = createPQExpBuffer();
+	appendBinaryPQExpBuffer(raw_buf, (const char *) valid_input, input_len);
+	appendPQExpBufferStr(raw_buf, NEVER_ACCESS_STR);
+	VALGRIND_MAKE_MEM_NOACCESS(&raw_buf->data[input_len],
+							   raw_buf->len - input_len);
+
+	/* need_escapes=true exercises the jsonb input path */
+	lex = makeJsonLexContextCstringLen(NULL, raw_buf->data, input_len,
+									   PG_GB18030, true);
+	json_error = pg_parse_json(lex, &sem);
+	report_result(tc, json_error == JSON_SUCCESS,
+				  "GB18030 multibyte backslash - pg_parse_json",
+				  "", "need_escapes=true",
+				  json_error == JSON_SUCCESS ?
+				  "accepted" : json_errdetail(json_error, lex));
+	freeJsonLexContext(lex);
+
+	/* need_escapes=false exercises the validation-only path */
+	lex = makeJsonLexContextCstringLen(NULL, raw_buf->data, input_len,
+									   PG_GB18030, false);
+	json_error = pg_parse_json(lex, &sem);
+	report_result(tc, json_error == JSON_SUCCESS,
+				  "GB18030 multibyte backslash - pg_parse_json",
+				  "", "need_escapes=false",
+				  json_error == JSON_SUCCESS ?
+				  "accepted" : json_errdetail(json_error, lex));
+	freeJsonLexContext(lex);
+	destroyPQExpBuffer(raw_buf);
+
+	/*
+	 * The truncated input advances beyond an ASCII run before ending at the
+	 * lead byte, so the reported position must not use the stale run start.
+	 */
+	input_len = sizeof(truncated_input);
+	raw_buf = createPQExpBuffer();
+	appendBinaryPQExpBuffer(raw_buf, (const char *) truncated_input, input_len);
+	appendPQExpBufferStr(raw_buf, NEVER_ACCESS_STR);
+	VALGRIND_MAKE_MEM_NOACCESS(&raw_buf->data[input_len],
+							   raw_buf->len - input_len);
+
+	lex = makeJsonLexContextCstringLen(NULL, raw_buf->data, input_len,
+									   PG_GB18030, false);
+	json_error = pg_parse_json(lex, &sem);
+
+	/*
+	 * The input must be rejected as an invalid token, and the reported token
+	 * must end at the truncated lead byte rather than at the ASCII run start.
+	 */
+	ok = (json_error == JSON_INVALID_TOKEN &&
+		  lex->token_terminator == raw_buf->data + input_len - 1);
+	report_result(tc, ok,
+				  "GB18030 truncated multibyte - pg_parse_json",
+				  "", "incomplete char at EOF",
+				  ok ? "token ends at truncated character" :
+				  json_errdetail(json_error, lex));
+	freeJsonLexContext(lex);
+	destroyPQExpBuffer(raw_buf);
+}
+
 
 static bool
 escape_literal(PGconn *conn, PQExpBuffer target,
@@ -958,6 +1053,7 @@ main(int argc, char *argv[])
 
 	test_gb18030_page_multiple(&tc);
 	test_gb18030_json(&tc);
+	test_gb18030_json_multibyte(&tc);
 
 	for (int i = 0; i < lengthof(pe_test_vectors); i++)
 	{

--- a/src/test/modules/test_escape/test_escape.c
+++ b/src/test/modules/test_escape/test_escape.c
@@ -269,6 +269,13 @@ test_gb18030_json_multibyte(pe_test_config *tc)
 		0xb9, 0xfa,				/* U+56FD */
 		0x22, 0x7d				/* "} */
 	};
+	static const unsigned char decoded_value[] = {
+		0xa5, 0xab, 0xa5, 0xca, 0xa5, 0xc0, 0xa1, 0xa2, /* U+30AB etc. */
+		0xa5, 0xa2, 0xa5, 0xe1, 0xa5, 0xea, 0xa5, 0xab, /* U+30A2 etc. */
+		0xba, 0xcf,				/* U+5408 */
+		0xd0, 0x5c,				/* U+8846; second byte is '\' */
+		0xb9, 0xfa				/* U+56FD */
+	};
 	static const unsigned char truncated_input[] = {
 		0x7b, 0x22, 0x6a, 0x61, 0x22, 0x3a, 0x22,	/* {"ja":" */
 		0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,	/* ABCDEFG */
@@ -292,11 +299,21 @@ test_gb18030_json_multibyte(pe_test_config *tc)
 	lex = makeJsonLexContextCstringLen(NULL, raw_buf->data, input_len,
 									   PG_GB18030, true);
 	json_error = pg_parse_json(lex, &sem);
-	report_result(tc, json_error == JSON_SUCCESS,
-				  "GB18030 multibyte backslash - pg_parse_json",
-				  "", "need_escapes=true",
-				  json_error == JSON_SUCCESS ?
-				  "accepted" : json_errdetail(json_error, lex));
+	if (json_error == JSON_SUCCESS)
+	{
+		ok = ((size_t) lex->strval->len == sizeof(decoded_value) &&
+			  memcmp(lex->strval->data, decoded_value, sizeof(decoded_value)) == 0);
+		report_result(tc, ok,
+					  "GB18030 multibyte backslash - pg_parse_json",
+					  "", "need_escapes=true",
+					  ok ? "accepted and decoded correctly" :
+					  "decoded content mismatch");
+	}
+	else
+		report_result(tc, false,
+					  "GB18030 multibyte backslash - pg_parse_json",
+					  "", "need_escapes=true",
+					  json_errdetail(json_error, lex));
 	freeJsonLexContext(lex);
 
 	/* need_escapes=false exercises the validation-only path */


### PR DESCRIPTION
## Summary

- resolve #1340 by scanning complete GB18030 characters while lexing JSON strings
- prevent a GB18030 trailing byte in the ASCII range from being interpreted as JSON syntax
- reject truncated GB18030 input without reading past the supplied buffer
- keep the behavior change scoped to the server-supported GB18030 encoding

## Verification

- rebased onto the current `master`
- built `src/test/modules/test_escape/test_escape` on `WZU_Server`
- ran all 1,029 `test_escape` cases against a SQL_ASCII database: 0 failures

Resolves #1340.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON string parsing for GB18030-encoded text containing multibyte characters.
  * Prevented valid continuation bytes from being misinterpreted as JSON syntax.
  * Improved handling and error reporting for truncated multibyte characters.

* **Tests**
  * Added regression coverage for GB18030 escape handling and incomplete input.
  * Added validation to ensure reported error positions are accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->