### PR TITLE
fix(test): ignore oracle-check artifacts

### DIFF
--- a/contrib/ivorysql_ora/.gitignore
+++ b/contrib/ivorysql_ora/.gitignore
@@ -1,1 +1,6 @@
 /ivorysql_ora--1.0.sql
+
+# Generated subdirectories
+/log/
+/results/
+/tmp_check/


### PR DESCRIPTION
## Why

Running `make oracle-check` in `contrib/ivorysql_ora` creates `log/`, `results/`, and `tmp_check/`, which currently appear as untracked files. This differs from the regression-test ignore convention used elsewhere in the tree.

Closes #1400.

## What Changed

Added the standard generated regression directories to `contrib/ivorysql_ora/.gitignore`.

## Verification

`git check-ignore -v` reports all three generated paths using the new rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ignore rules for generated log, results, and temporary check files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## AI assistance disclosure

This contribution was prepared with OpenAI Codex using GPT-5. The agent assisted with source and test inspection, issue scoping, drafting code, documentation and tests where applicable, running verification, and preparing the PR description. I directed the scope, reviewed the resulting changes against the source and test results, and remain responsible for the submission.
