### PR TITLE
Optimize ora_regexp_count: drop wasteful text_to_cstring + strlen

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -768,19 +768,16 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 	
 	if (PG_NARGS() == 4)
 	{
-		char	*str = text_to_cstring(s);
-		int 	 len = strlen(str);
-		int 	 i = 0;
-		if (len > 0) 
+		char   *str = VARDATA_ANY(s);
+		int     i;
+
+		for (i = 0; i < src_text_len; i++)
 		{
-			for (i = 0;i < len; i++)
-			{
-				if (str[i] == '\n')
-					num++;
-			}
-			if (str[len - 1] == '\n')
-				flag = true;
+			if (str[i] == '\n')
+				num++;
 		}
+		if (src_text_len > 0 && str[src_text_len - 1] == '\n')
+			flag = true;
 	}
 	/* Compile RE */
 	re = RE_compile_and_cache(p, flags.cflags, PG_GET_COLLATION());


### PR DESCRIPTION
### Optimization

The `ora_regexp_count` function had unnecessary full string copy and scanning when counting newline characters `\n`:

- **Old code**: `text_to_cstring(s)` (`palloc` + `memcpy` full copy) + `strlen(str)` (full scan)
- **New code**: Use `VARDATA_ANY(s)` to point to the original bytes directly + reuse the existing `src_text_len` (line 767)

Each call saves: 1 `palloc` + 1 `memcpy` + 1 full-string `strlen`.

### Behavioral difference

Only matters for the edge case where the string contains embedded `\0` — the old `strlen` truncates at `\0`, while the new code uses the real byte length, which is more accurate. Embedded `\0` in text type is extremely rare. Multi-byte safe: `\n` (0x0A) does not appear in UTF-8 continuation bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

#1455 

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved regular expression count handling for text containing newline characters.
  - Ensured newline occurrences are counted accurately across the full text, including when the text ends with a newline.
  - Removed issues caused by relying on string termination when processing text values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->