### PR TITLE
docs: complete package command reference

### DIFF
--- a/doc/src/sgml/ref/allfiles.sgml
+++ b/doc/src/sgml/ref/allfiles.sgml
@@ -79,7 +79,7 @@ Complete list of usable sgml source files in this directory.
 <!ENTITY createOperatorClass SYSTEM "create_opclass.sgml">
 <!ENTITY createOperatorFamily SYSTEM "create_opfamily.sgml">
 <!ENTITY createPackage      SYSTEM "create_package.sgml">
-<!ENTITY createPackageBody  SYSTEM "create_packagebody.sgml">
+<!ENTITY createPackageBody  SYSTEM "create_package_body.sgml">
 <!ENTITY createPolicy       SYSTEM "create_policy.sgml">
 <!ENTITY createProcedure    SYSTEM "create_procedure.sgml">
 <!ENTITY createPublication  SYSTEM "create_publication.sgml">

--- a/doc/src/sgml/ref/alter_package.sgml
+++ b/doc/src/sgml/ref/alter_package.sgml
@@ -16,18 +16,133 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>ALTER PACKAGE</refname>
-  <refpurpose>alter a package</refpurpose>
+  <refpurpose>change the definition of a package</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
 <synopsis>
-ALTER PACKAGE [schema.] <replaceable class="parameter">package_name</replaceable> { package_compile_clause | { EDITIONABLE | NONEDITIONABLE } } ;
-
-package_compile_clause:
-    COMPILE [ DEBUG ] [ compiler_parameters_clause ... ] [ REUSE SETTINGS ]
-	
-compiler_parameters_clause:
-    parameter_name = parameter_value
+ALTER PACKAGE <replaceable class="parameter">name</replaceable> { EDITIONABLE | NONEDITIONABLE }
+ALTER PACKAGE <replaceable class="parameter">name</replaceable> RENAME TO <replaceable class="parameter">new_name</replaceable>
+ALTER PACKAGE <replaceable class="parameter">name</replaceable> OWNER TO { <replaceable class="parameter">new_owner</replaceable> | CURRENT_ROLE | CURRENT_USER | SESSION_USER }
+ALTER PACKAGE <replaceable class="parameter">name</replaceable> SET SCHEMA <replaceable class="parameter">new_schema</replaceable>
 </synopsis>
-</refsynopsisdiv>
+ </refsynopsisdiv>
+
+ <refsect1 id="sql-alterpackage-description">
+  <title>Description</title>
+
+  <para>
+   <command>ALTER PACKAGE</command> changes the properties, name, owner, or
+   schema of an existing package.
+  </para>
+
+  <para>
+   You must own the package to use <command>ALTER PACKAGE</command>.
+   To change a package's schema, you must also have <literal>CREATE</literal>
+   privilege on the new schema.  To alter the owner, you must be able to
+   <literal>SET ROLE</literal> to the new owning role, and that role must have
+   <literal>CREATE</literal> privilege on the package's schema.  A superuser
+   can alter any package.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-alterpackage-parameters">
+  <title>Parameters</title>
+
+  <variablelist>
+   <varlistentry>
+    <term><replaceable class="parameter">name</replaceable></term>
+    <listitem>
+     <para>
+      The name (optionally schema-qualified) of an existing package.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>EDITIONABLE</literal></term>
+    <term><literal>NONEDITIONABLE</literal></term>
+    <listitem>
+     <para>
+      Change the editionability property of the package specification.  When
+      a package body is subsequently created or replaced, its editionability
+      must match this property.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">new_name</replaceable></term>
+    <listitem>
+     <para>
+      The new name of the package.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">new_owner</replaceable></term>
+    <listitem>
+     <para>
+      The new owner of the package.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">new_schema</replaceable></term>
+    <listitem>
+     <para>
+      The new schema for the package.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 id="sql-alterpackage-examples">
+  <title>Examples</title>
+
+  <para>
+   Mark the package <literal>inventory_api</literal> as noneditionable:
+<programlisting>
+ALTER PACKAGE inventory_api NONEDITIONABLE;
+</programlisting>
+  </para>
+
+  <para>
+   Rename the package:
+<programlisting>
+ALTER PACKAGE inventory_api RENAME TO stock_api;
+</programlisting>
+  </para>
+
+  <para>
+   Move the package to the <literal>application</literal> schema:
+<programlisting>
+ALTER PACKAGE stock_api SET SCHEMA application;
+</programlisting>
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-alterpackage-compatibility">
+  <title>Compatibility</title>
+
+  <para>
+   <command>ALTER PACKAGE</command> is an <productname>IvorySQL</productname>
+   extension for Oracle compatibility.  It is not defined by the SQL
+   standard.  Oracle forms that recompile a package, such as
+   <literal>ALTER PACKAGE ... COMPILE</literal>, are not currently supported.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-alterpackage-see-also">
+  <title>See Also</title>
+
+  <simplelist type="inline">
+   <member><xref linkend="sql-createpackage"/></member>
+   <member><xref linkend="sql-createpackagebody"/></member>
+   <member><xref linkend="sql-droppackage"/></member>
+  </simplelist>
+ </refsect1>
 </refentry>

