### PR TITLE
ci: validate and build documentation changes

### DIFF
--- a/.github/workflows/doc_check.yml
+++ b/.github/workflows/doc_check.yml
@@ -1,0 +1,56 @@
+name: doc_check
+
+on:
+  push:
+    branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
+    paths:
+      - 'doc/**'
+      - '.github/workflows/doc_check.yml'
+  pull_request:
+    branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
+    paths:
+      - 'doc/**'
+      - '.github/workflows/doc_check.yml'
+
+permissions:
+  contents: read
+
+# A new push to the same branch supersedes any run still in progress.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  doc_check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # The DocBook DTD and stylesheets must be present before configure runs:
+    # configure probes for xmllint and xsltproc and the documentation targets
+    # fail with "missing" if they were not found.
+    - name: dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential bison flex perl \
+              docbook-xml docbook-xsl libxml2-utils xsltproc
+
+    - name: configure
+      run: |
+        ./configure --without-icu --without-readline --without-zlib
+
+    # Validates the SGML against the DocBook DTD, resolving every entity and
+    # cross-reference, and rejects tabs and non-breaking spaces.
+    - name: check documentation
+      run: make -C doc/src/sgml check
+
+    - name: build html documentation
+      run: make -C doc/src/sgml html
+
+    - name: upload html documentation
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-doc
+        path: ${{ github.workspace }}/doc/src/sgml/html
+        retention-days: 7


### PR DESCRIPTION
### Related Issue

Closes #1436

### Motivation

The existing workflows compile the server but never touch `doc/`, so an invalid entity reference, a broken cross-reference or a stray tab in the SGML sources is only found when someone builds the manual by hand.

### Changes

New path-filtered workflow `.github/workflows/doc_check.yml`:

* triggers on pushes/PRs that touch `doc/**` or the workflow itself;
* installs the DocBook toolchain (`docbook-xml`, `docbook-xsl`, `libxml2-utils`, `xsltproc`) **before** `./configure`, because configure probes for `xmllint`/`xsltproc` and the documentation targets otherwise fall back to the Makefile `missing` stub;
* runs `make -C doc/src/sgml check` (DTD validation with entity and cross-reference resolution, plus the tab and non-breaking-space checks) and `make -C doc/src/sgml html`;
* uploads the rendered HTML as a 7-day artifact so documentation changes can be previewed from the run;
* uses `permissions: contents: read` and cancels superseded runs on the same branch.

### How Verified

Ran the exact command sequence on a clean Ubuntu 22.04 checkout of `master`:

* `./configure --without-icu --without-readline --without-zlib` succeeds and records `XMLLINT = /usr/bin/xmllint`, `XSLTPROC = /usr/bin/xsltproc` in `src/Makefile.global`;
* `make -C doc/src/sgml check` **fails** on `master` today:

```
./ref/alter_package.sgml:
./ref/create_package.sgml:	USING_NLS_COMP
./ref/create_package_body.sgml:
Tabs appear in SGML/XML files
make: *** [Makefile:266: check-tabs] Error 1
```

  and, past the tab check, `xmllint --valid` reports `failed to load external entity "ref/create_packagebody.sgml"` plus three `Element refentry content does not follow the DTD` errors for the package pages.

* With those four package pages fixed locally (i.e. what #1421 does), `make -C doc/src/sgml check` and `make -C doc/src/sgml html` both exit 0 and produce 1182 HTML files.

So the first run of this workflow is expected to be **red until #1421 lands** — that failure is the pre-existing breakage this workflow is meant to catch, not a defect in the workflow. Happy to rebase once #1421 is merged if you prefer a green first run.

---

Assisted-by: GitHub:Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added automated validation for documentation changes.
  * Documentation builds now produce downloadable HTML artifacts for review.
  * Checks run automatically for relevant updates to supported branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->