### PR TITLE
configure: require libxml2 by default and reject --without-libxml (#1353)

### DIFF
--- a/configure
+++ b/configure
@@ -1607,7 +1607,7 @@ Optional Packages:
   --with-ossp-uuid        obsolete spelling of --with-uuid=ossp
   --with-libcurl          build with libcurl support
   --with-libnuma          build with libnuma support
-  --with-libxml           build with XML support
+  --without-libxml        build with XML support
   --with-libxslt          use XSLT support when building contrib/xml2
   --with-system-tzdata=DIR
                           use system time zone data in DIR
@@ -9436,7 +9436,7 @@ $as_echo "#define USE_LIBXML 1" >>confdefs.h
 
       ;;
     no)
-      :
+      as_fn_error $? "--without-libxml is not supported. The ivorysql_ora plugin depends on the libxml library." "$LINENO" 5
       ;;
     *)
       as_fn_error $? "no argument expected for --with-libxml option" "$LINENO" 5
@@ -9444,7 +9444,9 @@ $as_echo "#define USE_LIBXML 1" >>confdefs.h
   esac
 
 else
-  with_libxml=no
+  with_libxml=yes
+
+$as_echo "#define USE_LIBXML 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1214,8 +1214,9 @@ fi
 # XML
 #
 AC_MSG_CHECKING([whether to build with XML support])
-PGAC_ARG_BOOL(with, libxml, no, [build with XML support],
-              [AC_DEFINE([USE_LIBXML], 1, [Define to 1 to build with XML support. (--with-libxml)])])
+PGAC_ARG_BOOL(with, libxml, yes, [build with XML support],
+              [AC_DEFINE([USE_LIBXML], 1, [Define to 1 to build with XML support. (--with-libxml)])],
+              [AC_MSG_ERROR([--without-libxml is not supported. The ivorysql_ora plugin depends on the libxml library.])])
 AC_MSG_RESULT([$with_libxml])
 AC_SUBST(with_libxml)
 

--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -1201,6 +1201,14 @@ build-postgresql:
         </para>
 
         <para>
+         In <productname>IvorySQL</productname>, libxml2 is enabled by default
+         and is required, because the <filename>ivorysql_ora</filename> plugin
+         depends on it.  The <option>--without-libxml</option> option is not
+         supported; <command>configure</command> will fail if it is given, or if
+         a usable libxml2 installation cannot be found.
+        </para>
+
+        <para>
          To detect the required compiler and linker options, PostgreSQL will
          query <command>pkg-config</command>, if that is installed and knows
          about libxml2.  Otherwise the program <command>xml2-config</command>,


### PR DESCRIPTION
## Summary

Fixes #1353.

`make` failed with `/usr/bin/ld: cannot find -lxml2` when building `ivorysql_ora` after a plain `./configure`, because `--with-libxml` was opt-in (default off), so libxml2 was never detected. The same `./configure` step works on upstream PostgreSQL.

Per the maintainer decision in #1353, libxml2 is now **mandatory** for IvorySQL because the `ivorysql_ora` plugin depends on it.

## Changes

- **`configure.ac`**: default `--with-libxml` to `yes`, and error out on `--without-libxml`:
  > `--without-libxml is not supported. The ivorysql_ora plugin depends on the libxml library.`
- **`configure`**: regenerated from `configure.ac` with autoconf 2.69 (only the libxml option handling changed).
- **`doc/src/sgml/installation.sgml`**: document that IvorySQL enables libxml2 by default and requires it.

## Behavior after this change

- `./configure` (no libxml flag): libxml2 is enabled and required. If libxml2-dev is missing, configure fails **early** with a clear message (`library 'xml2' ... is required for XML support` / `header file <libxml/parser.h> is required for XML support`) instead of failing later in `make`.
- `./configure --without-libxml`: configure fails immediately with the unsupported-option error.
- `make` / `ivorysql_ora`: builds and links libxml2 (`USE_LIBXML` defined, `-lxml2` linked).

## Verification

```
# --without-libxml is rejected
./configure --without-libxml --without-icu --without-zlib
# -> configure: error: --without-libxml is not supported. The ivorysql_ora plugin depends on the libxml library.

# default enables libxml2
./configure --without-icu --without-zlib
# -> checking whether to build with XML support... yes
# -> checking for libxml-2.0 >= 2.6.23... yes
# src/Makefile.global: with_libxml = yes
# src/include/pg_config.h: #define USE_LIBXML 1

make -C contrib/ivorysql_ora   # builds ivorysql_ora.so, links libxml2 symbols
```

The manually-applied `configure` edit is byte-identical to a fresh `autoconf 2.69` run on the edited `configure.ac` (only the libxml option section changed; no unrelated regeneration noise).

## Notes

- Leaves the conditional link in `contrib/ivorysql_ora/Makefile` (added in #1370) untouched; it is now always-true since `with_libxml` is always `yes` once configure succeeds, so it acts as harmless defense-in-depth.
- The meson path already defaults `libxml` to `auto` and links cleanly when absent, so it is unaffected; this change is scoped to the autoconf `./configure` path reported in the issue.

Assisted-by: opencode:glm-5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - XML support is now enabled by default during installation.
  - The build process automatically enables the required XML functionality when a usable `libxml2` installation is available.

- **Bug Fixes**
  - Installation now reports a clear error when XML support is explicitly disabled or when `libxml2` cannot be found.

- **Documentation**
  - Updated installation guidance to explain the default XML support, dependency requirements, and unsupported `--without-libxml` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->