### PR TITLE
fix(plisql): refresh package-dependent caches after discard

### DIFF
--- a/src/oracle_test/modules/test_package_reset/Makefile
+++ b/src/oracle_test/modules/test_package_reset/Makefile
@@ -7,7 +7,8 @@ EXTENSION = test_package_reset
 DATA = test_package_reset--1.0.sql
 
 REGRESS = test_package_reset
-ORA_REGRESS = $(REGRESS) test_reset_one_oid test_reset_all test_reset_defaults
+ORA_REGRESS = $(REGRESS) test_reset_one_oid test_reset_all test_reset_defaults \
+	test_discard_function_cache
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/src/oracle_test/modules/test_package_reset/expected/test_discard_function_cache.out
+++ b/src/oracle_test/modules/test_package_reset/expected/test_discard_function_cache.out
@@ -1,0 +1,64 @@
+-- Cached callers and plans must survive repeated package cache resets.
+CREATE PACKAGE discard_cache_pkg AS
+    FUNCTION value RETURN NUMBER;
+END discard_cache_pkg;
+/
+CREATE PACKAGE BODY discard_cache_pkg AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN 42;
+    END;
+END discard_cache_pkg;
+/
+CREATE OR REPLACE FUNCTION discard_cache_consumer RETURN NUMBER IS
+BEGIN
+    RETURN discard_cache_pkg.value();
+END;
+/
+SELECT discard_cache_consumer() AS cached_caller_value FROM dual;
+ cached_caller_value 
+---------------------
+ 42
+(1 row)
+
+PREPARE discard_package_call AS
+    SELECT discard_cache_pkg.value() AS cached_plan_value FROM dual;
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
+EXECUTE discard_package_call;
+                 QUERY PLAN                  
+---------------------------------------------
+ Seq Scan on dual (actual rows=1.00 loops=1)
+(1 row)
+
+DISCARD PACKAGE;
+SELECT discard_cache_consumer() AS cached_caller_value FROM dual;
+ cached_caller_value 
+---------------------
+ 42
+(1 row)
+
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
+EXECUTE discard_package_call;
+                 QUERY PLAN                  
+---------------------------------------------
+ Seq Scan on dual (actual rows=1.00 loops=1)
+(1 row)
+
+-- A second reset checks that rebuilt dependency lists do not retain stale links.
+DISCARD PACKAGE;
+SELECT discard_cache_consumer() AS cached_caller_value FROM dual;
+ cached_caller_value 
+---------------------
+ 42
+(1 row)
+
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
+EXECUTE discard_package_call;
+                 QUERY PLAN                  
+---------------------------------------------
+ Seq Scan on dual (actual rows=1.00 loops=1)
+(1 row)
+
+DEALLOCATE discard_package_call;
+DROP FUNCTION discard_cache_consumer;
+DROP PACKAGE discard_cache_pkg;

--- a/src/oracle_test/modules/test_package_reset/sql/test_discard_function_cache.sql
+++ b/src/oracle_test/modules/test_package_reset/sql/test_discard_function_cache.sql
@@ -1,0 +1,42 @@
+-- Cached callers and plans must survive repeated package cache resets.
+
+CREATE PACKAGE discard_cache_pkg AS
+    FUNCTION value RETURN NUMBER;
+END discard_cache_pkg;
+/
+
+CREATE PACKAGE BODY discard_cache_pkg AS
+    FUNCTION value RETURN NUMBER AS
+    BEGIN
+        RETURN 42;
+    END;
+END discard_cache_pkg;
+/
+
+CREATE OR REPLACE FUNCTION discard_cache_consumer RETURN NUMBER IS
+BEGIN
+    RETURN discard_cache_pkg.value();
+END;
+/
+
+SELECT discard_cache_consumer() AS cached_caller_value FROM dual;
+PREPARE discard_package_call AS
+    SELECT discard_cache_pkg.value() AS cached_plan_value FROM dual;
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
+EXECUTE discard_package_call;
+
+DISCARD PACKAGE;
+
+SELECT discard_cache_consumer() AS cached_caller_value FROM dual;
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
+EXECUTE discard_package_call;
+
+-- A second reset checks that rebuilt dependency lists do not retain stale links.
+DISCARD PACKAGE;
+SELECT discard_cache_consumer() AS cached_caller_value FROM dual;
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
+EXECUTE discard_package_call;
+
+DEALLOCATE discard_package_call;
+DROP FUNCTION discard_cache_consumer;
+DROP PACKAGE discard_cache_pkg;

