### PR TITLE
perf(plisql): optimize package dependency cleanup

### DIFF
--- a/src/oracle_test/modules/test_package_reset/Makefile
+++ b/src/oracle_test/modules/test_package_reset/Makefile
@@ -7,7 +7,8 @@ EXTENSION = test_package_reset
 DATA = test_package_reset--1.0.sql
 
 REGRESS = test_package_reset
-ORA_REGRESS = $(REGRESS) test_reset_one_oid test_reset_all test_reset_defaults
+ORA_REGRESS = $(REGRESS) test_reset_one_oid test_reset_all test_reset_defaults \
+	test_discard_dependencies
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/src/oracle_test/modules/test_package_reset/benchmark_discard_package_chain.sql
+++ b/src/oracle_test/modules/test_package_reset/benchmark_discard_package_chain.sql
@@ -1,0 +1,61 @@
+-- Reproduce the synthetic worst case for DISCARD PACKAGE dependency cleanup.
+--
+-- Run this in an Oracle-compatible database from an IvorySQL psql client:
+--
+--   psql -X -v ON_ERROR_STOP=1 -v package_count=1600 \
+--     -f benchmark_discard_package_chain.sql DATABASE
+--
+-- Repeat with increasing package_count values (for example 400, 800, 1600)
+-- against the base and patched revisions.  Only the timed DISCARD PACKAGE
+-- statement is part of the measurement.  Package bodies are created in
+-- reverse order while each body depends on its predecessor, deliberately
+-- producing the order that maximizes repeated scans in the old algorithm.
+
+\set ON_ERROR_STOP 1
+\if :{?package_count}
+\else
+\set package_count 800
+\endif
+
+SET client_min_messages = warning;
+
+SELECT format(
+           'CREATE PACKAGE %1$I AS FUNCTION value RETURN NUMBER; END %1$I;',
+           'discard_bench_pkg_' || package_no)
+FROM generate_series(1, :package_count) AS package_no
+\gexec
+
+SELECT CASE
+           WHEN package_no = 1 THEN
+               format(
+                   'CREATE PACKAGE BODY %1$I AS '
+                   'FUNCTION value RETURN NUMBER AS BEGIN RETURN 1; END; '
+                   'END %1$I;',
+                   'discard_bench_pkg_' || package_no)
+           ELSE
+               format(
+                   'CREATE PACKAGE BODY %1$I AS '
+                   'FUNCTION value RETURN NUMBER AS BEGIN RETURN %2$I.value(); END; '
+                   'END %1$I;',
+                   'discard_bench_pkg_' || package_no,
+                   'discard_bench_pkg_' || (package_no - 1))
+       END
+FROM generate_series(:package_count, 1, -1) AS package_no
+\gexec
+
+-- Compile and cache every package without recursing through the whole chain.
+\o /dev/null
+SELECT format('SELECT %I.value() FROM dual;',
+              'discard_bench_pkg_' || package_no)
+FROM generate_series(1, :package_count) AS package_no
+\gexec
+\o
+
+\echo Measuring DISCARD PACKAGE with :package_count cached packages
+\timing on
+DISCARD PACKAGE;
+\timing off
+
+SELECT format('DROP PACKAGE %I;', 'discard_bench_pkg_' || package_no)
+FROM generate_series(:package_count, 1, -1) AS package_no
+\gexec

--- a/src/oracle_test/modules/test_package_reset/expected/test_discard_dependencies.out
+++ b/src/oracle_test/modules/test_package_reset/expected/test_discard_dependencies.out
@@ -62,25 +62,7 @@ FROM dual;
  32            | 100
 (1 row)
 
-CREATE OR REPLACE FUNCTION dep_consumer RETURN NUMBER IS
-BEGIN
-    RETURN dep_root.value();
-END;
-/
-SELECT dep_consumer() AS dependent_function_value FROM dual;
- dependent_function_value 
---------------------------
- 32
-(1 row)
-
 DISCARD PACKAGE;
--- Packages and dependent functions must compile and execute again.
-SELECT dep_consumer() AS dependent_function_value FROM dual;
- dependent_function_value 
---------------------------
- 32
-(1 row)
-
 SELECT dep_root.value() AS layered_value,
        dep_independent.value() AS independent_value
 FROM dual;
@@ -138,4 +120,3 @@ DROP PACKAGE dep_leaf;
 DROP PACKAGE dep_independent;
 DROP PACKAGE dep_cycle_a;
 DROP PACKAGE dep_cycle_b;
-DROP FUNCTION dep_consumer;

