### PR TITLE
Fix conflicting SHARD option validation

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1770,7 +1770,7 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 			|| strcmp(defel->defname, "noshard") == 0)
 		{
 			shardcnt++;
-			if(keepcnt > 1)
+			if(shardcnt > 1)
 			{
 				ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),

--- a/src/oracle_test/regress/expected/sequence.out
+++ b/src/oracle_test/regress/expected/sequence.out
@@ -868,6 +868,11 @@ DROP SEQUENCE seq_shard4;
 create sequence seq_shard5 shard extend ;
 alter sequence seq_shard5 noshard ;
 DROP SEQUENCE seq_shard5;
+-- Reject conflicting SHARD options.
+CREATE SEQUENCE seq_shard_conflict SHARD EXTEND NOSHARD;
+ERROR:  dumplicate or conflicting SHARD EXTEND/NOEXTEND specifications
+LINE 1: CREATE SEQUENCE seq_shard_conflict SHARD EXTEND NOSHARD;
+                                                        ^
 create sequence seq;
 SELECT seq.NEXTVAL FROM DUAL;--result:1
  nextval 

--- a/src/oracle_test/regress/sql/sequence.sql
+++ b/src/oracle_test/regress/sql/sequence.sql
@@ -444,6 +444,9 @@ create sequence seq_shard5 shard extend ;
 alter sequence seq_shard5 noshard ;
 DROP SEQUENCE seq_shard5;
 
+-- Reject conflicting SHARD options.
+CREATE SEQUENCE seq_shard_conflict SHARD EXTEND NOSHARD;
+
 create sequence seq;
 SELECT seq.NEXTVAL FROM DUAL;--result:1
 alter sequence seq restart start with 10;


### PR DESCRIPTION
fix #1402 

## Summary

- use `shardcnt` when validating duplicate or conflicting SHARD options
- add Oracle regression coverage for `SHARD EXTEND` combined with `NOSHARD`

## Background

The Clang warning check in #1386 exposed that `shardcnt` was incremented but never read. The following validation condition mistakenly checked `keepcnt`, copied from the preceding KEEP/NOKEEP block. As a result, conflicting SHARD options were not rejected by the existing error path.

This runtime logic fix is split from #1386 so that the Clang CI PR remains CI-only.

## Testing

- `make check`
- `make oracle-check` (250 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation for conflicting sequence sharding options.
  * Invalid combinations such as `SHARD EXTEND NOSHARD` are now consistently rejected with an accurate error location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Related issue

Discovered while implementing the Clang warning check requested in #1221. The runtime fix is kept in this separate PR so that #1386 remains CI-only.