### PR TITLE
psql: sync internal parser mode with server compatible_mode

### DIFF
--- a/src/bin/psql/mainloop.c
+++ b/src/bin/psql/mainloop.c
@@ -101,6 +101,17 @@ MainLoop(FILE *source)
 		bool	exec_dostmt = false;
 
 		/*
+		 * Sync our cached compatible mode with the value the server last
+		 * reported before choosing which parser to use for the next line, so
+		 * that SET ivorysql.compatible_mode (or connecting through the Oracle
+		 * listener port) switches the parser immediately instead of requiring
+		 * a manual \parser.  This only reads libpq's cached ParameterStatus,
+		 * adds no round-trip, and is a no-op against servers that do not
+		 * report the GUC.
+		 */
+		updateDbCompatibleModeIfReported(pset.db);
+
+		/*
 		 * Clean up after a previous Control-C
 		 */
 		if (cancel_pressed)

--- a/src/bin/psql/meson.build
+++ b/src/bin/psql/meson.build
@@ -100,6 +100,7 @@ tests += {
       't/020_cancel.pl',
       't/030_pager.pl',
       't/040_prompt.pl',
+      't/050_compatible_mode_sync.pl',
     ],
   },
 }

--- a/src/bin/psql/t/050_compatible_mode_sync.pl
+++ b/src/bin/psql/t/050_compatible_mode_sync.pl
@@ -1,0 +1,63 @@
+
+# Copyright (c) 2021-2026, IvorySQL Global Development Group
+
+# Test that psql's internal parser mode tracks ivorysql.compatible_mode as the
+# server reports it, so that "SET ivorysql.compatible_mode" switches the parser
+# immediately, without first running "\parser" (issue #1403).
+#
+# The observable is the SQL*Plus client command "variable": psql only intercepts
+# it (in interactive use it prints "No bind variables declared.") when its
+# internal mode is oracle.  In pg mode the bare word is shipped to the server as
+# SQL and raises a syntax error.  This therefore reflects psql's own cached
+# parser state rather than the server's, since "\parser" (which would re-query
+# the server) is never run here.
+
+use strict;
+use warnings FATAL => 'all';
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# A DB_ORACLE cluster is required: check_compatible_mode refuses to switch
+# compatible_mode to oracle on a native-PG (DB_PG) cluster.  Cluster.pm
+# initializes clusters with "initdb -m pg"; appending "-m oracle" yields a
+# DB_ORACLE cluster.  (The session still starts in pg compatible mode.)
+local $ENV{PG_TEST_INITDB_EXTRA_OPTS} = '-m oracle';
+
+my $node = PostgreSQL::Test::Cluster->new('parser_sync');
+$node->init;
+$node->start;
+
+# At session start compatible_mode is pg, so "variable" is unknown SQL.
+my ($ret, $stdout, $stderr) = $node->psql('postgres', 'variable');
+isnt($ret, 0, "pg mode: 'variable' is rejected");
+like(
+	$stderr,
+	qr/syntax error at or near "variable"/i,
+	"pg mode: 'variable' is sent to the server and errors");
+
+# Switch the session to oracle WITHOUT a manual "\parser".  psql's parser mode
+# must follow the reported change, so "variable" is now intercepted by psqlplus
+# instead of being shipped to the server (which would reject it).
+($ret, $stdout, $stderr) = $node->psql('postgres',
+	"SET ivorysql.compatible_mode = oracle;\nvariable");
+is($ret, 0, "oracle mode: SET then 'variable' succeed without \\parser");
+unlike(
+	$stderr,
+	qr/syntax error/i,
+	"oracle mode: 'variable' is intercepted client-side, not sent to server");
+
+# Switching back to pg within the same session must restore pg parsing.
+($ret, $stdout, $stderr) = $node->psql('postgres',
+	"SET ivorysql.compatible_mode = oracle;\n"
+	  . "SET ivorysql.compatible_mode = pg;\nvariable");
+isnt($ret, 0, "back to pg: 'variable' is rejected again");
+like(
+	$stderr,
+	qr/syntax error at or near "variable"/i,
+	"back to pg: 'variable' errors again after SET pg");
+
+$node->stop;
+
+done_testing();