--- a/doc/src/sgml/ref/create_package.sgml
+++ b/doc/src/sgml/ref/create_package.sgml
@@ -16,41 +16,187 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>CREATE PACKAGE</refname>
-  <refpurpose>create a new package</refpurpose>
+  <refpurpose>define a new package specification</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
 <synopsis>
-CREATE [ OR REPLACE ] [ EDITIONABLE | NONEDITIONABLE ] PACKAGE [schema.] package_name [ sharing_clause ] [ { default_collation_clause | invoker_rights_clause | accessible_by_clause }... ]  { IS | AS } package_item_list END [ package_name ] ;
+CREATE [ OR REPLACE ] [ EDITIONABLE | NONEDITIONABLE ] PACKAGE <replaceable class="parameter">name</replaceable>
+    [ SHARING = { METADATA | NONE } ]
+    [ <replaceable class="parameter">package_property</replaceable> ... ]
+    { IS | AS }
+    [ <replaceable class="parameter">package_declaration</replaceable> ... ]
+END [ <replaceable class="parameter">name</replaceable> ]
 
-sharing_clause:
-    SHARING = { METADATA | NONE }
-	
-default_collation_clause:
-    DEFAULT COLLATION "collation_option"
+<phrase>where <replaceable class="parameter">package_property</replaceable> is one of:</phrase>
 
-collation_option: 
-	USING_NLS_COMP
+    AUTHID { DEFINER | CURRENT_USER }
+    ACCESSIBLE BY ( <replaceable class="parameter">accessor</replaceable> [, ...] )
+    DEFAULT COLLATION USING_NLS_COMP
 
-invoker_rights_clause:
-    AUTHID [CURRENT_USER | DEFINER]
-	
-accessible_by_clause:
-    ACCESSIBLE BY ( accessor [, accessor ]... )
-	
-accessor:
-    [ unit_kind ] [schema.]unit_name 
-	
-unit_kind:
-    [ FUNCTION | PROCEDURE | PACKAGE | TRIGGER | TYPE ]
-	
-package_item_list:
-    { type_definition 
-    | cursor_declaration 
-    | item_declaration 
-    | package_function_declaration 
-    | package_procedure_declaration } 
-...
+<phrase>and <replaceable class="parameter">accessor</replaceable> is:</phrase>
+
+    [ FUNCTION | PROCEDURE | PACKAGE | TRIGGER | TYPE ] [ <replaceable class="parameter">schema</replaceable>. ]<replaceable class="parameter">unit_name</replaceable>
 </synopsis>
