### PR TITLE
tools: add pg_show_plans integration

### DIFF
--- a/.github/workflows/ecosystem_pg_show_plans.yml
+++ b/.github/workflows/ecosystem_pg_show_plans.yml
@@ -1,0 +1,47 @@
+name: pg_show_plans ecosystem
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ecosystem_pg_show_plans.yml"
+      - "tools/ecosystem/pg_show_plans/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/ecosystem_pg_show_plans.yml"
+      - "tools/ecosystem/pg_show_plans/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pg-show-plans-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build integration image
+        working-directory: tools/ecosystem/pg_show_plans
+        run: make build
+
+      - name: Verify active plan visibility
+        working-directory: tools/ecosystem/pg_show_plans
+        run: make verify
+
+      - name: Show container logs
+        if: failure()
+        working-directory: tools/ecosystem/pg_show_plans
+        run: make logs
+
+      - name: Stop integration
+        if: always()
+        working-directory: tools/ecosystem/pg_show_plans
+        run: make down

--- a/tools/ecosystem/pg_show_plans/Dockerfile
+++ b/tools/ecosystem/pg_show_plans/Dockerfile
@@ -1,0 +1,86 @@
+FROM ubuntu:24.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG IVORYSQL_REF=IvorySQL_5.4
+ARG IVORYSQL_COMMIT=a45b0457520007970848fc33198d876807b98f55
+ARG PG_SHOW_PLANS_REF=v2.1.8
+ARG PG_SHOW_PLANS_COMMIT=92ecb21f8f2307a4bc7db8f01623599e75930fc2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bison \
+        build-essential \
+        ca-certificates \
+        flex \
+        git \
+        libxml2-dev \
+        uuid-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+RUN git clone --depth 1 --branch "${IVORYSQL_REF}" \
+        https://github.com/IvorySQL/IvorySQL.git ivorysql \
+    && test "$(git -C ivorysql rev-parse HEAD)" = "${IVORYSQL_COMMIT}"
+
+WORKDIR /build/ivorysql
+
+RUN ./configure \
+        --prefix=/opt/ivorysql \
+        --without-icu \
+        --without-readline \
+        --with-libxml \
+        --with-uuid=e2fs \
+    && make -C src -j"$(nproc)" \
+    && make -C src install \
+    && make -C contrib/gb18030_2022 -j"$(nproc)" \
+    && make -C contrib/gb18030_2022 install \
+    && make -C contrib/ivorysql_ora -j"$(nproc)" \
+    && make -C contrib/ivorysql_ora install
+
+WORKDIR /build
+
+RUN git clone --depth 1 --branch "${PG_SHOW_PLANS_REF}" \
+        https://github.com/cybertec-postgresql/pg_show_plans.git pg_show_plans \
+    && test "$(git -C pg_show_plans rev-parse HEAD)" = "${PG_SHOW_PLANS_COMMIT}" \
+    && make -C pg_show_plans \
+        PG_CONFIG=/opt/ivorysql/bin/pg_config \
+        -j"$(nproc)" \
+    && make -C pg_show_plans \
+        PG_CONFIG=/opt/ivorysql/bin/pg_config \
+        install
+
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libxml2 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/ivorysql /opt/ivorysql
+COPY entrypoint.sh /usr/local/bin/ivorysql-entrypoint
+COPY verify.sh /usr/local/bin/verify-pg-show-plans
+
+RUN useradd --create-home --uid 1000 ivorysql \
+    && mkdir -p /var/lib/ivorysql/data \
+    && chown -R ivorysql:ivorysql /var/lib/ivorysql \
+    && chmod 0755 \
+        /usr/local/bin/ivorysql-entrypoint \
+        /usr/local/bin/verify-pg-show-plans
+
+ENV PATH=/opt/ivorysql/bin:${PATH}
+ENV PGDATA=/var/lib/ivorysql/data
+
+USER ivorysql
+EXPOSE 5432
+
+HEALTHCHECK --interval=2s --timeout=3s --start-period=10s --retries=30 \
+    CMD pg_isready -d postgres || exit 1
+
+ENTRYPOINT ["/usr/local/bin/ivorysql-entrypoint"]