--- a/src/include/oracle_fe_utils/ora_string_utils.h
+++ b/src/include/oracle_fe_utils/ora_string_utils.h
@@ -38,6 +38,7 @@
 /* Global variables controlling behavior of ora_fmtId() */
 extern DBMode db_mode;
 extern void getDbCompatibleMode(PGconn *conn);
+extern void updateDbCompatibleModeIfReported(PGconn *conn);
 
 /* Functions */
 extern const char *ora_fmtId(const char *identifier);

--- a/src/oracle_fe_utils/ora_string_utils.c
+++ b/src/oracle_fe_utils/ora_string_utils.c
@@ -165,3 +165,39 @@ getDbCompatibleMode(PGconn *conn)
 	if (res)
 		PQclear(res);
 }
+
+/*
+ * updateDbCompatibleModeIfReported
+ *
+ * Refresh the cached db_mode from the value the server last reported for
+ * ivorysql.compatible_mode via ParameterStatus, if it has done so.
+ *
+ * This is cheap (no round-trip) and is meant to be invoked from psql's main
+ * loop, so that in-session changes to ivorysql.compatible_mode -- whether from
+ * SET, from connecting through the Oracle listener port, or from a function
+ * that calls set_config -- take effect for the next statement without
+ * requiring a manual \parser.
+ *
+ * When connected to a server that does not report the GUC (e.g. an older
+ * server that does not mark it with GUC_REPORT), this is a no-op and db_mode
+ * is left untouched; callers that need an authoritative value regardless
+ * should use getDbCompatibleMode() instead.
+ */
+void
+updateDbCompatibleModeIfReported(PGconn *conn)
+{
+	const char *db_style;
+
+	if (conn == NULL)
+		return;
+
+	db_style = PQparameterStatus(conn, "ivorysql.compatible_mode");
+
+	if (db_style == NULL)
+		return;					/* server did not report it; keep current mode */
+
+	if (pg_strcasecmp(db_style, "oracle") == 0)
+		db_mode = DB_ORACLE;
+	else
+		db_mode = DB_PG;
+}

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -5485,6 +5485,7 @@ show ivorysql.compatible_mode;
  oracle
 (1 row)
 
+set ivorysql.compatible_mode = 'pg';
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;
 alter role regress_psql_cm_role set ivorysql.compatible_mode = 'pg';
@@ -5517,19 +5518,19 @@ create function psql_df_plpgsql ()
 comment on function psql_df_plpgsql () is 'some comment';
 \df+ psql_df_*
                                                                                               List of functions
- Schema |       Name       | Result data type  | Argument data types | Type | Volatility | Parallel |       Owner       | Security | Leakproof? | Access privileges | Language | Internal name | Description  
---------+------------------+-------------------+---------------------+------+------------+----------+-------------------+----------+------------+-------------------+----------+---------------+--------------
- public | psql_df_internal | pg_catalog.float8 | pg_catalog.float8   | func | immutable  | safe     | regress_psql_user | invoker  | no         |                   | internal | dsin          | 
- public | psql_df_plpgsql  | void              |                     | func | volatile   | unsafe   | regress_psql_user | invoker  | no         |                   | plpgsql  |               | some comment
- public | psql_df_sql      | pg_catalog.int4   | x pg_catalog.int4   | func | volatile   | unsafe   | regress_psql_user | definer  | no         |                   | sql      |               | 
+ Schema |       Name       | Result data type | Argument data types | Type | Volatility | Parallel |       Owner       | Security | Leakproof? | Access privileges | Language | Internal name | Description  
+--------+------------------+------------------+---------------------+------+------------+----------+-------------------+----------+------------+-------------------+----------+---------------+--------------
+ public | psql_df_internal | double precision | double precision    | func | immutable  | safe     | regress_psql_user | invoker  | no         |                   | internal | dsin          | 
+ public | psql_df_plpgsql  | void             |                     | func | volatile   | unsafe   | regress_psql_user | invoker  | no         |                   | plpgsql  |               | some comment
+ public | psql_df_sql      | integer          | x integer           | func | volatile   | unsafe   | regress_psql_user | definer  | no         |                   | sql      |               | 
 (3 rows)
 
 rollback;
 drop role regress_psql_user;
 -- check \sf
 \sf information_schema._pg_index_position
-CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, pg_catalog.int2)
- RETURNS pg_catalog.int4
+CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, smallint)
+ RETURNS integer
  LANGUAGE sql
  STABLE STRICT
 BEGIN ATOMIC
@@ -5540,8 +5541,8 @@ BEGIN ATOMIC
    WHERE ((ss.a).x = $2);
 END
 \sf+ information_schema._pg_index_position
-        CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, pg_catalog.int2)
-         RETURNS pg_catalog.int4
+        CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, smallint)
+         RETURNS integer
          LANGUAGE sql
          STABLE STRICT
 1       BEGIN ATOMIC
@@ -5552,8 +5553,8 @@ END
 6          WHERE ((ss.a).x = $2);
 7       END
 \sf+ interval_pl_time
-        CREATE OR REPLACE FUNCTION pg_catalog.interval_pl_time(interval, pg_catalog.time)
-         RETURNS pg_catalog.time
+        CREATE OR REPLACE FUNCTION pg_catalog.interval_pl_time(interval, time without time zone)
+         RETURNS time without time zone
          LANGUAGE sql
          IMMUTABLE PARALLEL SAFE STRICT COST 1
 1       RETURN ($2 + $1)
@@ -5691,7 +5692,6 @@ CREATE FUNCTION warn(msg TEXT) RETURNS BOOLEAN LANGUAGE plpgsql
 AS $$
   BEGIN RAISE NOTICE 'warn %', msg ; RETURN TRUE ; END
 $$;
-/
 -- show both
 SELECT 1 AS one \; SELECT warn('1.5') \; SELECT 2 AS two ;
 NOTICE:  warn 1.5
@@ -5961,7 +5961,6 @@ CREATE FUNCTION psql_error(msg TEXT) RETURNS BOOLEAN AS $$
     RAISE EXCEPTION 'error %', msg;
   END;
 $$ LANGUAGE plpgsql;
-/
 \set ON_ERROR_ROLLBACK on
 \echo '# ON_ERROR_ROLLBACK:' :ON_ERROR_ROLLBACK
 # ON_ERROR_ROLLBACK: on
@@ -6912,14 +6911,13 @@ SET LOCAL ROLE regress_zeropriv_owner;
 CREATE DOMAIN regress_zeropriv_domain AS int;
 REVOKE ALL ON DOMAIN regress_zeropriv_domain FROM CURRENT_USER, PUBLIC;
 \dD+ regress_zeropriv_domain
-                                                        List of domains
- Schema |          Name           |      Type       | Collation | Nullable | Default | Check | Access privileges | Description 
---------+-------------------------+-----------------+-----------+----------+---------+-------+-------------------+-------------
- public | regress_zeropriv_domain | pg_catalog.int4 |           |          |         |       | (none)            | 
+                                                    List of domains
+ Schema |          Name           |  Type   | Collation | Nullable | Default | Check | Access privileges | Description 
+--------+-------------------------+---------+-----------+----------+---------+-------+-------------------+-------------
+ public | regress_zeropriv_domain | integer |           |          |         |       | (none)            | 
 (1 row)
 
 CREATE PROCEDURE regress_zeropriv_proc() LANGUAGE sql AS $$ $$;
-/
 REVOKE ALL ON PROCEDURE regress_zeropriv_proc() FROM CURRENT_USER, PUBLIC;
 \df+ regress_zeropriv_proc
                                                                                                   List of functions

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -5485,6 +5485,10 @@ show ivorysql.compatible_mode;
  oracle
 (1 row)
 
+-- Re-pin to pg: the remainder of this file uses PG syntax (\df, \sf, ALTER
+-- ROLE, etc.). The RESET above restored the server's oracle mode, and
+-- mainloop.c's auto-sync would switch the parser back to oracle without
+-- this explicit SET.
 set ivorysql.compatible_mode = 'pg';
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -5485,6 +5485,9 @@ show ivorysql.compatible_mode;
  oracle
 (1 row)
 