-</refsynopsisdiv>
+ </refsynopsisdiv>
+
+ <refsect1 id="sql-createpackage-description">
+  <title>Description</title>
+
+  <para>
+   <command>CREATE PACKAGE</command> defines a package specification.  The
+   specification is the public interface of a package and can declare public
+   variables, constants, types, cursors, procedures, and functions.  Use
+   <xref linkend="sql-createpackagebody"/> to provide implementations and
+   private declarations.
+  </para>
+
+  <para>
+   If a schema name is included, the package is created in the specified
+   schema.  Otherwise it is created in the current schema.  The user that
+   creates the package becomes its owner and must have
+   <literal>CREATE</literal> privilege on the target schema.  The PL/iSQL
+   language must also be available to the user.
+  </para>
+
+  <para>
+   <command>CREATE OR REPLACE PACKAGE</command> creates a package or replaces
+   the specification of an existing package.  Replacing a package preserves
+   its ownership and access privileges, and requires ownership of the existing
+   package.  It cannot change the existing package's
+   <literal>EDITIONABLE</literal> property.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-createpackage-parameters">
+  <title>Parameters</title>
+
+  <variablelist>
+   <varlistentry>
+    <term><literal>OR REPLACE</literal></term>
+    <listitem>
+     <para>
+      Replace the specification if a package of the same name already exists.
+      Without this clause, an existing package causes an error.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>EDITIONABLE</literal></term>
+    <term><literal>NONEDITIONABLE</literal></term>
+    <listitem>
+     <para>
+      Set the package's editionability property.  The default is
+      <literal>EDITIONABLE</literal>.  A package body must use the same value.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">name</replaceable></term>
+    <listitem>
+     <para>
+      The name (optionally schema-qualified) of the package to create.  Only
+      one package of a given name can exist in a schema.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>SHARING = { METADATA | NONE }</literal></term>
+    <listitem>
+     <para>
+      This clause is accepted for Oracle syntax compatibility.  It currently
+      has no effect on package behavior.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>AUTHID DEFINER</literal></term>
+    <term><literal>AUTHID CURRENT_USER</literal></term>
+    <listitem>
+     <para>
+      Select whether package code executes with the privileges of the package
+      owner or the calling user.  <literal>AUTHID DEFINER</literal> is the
+      default.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>ACCESSIBLE BY ( <replaceable class="parameter">accessor</replaceable> [, ...] )</literal></term>
+    <listitem>
+     <para>
+      Record a list of program units that are intended to call the package.
+      Each accessor can include a unit kind and a schema qualification.  The
+      clause is retained in the package definition for compatibility, but is
+      not currently enforced as a run-time call restriction.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>DEFAULT COLLATION USING_NLS_COMP</literal></term>
+    <listitem>
+     <para>
+      Record the Oracle-compatible default collation clause on the package.
+      The clause is retained in the package definition but does not currently
+      change run-time collation behavior.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">package_declaration</replaceable></term>
+    <listitem>
+     <para>
+      A public PL/iSQL declaration, such as a variable, constant, type, cursor,
+      procedure, or function declaration.  Declarations are separated by
+      semicolons.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <para>
+   Each package property can appear at most once.  Specifying the same
+   property more than once causes an error.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-createpackage-examples">
+  <title>Examples</title>
+
+  <para>
+   Define a package specification with one public procedure:
+<programlisting>
+CREATE OR REPLACE PACKAGE inventory_api AUTHID DEFINER AS
+  PROCEDURE add_item(p_id INT, p_label TEXT);
+END inventory_api;
+</programlisting>
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-createpackage-compatibility">
+  <title>Compatibility</title>
+
+  <para>
+   <command>CREATE PACKAGE</command> is an
+   <productname>IvorySQL</productname> extension for Oracle compatibility.  It
+   is not defined by the SQL standard.  The supported syntax is a subset of
+   Oracle package syntax; compatibility-only clauses are described above.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-createpackage-see-also">
+  <title>See Also</title>
+
+  <simplelist type="inline">
+   <member><xref linkend="sql-createpackagebody"/></member>
+   <member><xref linkend="sql-alterpackage"/></member>
+   <member><xref linkend="sql-droppackage"/></member>
+  </simplelist>
+ </refsect1>
 </refentry>

--- a/doc/src/sgml/ref/create_package_body.sgml
+++ b/doc/src/sgml/ref/create_package_body.sgml
@@ -16,42 +16,153 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>CREATE PACKAGE BODY</refname>
-  <refpurpose>define a new package body</refpurpose>
+  <refpurpose>define a package body</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
 <synopsis>
-
-CREATE [ OR REPLACE ] [ EDITIONABLE | NONEDITIONABLE ] PACKAGE BODY [schema.] package_name [ sharing_clause ] [IS | AS] declare_section [ initialize_section ] END [ package_name ] ;
-
-sharing_clause:
-    SHARING = { METADATA | NONE }
-	
-declare_section:
-    { item_list_1 [ item_list_2 ] | item_list_2 }
-	
-initialize_section:
-    BEGIN statement...
-      [ EXCEPTION exception_handler... ]
-	  
-item_list_1:
-    { type_definition
-    | cursor_declaration
-    | item_declaration
-    | function_declaration
-    | procedure_declaration
-    }
-     ...
-    
-item_list_2:
-    { cursor_declaration
-    | cursor_definition
-    | function_declaration
-    | function_definition
-    | procedure_declaration
-    | procedure_definition
-    }
-     ...
+CREATE [ OR REPLACE ] [ EDITIONABLE | NONEDITIONABLE ] PACKAGE BODY <replaceable class="parameter">name</replaceable>
+    [ SHARING = { METADATA | NONE } ]
+    { IS | AS }
+    [ <replaceable class="parameter">package_body_item</replaceable> ... ]
+    [ BEGIN
+        <replaceable class="parameter">statement</replaceable> ...
+      [ EXCEPTION
+        <replaceable class="parameter">exception_handler</replaceable> ... ] ]
+END [ <replaceable class="parameter">name</replaceable> ]
 </synopsis>
