### PR TITLE
[fix][parser] Correct typo msut -> must in SPLIT PARTITION error hint

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -3802,7 +3802,7 @@ transformPartitionCmdForSplit(CreateStmtContext *cxt, PartitionCmd *partcmd)
 				errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 				errmsg("can not split DEFAULT partition \"%s\"",
 					   get_rel_name(splitPartOid)),
-				errhint("To split DEFAULT partition one of the new partition msut be DEFAULT"),
+				errhint("To split DEFAULT partition one of the new partition must be DEFAULT"),
 				parser_errposition(cxt->pstate, ((SinglePartitionSpec *) linitial(splitlist))->name->location));
 
 	/*

--- a/src/test/regress/expected/partition_split.out
+++ b/src/test/regress/expected/partition_split.out
@@ -507,7 +507,7 @@ LINE 3:    PARTITION sales_error FOR VALUES FROM ('2021-12-01') TO (...
 DETAIL:  lower bound of partition "sales_error" is not equal to the upper bound of partition "sales_dec2021"
 HINT:  ALTER TABLE ... SPLIT PARTITION requires the partition bounds to be adjacent.
 -- ERROR:  can not split DEFAULT partition "sales_others"
--- HINT:  To split DEFAULT partition one of the new partition msut be DEFAULT
+-- HINT:  To split DEFAULT partition one of the new partition must be DEFAULT
 ALTER TABLE sales_range SPLIT PARTITION sales_others INTO
   (PARTITION sales_dec2021 FOR VALUES FROM ('2021-12-01') TO ('2022-01-01'),
    PARTITION sales_jan2022 FOR VALUES FROM ('2022-01-01') TO ('2022-02-01'),
@@ -515,7 +515,7 @@ ALTER TABLE sales_range SPLIT PARTITION sales_others INTO
 ERROR:  can not split DEFAULT partition "sales_others"
 LINE 2:   (PARTITION sales_dec2021 FOR VALUES FROM ('2021-12-01') TO...
                      ^
-HINT:  To split DEFAULT partition one of the new partition msut be DEFAULT
+HINT:  To split DEFAULT partition one of the new partition must be DEFAULT
 -- no error: bounds of sales_noerror are between sales_dec2021 and sales_feb2022
 ALTER TABLE sales_range SPLIT PARTITION sales_others INTO
   (PARTITION sales_dec2021 FOR VALUES FROM ('2021-12-01') TO ('2022-01-01'),

--- a/src/test/regress/sql/partition_split.sql
+++ b/src/test/regress/sql/partition_split.sql
@@ -331,7 +331,7 @@ ALTER TABLE sales_range SPLIT PARTITION sales_others INTO
    PARTITION sales_others DEFAULT);
 
 -- ERROR:  can not split DEFAULT partition "sales_others"
--- HINT:  To split DEFAULT partition one of the new partition msut be DEFAULT
+-- HINT:  To split DEFAULT partition one of the new partition must be DEFAULT
 ALTER TABLE sales_range SPLIT PARTITION sales_others INTO
   (PARTITION sales_dec2021 FOR VALUES FROM ('2021-12-01') TO ('2022-01-01'),
    PARTITION sales_jan2022 FOR VALUES FROM ('2022-01-01') TO ('2022-02-01'),


### PR DESCRIPTION
## Summary
Fix typo `msut` to `must` in the error hint message inside `transformPartitionCmdForSplit()`.

## Changes
File: `src/backend/parser/parse_utilcmd.c`
- Revise the errhint string for SPLIT PARTITION syntax check:
  Original: `one of the new partition msut be DEFAULT`
  Fixed: `one of the new partition must be DEFAULT`

## Impact
This change only modifies user-facing error prompt text, with zero functional logic changes.
When users execute SPLIT PARTITION without including a DEFAULT partition in new partitions list, the error message will display grammatically correct English text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in the error hint shown when splitting a `DEFAULT` partition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->