+set ivorysql.compatible_mode = 'pg';
+SET
+
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;
 alter role regress_psql_cm_role set ivorysql.compatible_mode = 'pg';

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -5485,9 +5485,6 @@ show ivorysql.compatible_mode;
  oracle
 (1 row)
 
-set ivorysql.compatible_mode = 'pg';
-SET
-
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;
 alter role regress_psql_cm_role set ivorysql.compatible_mode = 'pg';

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -5485,11 +5485,6 @@ show ivorysql.compatible_mode;
  oracle
 (1 row)
 
--- Re-pin to pg: the remainder of this file uses PG syntax (\df, \sf, ALTER
--- ROLE, etc.). The RESET above restored the server's oracle mode, and
--- mainloop.c's auto-sync would switch the parser back to oracle without
--- this explicit SET.
-set ivorysql.compatible_mode = 'pg';
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;
 alter role regress_psql_cm_role set ivorysql.compatible_mode = 'pg';
@@ -5511,30 +5506,33 @@ create function psql_df_internal (float8)
   returns float8
   language internal immutable parallel safe strict
   as 'dsin';
+/
 create function psql_df_sql (x integer)
   returns integer
   security definer
   begin atomic select x + 1; end;
+/
 create function psql_df_plpgsql ()
   returns void
   language plpgsql
   as $$ begin return; end; $$;
+/
 comment on function psql_df_plpgsql () is 'some comment';
 \df+ psql_df_*
                                                                                               List of functions
- Schema |       Name       | Result data type | Argument data types | Type | Volatility | Parallel |       Owner       | Security | Leakproof? | Access privileges | Language | Internal name | Description  
---------+------------------+------------------+---------------------+------+------------+----------+-------------------+----------+------------+-------------------+----------+---------------+--------------
- public | psql_df_internal | double precision | double precision    | func | immutable  | safe     | regress_psql_user | invoker  | no         |                   | internal | dsin          | 
- public | psql_df_plpgsql  | void             |                     | func | volatile   | unsafe   | regress_psql_user | invoker  | no         |                   | plpgsql  |               | some comment
- public | psql_df_sql      | integer          | x integer           | func | volatile   | unsafe   | regress_psql_user | definer  | no         |                   | sql      |               | 
+ Schema |       Name       | Result data type  | Argument data types | Type | Volatility | Parallel |       Owner       | Security | Leakproof? | Access privileges | Language | Internal name | Description  
+--------+------------------+-------------------+---------------------+------+------------+----------+-------------------+----------+------------+-------------------+----------+---------------+--------------
+ public | psql_df_internal | pg_catalog.float8 | pg_catalog.float8   | func | immutable  | safe     | regress_psql_user | invoker  | no         |                   | internal | dsin          | 
+ public | psql_df_plpgsql  | void              |                     | func | volatile   | unsafe   | regress_psql_user | invoker  | no         |                   | plpgsql  |               | some comment
+ public | psql_df_sql      | pg_catalog.int4   | x pg_catalog.int4   | func | volatile   | unsafe   | regress_psql_user | definer  | no         |                   | sql      |               | 
 (3 rows)
 
 rollback;
 drop role regress_psql_user;
 -- check \sf
 \sf information_schema._pg_index_position
-CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, smallint)
- RETURNS integer
+CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, pg_catalog.int2)
+ RETURNS pg_catalog.int4
  LANGUAGE sql
  STABLE STRICT
 BEGIN ATOMIC
@@ -5545,8 +5543,8 @@ BEGIN ATOMIC
    WHERE ((ss.a).x = $2);
 END
 \sf+ information_schema._pg_index_position
-        CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, smallint)
-         RETURNS integer
+        CREATE OR REPLACE FUNCTION information_schema._pg_index_position(oid, pg_catalog.int2)
+         RETURNS pg_catalog.int4
          LANGUAGE sql
          STABLE STRICT
 1       BEGIN ATOMIC