-</refsynopsisdiv>
+ </refsynopsisdiv>
+
+ <refsect1 id="sql-createpackagebody-description">
+  <title>Description</title>
+
+  <para>
+   <command>CREATE PACKAGE BODY</command> defines the implementation of a
+   package.  It supplies definitions for public procedures and functions
+   declared by the package specification, and can also contain private
+   declarations and definitions.  An optional <literal>BEGIN</literal> block
+   provides package initialization code.
+  </para>
+
+  <para>
+   A package specification of the same name must already exist.  If a schema
+   name is included, the package is looked up in that schema; otherwise the
+   current schema is used.  The body and specification must have the same
+   editionability property.
+  </para>
+
+  <para>
+   The user must have <literal>CREATE</literal> privilege on the target schema.
+   Replacing an existing package body additionally requires ownership of the
+   package.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-createpackagebody-parameters">
+  <title>Parameters</title>
+
+  <variablelist>
+   <varlistentry>
+    <term><literal>OR REPLACE</literal></term>
+    <listitem>
+     <para>
+      Replace the body if one already exists.  Without this clause, an
+      existing package body causes an error.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>EDITIONABLE</literal></term>
+    <term><literal>NONEDITIONABLE</literal></term>
+    <listitem>
+     <para>
+      Specify the editionability expected by the package specification.  The
+      default is <literal>EDITIONABLE</literal>.  Use
+      <literal>NONEDITIONABLE</literal> explicitly for a noneditionable
+      specification.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">name</replaceable></term>
+    <listitem>
+     <para>
+      The name (optionally schema-qualified) of the package whose body is being
+      defined.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>SHARING = { METADATA | NONE }</literal></term>
+    <listitem>
+     <para>
+      This clause is accepted for Oracle syntax compatibility and currently
+      has no effect on package behavior.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">package_body_item</replaceable></term>
+    <listitem>
+     <para>
+      A PL/iSQL declaration or definition.  Public procedure and function
+      definitions must agree with their declarations in the package
+      specification.  Additional declarations are private to the body.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">statement</replaceable></term>
+    <term><replaceable class="parameter">exception_handler</replaceable></term>
+    <listitem>
+     <para>
+      Statements in the optional package initialization block and handlers for
+      exceptions raised by that block.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 id="sql-createpackagebody-examples">
+  <title>Examples</title>
+
+  <para>
+   Define the body for the <literal>inventory_api</literal> specification:
+<programlisting>
+CREATE OR REPLACE PACKAGE BODY inventory_api AS
+  PROCEDURE add_item(p_id INT, p_label TEXT) AS
+  BEGIN
+    RAISE NOTICE 'adding item %: %', p_id, p_label;
+  END add_item;
+END inventory_api;
+</programlisting>
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-createpackagebody-compatibility">
+  <title>Compatibility</title>
+
+  <para>
+   <command>CREATE PACKAGE BODY</command> is an
+   <productname>IvorySQL</productname> extension for Oracle compatibility.  It
+   is not defined by the SQL standard.  The supported syntax is a subset of
+   Oracle package body syntax.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-createpackagebody-see-also">
+  <title>See Also</title>
+
+  <simplelist type="inline">
+   <member><xref linkend="sql-createpackage"/></member>
+   <member><xref linkend="sql-alterpackage"/></member>
+   <member><xref linkend="sql-droppackage"/></member>
+  </simplelist>
+ </refsect1>
 </refentry>

--- a/doc/src/sgml/ref/drop_package.sgml
+++ b/doc/src/sgml/ref/drop_package.sgml
@@ -16,12 +16,122 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>DROP PACKAGE</refname>
-  <refpurpose>drop a package</refpurpose>
+  <refpurpose>remove a package or package body</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
 <synopsis>
