### PR TITLE
docs: document PGroonga UTF-8 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Furthermore, for more detailed installation instructions, please refer to the [I
 - [Rpm installation](https://docs.ivorysql.org/en/ivorysql-doc/v5.4/4.1#Rpm-installation)
 - [Source code installation](https://docs.ivorysql.org/en/ivorysql-doc/v5.4/4.1#Source-code-installation)
 
+## Third-party extension compatibility
+
+### PGroonga
+
+PGroonga relies on [Groonga's supported encodings](https://groonga.org/docs/reference/api/util_8h.html#c.grn_encoding), which do not include GB18030. A PGroonga index created in a GB18030-encoded database may therefore contain no tokens and return no matches. Create a UTF-8 database for workloads that use PGroonga:
+
+```sql
+CREATE DATABASE search_db
+  WITH ENCODING 'UTF8'
+       LC_COLLATE 'C'
+       LC_CTYPE 'C'
+       TEMPLATE template0;
+```
+
+Changing Groonga's runtime encoding or rebuilding the index does not change the database encoding. Existing data must be migrated or reloaded into a UTF-8 database before creating the PGroonga index.
+
 ## Development with Docker
 
 For a consistent development environment, we provide a Docker-based setup that includes all build dependencies.

--- a/README_CN.md
+++ b/README_CN.md
@@ -35,6 +35,22 @@ IvorySQL 项目采用 Apache 2.0 许可协议发布，并鼓励各种形式的�
 - [RPM 安装](https://docs.ivorysql.org/cn/ivorysql-doc/v5.4/4.1#rpm安装)
 - [源代码安装](https://docs.ivorysql.org/cn/ivorysql-doc/v5.4/4.1#源码安装)
 
+## 第三方扩展兼容性
+
+### PGroonga
+
+PGroonga 依赖 [Groonga 支持的字符编码](https://groonga.org/docs/reference/api/util_8h.html#c.grn_encoding)，其中不包含 GB18030。因此，在 GB18030 编码的数据库中创建 PGroonga 索引时，索引可能没有生成词元，并导致查询无法返回匹配结果。使用 PGroonga 的业务应创建 UTF-8 编码的数据库：
+
+```sql
+CREATE DATABASE search_db
+  WITH ENCODING 'UTF8'
+       LC_COLLATE 'C'
+       LC_CTYPE 'C'
+       TEMPLATE template0;
+```
+
+修改 Groonga 的运行时编码或重建索引不会改变数据库编码。已有数据需要迁移或重新导入 UTF-8 数据库，再创建 PGroonga 索引。
+
 ## 为IvorySQL做贡献
 有许多方式可以为 IvorySQL 做出贡献。您可以通过更新文档或提供文档翻译来贡献。如果您具备设计技能，还可以参与 IvorySQL 官网项目的建设。
 


### PR DESCRIPTION
## Summary

- document that Groonga does not support GB18030 and PGroonga indexes may consequently be empty in GB18030 databases
- add matching English and Chinese compatibility guidance
- provide a UTF-8 database creation example and migration guidance for existing data

## Root cause

PGroonga uses Groonga for tokenization and indexing. GB18030 is not one of Groonga's supported encodings, and changing Groonga's runtime setting or rebuilding an index cannot change the PostgreSQL database encoding.

## Testing

- `git diff --check`
- verified the English and Chinese examples stay in sync

Fixes #1347


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese guidance on PGroonga compatibility with GB18030 databases.
  * Documented how to create a UTF-8 database for PGroonga and explained that existing data must be migrated or reloaded before creating indexes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->