--- a/tools/ecosystem/pg_show_plans/Dockerfile
+++ b/tools/ecosystem/pg_show_plans/Dockerfile
@@ -67,7 +67,7 @@ COPY --from=builder /opt/ivorysql /opt/ivorysql
 COPY entrypoint.sh /usr/local/bin/ivorysql-entrypoint
 COPY verify.sh /usr/local/bin/verify-pg-show-plans
 
-RUN useradd --create-home --uid 1000 ivorysql \
+RUN useradd --create-home --user-group ivorysql \
     && mkdir -p /var/lib/ivorysql/data \
     && chown -R ivorysql:ivorysql /var/lib/ivorysql \
     && chmod 0755 \

--- a/tools/ecosystem/pg_show_plans/Makefile
+++ b/tools/ecosystem/pg_show_plans/Makefile
@@ -1,0 +1,18 @@
+COMPOSE = docker compose
+
+.PHONY: build down logs up verify
+
+build:
+	$(COMPOSE) build
+
+up:
+	$(COMPOSE) up --detach --wait
+
+verify: up
+	$(COMPOSE) exec --no-TTY database verify-pg-show-plans
+
+logs:
+	$(COMPOSE) logs
+
+down:
+	$(COMPOSE) down --volumes --remove-orphans

--- a/tools/ecosystem/pg_show_plans/README.md
+++ b/tools/ecosystem/pg_show_plans/README.md
@@ -1,0 +1,46 @@
+# IvorySQL with pg_show_plans
+
+This integration verifies that
+[pg_show_plans](https://github.com/cybertec-postgresql/pg_show_plans)
+can display the execution plan of a query that is currently running on
+IvorySQL.
+
+The image pins both upstream revisions:
+
+- IvorySQL 5.4:
+  `a45b0457520007970848fc33198d876807b98f55`
+- pg_show_plans 2.1.8:
+  `92ecb21f8f2307a4bc7db8f01623599e75930fc2`
+
+## Run the integration
+
+Docker with the Compose plugin is required.
+
+```sh
+cd tools/ecosystem/pg_show_plans
+make build
+make verify
+make down
+```
+
+`make verify` starts an IvorySQL 5.4 cluster with `pg_show_plans` in
+`shared_preload_libraries`, creates the extension, and starts a query that
+sleeps inside a `generate_series` scan. A second connection must observe the
+active query and its `Function Scan on generate_series` plan through
+`pg_show_plans_q`.
+
+The check also verifies the IvorySQL server and extension versions. The image
+build rejects either source checkout unless it matches the pinned commit.
+
+## Operational notes
+
+`pg_show_plans` stores plans in a fixed-size shared-memory hash table and
+requires a server restart when it is added to `shared_preload_libraries`.
+The extension documentation reports a measurable overhead under read-heavy
+benchmarks, so enable it deliberately and size
+`pg_show_plans.max_plan_length` for the workload.
+
+IvorySQL `master` currently follows PostgreSQL 19 development, whose
+`ShmemInitHash` API is not supported by pg_show_plans 2.1.8. This integration
+therefore targets the released IvorySQL 5.4 / PostgreSQL 18.4 combination
+rather than carrying a downstream patch for the third-party extension.

--- a/tools/ecosystem/pg_show_plans/compose.yaml
+++ b/tools/ecosystem/pg_show_plans/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  database:
+    build:
+      context: .
+      args:
+        IVORYSQL_COMMIT: a45b0457520007970848fc33198d876807b98f55
+        IVORYSQL_REF: IvorySQL_5.4
+        PG_SHOW_PLANS_COMMIT: 92ecb21f8f2307a4bc7db8f01623599e75930fc2
+        PG_SHOW_PLANS_REF: v2.1.8
+    environment:
+      PGDATA: /var/lib/ivorysql/data
+    ports:
+      - "55432:5432"

--- a/tools/ecosystem/pg_show_plans/entrypoint.sh
+++ b/tools/ecosystem/pg_show_plans/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ ! -s "${PGDATA}/PG_VERSION" ]]; then
+    initdb \
+        --auth-host=trust \
+        --auth-local=trust \
+        --no-instructions \
+        -C normal \
+        -D "${PGDATA}" \
+        -m pg
+fi
+
+exec postgres \
+    -D "${PGDATA}" \
+    -c listen_addresses='*' \
+    -c shared_preload_libraries=pg_show_plans