-DROP PACKAGE [BODY] [schema.] <replaceable class="parameter">package_name</replaceable> ;
+DROP PACKAGE [ BODY ] [ IF EXISTS ] <replaceable class="parameter">name</replaceable> [, ...] [ CASCADE | RESTRICT ]
 </synopsis>
-</refsynopsisdiv>
+ </refsynopsisdiv>
+
+ <refsect1 id="sql-droppackage-description">
+  <title>Description</title>
+
+  <para>
+   <command>DROP PACKAGE</command> removes one or more package
+   specifications.  A package body depends on its specification, so dropping
+   the specification also removes its body.  Specifying <literal>BODY</literal>
+   removes only the package body and leaves the specification in place.
+  </para>
+
+  <para>
+   To execute this command, the user must own each package being dropped.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-droppackage-parameters">
+  <title>Parameters</title>
+
+  <variablelist>
+   <varlistentry>
+    <term><literal>BODY</literal></term>
+    <listitem>
+     <para>
+      Drop the package body instead of the package specification.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>IF EXISTS</literal></term>
+    <listitem>
+     <para>
+      Do not throw an error if a named package or package body does not exist.
+      A notice is issued instead.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="parameter">name</replaceable></term>
+    <listitem>
+     <para>
+      The name (optionally schema-qualified) of a package.  Multiple package
+      names can be specified, separated by commas.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>CASCADE</literal></term>
+    <listitem>
+     <para>
+      Automatically drop objects that depend on the package, and in turn all
+      objects that depend on those objects (see <xref linkend="ddl-depend"/>).
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>RESTRICT</literal></term>
+    <listitem>
+     <para>
+      Refuse to drop the package if objects other than its package body depend
+      on it.  This is the default.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 id="sql-droppackage-examples">
+  <title>Examples</title>
+
+  <para>
+   Remove the body of <literal>inventory_api</literal> while keeping its
+   specification:
+<programlisting>
+DROP PACKAGE BODY inventory_api;
+</programlisting>
+  </para>
+
+  <para>
+   Remove the package specification and its body:
+<programlisting>
+DROP PACKAGE inventory_api;
+</programlisting>
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-droppackage-compatibility">
+  <title>Compatibility</title>
+
+  <para>
+   <command>DROP PACKAGE</command> is an <productname>IvorySQL</productname>
+   extension for Oracle compatibility.  It is not defined by the SQL
+   standard.  Allowing multiple package names in one command is an
+   <productname>IvorySQL</productname> extension to Oracle syntax.
+  </para>
+ </refsect1>
+
+ <refsect1 id="sql-droppackage-see-also">
+  <title>See Also</title>
+
+  <simplelist type="inline">
+   <member><xref linkend="sql-createpackage"/></member>
+   <member><xref linkend="sql-createpackagebody"/></member>
+   <member><xref linkend="sql-alterpackage"/></member>
+  </simplelist>
+ </refsect1>
 </refentry>


### PR DESCRIPTION
## Why

The package command reference pages contain only skeletal synopses, and several forms do not match the Oracle parser. In particular, `ALTER PACKAGE ... COMPILE` is documented but unsupported, while supported `ALTER` and `DROP` forms are missing. The `CREATE PACKAGE BODY` entity also points to a nonexistent file name, so that page is omitted from the manual and its cross-references cannot be validated.

## What Changed

- Documented the supported syntax, behavior, privileges, parameters, examples, and compatibility notes for `CREATE PACKAGE`, `CREATE PACKAGE BODY`, `ALTER PACKAGE`, and `DROP PACKAGE`.
- Corrected `AUTHID`, default collation, mandatory `IS`/`AS`, `IF EXISTS`, multi-name drop, and dependency behavior in the command synopses.
- Removed unsupported package recompilation syntax from the reference.
- Documented the current runtime limits of compatibility-only package clauses.
- Corrected the package body entity path so the page is included in the manual.

## Verification

The full out-of-tree `doc/src/sgml` check passes, including DocBook DTD validation, cross-reference validation, tab checks, and non-breaking-space checks.

## Related issue

Fixes #1425

## AI assistance disclosure

This contribution was prepared with OpenAI Codex using GPT-5. The agent assisted with source and test inspection, issue scoping, drafting code, documentation and tests where applicable, running verification, and preparing the PR description. I directed the scope, reviewed the resulting changes against the source and test results, and remain responsible for the submission.
