### PR TITLE
ci: validate and build documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: documentation
+
+on:
+  push:
+    branches: [master, IVORY_REL_4_STABLE, IVORYSQL_REL_1_STABLE]
+    paths:
+      - "doc/**"
+      - "src/backend/catalog/sql_feature_packages.txt"
+      - "src/backend/catalog/sql_features.txt"
+      - "src/backend/utils/activity/wait_event_names.txt"
+      - "src/backend/utils/errcodes.txt"
+      - "src/include/parser/kwlist.h"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [master, IVORY_REL_4_STABLE, IVORYSQL_REL_1_STABLE]
+    paths:
+      - "doc/**"
+      - "src/backend/catalog/sql_feature_packages.txt"
+      - "src/backend/catalog/sql_features.txt"
+      - "src/backend/utils/activity/wait_event_names.txt"
+      - "src/backend/utils/errcodes.txt"
+      - "src/include/parser/kwlist.h"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: documentation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install documentation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bison \
+            docbook-xml \
+            docbook-xsl \
+            flex \
+            libxml2-utils \
+            xsltproc
+
+      - name: Configure source tree
+        run: |
+          ./configure \
+            --without-icu \
+            --without-readline \
+            --without-zlib
+
+      - name: Validate SGML
+        run: make -C doc/src/sgml check
+
+      - name: Build HTML documentation
+        run: make -C doc/src/sgml html


### PR DESCRIPTION
## Summary

- add a path-filtered documentation workflow for pull requests and maintained branches
- install the minimal SGML and XSLT dependencies on Ubuntu
- configure a lightweight build without unrelated optional server dependencies
- run both `make -C doc/src/sgml check` and the complete HTML build
- use read-only permissions and cancel superseded runs

Fixes #1436

## Verification

- reproduced the workflow configure command in a clean out-of-tree build
- `make -C doc/src/sgml check` passed
- `make -C doc/src/sgml html` passed with the packaged DocBook XSL catalog
- verified all named Ubuntu packages are available
- `git diff --check`

The new workflow itself will provide the final runner-level verification on this PR.

## AI assistance disclosure

This contribution was prepared with OpenAI Codex using GPT-5. The agent assisted with source and test inspection, issue scoping, drafting code, documentation and tests where applicable, running verification, and preparing the PR description. I directed the scope, reviewed the resulting changes against the source and test results, and remain responsible for the submission.
