### PR TITLE
docs: document DISCARD PACKAGE session cleanup

### DIFF
--- a/doc/src/sgml/ref/discard.sgml
+++ b/doc/src/sgml/ref/discard.sgml
@@ -21,7 +21,7 @@ PostgreSQL documentation
 
  <refsynopsisdiv>
 <synopsis>
-DISCARD { ALL | PLANS | SEQUENCES | TEMPORARY | TEMP }
+DISCARD { ALL | PACKAGE | PLANS | SEQUENCES | TEMPORARY | TEMP }
 </synopsis>
  </refsynopsisdiv>
 
@@ -41,6 +41,24 @@ DISCARD { ALL | PLANS | SEQUENCES | TEMPORARY | TEMP }
   <title>Parameters</title>
 
   <variablelist>
+
+   <varlistentry>
+    <term><literal>PACKAGE</literal></term>
+    <listitem>
+     <para>
+      Discards all cached PL/iSQL package definitions and their run-time state
+      in the current session.  The next access to a package recompiles it and
+      runs its initialization code again.  This does not drop any package or
+      affect package state in other sessions.
+     </para>
+     <para>
+      This form is available in Oracle compatibility mode.  When the
+      <filename>ivorysql_ora</filename> module is loaded, it also resets
+      <literal>DBMS_OUTPUT</literal> buffer state and
+      <literal>DBMS_SESSION</literal> application contexts.
+     </para>
+    </listitem>
+   </varlistentry>
 
    <varlistentry>
     <term><literal>PLANS</literal></term>
@@ -93,7 +111,10 @@ SELECT pg_advisory_unlock_all();
 DISCARD PLANS;
 DISCARD TEMP;
 DISCARD SEQUENCES;
-</programlisting></para>
+</programlisting>
+      In Oracle compatibility mode, it also discards package state as
+      described for <literal>PACKAGE</literal> above.
+     </para>
     </listitem>
    </varlistentry>
 
@@ -113,6 +134,8 @@ DISCARD SEQUENCES;
 
   <para>
    <command>DISCARD</command> is a <productname>PostgreSQL</productname> extension.
+   The <literal>PACKAGE</literal> variant is an
+   <productname>IvorySQL</productname> extension for Oracle compatibility.
   </para>
  </refsect1>
 </refentry>


### PR DESCRIPTION
## Summary

- add the Oracle-mode DISCARD PACKAGE syntax to the DISCARD reference
- explain that it clears current-session PL/iSQL package cache and run-time state without dropping catalog objects
- document the additional DBMS_OUTPUT and DBMS_SESSION cleanup performed by ivorysql_ora
- clarify that DISCARD ALL includes package-state cleanup in Oracle compatibility mode

## Verification

- executed SET ivorysql.compatible_mode = oracle followed by DISCARD PACKAGE against an assertion-enabled build; server returned DISCARD PACKAGES
- xmllint well-formedness check passed for discard.sgml
- git diff --check passed

## Related issue

Related to #1376


<!-- governance-retry -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the new `DISCARD PACKAGE` command for clearing cached PL/pgSQL package definitions and session runtime state.
  * Clarified that `DISCARD ALL` also clears package state in Oracle compatibility mode.
  * Added compatibility details identifying `DISCARD PACKAGE` as an IvorySQL extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## AI assistance disclosure

This contribution was prepared with OpenAI Codex using GPT-5. The agent assisted with source and test inspection, issue scoping, drafting code, documentation and tests where applicable, running verification, and preparing the PR description. I directed the scope, reviewed the resulting changes against the source and test results, and remain responsible for the submission.