--- a/src/pl/plisql/src/pl_package.c
+++ b/src/pl/plisql/src/pl_package.c
@@ -66,6 +66,8 @@ static void plisql_addfunction_references(PLiSQL_function *func,
 														PackageCacheItem *item);
 static void plisql_get_package_depends(PLiSQL_function *func,
 								List **funclist, List **itemlist);
+static void plisql_invalidate_dependent_function(PLiSQL_function *func);
+static PLiSQL_function *plisql_refresh_package_funcexpr(FuncExpr *funcexpr);
 
 static List *plisql_package_sort(List *pkglist);
 
@@ -452,7 +454,7 @@ plisql_free_package_function(PackageCacheItem *items)
 
 		/* remove function */
 		elog(DEBUG1, "realy free function %u", dfunc->fn_oid);
-		delete_function(dfunc);
+		plisql_invalidate_dependent_function(dfunc);
 	}
 
 	/* free packages */
@@ -555,7 +557,7 @@ plisql_free_packagelist(List *pkglist)
 		dfunc = (PLiSQL_function *) lfirst(lc);
 
 		elog(DEBUG1, "realy free function %u", dfunc->fn_oid);
-		delete_function(dfunc);
+		plisql_invalidate_dependent_function(dfunc);
 	}
 
 	/* second delete packages */
@@ -758,6 +760,20 @@ plisql_get_package_depends(PLiSQL_function *func, List **funclist,
 		*funclist = list_append_unique(*funclist, funcs);
 	}
 	return;
+}
+
+
+/*
+ * A package dependency can invalidate a function without changing its
+ * pg_proc tuple.  Invalidate the cached tuple identity before freeing the
+ * compiled tree so an existing FmgrInfo fn_extra pointer cannot treat the
+ * emptied function structure as a still-valid compiled function.
+ */
+static void
+plisql_invalidate_dependent_function(PLiSQL_function *func)
+{
+	func->fn_xmin = InvalidTransactionId;
+	delete_function(func);
 }
 
 
@@ -2337,6 +2353,7 @@ plisql_get_package_func(FunctionCallInfo fcinfo, bool forValidator)
 	funcexpr = (FuncExpr *) fcinfo->flinfo->fn_expr;
 
 	Assert(funcexpr->function_from == FUNC_FROM_PACKAGE);
+	pfunc = plisql_refresh_package_funcexpr(funcexpr);
 
 	if (!OidIsValid(funcexpr->pkgoid))
 		elog(ERROR, "funcexpr include invalid pkgoid");
@@ -2352,9 +2369,6 @@ plisql_get_package_func(FunctionCallInfo fcinfo, bool forValidator)
 		psource->status = PLISQL_PACKAGE_NO_INIT;
 		elog(ERROR, "existing state of packages has been discarded");
 	}
-	pfunc = &psource->source;
-
-	pfunc = (PLiSQL_function *) funcexpr->parent_func;
 	fno = (int) funcexpr->funcid;
 
 	if (pfunc == NULL)
@@ -2482,6 +2496,7 @@ plisql_remove_function_relations(PLiSQL_function *func)
 
 		plisql_remove_function_references(func, refcache);
 	}
+	func->pkgcachelist = NIL;
 
 	return;
 }
