### PR TITLE
fix: add GUC_DISALLOW_IN_DB_ROLE_SETTING to ivorysql.enable_case_switch

### DIFF
--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1404,7 +1404,7 @@
 
 { name => 'ivorysql.enable_case_switch', type => 'bool', context => 'PGC_USERSET', group => 'CLIENT_CONN_STATEMENT',
   short_desc => 'whether enable case conversion feature in oracle compatible mode.',
-  flags => 'GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE',
+  flags => 'GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING',
   variable => 'enable_case_switch',
   boot_val => 'true',
 },

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -128,7 +128,7 @@ static struct config_bool Ivy_ConfigureNamesBool[] =
 		{"ivorysql.enable_case_switch", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("whether enable case conversion feature in oracle compatible mode."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_DB_ROLE_SETTING
 		},
 		&enable_case_switch,
 		true,


### PR DESCRIPTION
## 痛点

ivorysql.enable_case_switch 控制 Oracle 兼容模式下的标识符大小写转换行为。该参数已有 GUC_DISALLOW_IN_FILE 限制，但缺少 GUC_DISALLOW_IN_DB_ROLE_SETTING，导致可通过 ALTER DATABASE ... SET 或 ALTER ROLE ... SET 设置 per-database/per-role 覆盖值，影响共享同一数据库的其他会话的标识符解析。

Fixes #1449

## 已实现

- 在 ivy_guc.c 中为 ivorysql.enable_case_switch 添加 GUC_DISALLOW_IN_DB_ROLE_SETTING 标志
- 在 guc_parameters.dat 中同步添加该标志

## 验证

- 改动仅涉及 GUC 标志位，不影响运行时逻辑
- 与同文件中其他具有相同限制的参数保持一致
- 依赖 CI 编译验证

Signed-off-by: btlqql <2977859784@qq.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented `ivorysql.enable_case_switch` from being overridden via database role configuration. This ensures the setting is applied consistently and can’t be changed indirectly through role-level configuration, improving administrative control and reducing unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->