### PR TITLE
compat: restore upstream signatures for ExecTypeFromTL and friends (fix mysql_fdw build)

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -1675,7 +1675,7 @@ iso_year(int y, int m, int d)
  * Get the timezone value of the operating system.
  */
 static int64
-sys_time_zone()
+sys_time_zone(void)
 {
 
 #ifdef _WIN64

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
@@ -81,7 +81,7 @@ static HTAB *dbms_lock_hash_table = NULL;
 /*
  * static routines
  */
-static void dbms_lock_init_hash_table();
+static void dbms_lock_init_hash_table(void);
 static bool dbms_lock_record_acquire(int64, int8);
 static bool dbms_lock_check(int64, int8);
 static bool dbms_lock_record_release(int64, int8);

--- a/src/backend/access/common/tupdesc.c
+++ b/src/backend/access/common/tupdesc.c
@@ -206,15 +206,23 @@ CreateTemplateTupleDesc(int natts)
 }
 
 /*
- * CreateTupleDesc
+ * CreateTupleDescWithRowId
  *		This function allocates a new TupleDesc by copying a given
  *		Form_pg_attribute array.
  *
  * Tuple type ID information is initially set for an anonymous record type;
  * caller can overwrite this if needed.
+ *
+ * IvorySQL rowid-aware variant: tdhasrowid records whether the resulting
+ * tuple descriptor carries an Oracle-style rowid attribute; is_sysattr
+ * indicates that the trailing attribute is a system attribute (and thus
+ * should be stripped from the count when no rowid is requested).  This is
+ * the real implementation; CreateTupleDesc() below forwards here with
+ * tdhasrowid=false and is_sysattr=false to preserve the upstream
+ * PostgreSQL signature.
  */
 TupleDesc