@@ -3496,6 +3511,44 @@ plisql_get_subprocs_from_package(Oid pkgoid,
 }
 
 /*
+ * Refresh a package function expression after its package cache entry has
+ * been discarded.  Cached plans can outlive the package memory context that
+ * parent_func originally referenced, so resolve the saved package/function
+ * identity against the current cache entry before dereferencing it.
+ */
+static PLiSQL_function *
+plisql_refresh_package_funcexpr(FuncExpr *funcexpr)
+{
+	PackageCacheItem *item;
+	PLiSQL_package *psource;
+
+	if (!FUNC_EXPR_FROM_PACKAGE(funcexpr->function_from))
+	{
+		if (funcexpr->parent_func == NULL)
+			elog(ERROR, "parent_func has not been set");
+		return (PLiSQL_function *) funcexpr->parent_func;
+	}
+	if (!OidIsValid(funcexpr->pkgoid))
+		elog(ERROR, "package FuncExpr has an invalid package OID");
+
+	item = PackageCacheLookup(&funcexpr->pkgoid);
+	if (item != NULL)
+	{
+		psource = (PLiSQL_package *) item->source;
+		if (funcexpr->parent_func == &psource->source)
+			return &psource->source;
+	}
+
+	funcexpr->parent_func = NULL;
+	set_pkginfo_from_funcexpr(funcexpr);
+	if (funcexpr->parent_func == NULL)
+		elog(ERROR, "package FuncExpr could not be refreshed");
+
+	return (PLiSQL_function *) funcexpr->parent_func;
+}
+
+
+/*
  * get subproc arginfo
  */
 int
@@ -3513,10 +3566,7 @@ plisql_get_subproc_arg_info (FuncExpr *fexpr,
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	if (fexpr->parent_func == NULL)
-		elog(ERROR, "parent_func has not been set");
-
-	function = (PLiSQL_function *) fexpr->parent_func;
+	function = plisql_refresh_package_funcexpr(fexpr);
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3574,10 +3624,7 @@ plisql_get_subproc_prokind (FuncExpr *fexpr)
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	if (fexpr->parent_func == NULL)
-		elog(ERROR, "parent_func has not been set");
-
-	function = (PLiSQL_function *) fexpr->parent_func;
+	function = plisql_refresh_package_funcexpr(fexpr);
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3604,10 +3651,7 @@ plisql_subproc_should_change_return_type(FuncExpr *fexpr,
 	if (FUNC_EXPR_FROM_PG_PROC(fexpr->function_from))
 		elog(ERROR, "FuncExpr is not an internal function");
 
-	if (fexpr->parent_func == NULL)
-		elog(ERROR, "parent_func has not been set");
-
-	function = (PLiSQL_function *) fexpr->parent_func;
+	function = plisql_refresh_package_funcexpr(fexpr);
 
 	if (fexpr->funcid < 0 || fexpr->funcid >= function->nsubprocfuncs)
 		elog(ERROR, "invalid fno %d", fexpr->funcid);
@@ -3823,4 +3867,3 @@ release_package_func_usecount(FunctionCallInfo fcinfo)
 
 	return;
 }
-


### PR DESCRIPTION
## Summary

- invalidate cached PL/iSQL functions that depend on a discarded package
- refresh stale parent-function pointers from the package cache before reusing package subprogram metadata
- clear package cache dependency lists after unlinking them
- add focused regression coverage for cached standalone callers and prepared package calls across repeated `DISCARD PACKAGE` operations

This correctness fix was split from #1422 at the maintainer’s request so the crash fix can be reviewed independently from the performance optimization.

Fixes #1452

## Verification

- `make -C src/oracle_test/modules/test_package_reset oracle-check` — 5/5 tests passed
- ran the focused regression against the performance-only branch before applying this fix: the backend terminated with signal 11 on the first cached standalone call after `DISCARD PACKAGE`
- ran the same regression on this branch: it passes, including repeated discard and prepared-call coverage

## AI assistance disclosure

This contribution was prepared with OpenAI Codex using GPT-5. The agent assisted with source and test inspection, issue scoping, drafting code and tests, running verification, reproducing the pre-fix crash, and preparing the PR description. I directed the scope, reviewed the resulting changes against the source and test results, and remain responsible for the submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package-backed functions becoming invalid after repeated `DISCARD PACKAGE` operations.
  * Preserved correct execution of cached callers and prepared statements after package cache invalidation.
  * Improved reliability of package function refreshes and execution plans following cache resets.

* **Tests**
  * Added regression coverage for package function caching, prepared execution, and repeated package discards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->