--- a/src/oracle_test/modules/test_package_reset/expected/test_discard_dependencies.out
+++ b/src/oracle_test/modules/test_package_reset/expected/test_discard_dependencies.out
@@ -1,0 +1,141 @@
+-- DISCARD PACKAGE handles layered and cyclic package dependencies.
+CREATE PACKAGE dep_leaf AS
+    FUNCTION value RETURN NUMBER;
+END dep_leaf;
+/
+CREATE PACKAGE BODY dep_leaf AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN 1;
+    END;
+END dep_leaf;
+/
+CREATE PACKAGE dep_left AS
+    FUNCTION value RETURN NUMBER;
+END dep_left;
+/
+CREATE PACKAGE BODY dep_left AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN dep_leaf.value() + 10;
+    END;
+END dep_left;
+/
+CREATE PACKAGE dep_right AS
+    FUNCTION value RETURN NUMBER;
+END dep_right;
+/
+CREATE PACKAGE BODY dep_right AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN dep_leaf.value() + 20;
+    END;
+END dep_right;
+/
+CREATE PACKAGE dep_root AS
+    FUNCTION value RETURN NUMBER;
+END dep_root;
+/
+CREATE PACKAGE BODY dep_root AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN dep_left.value() + dep_right.value();
+    END;
+END dep_root;
+/
+CREATE PACKAGE dep_independent AS
+    FUNCTION value RETURN NUMBER;
+END dep_independent;
+/
+CREATE PACKAGE BODY dep_independent AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN 100;
+    END;
+END dep_independent;
+/
+SELECT dep_root.value() AS layered_value,
+       dep_independent.value() AS independent_value
+FROM dual;
+ layered_value | independent_value 
+---------------+-------------------
+ 32            | 100
+(1 row)
+
+CREATE OR REPLACE FUNCTION dep_consumer RETURN NUMBER IS
+BEGIN
+    RETURN dep_root.value();
+END;
+/
+SELECT dep_consumer() AS dependent_function_value FROM dual;
+ dependent_function_value 
+--------------------------
+ 32
+(1 row)
+
+DISCARD PACKAGE;
+-- Packages and dependent functions must compile and execute again.
+SELECT dep_consumer() AS dependent_function_value FROM dual;
+ dependent_function_value 
+--------------------------
+ 32
+(1 row)
+
+SELECT dep_root.value() AS layered_value,
+       dep_independent.value() AS independent_value
+FROM dual;
+ layered_value | independent_value 
+---------------+-------------------
+ 32            | 100
+(1 row)
+
+CREATE PACKAGE dep_cycle_a AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER;
+END dep_cycle_a;
+/
+CREATE PACKAGE dep_cycle_b AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER;
+END dep_cycle_b;
+/
+CREATE PACKAGE BODY dep_cycle_a AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER AS
+    BEGIN
+        IF p_depth = 0 THEN
+            RETURN 1;
+        END IF;
+        RETURN dep_cycle_b.value(p_depth - 1) + 1;
+    END;
+END dep_cycle_a;
+/
+CREATE PACKAGE BODY dep_cycle_b AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER AS
+    BEGIN
+        IF p_depth = 0 THEN
+            RETURN 1;
+        END IF;
+        RETURN dep_cycle_a.value(p_depth - 1) + 1;
+    END;
+END dep_cycle_b;
+/
+SELECT dep_cycle_a.value(2) AS cycle_value FROM dual;
+ cycle_value 
+-------------
+ 3
+(1 row)
+
+DISCARD PACKAGE;
+-- Cycles retain the old fallback ordering and remain safe to discard.
+SELECT dep_cycle_b.value(3) AS cycle_value FROM dual;
+ cycle_value 
+-------------
+ 4
+(1 row)
+
+DROP PACKAGE dep_root;
+DROP PACKAGE dep_left;
+DROP PACKAGE dep_right;
+DROP PACKAGE dep_leaf;
+DROP PACKAGE dep_independent;
+DROP PACKAGE dep_cycle_a;
+DROP PACKAGE dep_cycle_b;
+DROP FUNCTION dep_consumer;

--- a/src/oracle_test/modules/test_package_reset/sql/test_discard_dependencies.sql
+++ b/src/oracle_test/modules/test_package_reset/sql/test_discard_dependencies.sql
@@ -69,18 +69,7 @@ SELECT dep_root.value() AS layered_value,
        dep_independent.value() AS independent_value
 FROM dual;
 
-CREATE OR REPLACE FUNCTION dep_consumer RETURN NUMBER IS
-BEGIN
-    RETURN dep_root.value();
-END;
-/
-
-SELECT dep_consumer() AS dependent_function_value FROM dual;
-
 DISCARD PACKAGE;
-
--- Packages and dependent functions must compile and execute again.
-SELECT dep_consumer() AS dependent_function_value FROM dual;
 
 SELECT dep_root.value() AS layered_value,
        dep_independent.value() AS independent_value
@@ -132,4 +121,3 @@ DROP PACKAGE dep_leaf;
 DROP PACKAGE dep_independent;
 DROP PACKAGE dep_cycle_a;
 DROP PACKAGE dep_cycle_b;
-DROP FUNCTION dep_consumer;

