### PR TITLE
docs: describe Oracle-compatible ROWID

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -1451,8 +1451,10 @@ CREATE TABLE circles (
 
   <para>
    Every table has several <firstterm>system columns</firstterm> that are
-   implicitly defined by the system.  Therefore, these names cannot be
-   used as names of user-defined columns.  (Note that these
+   implicitly defined by the system.  Oracle-compatible tables can also
+   have the optional <structfield>ROWID</structfield> system column described
+   below.  Therefore, these names cannot be used as names of user-defined
+   columns.  (Note that these
    restrictions are separate from whether the name is a key word or
    not; quoting a name will not allow you to escape these
    restrictions.)  You do not really need to be concerned about these
@@ -1560,6 +1562,88 @@ CREATE TABLE circles (
       updated or moved by <command>VACUUM FULL</command>.  Therefore
       <structfield>ctid</structfield> should not be used as a row
       identifier.  A primary key should be used to identify logical rows.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry id="ddl-system-columns-rowid">
+    <term><structfield>rowid</structfield></term>
+    <listitem>
+     <indexterm>
+      <primary>ROWID</primary>
+     </indexterm>
+
+     <para>
+      In an Oracle-compatible database, a table created
+      <literal>WITH ROWID</literal> has a <type>sys.rowid</type> system
+      column.  Its value contains two fields: <structfield>rowoid</structfield>,
+      the OID of the physical table containing the row, and
+      <structfield>rowno</structfield>, a sequence-generated
+      <type>bigint</type> that identifies the row within that table.  Use
+      parentheses to select a field:
+<programlisting>
+SELECT (rowid).rowoid, (rowid).rowno, customer_name
+FROM customers
+WHERE (rowid).rowno = 42;
+</programlisting>
+      When a query contains more than one table, qualify the system column,
+      for example <literal>(customers.rowid).rowno</literal>.
+     </para>
+
+     <para>
+      <structfield>rowno</structfield> values are assigned automatically on
+      insert and are preserved by ordinary updates.  They can contain gaps
+      because they are allocated from an internal sequence.  A B-tree index
+      on <structfield>rowid</structfield> is created automatically.  The
+      system column cannot be supplied by <command>INSERT</command>, changed
+      by <command>UPDATE</command>, dropped as an ordinary column, or used as
+      the name of a user-defined column.  Equality conditions on the complete
+      <structfield>ROWID</structfield> value can use the automatic index;
+      conditions on an extracted field such as
+      <literal>(rowid).rowno</literal> do not necessarily use it.
+     </para>
+
+     <para>
+      For a partitioned table, each leaf partition has its own sequence, so
+      <structfield>rowno</structfield> values can repeat between partitions.
+      The <structfield>rowoid</structfield> field distinguishes those physical
+      tables.  Do not use <structfield>ROWID</structfield> as a durable
+      application key: its value can change when a row is moved to another
+      physical table, when <literal>ROWID</literal> support is removed and
+      added again, or when data is dumped and restored.  Define a primary key
+      when a stable logical identity is required.
+     </para>
+
+     <para>
+      Specify <literal>WITH ROWID</literal> or <literal>WITHOUT ROWID</literal>
+      in <command>CREATE TABLE</command> to override the session default.
+      <command>ALTER TABLE ... SET WITH ROWID</command> adds and populates the
+      system column for an existing table, while
+      <command>ALTER TABLE ... SET WITHOUT ROWID</command> removes it.  Both
+      forms rewrite existing table data.  The
+      <varname>ivorysql.default_with_rowids</varname> setting controls the
+      default for newly created Oracle-compatible tables and is
+      <literal>off</literal> by default.  The
+      <varname>ivorysql.rowid_seq_cache</varname> setting controls the cache
+      size of newly created internal <literal>ROWID</literal> sequences; its
+      default is 20 and its valid range is 1 through 60000.
+     </para>
+
+     <para>
+      A table created with <literal>LIKE</literal> from a table that has
+      <structfield>ROWID</structfield> also has it.  Inheritance and partition
+      hierarchies propagate <structfield>ROWID</structfield> from the parent;
+      in those cases <literal>WITHOUT ROWID</literal> cannot override the
+      parent's requirement.
+     </para>
+
+     <para>
+      In PostgreSQL-compatible databases, <literal>ROWID</literal> has no
+      system-column meaning and can be used as an ordinary identifier.  In
+      Oracle-compatible SQL, <literal>ROWID</literal> and
+      <literal>ROWNUM</literal> cannot be used as explicit column aliases or
+      table aliases, although PL/iSQL local variables and parameters may use
+      those names.
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -83,6 +83,8 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="parameter">name</replaceable>
     CLUSTER ON <replaceable class="parameter">index_name</replaceable>
     SET WITHOUT CLUSTER
     SET WITHOUT OIDS
+    SET WITH ROWID
+    SET WITHOUT ROWID
     SET ACCESS METHOD { <replaceable class="parameter">new_access_method</replaceable> | DEFAULT }
     SET TABLESPACE <replaceable class="parameter">new_tablespace</replaceable>
     SET { LOGGED | UNLOGGED }
@@ -772,6 +774,21 @@ WITH ( MODULUS <replaceable class="parameter">numeric_literal</replaceable>, REM
       Backward-compatible syntax for removing the <literal>oid</literal>
       system column.  As <literal>oid</literal> system columns cannot be
       added anymore, this never has an effect.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry id="sql-altertable-desc-set-rowid">
+    <term><literal>SET WITH ROWID</literal></term>
+    <term><literal>SET WITHOUT ROWID</literal></term>
+    <listitem>
+     <para>
+      In an Oracle-compatible database, these forms add or remove the
+      <structfield>ROWID</structfield> system column.  Adding it assigns a
+      value to every existing row and creates the supporting sequence and
+      index; removing it also removes those supporting objects.  Either form
+      rewrites the table and takes an <literal>ACCESS EXCLUSIVE</literal>
+      lock.  See <xref linkend="ddl-system-columns-rowid"/>.
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -30,7 +30,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 [ INHERITS ( <replaceable>parent_table</replaceable> [, ... ] ) ]
 [ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ USING <replaceable class="parameter">method</replaceable> ]
-[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS ]
+[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS | WITH ROWID | WITHOUT ROWID ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
 
@@ -42,7 +42,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 ) ]
 [ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ USING <replaceable class="parameter">method</replaceable> ]
-[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS ]
+[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS | WITH ROWID | WITHOUT ROWID ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
 
@@ -54,7 +54,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 ) ] { FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable> | DEFAULT }
 [ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ USING <replaceable class="parameter">method</replaceable> ]
-[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS ]
+[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS | WITH ROWID | WITHOUT ROWID ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
 
@@ -1470,6 +1470,23 @@ WITH ( MODULUS <replaceable class="parameter">numeric_literal</replaceable>, REM
       This is backward-compatible syntax for declaring a table
       <literal>WITHOUT OIDS</literal>, creating a table <literal>WITH
       OIDS</literal> is not supported anymore.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry id="sql-createtable-parms-with-rowid">
+    <term><literal>WITH ROWID</literal></term>
+    <term><literal>WITHOUT ROWID</literal></term>
+    <listitem>
+     <para>
+      In an Oracle-compatible database, <literal>WITH ROWID</literal> adds
+      the Oracle-compatible <structfield>ROWID</structfield> system column to
+      the new table.  <literal>WITHOUT ROWID</literal> explicitly disables
+      it, unless it is required by a parent table.  If neither form is
+      specified, the
+      <varname>ivorysql.default_with_rowids</varname> setting determines the
+      behavior.  See <xref linkend="ddl-system-columns-rowid"/> for the
+      column's representation and usage.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
## Summary

- document the `sys.rowid` value representation and lookup behavior
- explain `WITH ROWID` and `WITHOUT ROWID` in `CREATE TABLE` and `ALTER TABLE`
- cover the controlling compatibility settings and generated index and sequence objects
- call out partition-local identity, physical maintenance, backup, and portability limitations

Fixes #1431

## Verification

- `make -C doc/src/sgml check`
- `make -C doc/src/sgml html`
- `git diff --check`

The SGML and HTML checks were run in an out-of-tree cumulative documentation build containing this change and the other independently proposed documentation additions.

## AI assistance disclosure

This contribution was prepared with OpenAI Codex using GPT-5. The agent assisted with source and test inspection, issue scoping, drafting code, documentation and tests where applicable, running verification, and preparing the PR description. I directed the scope, reviewed the resulting changes against the source and test results, and remain responsible for the submission.
