### PR TITLE
clean the warnings during compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,4 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make CFLAGS="$CFLAGS  -Wshadow=compatible-local -Wall -Werror -Wno-stringop-truncation"
+      run: make COPT="-Wshadow=compatible-local -Wall -Werror -Wno-stringop-truncation"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,4 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make CFLAGS="$CFLAGS  -Wshadow=compatible-local -Werror=missing-variable-declarations -Werror=maybe-uninitialized -Werror=unused-value -Werror=unused-but-set-variable -Werror=missing-prototypes -Werror=unused-variable"
+      run: make CFLAGS="$CFLAGS  -Wshadow=compatible-local -Wall -Werror -Wno-stringop-truncation"

--- a/contrib/ivorysql_ora/src/datatype/dsinterval.c
+++ b/contrib/ivorysql_ora/src/datatype/dsinterval.c
@@ -346,6 +346,7 @@ DecodeDsinterval(char **field, int *ftype, int nf, int range,
 				 */
 
 				/* FALL THROUGH */
+				pg_fallthrough;
 
 			case DTK_DATE:
 			case DTK_NUMBER:
@@ -1229,6 +1230,7 @@ ora_DecodeISO8601Interval(char *str,
 					}
 					/* Else fall through to extended alternative format */
 					/* FALLTHROUGH */
+					pg_fallthrough;
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -1308,6 +1310,7 @@ ora_DecodeISO8601Interval(char *str,
 					}
 					/* Else fall through to extended alternative format */
 					/* FALLTHROUGH */
+					pg_fallthrough;
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)

--- a/contrib/ivorysql_ora/src/datatype/yminterval.c
+++ b/contrib/ivorysql_ora/src/datatype/yminterval.c
@@ -511,6 +511,7 @@ DecodeYminterval(char **field, int *ftype, int nf, int range,
 				 */
 
 				/* FALL THROUGH */
+				pg_fallthrough;
 
 			case DTK_DATE:
 			case DTK_NUMBER:
@@ -1074,6 +1075,7 @@ ora_DecodeISO8601Interval(char *str,
 					}
 					/* Else fall through to extended alternative format */
 					/* FALLTHROUGH */
+					pg_fallthrough;
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -1153,6 +1155,7 @@ ora_DecodeISO8601Interval(char *str,
 					}
 					/* Else fall through to extended alternative format */
 					/* FALLTHROUGH */
+					pg_fallthrough;
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)