--- a/src/oracle_test/modules/test_package_reset/sql/test_discard_dependencies.sql
+++ b/src/oracle_test/modules/test_package_reset/sql/test_discard_dependencies.sql
@@ -1,0 +1,135 @@
+-- DISCARD PACKAGE handles layered and cyclic package dependencies.
+
+CREATE PACKAGE dep_leaf AS
+    FUNCTION value RETURN NUMBER;
+END dep_leaf;
+/
+
+CREATE PACKAGE BODY dep_leaf AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN 1;
+    END;
+END dep_leaf;
+/
+
+CREATE PACKAGE dep_left AS
+    FUNCTION value RETURN NUMBER;
+END dep_left;
+/
+
+CREATE PACKAGE BODY dep_left AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN dep_leaf.value() + 10;
+    END;
+END dep_left;
+/
+
+CREATE PACKAGE dep_right AS
+    FUNCTION value RETURN NUMBER;
+END dep_right;
+/
+
+CREATE PACKAGE BODY dep_right AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN dep_leaf.value() + 20;
+    END;
+END dep_right;
+/
+
+CREATE PACKAGE dep_root AS
+    FUNCTION value RETURN NUMBER;
+END dep_root;
+/
+
+CREATE PACKAGE BODY dep_root AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN dep_left.value() + dep_right.value();
+    END;
+END dep_root;
+/
+
+CREATE PACKAGE dep_independent AS
+    FUNCTION value RETURN NUMBER;
+END dep_independent;
+/
+
+CREATE PACKAGE BODY dep_independent AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN 100;
+    END;
+END dep_independent;
+/
+
+SELECT dep_root.value() AS layered_value,
+       dep_independent.value() AS independent_value
+FROM dual;
+
+CREATE OR REPLACE FUNCTION dep_consumer RETURN NUMBER IS
+BEGIN
+    RETURN dep_root.value();
+END;
+/
+
+SELECT dep_consumer() AS dependent_function_value FROM dual;
+
+DISCARD PACKAGE;
+
+-- Packages and dependent functions must compile and execute again.
+SELECT dep_consumer() AS dependent_function_value FROM dual;
+
+SELECT dep_root.value() AS layered_value,
+       dep_independent.value() AS independent_value
+FROM dual;
+
+CREATE PACKAGE dep_cycle_a AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER;
+END dep_cycle_a;
+/
+
+CREATE PACKAGE dep_cycle_b AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER;
+END dep_cycle_b;
+/
+
+CREATE PACKAGE BODY dep_cycle_a AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER AS
+    BEGIN
+        IF p_depth = 0 THEN
+            RETURN 1;
+        END IF;
+        RETURN dep_cycle_b.value(p_depth - 1) + 1;
+    END;
+END dep_cycle_a;
+/
+
+CREATE PACKAGE BODY dep_cycle_b AS
+    FUNCTION value(p_depth NUMBER) RETURN NUMBER AS
+    BEGIN
+        IF p_depth = 0 THEN
+            RETURN 1;
+        END IF;
+        RETURN dep_cycle_a.value(p_depth - 1) + 1;
+    END;
+END dep_cycle_b;
+/
+
+SELECT dep_cycle_a.value(2) AS cycle_value FROM dual;
+
+DISCARD PACKAGE;
+
+-- Cycles retain the old fallback ordering and remain safe to discard.
+SELECT dep_cycle_b.value(3) AS cycle_value FROM dual;
+
+DROP PACKAGE dep_root;
+DROP PACKAGE dep_left;
+DROP PACKAGE dep_right;
+DROP PACKAGE dep_leaf;
+DROP PACKAGE dep_independent;
+DROP PACKAGE dep_cycle_a;
+DROP PACKAGE dep_cycle_b;
+DROP FUNCTION dep_consumer;

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -69,8 +69,6 @@ static void plisql_get_package_depends(PLiSQL_function *func,
 								List **funclist, List **itemlist);
 static List *plisql_get_packagelist_depends(List *pkglist);
 static bool plisql_function_is_compiling(PLiSQL_function *func);
-static void plisql_invalidate_dependent_function(PLiSQL_function *func);
-static PLiSQL_function *plisql_refresh_package_funcexpr(FuncExpr *funcexpr);
 
 static List *plisql_package_sort(List *pkglist);
 
@@ -457,7 +455,7 @@ plisql_free_package_function(PackageCacheItem *items)
 
 		/* remove function */
 		elog(DEBUG1, "realy free function %u", dfunc->fn_oid);
-		plisql_invalidate_dependent_function(dfunc);
+		delete_function(dfunc);
 	}
 
 	/* free packages */
@@ -533,7 +531,7 @@ plisql_free_packagelist(List *pkglist)
 		dfunc = (PLiSQL_function *) lfirst(lc);
 
 		elog(DEBUG1, "realy free function %u", dfunc->fn_oid);
-		plisql_invalidate_dependent_function(dfunc);
+		delete_function(dfunc);
 	}
 
 	/* second delete packages */
@@ -989,21 +987,6 @@ plisql_function_is_compiling(PLiSQL_function *func)
 
 	return false;
 }
-
-
-/*
- * A package dependency can invalidate a function without changing its
- * pg_proc tuple.  Mark the cached tuple identity invalid before freeing the
- * compiled tree, so an existing FmgrInfo fn_extra pointer cannot mistake the
- * emptied function structure for a still-valid compiled function.
- */
-static void
-plisql_invalidate_dependent_function(PLiSQL_function *func)
-{
-	func->fn_xmin = InvalidTransactionId;
-	delete_function(func);
-}
-
 
 
 /*
@@ -2581,7 +2564,6 @@ plisql_get_package_func(FunctionCallInfo fcinfo, bool forValidator)
 	funcexpr = (FuncExpr *) fcinfo->flinfo->fn_expr;
 
 	Assert(funcexpr->function_from == FUNC_FROM_PACKAGE);
-	pfunc = plisql_refresh_package_funcexpr(funcexpr);
 
 	if (!OidIsValid(funcexpr->pkgoid))
 		elog(ERROR, "funcexpr include invalid pkgoid");
@@ -2597,6 +2579,9 @@ plisql_get_package_func(FunctionCallInfo fcinfo, bool forValidator)
 		psource->status = PLISQL_PACKAGE_NO_INIT;
 		elog(ERROR, "existing state of packages has been discarded");
 	}
+	pfunc = &psource->source;
+
+	pfunc = (PLiSQL_function *) funcexpr->parent_func;
 	fno = (int) funcexpr->funcid;
 
 	if (pfunc == NULL)
@@ -2724,7 +2709,6 @@ plisql_remove_function_relations(PLiSQL_function *func)
 
 		plisql_remove_function_references(func, refcache);
 	}
-	func->pkgcachelist = NIL;
 
 	return;
 }
@@ -3737,47 +3721,9 @@ plisql_get_subprocs_from_package(Oid pkgoid,
 
 	return;
 }
-
 /*
  * get subproc arginfo
  */