--- a/tools/ecosystem/pg_show_plans/verify.sh
+++ b/tools/ecosystem/pg_show_plans/verify.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly database=pg_show_plans_test
+
+dropdb --if-exists --force "${database}"
+createdb "${database}"
+psql -X -v ON_ERROR_STOP=1 -d "${database}" \
+    -c 'CREATE EXTENSION pg_show_plans;'
+
+psql -X -v ON_ERROR_STOP=1 -d "${database}" \
+    -c 'SELECT pg_sleep(8) FROM generate_series(1, 1);' \
+    >/tmp/pg-show-plans-workload.log 2>&1 &
+workload_pid=$!
+
+cleanup()
+{
+    kill "${workload_pid}" 2>/dev/null || true
+    wait "${workload_pid}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+observed=false
+for _ in $(seq 1 20); do
+    snapshot=$(
+        psql -X -A -t -v ON_ERROR_STOP=1 -d "${database}" -c "
+            SELECT pid, level, plan, query
+            FROM pg_show_plans_q
+            WHERE query LIKE
+                'SELECT pg_sleep(8) FROM generate_series(1, 1)%';
+        "
+    )
+
+    if grep -Fq 'Function Scan on generate_series' <<<"${snapshot}"; then
+        observed=true
+        break
+    fi
+
+    sleep 0.5
+done
+
+wait "${workload_pid}"
+trap - EXIT
+
+if [[ "${observed}" != true ]]; then
+    echo "pg_show_plans did not expose the active workload plan" >&2
+    exit 1
+fi
+
+extension_version=$(
+    psql -X -A -t -v ON_ERROR_STOP=1 -d "${database}" -c "
+        SELECT extversion
+        FROM pg_extension
+        WHERE extname = 'pg_show_plans';
+    "
+)
+server_version_num=$(
+    psql -X -A -t -v ON_ERROR_STOP=1 -d "${database}" \
+        -c 'SHOW server_version_num;'
+)
+
+[[ "${extension_version}" == 2.1 ]]
+[[ "${server_version_num}" == 180004 ]]
+
+printf 'verified IvorySQL %s with pg_show_plans %s\n' \
+    "${server_version_num}" \
+    "${extension_version}"


### PR DESCRIPTION
## Summary

- build pinned IvorySQL 5.4 and pg_show_plans 2.1.8 revisions in a reproducible multi-stage image
- start IvorySQL with pg_show_plans preloaded and verify a concurrently running query plan through pg_show_plans_q
- add Compose and Make targets, operational notes, and a path-scoped GitHub Actions workflow

## Compatibility

pg_show_plans 2.1.8 does not compile against the PostgreSQL 19 development API currently used by IvorySQL master because ShmemInitHash changed. This integration therefore validates the released IvorySQL 5.4 / PostgreSQL 18.4 combination without carrying a downstream third-party patch.

## Validation

- built IvorySQL 5.4 at a45b0457520007970848fc33198d876807b98f55 and pg_show_plans 2.1.8 at 92ecb21f8f2307a4bc7db8f01623599e75930fc2 from source
- started a real IvorySQL 18.4 instance with shared_preload_libraries=pg_show_plans
- created the extension and observed Function Scan on generate_series from a second session
- ran verify.sh successfully: verified IvorySQL 180004 with pg_show_plans 2.1
- validated both shell scripts with bash -n and parsed the Compose and workflow YAML files

## AI assistance disclosure

OpenAI Codex assisted with preparing this contribution. I directed the scope, reviewed the implementation against upstream source and live test results, and remain responsible for the submission.

Closes #1308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a containerized IvorySQL ecosystem integration to validate `pg_show_plans`.
  * Introduced an automated verification run that checks captured plans from an active workload.
  * Added a health-checked PostgreSQL setup with required startup configuration and version validation.
* **Documentation**
  * Added README with build/verify/cleanup commands and operational notes.
* **Tests**
  * Added a GitHub Actions workflow to run the integration build and verification on relevant changes, including log capture on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->