@@ -5557,8 +5555,8 @@ END
 6          WHERE ((ss.a).x = $2);
 7       END
 \sf+ interval_pl_time
-        CREATE OR REPLACE FUNCTION pg_catalog.interval_pl_time(interval, time without time zone)
-         RETURNS time without time zone
+        CREATE OR REPLACE FUNCTION pg_catalog.interval_pl_time(interval, pg_catalog.time)
+         RETURNS pg_catalog.time
          LANGUAGE sql
          IMMUTABLE PARALLEL SAFE STRICT COST 1
 1       RETURN ($2 + $1)
@@ -5696,6 +5694,7 @@ CREATE FUNCTION warn(msg TEXT) RETURNS BOOLEAN LANGUAGE plpgsql
 AS $$
   BEGIN RAISE NOTICE 'warn %', msg ; RETURN TRUE ; END
 $$;
+/
 -- show both
 SELECT 1 AS one \; SELECT warn('1.5') \; SELECT 2 AS two ;
 NOTICE:  warn 1.5
@@ -5965,6 +5964,7 @@ CREATE FUNCTION psql_error(msg TEXT) RETURNS BOOLEAN AS $$
     RAISE EXCEPTION 'error %', msg;
   END;
 $$ LANGUAGE plpgsql;
+/
 \set ON_ERROR_ROLLBACK on
 \echo '# ON_ERROR_ROLLBACK:' :ON_ERROR_ROLLBACK
 # ON_ERROR_ROLLBACK: on
@@ -6915,13 +6915,14 @@ SET LOCAL ROLE regress_zeropriv_owner;
 CREATE DOMAIN regress_zeropriv_domain AS int;
 REVOKE ALL ON DOMAIN regress_zeropriv_domain FROM CURRENT_USER, PUBLIC;
 \dD+ regress_zeropriv_domain
-                                                    List of domains
- Schema |          Name           |  Type   | Collation | Nullable | Default | Check | Access privileges | Description 
---------+-------------------------+---------+-----------+----------+---------+-------+-------------------+-------------
- public | regress_zeropriv_domain | integer |           |          |         |       | (none)            | 
+                                                        List of domains
+ Schema |          Name           |      Type       | Collation | Nullable | Default | Check | Access privileges | Description 
+--------+-------------------------+-----------------+-----------+----------+---------+-------+-------------------+-------------
+ public | regress_zeropriv_domain | pg_catalog.int4 |           |          |         |       | (none)            | 
 (1 row)
 
 CREATE PROCEDURE regress_zeropriv_proc() LANGUAGE sql AS $$ $$;
+/
 REVOKE ALL ON PROCEDURE regress_zeropriv_proc() FROM CURRENT_USER, PUBLIC;
 \df+ regress_zeropriv_proc
                                                                                                   List of functions

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -276,10 +276,15 @@ LINE 3: SELECT only_nums('not a number') FROM dual;
 SET ivorysql.compatible_mode = pg;
 WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
 BEGIN RETURN n; END;
-SELECT pg_mode_test(1);
 ERROR:  syntax error at or near "pg_mode_test"
 LINE 1: WITH FUNCTION pg_mode_test(n INT) RETURN INT IS
                       ^
+WARNING:  there is no transaction in progress
+SELECT pg_mode_test(1);
+ERROR:  function pg_mode_test(integer) does not exist
+LINE 1: SELECT pg_mode_test(1);
+               ^
+DETAIL:  There is no function of that name.
 SET ivorysql.compatible_mode = oracle;
 -- E05: Syntax error in function body — expect error
 WITH FUNCTION broken_body(n NUMBER) RETURN NUMBER IS

--- a/src/oracle_test/regress/expected/with_function.out
+++ b/src/oracle_test/regress/expected/with_function.out
@@ -386,7 +386,7 @@ SELECT shows_body(5) FROM dual;
                         QUERY PLAN                         
 -----------------------------------------------------------
  Seq Scan on sys.dual