-static PLiSQL_function *
-plisql_refresh_package_funcexpr(FuncExpr *funcexpr)
-{
-	PackageCacheItem *item;
-	PLiSQL_package *psource;
-
-	if (!FUNC_EXPR_FROM_PACKAGE(funcexpr->function_from))
-	{
-		if (funcexpr->parent_func == NULL)
-			elog(ERROR, "parent_func has not been set");
-		return (PLiSQL_function *) funcexpr->parent_func;
-	}
-	if (!OidIsValid(funcexpr->pkgoid))
-		elog(ERROR, "package FuncExpr has an invalid package OID");
-
-	item = PackageCacheLookup(&funcexpr->pkgoid);
-	if (item != NULL)
-	{
-		psource = (PLiSQL_package *) item->source;
-		if (funcexpr->parent_func == &psource->source)
-			return &psource->source;
-	}
-
-	/*
-	 * Cached plans can outlive the package memory context referenced by the
-	 * raw parent_func pointer.  Clear it so the saved qualified function name
-	 * is resolved against the current package cache entry.
-	 */
-	funcexpr->parent_func = NULL;
-	set_pkginfo_from_funcexpr(funcexpr);
-	if (funcexpr->parent_func == NULL)
-		elog(ERROR, "package FuncExpr could not be refreshed");
-
-	return (PLiSQL_function *) funcexpr->parent_func;
-}
-
-
 int
 plisql_get_subproc_arg_info (FuncExpr *fexpr,
 				Oid **p_argtypes,
@@ -3793,7 +3739,10 @@ plisql_get_subproc_arg_info (FuncExpr *fexpr,
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	function = plisql_refresh_package_funcexpr(fexpr);
+	if (fexpr->parent_func == NULL)
+		elog(ERROR, "parent_func has not been set");
+
+	function = (PLiSQL_function *) fexpr->parent_func;
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3851,7 +3800,10 @@ plisql_get_subproc_prokind (FuncExpr *fexpr)
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	function = plisql_refresh_package_funcexpr(fexpr);
+	if (fexpr->parent_func == NULL)
+		elog(ERROR, "parent_func has not been set");
+
+	function = (PLiSQL_function *) fexpr->parent_func;
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3878,7 +3830,10 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	function = plisql_refresh_package_funcexpr(fexpr);
+	if (fexpr->parent_func == NULL)
+		elog(ERROR, "parent_func has not been set");
+
+	function = (PLiSQL_function *) fexpr->parent_func;
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -45,6 +45,7 @@
 #include "catalog/pg_depend.h"
 #include "access/genam.h"
 #include "utils/fmgroids.h"
+#include "utils/hsearch.h"
 #include "utils/lsyscache.h"
 
 
@@ -66,6 +67,10 @@ static void plisql_addfunction_references(PLiSQL_function *func,
 														PackageCacheItem *item);
 static void plisql_get_package_depends(PLiSQL_function *func,
 								List **funclist, List **itemlist);
+static List *plisql_get_packagelist_depends(List *pkglist);
+static bool plisql_function_is_compiling(PLiSQL_function *func);
+static void plisql_invalidate_dependent_function(PLiSQL_function *func);
+static PLiSQL_function *plisql_refresh_package_funcexpr(FuncExpr *funcexpr);
 
 static List *plisql_package_sort(List *pkglist);
 
@@ -452,7 +457,7 @@ plisql_free_package_function(PackageCacheItem *items)
 
 		/* remove function */
 		elog(DEBUG1, "realy free function %u", dfunc->fn_oid);
-		delete_function(dfunc);
+		plisql_invalidate_dependent_function(dfunc);
 	}
 
 	/* free packages */
@@ -506,39 +511,12 @@ plisql_free_packagelist(List *pkglist)
 	ListCell *lc;
 	PLiSQL_package *psource;
 	PackageCacheItem *item;
-	List *funclist = NIL;
-	List *dfunclist = NIL;
+	List *dfunclist;
 	PLiSQL_function *dfunc = NULL;
 
 
 	pkglist = plisql_package_sort(pkglist);
-
-
-	/* find function rely on package */
-	foreach (lc, pkglist)
-	{
-		ListCell *llc;
-		List *itemlist = NIL;
-
-		item = (PackageCacheItem *) lfirst(lc);
-
-		psource = (PLiSQL_package *) item->source;
-
-
-		itemlist = list_make1(item);
-		plisql_get_package_depends(&psource->source, &funclist, &itemlist);
-		list_free(itemlist);
-
-		foreach (llc, funclist)
-		{
-			dfunc = (PLiSQL_function *) lfirst(llc);
-
-			Assert(dfunc->item == NULL);
-			dfunclist = list_append_unique(dfunclist, dfunc);
-		}
-		list_free(funclist);
-		funclist = NIL;
-	}
+	dfunclist = plisql_get_packagelist_depends(pkglist);
 
 	foreach (lc, pkglist)
 	{
@@ -555,7 +533,7 @@ plisql_free_packagelist(List *pkglist)
 		dfunc = (PLiSQL_function *) lfirst(lc);
 
 		elog(DEBUG1, "realy free function %u", dfunc->fn_oid);
-		delete_function(dfunc);
+		plisql_invalidate_dependent_function(dfunc);
 	}
 
 	/* second delete packages */
@@ -593,72 +571,226 @@ plisql_free_packagelist(List *pkglist)
 
 
 
+typedef struct PackageSortItem
+{
+	PackageCacheItem *item;
+	List	   *dependents;
+	int			remaining_dependencies;
+	int			pass;
+	bool		has_external_dependency;
+	bool		processed;
+} PackageSortItem;
+
+typedef struct PackageSortIndexEntry
+{
+	PackageCacheItem *item;
+	int			index;
+} PackageSortIndexEntry;
+
+typedef struct PackageSortEdgeKey
+{
+	int			dependency;
+	int			dependent;
+} PackageSortEdgeKey;
+
+typedef struct PackageSortEdgeEntry
+{
+	PackageSortEdgeKey key;
+} PackageSortEdgeEntry;
+
+
 /*
- * package has references, we should sort it
+ * Sort packages so dependents are freed before their dependencies.
+ *
+ * The old implementation repeatedly scanned the remaining packages and used
+ * linear List membership and difference operations.  Besides the repeated
+ * scans, every membership check was itself linear, making a long dependency
+ * chain take cubic time.
+ *
+ * Build the dependency graph once and use Kahn's algorithm instead.  To keep
+ * the old stable ordering exactly, assign each package the scan pass in which
+ * the old algorithm would have accepted it.  A dependency that appears later
+ * in the input forces its dependent into the next pass; an earlier dependency
+ * can be accepted during the same pass.  Counting by pass and then scanning
+ * input positions preserves the old pass-and-input ordering in O(V + E).
+ * Cycles and dependencies outside pkglist are appended in input order, just
+ * as the old no-progress fallback did.  Finally, reverse the result so package
+ * dependents precede the packages they reference.
  */
 static List *
 plisql_package_sort(List *pkglist)
 {
-	int origin_len;
-	List *result = NIL;
-	List *retlist = NIL;
-	ListCell *lc;
-	PackageCacheItem *item;
-	PLiSQL_package *psource;
-	PLiSQL_function *func;
-	int i;
+	int			origin_len = list_length(pkglist);
+	PackageSortItem *sort_items;
+	PackageCacheItem **ordered_items;
+	int		   *work_queue;
+	int		   *pass_counts;
+	HTAB	   *item_indexes;
+	HTAB	   *edges;
+	HASHCTL		ctl;
+	List	   *retlist = NIL;
+	ListCell   *lc;
+	int			queue_head = 0;
+	int			queue_tail = 0;
+	int			processed_count = 0;
+	int			max_pass = 0;
+	int			i;
 
-	origin_len = list_length(pkglist);
+	if (origin_len == 0)
+		return NIL;
 
-	/* loop utils pkglist is null */
-	while (list_length(pkglist) != 0)
+	sort_items = palloc0_array(PackageSortItem, origin_len);
+	ordered_items = palloc_array(PackageCacheItem *, origin_len);
+	work_queue = palloc_array(int, origin_len);
+	pass_counts = palloc0_array(int, origin_len);
+
+	ctl.keysize = sizeof(PackageCacheItem *);
+	ctl.entrysize = sizeof(PackageSortIndexEntry);
+	item_indexes = hash_create("PL/iSQL package sort indexes",
+								   origin_len,
+								   &ctl,
+								   HASH_ELEM | HASH_BLOBS);
+
+	i = 0;
+	foreach (lc, pkglist)
 	{
-		bool add = false;
-		List *delete_list = NIL;
+		PackageCacheItem *item = (PackageCacheItem *) lfirst(lc);
+		PackageSortIndexEntry *index_entry;
+		bool		found;
 
-		for (lc = list_head(pkglist); lc != NULL;)
+		index_entry = hash_search(item_indexes, &item, HASH_ENTER, &found);
+		Assert(!found);
+		index_entry->index = i;
+		sort_items[i].item = item;
+		i++;
+	}
+	Assert(i == origin_len);
+
+	ctl.keysize = sizeof(PackageSortEdgeKey);
+	ctl.entrysize = sizeof(PackageSortEdgeEntry);
+	edges = hash_create("PL/iSQL package sort edges",
+						origin_len,
+						&ctl,
+						HASH_ELEM | HASH_BLOBS);
+
+	for (i = 0; i < origin_len; i++)
+	{
+		PackageCacheItem *item = sort_items[i].item;
+		PLiSQL_package *psource = (PLiSQL_package *) item->source;
+		PLiSQL_function *func = &psource->source;
+		ListCell   *llc;
+
+		foreach (llc, func->pkgcachelist)
 		{
-			ListCell *llc;
+			PackageCacheItem *dependency = (PackageCacheItem *) lfirst(llc);
+			PackageSortIndexEntry *dependency_entry;
+			PackageSortEdgeKey edge_key;
+			bool		found;
 
-			item = (PackageCacheItem *) lfirst(lc);
-			psource = (PLiSQL_package *) item->source;
-			func = &psource->source;
-
-			/* add all rely on result */
-			foreach (llc, func->pkgcachelist)
+			dependency_entry = hash_search(item_indexes, &dependency,
+										   HASH_FIND, NULL);
+			if (dependency_entry == NULL)
 			{
-				PackageCacheItem *litem = (PackageCacheItem *) lfirst(llc);
-
-				if (!list_member_ptr(result, litem))
-					break;
+				sort_items[i].has_external_dependency = true;
+				continue;
 			}
 
-			if (llc == NULL)
+			MemSet(&edge_key, 0, sizeof(edge_key));
+			edge_key.dependency = dependency_entry->index;
+			edge_key.dependent = i;
+			(void) hash_search(edges, &edge_key, HASH_ENTER, &found);
+			if (!found)
 			{
-				add = true;
-				result = list_append_unique(result, item);
-				delete_list = list_append_unique(delete_list, item);
+				PackageSortItem *dependency_item =
+					&sort_items[dependency_entry->index];
+
+				dependency_item->dependents =
+					lappend_int(dependency_item->dependents, i);
+				sort_items[i].remaining_dependencies++;
 			}
-			lc = lnext(pkglist, lc);
-		}
-		if (delete_list != NIL)
-		{
-			pkglist = list_difference(pkglist, delete_list);
-			list_free(delete_list);
-		}
-		if (!add)
-		{
-			result = list_union(result, pkglist);
-			break;
 		}
 	}
-	Assert(list_length(result) == origin_len);
 
-	/* finially, we reorder it */
-	for(i = origin_len - 1; i >= 0; i--)
-		retlist = lappend(retlist, list_nth(result, i));
+	for (i = 0; i < origin_len; i++)
+	{
+		if (sort_items[i].remaining_dependencies == 0 &&
+			!sort_items[i].has_external_dependency)
+			work_queue[queue_tail++] = i;
+	}
 
-	list_free(result);
+	while (queue_head < queue_tail)
+	{
+		int			item_index = work_queue[queue_head++];
+		PackageSortItem *item = &sort_items[item_index];
+		ListCell   *dependent_cell;
+
+		Assert(!item->processed);
+		Assert(item->pass >= 0 && item->pass < origin_len);
+		item->processed = true;
+		processed_count++;
+		pass_counts[item->pass]++;
+		max_pass = Max(max_pass, item->pass);
+
+		foreach (dependent_cell, item->dependents)
+		{
+			int			dependent_index = lfirst_int(dependent_cell);
+			PackageSortItem *dependent = &sort_items[dependent_index];
+			int			required_pass = item->pass;
+
+			Assert(!dependent->processed);
+			Assert(dependent->remaining_dependencies > 0);
+			if (item_index > dependent_index)
+				required_pass++;
+			dependent->pass = Max(dependent->pass, required_pass);
+
+			dependent->remaining_dependencies--;
+			if (dependent->remaining_dependencies == 0 &&
+				!dependent->has_external_dependency)
+				work_queue[queue_tail++] = dependent_index;
+		}
+	}
+	Assert(queue_tail == processed_count);
+
+	/* Counting-sort processed packages by old scan pass, then input index. */
+	{
+		int			position = 0;
+
+		for (i = 0; i <= max_pass; i++)
+		{
+			int			count = pass_counts[i];
+
+			pass_counts[i] = position;
+			position += count;
+		}
+		Assert(position == processed_count);
+
+		for (i = 0; i < origin_len; i++)
+		{
+			if (sort_items[i].processed)
+				ordered_items[pass_counts[sort_items[i].pass]++] =
+					sort_items[i].item;
+		}
+
+		position = processed_count;
+		for (i = 0; i < origin_len; i++)
+		{
+			if (!sort_items[i].processed)
+				ordered_items[position++] = sort_items[i].item;
+		}
+		Assert(position == origin_len);
+	}
+
+	for (i = origin_len - 1; i >= 0; i--)
+		retlist = lappend(retlist, ordered_items[i]);
+
+	for (i = 0; i < origin_len; i++)
+		list_free(sort_items[i].dependents);
+	hash_destroy(edges);
+	hash_destroy(item_indexes);
+	pfree(pass_counts);
+	pfree(work_queue);
+	pfree(ordered_items);
+	pfree(sort_items);
 
 	return retlist;
 }
@@ -717,14 +849,10 @@ plisql_get_package_depends(PLiSQL_function *func, List **funclist,
 					List **itemlist)
 {
 	ListCell *lc;
-	bool	iscompiling = false;
-	int i;
 
 	foreach (lc, func->funclist)
 	{
 		PLiSQL_function *funcs = (PLiSQL_function *) lfirst(lc);
-
-		iscompiling = false;
 
 		/*
 		 * if funcs is compiling, we doesn't free its memory, this
@@ -735,15 +863,7 @@ plisql_get_package_depends(PLiSQL_function *func, List **funclist,
 		 * and free package memory, then we must not free this anonymous
 		 * memory context, because it may be used later.
 		 */
-		for (i = 0; i < plisql_curr_global_proper_level; i++)
-		{
-			if (plisql_saved_compile_proper[i].plisql_saved_compile[0] == funcs)
-			{
-				iscompiling = true;
-				break;
-			}
-		}
-		if (iscompiling)
+		if (plisql_function_is_compiling(funcs))
 			continue;
 
 		if (funcs->item != NULL)
@@ -758,6 +878,130 @@ plisql_get_package_depends(PLiSQL_function *func, List **funclist,
 		*funclist = list_append_unique(*funclist, funcs);
 	}
 	return;
+}
+
+
+typedef struct PackageDependHashEntry
+{
+	void	   *pointer;
+} PackageDependHashEntry;
+
+
+/*
+ * Find every non-package function that depends on any package in pkglist.
+ *
+ * plisql_free_packagelist() used to call plisql_get_package_depends() once
+ * per package.  Each call recursively walked the same package dependency
+ * graph and used linear List membership checks, so a long chain was visited
+ * quadratically and searched cubically.  Traverse all roots together and use
+ * pointer hash tables to visit each package and collect each function once.
+ */
+static List *
+plisql_get_packagelist_depends(List *pkglist)
+{
+	HASHCTL		ctl;
+	HTAB	   *seen_packages;
+	HTAB	   *seen_functions;
+	List	   *package_queue = NIL;
+	List	   *funclist = NIL;
+	ListCell   *lc;
+	int			queue_index;
+
+	if (pkglist == NIL)
+		return NIL;
+
+	ctl.keysize = sizeof(void *);
+	ctl.entrysize = sizeof(PackageDependHashEntry);
+	seen_packages = hash_create("PL/iSQL package dependency traversal",
+									list_length(pkglist),
+									&ctl,
+									HASH_ELEM | HASH_BLOBS);
+	seen_functions = hash_create("PL/iSQL dependent function collection",
+									32,
+									&ctl,
+									HASH_ELEM | HASH_BLOBS);
+
+	foreach (lc, pkglist)
+	{
+		PackageCacheItem *item = (PackageCacheItem *) lfirst(lc);
+		PLiSQL_package *psource = (PLiSQL_package *) item->source;
+		bool		found;
+
+		(void) hash_search(seen_packages, &item, HASH_ENTER, &found);
+		if (!found)
+			package_queue = lappend(package_queue, &psource->source);
+	}
+
+	for (queue_index = 0;
+		 queue_index < list_length(package_queue);
+		 queue_index++)
+	{
+		PLiSQL_function *func =
+			(PLiSQL_function *) list_nth(package_queue, queue_index);
+		ListCell   *function_cell;
+
+		foreach (function_cell, func->funclist)
+		{
+			PLiSQL_function *dependent =
+				(PLiSQL_function *) lfirst(function_cell);
+			bool		found;
+
+			if (plisql_function_is_compiling(dependent))
+				continue;
+
+			if (dependent->item != NULL)
+			{
+				PackageCacheItem *dependent_item = dependent->item;
+
+				(void) hash_search(seen_packages, &dependent_item,
+									  HASH_ENTER, &found);
+				if (!found)
+					package_queue = lappend(package_queue, dependent);
+			}
+			else
+			{
+				(void) hash_search(seen_functions, &dependent,
+									  HASH_ENTER, &found);
+				if (!found)
+					funclist = lappend(funclist, dependent);
+			}
+		}
+	}
+
+	list_free(package_queue);
+	hash_destroy(seen_functions);
+	hash_destroy(seen_packages);
+
+	return funclist;
+}
+
+
+static bool
+plisql_function_is_compiling(PLiSQL_function *func)
+{
+	int			i;
+
+	for (i = 0; i < plisql_curr_global_proper_level; i++)
+	{
+		if (plisql_saved_compile_proper[i].plisql_saved_compile[0] == func)
+			return true;
+	}
+
+	return false;
+}
+
+
+/*
+ * A package dependency can invalidate a function without changing its
+ * pg_proc tuple.  Mark the cached tuple identity invalid before freeing the
+ * compiled tree, so an existing FmgrInfo fn_extra pointer cannot mistake the
+ * emptied function structure for a still-valid compiled function.
+ */
+static void
+plisql_invalidate_dependent_function(PLiSQL_function *func)
+{
+	func->fn_xmin = InvalidTransactionId;
+	delete_function(func);
 }
 
 
@@ -2337,6 +2581,7 @@ plisql_get_package_func(FunctionCallInfo fcinfo, bool forValidator)
 	funcexpr = (FuncExpr *) fcinfo->flinfo->fn_expr;
 
 	Assert(funcexpr->function_from == FUNC_FROM_PACKAGE);
+	pfunc = plisql_refresh_package_funcexpr(funcexpr);
 
 	if (!OidIsValid(funcexpr->pkgoid))
 		elog(ERROR, "funcexpr include invalid pkgoid");
@@ -2352,9 +2597,6 @@ plisql_get_package_func(FunctionCallInfo fcinfo, bool forValidator)
 		psource->status = PLISQL_PACKAGE_NO_INIT;
 		elog(ERROR, "existing state of packages has been discarded");
 	}
-	pfunc = &psource->source;
-
-	pfunc = (PLiSQL_function *) funcexpr->parent_func;
 	fno = (int) funcexpr->funcid;
 
 	if (pfunc == NULL)
@@ -2482,6 +2724,7 @@ plisql_remove_function_relations(PLiSQL_function *func)
 
 		plisql_remove_function_references(func, refcache);
 	}