-CreateTupleDesc(int natts, Form_pg_attribute *attrs, bool tdhasrowid, bool is_sysattr)
+CreateTupleDescWithRowId(int natts, Form_pg_attribute *attrs, bool tdhasrowid, bool is_sysattr)
 {
 	TupleDesc	desc;
 	int			i;
@@ -233,6 +241,19 @@ CreateTupleDesc(int natts, Form_pg_attribute *attrs, bool tdhasrowid, bool is_sy
 	TupleDescFinalize(desc);
 
 	return desc;
+}
+
+/*
+ * CreateTupleDesc
+ *		Upstream PostgreSQL signature: (int, Form_pg_attribute *).
+ *		Forwards to CreateTupleDescWithRowId with tdhasrowid=false and
+ *		is_sysattr=false, matching upstream semantics (no rowid attribute,
+ *		no trailing system attribute to strip).
+ */
+TupleDesc
+CreateTupleDesc(int natts, Form_pg_attribute *attrs)
+{
+	return CreateTupleDescWithRowId(natts, attrs, false, false);
 }
 
 /*

--- a/src/backend/bootstrap/bootparse.y
+++ b/src/backend/bootstrap/bootparse.y
@@ -177,7 +177,7 @@ Boot_CreateStmt:
 
 					do_start();
 
-					tupdesc = CreateTupleDesc(numattr, attrtypes, false, false);
+					tupdesc = CreateTupleDescWithRowId(numattr, attrtypes, false, false);
 
 					shared_relation = $5;
 

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -690,7 +690,7 @@ InsertOneTuple(void)
 
 	elog(DEBUG4, "inserting row with %d columns", numattr);
 
-	tupDesc = CreateTupleDesc(numattr, attrtypes, false, false);
+	tupDesc = CreateTupleDescWithRowId(numattr, attrtypes, false, false);
 	tuple = heap_form_tuple(tupDesc, values, Nulls);
 	pfree(tupDesc);				/* just free's tupDesc, not the attrtypes */
 

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -903,7 +903,7 @@ AddNewAttributeTuples(Oid new_rel_oid,
 	{
 		TupleDesc	td;
 
-		td = CreateTupleDesc(lengthof(SysAtt), (FormData_pg_attribute **) &SysAtt, tupdesc->tdhasrowid, true);
+		td = CreateTupleDescWithRowId(lengthof(SysAtt), (FormData_pg_attribute **) &SysAtt, tupdesc->tdhasrowid, true);
 
 		InsertPgAttributeTuples(rel, td, new_rel_oid, NULL, indstate);
 		FreeTupleDesc(td);

--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -3367,7 +3367,7 @@ ExecInitWholeRowVar(ExprEvalStep *scratch, Var *variable, ExprState *state)
 			if (junk_filter_needed)
 			{
 				scratch->d.wholerow.junkFilter =
-					ExecInitJunkFilter(subplan->plan->targetlist,
+					ExecInitJunkFilterWithRowId(subplan->plan->targetlist,
 									   ExecGetResultType(subplan)->tdhasrowid,
 									   ExecInitExtraTupleSlot(parent->state, NULL,
 															  &TTSOpsVirtual));

--- a/src/backend/executor/execJunk.c
+++ b/src/backend/executor/execJunk.c
@@ -48,16 +48,15 @@
  */
 
 /*
- * ExecInitJunkFilter
+ * ExecInitJunkFilterWithRowId -- IvorySQL rowid-aware Junk filter init.
  *
- * Initialize the Junk filter.
- *
- * The source targetlist is passed in.  The output tuple descriptor is
- * built from the non-junk tlist entries.
- * An optional resultSlot can be passed as well; otherwise, we create one.
+ * Like ExecInitJunkFilter below, but the caller decides whether the produced
+ * clean tuple descriptor carries an Oracle-style rowid attribute.  This is
+ * the real implementation; ExecInitJunkFilter() forwards here with
+ * hasrowid=false to preserve the upstream PostgreSQL signature.
  */
 JunkFilter *
-ExecInitJunkFilter(List *targetList, bool hasrowid, TupleTableSlot *slot)
+ExecInitJunkFilterWithRowId(List *targetList, bool hasrowid, TupleTableSlot *slot)
 {
 	JunkFilter *junkfilter;
 	TupleDesc	cleanTupType;
@@ -67,7 +66,7 @@ ExecInitJunkFilter(List *targetList, bool hasrowid, TupleTableSlot *slot)
 	/*
 	 * Compute the tuple descriptor for the cleaned tuple.
 	 */
-	cleanTupType = ExecCleanTypeFromTL(targetList, hasrowid);
+	cleanTupType = ExecCleanTypeFromTLWithRowId(targetList, hasrowid);
 
 	/*
 	 * Use the given slot, or make a new slot if we weren't given one.
@@ -121,6 +120,20 @@ ExecInitJunkFilter(List *targetList, bool hasrowid, TupleTableSlot *slot)
 	junkfilter->jf_resultSlot = slot;
 
 	return junkfilter;
+}
+
+/*
+ * ExecInitJunkFilter
+ *
+ * Initialize the Junk filter.  Upstream PostgreSQL signature: the clean
+ * tuple descriptor is built with hasrowid=false.  Callers that need to
+ * control the rowid attribute (Oracle compatibility) should use
+ * ExecInitJunkFilterWithRowId() above.
+ */
+JunkFilter *
+ExecInitJunkFilter(List *targetList, TupleTableSlot *slot)
+{
+	return ExecInitJunkFilterWithRowId(targetList, false, slot);
 }
 
 /*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1026,7 +1026,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			TupleTableSlot *slot;
 
 			slot = ExecInitExtraTupleSlot(estate, NULL, &TTSOpsVirtual);
-			j = ExecInitJunkFilter(planstate->plan->targetlist, tupType->tdhasrowid,
+			j = ExecInitJunkFilterWithRowId(planstate->plan->targetlist, tupType->tdhasrowid,
 								   slot);
 			estate->es_junkFilter = j;
 

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -2039,7 +2039,7 @@ ExecInitResultTypeTL(PlanState *planstate)
 		hasrowid = false;
 	}
 
-	tupDesc = ExecTypeFromTL(planstate->plan->targetlist, hasrowid);
+	tupDesc = ExecTypeFromTLWithRowId(planstate->plan->targetlist, hasrowid);
 
 	planstate->ps_ResultTupleDesc = tupDesc;
 }
@@ -2212,10 +2212,28 @@ slot_getsomeattrs_int(TupleTableSlot *slot, int attnum)
  *		Currently there are about 4 different places where we create
  *		TupleDescriptors.  They should all be merged, or perhaps
  *		be rewritten to call BuildDesc().
+ *
+ *		IvorySQL note: this function preserves the upstream PostgreSQL
+ *		signature (List *) and semantics (no rowid attribute in the
+ *		resulting tuple header).  Code that needs Oracle-style rowid
+ *		support should call ExecTypeFromTLWithRowId() and pass the
+ *		desired hasrowid value explicitly.
  * ----------------------------------------------------------------
  */
 TupleDesc
-ExecTypeFromTL(List *targetList, bool hasrowid)
+ExecTypeFromTL(List *targetList)
+{
+	return ExecTypeFromTLInternal(targetList, false, false);
+}
+
+/*
+ * ExecTypeFromTLWithRowId -- IvorySQL rowid-aware variant.
+ *
+ * Like ExecTypeFromTL, but the caller decides whether the produced tuple
+ * descriptor carries a rowid attribute (Oracle compatibility).
+ */
+TupleDesc
+ExecTypeFromTLWithRowId(List *targetList, bool hasrowid)
 {
 	return ExecTypeFromTLInternal(targetList, hasrowid, false);
 }
@@ -2223,11 +2241,23 @@ ExecTypeFromTL(List *targetList, bool hasrowid)
 /* ----------------------------------------------------------------
  *		ExecCleanTypeFromTL
  *
- *		Same as above, but resjunk columns are omitted from the result.
+ *		Same as ExecTypeFromTL, but resjunk columns are omitted from
+ *		the result.  IvorySQL note: see ExecTypeFromTL() above -- this
+ *		is the upstream signature; use ExecCleanTypeFromTLWithRowId()
+ *		when rowid control is needed.
  * ----------------------------------------------------------------
  */
 TupleDesc
-ExecCleanTypeFromTL(List *targetList, bool hasrowid)
+ExecCleanTypeFromTL(List *targetList)
+{
+	return ExecTypeFromTLInternal(targetList, false, true);
+}
+
+/*
+ * ExecCleanTypeFromTLWithRowId -- IvorySQL rowid-aware variant.
+ */
+TupleDesc
+ExecCleanTypeFromTLWithRowId(List *targetList, bool hasrowid)
 {
 	return ExecTypeFromTLInternal(targetList, hasrowid, true);
 }

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -831,7 +831,7 @@ init_execution_state(SQLFunctionCachePtr fcache)
 															  fcache->func->rettupdesc,
 															  slot);
 		else
-			fcache->junkFilter = ExecInitJunkFilter(resulttlist, false, slot);
+			fcache->junkFilter = ExecInitJunkFilterWithRowId(resulttlist, false, slot);
 
 		/*
 		 * The resulttlist tree belongs to the plancache and might disappear

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1676,7 +1676,7 @@ find_hash_columns(AggState *aggstate)
 				Max(varNumber + 1, perhash->largestGrpColIdx);
 		}
 
-		hashDesc = ExecTypeFromTL(hashTlist, false);
+		hashDesc = ExecTypeFromTLWithRowId(hashTlist, false);
 
 		execTuplesHashPrepare(perhash->numCols,
 							  perhash->aggnode->grpOperators,
@@ -4285,7 +4285,7 @@ build_pertrans_for_aggref(AggStatePerTrans pertrans,
 	 */
 	if (numSortCols > 0 || aggref->aggfilter)
 	{
-		pertrans->sortdesc = ExecTypeFromTL(aggref->args, false);
+		pertrans->sortdesc = ExecTypeFromTLWithRowId(aggref->args, false);
 		pertrans->sortslot =
 			ExecInitExtraTupleSlot(estate, pertrans->sortdesc,
 								   &TTSOpsMinimalTuple);

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -78,7 +78,7 @@ ExecInitCustomScan(CustomScan *cscan, EState *estate, int eflags)
 	{
 		TupleDesc	scan_tupdesc;
 
-		scan_tupdesc = ExecTypeFromTL(cscan->custom_scan_tlist, false);
+		scan_tupdesc = ExecTypeFromTLWithRowId(cscan->custom_scan_tlist, false);
 		ExecInitScanTupleSlot(estate, &css->ss, scan_tupdesc, slotOps, 0);
 		/* Node's targetlist will contain Vars with varno = INDEX_VAR */
 		tlistvarno = INDEX_VAR;

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -189,7 +189,7 @@ ExecInitForeignScan(ForeignScan *node, EState *estate, int eflags)
 	{
 		TupleDesc	scan_tupdesc;
 
-		scan_tupdesc = ExecTypeFromTL(node->fdw_scan_tlist, false);
+		scan_tupdesc = ExecTypeFromTLWithRowId(node->fdw_scan_tlist, false);
 		ExecInitScanTupleSlot(estate, &scanstate->ss, scan_tupdesc,
 							  &TTSOpsHeapTuple, 0);
 		/* Node's targetlist will contain Vars with varno = INDEX_VAR */

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -566,7 +566,7 @@ ExecInitIndexOnlyScan(IndexOnlyScan *node, EState *estate, int eflags)
 	 * types of the original datums.  (It's the AM's responsibility to return
 	 * suitable data anyway.)
 	 */
-	tupDesc = ExecTypeFromTL(node->indextlist, false);
+	tupDesc = ExecTypeFromTLWithRowId(node->indextlist, false);
 	ExecInitScanTupleSlot(estate, &indexstate->ss, tupDesc,
 						  &TTSOpsVirtual,
 						  0);

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1063,7 +1063,7 @@ ExecInitSubPlan(SubPlan *subplan, PlanState *parent)
 		 * (hack alert!).  The righthand expressions will be evaluated in our
 		 * own innerecontext.
 		 */
-		tupDescLeft = ExecTypeFromTL(lefttlist, false);
+		tupDescLeft = ExecTypeFromTLWithRowId(lefttlist, false);
 		slot = ExecInitExtraTupleSlot(estate, tupDescLeft, &TTSOpsVirtual);
 		sstate->projLeft = ExecBuildProjectionInfo(lefttlist,
 												   NULL,
@@ -1071,7 +1071,7 @@ ExecInitSubPlan(SubPlan *subplan, PlanState *parent)
 												   parent,
 												   NULL);
 
-		sstate->descRight = tupDescRight = ExecTypeFromTL(righttlist, false);
+		sstate->descRight = tupDescRight = ExecTypeFromTLWithRowId(righttlist, false);
 		slot = ExecInitExtraTupleSlot(estate, tupDescRight, &TTSOpsVirtual);
 		sstate->projRight = ExecBuildProjectionInfo(righttlist,
 													sstate->innerecontext,

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -670,7 +670,7 @@ PortalStart(Portal portal, ParamListInfo params,
 
 					pstmt = PortalGetPrimaryStmt(portal);
 					portal->tupDesc =
-						ExecCleanTypeFromTL(pstmt->planTree->targetlist, false);
+						ExecCleanTypeFromTLWithRowId(pstmt->planTree->targetlist, false);
 				}
 
 				/*

--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -214,7 +214,7 @@ ordered_set_startup(FunctionCallInfo fcinfo, bool use_tuples)
 			 * Get a tupledesc corresponding to the aggregated inputs
 			 * (including sort expressions) of the agg.
 			 */
-			qstate->tupdesc = ExecTypeFromTL(aggref->args, false);
+			qstate->tupdesc = ExecTypeFromTLWithRowId(aggref->args, false);
 
 			/* If we need a flag column, hack the tupledesc to include that */
 			if (ishypothetical)

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -2140,12 +2140,12 @@ PlanCacheComputeResultDesc(List *stmt_list)
 		case PORTAL_ONE_SELECT:
 		case PORTAL_ONE_MOD_WITH:
 			query = linitial_node(Query, stmt_list);
-			return ExecCleanTypeFromTL(query->targetList, false);
+			return ExecCleanTypeFromTLWithRowId(query->targetList, false);
 
 		case PORTAL_ONE_RETURNING:
 			query = QueryListGetPrimaryStmt(stmt_list);
 			Assert(query->returningList);
-			return ExecCleanTypeFromTL(query->returningList, false);
+			return ExecCleanTypeFromTLWithRowId(query->returningList, false);
 
 		case PORTAL_UTIL_SELECT:
 			query = linitial_node(Query, stmt_list);

--- a/src/include/access/tupdesc.h
+++ b/src/include/access/tupdesc.h
@@ -206,7 +206,21 @@ TupleDescCompactAttr(TupleDesc tupdesc, int i)
 
 extern TupleDesc CreateTemplateTupleDesc(int natts);
 
-extern TupleDesc CreateTupleDesc(int natts, Form_pg_attribute *attrs, bool tdhasrowid, bool is_sysattr);
+/*
+ * CreateTupleDesc preserves the upstream PostgreSQL signature
+ * (int, Form_pg_attribute *) for source and ABI compatibility with
+ * extensions written against standard PostgreSQL; the resulting tuple
+ * descriptor carries no rowid attribute (tdhasrowid=false).
+ *
+ * IvorySQL exposes the rowid-aware variant under a separate name,
+ * CreateTupleDescWithRowId, so the caller can control the rowid attribute
+ * (Oracle compatibility) and indicate whether the trailing attribute is a
+ * system attribute.  Internal code that needs rowid control should use
+ * the WithRowId variant.
+ */
+extern TupleDesc CreateTupleDesc(int natts, Form_pg_attribute *attrs);
+extern TupleDesc CreateTupleDescWithRowId(int natts, Form_pg_attribute *attrs,
+										  bool tdhasrowid, bool is_sysattr);
 
 extern TupleDesc CreateTupleDescCopy(TupleDesc tupdesc);
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -203,9 +203,18 @@ TupleHashEntryGetAdditional(TupleHashTable hashtable, TupleHashEntry entry)
 
 /*
  * prototypes from functions in execJunk.c
+ *
+ * ExecInitJunkFilter preserves the upstream PostgreSQL signature
+ * (List *, TupleTableSlot *) and builds the clean tuple descriptor with
+ * hasrowid=false.  IvorySQL exposes the rowid-aware variant under a
+ * separate name, ExecInitJunkFilterWithRowId, so the caller can control
+ * the rowid attribute (Oracle compatibility).  Internal code that needs
+ * rowid control should use the WithRowId variant.
  */
-extern JunkFilter *ExecInitJunkFilter(List *targetList, bool hasrowid, 
+extern JunkFilter *ExecInitJunkFilter(List *targetList,
 									  TupleTableSlot *slot);
+extern JunkFilter *ExecInitJunkFilterWithRowId(List *targetList, bool hasrowid,
+											   TupleTableSlot *slot);
 extern JunkFilter *ExecInitJunkFilterConversion(List *targetList,
 												TupleDesc cleanTupType,
 												TupleTableSlot *slot);
@@ -608,8 +617,22 @@ extern TupleTableSlot *ExecInitExtraTupleSlot(EState *estate,
 											  const TupleTableSlotOps *tts_ops);
 extern TupleTableSlot *ExecInitNullTupleSlot(EState *estate, TupleDesc tupType,
 											 const TupleTableSlotOps *tts_ops);
-extern TupleDesc ExecTypeFromTL(List *targetList, bool hasrowid);
-extern TupleDesc ExecCleanTypeFromTL(List *targetList, bool hasrowid);
+/*
+ * ExecTypeFromTL / ExecCleanTypeFromTL preserve the upstream PostgreSQL
+ * signatures (single List * argument) for source and ABI compatibility
+ * with extensions written against standard PostgreSQL.  The resulting
+ * tuple descriptor carries no rowid attribute.
+ *
+ * IvorySQL exposes the rowid-aware variants under separate names
+ * (ExecTypeFromTLWithRowId / ExecCleanTypeFromTLWithRowId) so the caller
+ * can control whether the tuple descriptor carries an Oracle-style rowid
+ * attribute.  Internal code that needs rowid control should use the
+ * WithRowId variants.
+ */
+extern TupleDesc ExecTypeFromTL(List *targetList);
+extern TupleDesc ExecTypeFromTLWithRowId(List *targetList, bool hasrowid);
+extern TupleDesc ExecCleanTypeFromTL(List *targetList);
+extern TupleDesc ExecCleanTypeFromTLWithRowId(List *targetList, bool hasrowid);
 extern TupleDesc ExecTypeFromExprList(List *exprList);
 extern void ExecTypeSetColNames(TupleDesc typeInfo, List *namesList);
 extern void UpdateChangedParamSet(PlanState *node, Bitmapset *newchg);

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -2051,7 +2051,7 @@ plisql_push_compile_global_proper(void)
  * pop global compile informations
  */
 static void
-plisql_pop_compile_global_proper()
+plisql_pop_compile_global_proper(void)
 {
 	int i;
 	int neste_level;


### PR DESCRIPTION
## Problem

IvorySQL modifies four public PostgreSQL executor/tuple-descriptor APIs **in place** to add Oracle rowid support, breaking source compatibility for extensions written against standard PostgreSQL:

| API | Upstream PostgreSQL (PG18) | IvorySQL 5.4 (before) |
| --- | --- | --- |
| `ExecTypeFromTL` | `(List *)` | `(List *, bool hasrowid)` |
| `ExecCleanTypeFromTL` | `(List *)` | `(List *, bool hasrowid)` |
| `ExecInitJunkFilter` | `(List *, TupleTableSlot *)` | `(List *, bool hasrowid, TupleTableSlot *)` |
| `CreateTupleDesc` | `(int, Form_pg_attribute *)` | `(int, Form_pg_attribute *, bool tdhasrowid, bool is_sysattr)` |

`mysql_fdw` fails to compile because `mysql_fdw.c:613` calls the upstream one-argument form (`ExecTypeFromTL(scan_tlist)`), reported in #1379.

## Fix

**Restore the upstream signatures and symbols exactly**, and expose the IvorySQL rowid-aware variants under new `*WithRowId` names. Internal call sites that pass `hasrowid` (18 sites across 14 files) are updated to call the WithRowId variants.

| Upstream entry point (preserved, hasrowid=false) | IvorySQL variant |
| --- | --- |
| `ExecTypeFromTL(List *)` | `ExecTypeFromTLWithRowId(List *, bool hasrowid)` |
| `ExecCleanTypeFromTL(List *)` | `ExecCleanTypeFromTLWithRowId(List *, bool hasrowid)` |
| `ExecInitJunkFilter(List *, TupleTableSlot *)` | `ExecInitJunkFilterWithRowId(List *, bool hasrowid, TupleTableSlot *)` |
| `CreateTupleDesc(int, Form_pg_attribute *)` | `CreateTupleDescWithRowId(int, Form_pg_attribute *, bool tdhasrowid, bool is_sysattr)` |

Extensions written against upstream PostgreSQL continue to compile and link **unchanged** — both source-level and ABI compatibility hold, because `ExecTypeFromTL` etc. remain real exported functions with their original signatures.

## Why this approach (vs. the earlier macro dispatcher)

The first iteration of this PR used argument-count dispatcher macros to route calls based on arity. Reviewer @bigplaice pointed out two issues:
1. **ABI breakage** — replacing the `ExecTypeFromTL` symbol with `_1`/`_2` variants breaks pre-compiled extensions that expect the upstream symbol under the bare name.
2. **Unnecessary preprocessor complexity** — a plain rename of internal callers achieves the same source-compat goal more cleanly.

This rework drops all macros and restores the upstream symbols as real functions. (See [PR comment](https://github.com/IvorySQL/IvorySQL/pull/1448#issuecomment-5020989879).)

## Verification

- `make -C src/backend` builds clean with **zero new warnings**.
- `-std=c99 -pedantic -Wall` on a probe exercising all eight call combinations (4 upstream + 4 WithRowId) produces **no warnings** related to this change (no macros → no variadic-macro concerns).
- Symbols verified present in object files via `nm`:
  ```
  T ExecTypeFromTL            T ExecTypeFromTLWithRowId
  T ExecCleanTypeFromTL       T ExecCleanTypeFromTLWithRowId
  T ExecInitJunkFilter        T ExecInitJunkFilterWithRowId
  T CreateTupleDesc           T CreateTupleDescWithRowId
  ```
  The upstream symbols are real global functions, so pre-compiled extensions also resolve correctly.

Fixes #1379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Restored upstream-compatible calling conventions for tuple-descriptor creation and executor helpers, while retaining RowId-aware behavior via dedicated “WithRowId” APIs.
  * Updated tuple-type construction throughout planning/execution (including cleaned tuple types and junk-filter initialization) to consistently include or omit RowId as appropriate.
  * Adjusted tuple-descriptor usage for relation creation, system-attribute handling, and portal/result descriptors to align RowId expectations end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->