### PR TITLE
disallow setting ivorysql.enable_case_switch via ALTER USER/DATABASE SET

### DIFF
--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1404,7 +1404,7 @@
 
 { name => 'ivorysql.enable_case_switch', type => 'bool', context => 'PGC_USERSET', group => 'CLIENT_CONN_STATEMENT',
   short_desc => 'whether enable case conversion feature in oracle compatible mode.',
-  flags => 'GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE',
+  flags => 'GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING',
   variable => 'enable_case_switch',
   boot_val => 'true',
 },

--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1404,7 +1404,7 @@
 
 { name => 'ivorysql.enable_case_switch', type => 'bool', context => 'PGC_USERSET', group => 'CLIENT_CONN_STATEMENT',
   short_desc => 'whether enable case conversion feature in oracle compatible mode.',
-  flags => 'GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING',
+  flags => 'GUC_NOT_IN_SAMPLE',
   variable => 'enable_case_switch',
   boot_val => 'true',
 },

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -34,9 +34,9 @@ int			identifier_case_switch = INTERCHANGE;
 bool		identifier_case_from_pg_dump = false;
 bool		enable_case_switch = true;
 
-static char	   *nls_territory = "AMERICA";
-static char	   *nls_currency = "$";
-static char	   *nls_iso_currency = "AMERICA";
+static char *nls_territory = "AMERICA";
+static char *nls_currency = "$";
+static char *nls_iso_currency = "AMERICA";
 
 bool		enable_emptystring_to_NULL = false;
 
@@ -128,7 +128,7 @@ static struct config_bool Ivy_ConfigureNamesBool[] =
 		{"ivorysql.enable_case_switch", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("whether enable case conversion feature in oracle compatible mode."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING
 		},
 		&enable_case_switch,
 		true,
@@ -186,12 +186,11 @@ static struct config_bool Ivy_ConfigureNamesBool[] =
 	/*
 	 * ivorysql.default_with_rowids
 	 *
-	 * When enabled, all newly created tables will automatically include
-	 * an Oracle-compatible ROWID pseudo-column. This provides compatibility
-	 * with Oracle applications that rely on ROWID for row identification.
+	 * When enabled, all newly created tables will automatically include an
+	 * Oracle-compatible ROWID pseudo-column. This provides compatibility with
+	 * Oracle applications that rely on ROWID for row identification.
 	 *
-	 * Default: off
-	 * Context: USERSET (can be changed by any user)
+	 * Default: off Context: USERSET (can be changed by any user)
 	 */
 	{
 		{"ivorysql.default_with_rowids", PGC_USERSET, DEVELOPER_OPTIONS,
@@ -529,7 +528,7 @@ static void
 nls_case_conversion(char **param, char type)
 {
 	char	   *p;
-	size_t	  len;
+	size_t		len;
 
 CASE_CONVERSION:
 	len = strlen(*param);

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -34,9 +34,9 @@ int			identifier_case_switch = INTERCHANGE;
 bool		identifier_case_from_pg_dump = false;
 bool		enable_case_switch = true;
 
-static char *nls_territory = "AMERICA";
-static char *nls_currency = "$";
-static char *nls_iso_currency = "AMERICA";
+static char	   *nls_territory = "AMERICA";
+static char	   *nls_currency = "$";
+static char	   *nls_iso_currency = "AMERICA";
 
 bool		enable_emptystring_to_NULL = false;
 
@@ -186,11 +186,12 @@ static struct config_bool Ivy_ConfigureNamesBool[] =
 	/*
 	 * ivorysql.default_with_rowids
 	 *
-	 * When enabled, all newly created tables will automatically include an
-	 * Oracle-compatible ROWID pseudo-column. This provides compatibility with
-	 * Oracle applications that rely on ROWID for row identification.
+	 * When enabled, all newly created tables will automatically include
+	 * an Oracle-compatible ROWID pseudo-column. This provides compatibility
+	 * with Oracle applications that rely on ROWID for row identification.
 	 *
-	 * Default: off Context: USERSET (can be changed by any user)
+	 * Default: off
+	 * Context: USERSET (can be changed by any user)
 	 */
 	{
 		{"ivorysql.default_with_rowids", PGC_USERSET, DEVELOPER_OPTIONS,
@@ -528,7 +529,7 @@ static void
 nls_case_conversion(char **param, char type)
 {
 	char	   *p;
-	size_t		len;
+	size_t	  len;
 
 CASE_CONVERSION:
 	len = strlen(*param);

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -34,9 +34,9 @@ int			identifier_case_switch = INTERCHANGE;
 bool		identifier_case_from_pg_dump = false;
 bool		enable_case_switch = true;
 
-static char	   *nls_territory = "AMERICA";
-static char	   *nls_currency = "$";
-static char	   *nls_iso_currency = "AMERICA";
+static char *nls_territory = "AMERICA";
+static char *nls_currency = "$";
+static char *nls_iso_currency = "AMERICA";
 
 bool		enable_emptystring_to_NULL = false;
 
@@ -128,7 +128,7 @@ static struct config_bool Ivy_ConfigureNamesBool[] =
 		{"ivorysql.enable_case_switch", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("whether enable case conversion feature in oracle compatible mode."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING
+			GUC_NOT_IN_SAMPLE
 		},
 		&enable_case_switch,
 		true,
@@ -186,12 +186,11 @@ static struct config_bool Ivy_ConfigureNamesBool[] =
 	/*
 	 * ivorysql.default_with_rowids
 	 *
-	 * When enabled, all newly created tables will automatically include
-	 * an Oracle-compatible ROWID pseudo-column. This provides compatibility
-	 * with Oracle applications that rely on ROWID for row identification.
+	 * When enabled, all newly created tables will automatically include an
+	 * Oracle-compatible ROWID pseudo-column. This provides compatibility with
+	 * Oracle applications that rely on ROWID for row identification.
 	 *
-	 * Default: off
-	 * Context: USERSET (can be changed by any user)
+	 * Default: off Context: USERSET (can be changed by any user)
 	 */
 	{
 		{"ivorysql.default_with_rowids", PGC_USERSET, DEVELOPER_OPTIONS,
@@ -529,7 +528,7 @@ static void
 nls_case_conversion(char **param, char type)
 {
 	char	   *p;
-	size_t	  len;
+	size_t		len;
 
 CASE_CONVERSION:
 	len = strlen(*param);


### PR DESCRIPTION
fix: #1449 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `ivorysql.enable_case_switch` configuration so it’s less restricted and is now displayed with the complete set of options, rather than being hidden or limited in certain contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->