+	func->pkgcachelist = NIL;
 
 	return;
 }
@@ -3498,6 +3741,43 @@ plisql_get_subprocs_from_package(Oid pkgoid,
 /*
  * get subproc arginfo
  */
+static PLiSQL_function *
+plisql_refresh_package_funcexpr(FuncExpr *funcexpr)
+{
+	PackageCacheItem *item;
+	PLiSQL_package *psource;
+
+	if (!FUNC_EXPR_FROM_PACKAGE(funcexpr->function_from))
+	{
+		if (funcexpr->parent_func == NULL)
+			elog(ERROR, "parent_func has not been set");
+		return (PLiSQL_function *) funcexpr->parent_func;
+	}
+	if (!OidIsValid(funcexpr->pkgoid))
+		elog(ERROR, "package FuncExpr has an invalid package OID");
+
+	item = PackageCacheLookup(&funcexpr->pkgoid);
+	if (item != NULL)
+	{
+		psource = (PLiSQL_package *) item->source;
+		if (funcexpr->parent_func == &psource->source)
+			return &psource->source;
+	}
+
+	/*
+	 * Cached plans can outlive the package memory context referenced by the
+	 * raw parent_func pointer.  Clear it so the saved qualified function name
+	 * is resolved against the current package cache entry.
+	 */
+	funcexpr->parent_func = NULL;
+	set_pkginfo_from_funcexpr(funcexpr);
+	if (funcexpr->parent_func == NULL)
+		elog(ERROR, "package FuncExpr could not be refreshed");
+
+	return (PLiSQL_function *) funcexpr->parent_func;
+}
+
+
 int
 plisql_get_subproc_arg_info (FuncExpr *fexpr,
 				Oid **p_argtypes,
@@ -3513,10 +3793,7 @@ plisql_get_subproc_arg_info (FuncExpr *fexpr,
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	if (fexpr->parent_func == NULL)
-		elog(ERROR, "parent_func has not been set");
-
-	function = (PLiSQL_function *) fexpr->parent_func;
+	function = plisql_refresh_package_funcexpr(fexpr);
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3574,10 +3851,7 @@ plisql_get_subproc_prokind (FuncExpr *fexpr)
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	if (fexpr->parent_func == NULL)
-		elog(ERROR, "parent_func has not been set");
-
-	function = (PLiSQL_function *) fexpr->parent_func;
+	function = plisql_refresh_package_funcexpr(fexpr);
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3604,10 +3878,7 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	if (fexpr->parent_func == NULL)
-		elog(ERROR, "parent_func has not been set");
-
-	function = (PLiSQL_function *) fexpr->parent_func;
+	function = plisql_refresh_package_funcexpr(fexpr);
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3823,4 +4094,3 @@ release_package_func_usecount(FunctionCallInfo fcinfo)
 
 	return;
 }
-


### PR DESCRIPTION
## Summary

- replace repeated package-list scans with a hash-indexed dependency graph and stable Kahn traversal
- collect dependent packages and standalone functions in one graph walk instead of recursively revisiting the graph from every package
- preserve the previous scan-pass and input ordering, including the existing fallback for cycles and dependencies outside the input list
- add Oracle-mode regression coverage for layered, independent, and cyclic package dependencies
- include an executable SQL benchmark for the old algorithm’s worst-case dependency order

This PR is now performance-only. The pre-existing cache correctness issue identified during review was split into #1453 with its own regression test and issue.

## Performance background

I did not encounter this in a production deployment, so I do not want to imply a real-world incident. Source inspection showed that the previous cleanup repeatedly scanned the remaining package list, making reverse-ordered dependency chains quadratic. The benchmark is an explicitly synthetic worst case intended to make the complexity and scaling reproducible; ordinary installations with fewer cached packages or shallower dependency graphs will see a smaller effect.

The reproducer is committed at `src/oracle_test/modules/test_package_reset/benchmark_discard_package_chain.sql`. Run it from an IvorySQL `psql` client against the base and patched revisions, for example:

```sh
psql -X -v ON_ERROR_STOP=1 -v package_count=1600 \
  -f src/oracle_test/modules/test_package_reset/benchmark_discard_package_chain.sql DATABASE
```

Only `DISCARD PACKAGE` is timed. Package bodies are created in reverse order and each body depends on its predecessor.

| Packages | Before | After |
| ---: | ---: | ---: |
| 3,200 | 8,040.366 ms | 16.647 ms |
| 6,400 | not run | 36.427 ms |

The 3,200-package synthetic case is about 483x faster, while the patched 3,200-to-6,400 result is close to linear scaling.

## Verification

- `make -C src/oracle_test/modules/test_package_reset oracle-check NO_TEMP_INSTALL=1` — 5/5 passed
- compared the new and old ordering algorithms on 360,000 randomized dependency graphs; all orders matched
- executed the committed benchmark with `package_count=10` after the split to verify that the reproducer runs end to end
- `git diff --check`

Fixes #1426

## AI assistance disclosure

This contribution was prepared with OpenAI Codex using GPT-5. The agent assisted with source and test inspection, issue scoping, drafting code and tests, running verification, benchmarking, and preparing the PR description. I directed the scope, reviewed the resulting changes against the source and test results, and remain responsible for the submission.