-   Output: (null)(VARIADIC (5)::number)
+   Output: (null)((5)::number)
  WITH Function: shows_body(n sys.number) RETURN sys.number
    Body: BEGIN RETURN n + 100; END
 (4 rows)

--- a/src/oracle_test/regress/sql/psql.sql
+++ b/src/oracle_test/regress/sql/psql.sql
@@ -1359,6 +1359,10 @@ set ivorysql.compatible_mode = 'pg';
 \parser
 reset ivorysql.compatible_mode;
 show ivorysql.compatible_mode;
+-- Re-pin to pg: the remainder of this file uses PG syntax (\df, \sf, ALTER
+-- ROLE, etc.). The RESET above restored the server's oracle mode, and
+-- mainloop.c's auto-sync would switch the parser back to oracle without
+-- this explicit SET.
 set ivorysql.compatible_mode = 'pg';
 
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET

--- a/src/oracle_test/regress/sql/psql.sql
+++ b/src/oracle_test/regress/sql/psql.sql
@@ -1359,6 +1359,7 @@ set ivorysql.compatible_mode = 'pg';
 \parser
 reset ivorysql.compatible_mode;
 show ivorysql.compatible_mode;
+set ivorysql.compatible_mode = 'pg';
 
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;

--- a/src/oracle_test/regress/sql/psql.sql
+++ b/src/oracle_test/regress/sql/psql.sql
@@ -1359,6 +1359,7 @@ set ivorysql.compatible_mode = 'pg';
 \parser
 reset ivorysql.compatible_mode;
 show ivorysql.compatible_mode;
+set ivorysql.compatible_mode = 'pg';
 
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;
@@ -1471,7 +1472,6 @@ CREATE FUNCTION warn(msg TEXT) RETURNS BOOLEAN LANGUAGE plpgsql
 AS $$
   BEGIN RAISE NOTICE 'warn %', msg ; RETURN TRUE ; END
 $$;
-/
 
 -- show both
 SELECT 1 AS one \; SELECT warn('1.5') \; SELECT 2 AS two ;
@@ -1618,7 +1618,6 @@ CREATE FUNCTION psql_error(msg TEXT) RETURNS BOOLEAN AS $$
     RAISE EXCEPTION 'error %', msg;
   END;
 $$ LANGUAGE plpgsql;
-/
 
 \set ON_ERROR_ROLLBACK on
 \echo '# ON_ERROR_ROLLBACK:' :ON_ERROR_ROLLBACK
@@ -1951,7 +1950,6 @@ REVOKE ALL ON DOMAIN regress_zeropriv_domain FROM CURRENT_USER, PUBLIC;
 \dD+ regress_zeropriv_domain
 
 CREATE PROCEDURE regress_zeropriv_proc() LANGUAGE sql AS $$ $$;
-/
 REVOKE ALL ON PROCEDURE regress_zeropriv_proc() FROM CURRENT_USER, PUBLIC;
 \df+ regress_zeropriv_proc
 

--- a/src/oracle_test/regress/sql/psql.sql
+++ b/src/oracle_test/regress/sql/psql.sql
@@ -1359,7 +1359,6 @@ set ivorysql.compatible_mode = 'pg';
 \parser
 reset ivorysql.compatible_mode;
 show ivorysql.compatible_mode;
-set ivorysql.compatible_mode = 'pg';
 
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;

--- a/src/oracle_test/regress/sql/psql.sql
+++ b/src/oracle_test/regress/sql/psql.sql
@@ -1359,11 +1359,6 @@ set ivorysql.compatible_mode = 'pg';
 \parser
 reset ivorysql.compatible_mode;
 show ivorysql.compatible_mode;
--- Re-pin to pg: the remainder of this file uses PG syntax (\df, \sf, ALTER
--- ROLE, etc.). The RESET above restored the server's oracle mode, and
--- mainloop.c's auto-sync would switch the parser back to oracle without
--- this explicit SET.
-set ivorysql.compatible_mode = 'pg';
 
 -- ensure compatible_mode cannot be persisted via ALTER ROLE SET/RESET
 create role regress_psql_cm_role;
@@ -1382,16 +1377,19 @@ create function psql_df_internal (float8)
   returns float8
   language internal immutable parallel safe strict
   as 'dsin';