--- a/contrib/ora_btree_gin/ora_btree_gin.c
+++ b/contrib/ora_btree_gin/ora_btree_gin.c
@@ -95,6 +95,7 @@ gin_btree_extract_query(FunctionCallInfo fcinfo,
 		case BTGreaterStrategyNumber:
 			*ptr_partialmatch = true;
 			/* FALLTHROUGH */
+			pg_fallthrough;
 		case BTEqualStrategyNumber:
 			entries[0] = datum;
 			break;

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -943,6 +943,12 @@ endif
 %.c: %.l
 	$(FLEX) $(if $(FLEX_NO_BACKUP),-b) $(FLEXFLAGS) -o'$@' $<
 	@$(if $(FLEX_NO_BACKUP),if [ `wc -l <lex.backup` -eq 1 ]; then rm lex.backup; else echo "Scanner requires backup; see lex.backup." 1>&2; exit 1; fi)
+	@# Flex marks the intentional fallthrough in its generated input()/
+	@# yy_get_next_buffer() with an old-style "/*FALLTHROUGH*/" comment,
+	@# which -Wimplicit-fallthrough=5 (see configure.ac) does not honor.
+	@# Rewrite it to a real annotation for scanners that call input()
+	@# themselves and thus cannot use "%option noinput" to suppress it.
+	$(if $(FLEX_FIX_WARNING),sed -i.bak -e 's|/\*FALLTHROUGH\*/|pg_fallthrough;|' $@ && rm -f $@.bak)
 
 %.c: %.y
 	$(if $(BISON_CHECK_CMD),$(BISON_CHECK_CMD))

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -948,7 +948,7 @@ endif
 	@# which -Wimplicit-fallthrough=5 (see configure.ac) does not honor.
 	@# Rewrite it to a real annotation for scanners that call input()
 	@# themselves and thus cannot use "%option noinput" to suppress it.
-	$(if $(FLEX_FIX_WARNING),sed -i.bak -e 's|/\*FALLTHROUGH\*/|pg_fallthrough;|' $@ && rm -f $@.bak)
+	$(if $(FLEX_FIX_WARNING),sed -e 's|/\*FALLTHROUGH\*/|pg_fallthrough;|' $@ >$@.tmp && mv $@.tmp $@ || rm -f $@.tmp)
 
 %.c: %.y
 	$(if $(BISON_CHECK_CMD),$(BISON_CHECK_CMD))

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -948,7 +948,7 @@ endif
 	@# which -Wimplicit-fallthrough=5 (see configure.ac) does not honor.
 	@# Rewrite it to a real annotation for scanners that call input()
 	@# themselves and thus cannot use "%option noinput" to suppress it.
-	$(if $(FLEX_FIX_WARNING),sed -e 's|/\*FALLTHROUGH\*/|pg_fallthrough;|' $@ >$@.tmp && mv $@.tmp $@ || rm -f $@.tmp)
+	$(if $(FLEX_FIX_WARNING),sed -e 's|/\*FALLTHROUGH\*/|pg_fallthrough;|g' $@ >$@.tmp && mv $@.tmp $@ || rm -f $@.tmp)
 
 %.c: %.y
 	$(if $(BISON_CHECK_CMD),$(BISON_CHECK_CMD))

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -3629,7 +3629,7 @@ DCH_from_char(FormatNode *node, const char *in, TmFromChar *out,
 			case DCH_FF:
 				if (n->key->id == DCH_FF)
 					out->ff = 6;	/* FF default precision */
-				/* FALLTHROUGH */
+				pg_fallthrough;
 			case DCH_US:		/* microsecond */
 				if (ORA_PARSER == compatible_db)
 				{

--- a/src/bin/psql/ora_prompt.c
+++ b/src/bin/psql/ora_prompt.c
@@ -189,6 +189,7 @@ ora_get_prompt(Ora_promptStatus_t status, ConditionalStack cstack)
 						if (service_name)
 							strlcpy(buf, service_name, sizeof(buf));
 					}
+					pg_fallthrough;
 					/* backend pid */
 				case 'p':
 					if (pset.db)

--- a/src/pl/plisql/src/pl_comp.c
+++ b/src/pl/plisql/src/pl_comp.c
@@ -2637,6 +2637,7 @@ plisql_parse_wordrowtype(char *ident)
 	TypeName	*typname;
 	bool		missing_ok = false;
 	TypeName   *typeName;
+	ObjectAddress *refobj;
     MemoryContext oldCxt;
 
     /* Avoid memory leaks in long-term function context */
@@ -2694,8 +2695,6 @@ plisql_parse_wordrowtype(char *ident)
 	if (check_referenced_objects)
 	{
         MemoryContextSwitchTo(oldCxt);
-
-		ObjectAddress *refobj;
 
 		refobj = (ObjectAddress *) palloc(sizeof(ObjectAddress));
 		refobj->classId = RelationRelationId;


### PR DESCRIPTION
fix #1399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Made intentional switch fall-throughs explicit across interval parsing, datetime parsing, prompt escape handling, and query extraction for clearer compiler intent.
  * Updated Flex-generated scanner handling (when enabled) to apply the same explicit fall-through marker consistently.
  * Adjusted Linux build warning-as-error configuration to relax overly strict warning categories while keeping targeted checks.

* **Refactor**
  * Minor internal PL/pgSQL parsing variable scoping cleanup with no expected user-visible behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->