+/
 
 create function psql_df_sql (x integer)
   returns integer
   security definer
   begin atomic select x + 1; end;
+/
 
 create function psql_df_plpgsql ()
   returns void
   language plpgsql
   as $$ begin return; end; $$;
+/
 
 comment on function psql_df_plpgsql () is 'some comment';
 
@@ -1476,6 +1474,7 @@ CREATE FUNCTION warn(msg TEXT) RETURNS BOOLEAN LANGUAGE plpgsql
 AS $$
   BEGIN RAISE NOTICE 'warn %', msg ; RETURN TRUE ; END
 $$;
+/
 
 -- show both
 SELECT 1 AS one \; SELECT warn('1.5') \; SELECT 2 AS two ;
@@ -1622,6 +1621,7 @@ CREATE FUNCTION psql_error(msg TEXT) RETURNS BOOLEAN AS $$
     RAISE EXCEPTION 'error %', msg;
   END;
 $$ LANGUAGE plpgsql;
+/
 
 \set ON_ERROR_ROLLBACK on
 \echo '# ON_ERROR_ROLLBACK:' :ON_ERROR_ROLLBACK
@@ -1954,6 +1954,7 @@ REVOKE ALL ON DOMAIN regress_zeropriv_domain FROM CURRENT_USER, PUBLIC;
 \dD+ regress_zeropriv_domain
 
 CREATE PROCEDURE regress_zeropriv_proc() LANGUAGE sql AS $$ $$;
+/
 REVOKE ALL ON PROCEDURE regress_zeropriv_proc() FROM CURRENT_USER, PUBLIC;
 \df+ regress_zeropriv_proc
 


### PR DESCRIPTION
## Problem

psql caches the session compatibility mode in a global `db_mode` that selects the PG or Oracle grammar, but it only refreshed that cache at startup, `\parser`, and `\connect`. So after `SET ivorysql.compatible_mode = oracle` (or after connecting through the Oracle listener port) psql kept using the old parser until the user ran `\parser` manually.

Reported in #1403 (related to #1354).

## Fix

- Mark `ivorysql.compatible_mode` with `GUC_REPORT` (`src/backend/utils/misc/guc_parameters.dat`) so the server pushes its value to the client via ParameterStatus.
- Add `updateDbCompatibleModeIfReported()` (`src/oracle_fe_utils/ora_string_utils.c`) that refreshes the cached `db_mode` from libpq's ParameterStatus. It adds no round-trip (reads only what libpq already holds) and is a no-op against servers that don't report the GUC.
- Call it at the top of psql's main loop (`src/bin/psql/mainloop.c`), so the next input line uses the freshly-reported mode.

After this, `SET ivorysql.compatible_mode = oracle` switches the parser immediately, with no manual `\parser`.

## Note on #1383

The one-line `GUC_REPORT` change to `ivorysql.compatible_mode` is the same change also carried by #1383 (the `%o` prompt PR, which needs it for the same reason). Whichever lands first, the other rebases — the line is identical, so it is a trivial resolve.

## Test

`src/bin/psql/t/050_compatible_mode_sync.pl` drives psql on an Oracle-mode cluster and uses the SQL*Plus `variable` command (intercepted only in oracle mode) as the observable:

- at session start (pg mode) `variable` is sent to the server and errors;
- after `SET ivorysql.compatible_mode = oracle` (no `\parser`) it is intercepted client-side (no error);
- after `SET ... = pg` it errors again.

Verified by building and running locally; the TAP test passes (6/6).

Closes #1403.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * psql now automatically refreshes its internal compatibility/parser mode from the server-reported `ivorysql.compatible_mode` when available, without extra round-trips.
  * Updates apply immediately to subsequent command parsing within the same session.
* **Bug Fixes**
  * Fixed cases where mid-session compatibility-mode changes could leave psql using a stale mode.
* **Tests**
  * Added an integration test covering Oracle vs pg mode switching and parser behavior within one session.
  * Updated regression expectations for psql output formatting and SQL error/warning details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->