### PR TITLE
dbms_utility: fix backtrace/call-stack qualification for package members

### DIFF
--- a/contrib/ivorysql_ora/expected/dbms_utility.out
+++ b/contrib/ivorysql_ora/expected/dbms_utility.out
@@ -1,6 +1,9 @@
 --
 -- Tests for DBMS_UTILITY package
 --
+-- Backtrace/call-stack frames are qualified per ivorysql.identifier_case_switch
+SET ivorysql.enable_case_switch = true;
+SET ivorysql.identifier_case_switch = interchange;
 -- Test 1: FORMAT_ERROR_BACKTRACE - Basic exception in procedure
 CREATE OR REPLACE PROCEDURE test_basic_error AS
   v_backtrace VARCHAR2(4000);
@@ -196,8 +199,8 @@ CREATE OR REPLACE PACKAGE BODY test_pkg IS
 END test_pkg;
 /
 CALL test_pkg.pkg_caller();
-INFO:  Package backtrace: ORA-06512: at "PUBLIC.PKG_ERROR", line 3
-ORA-06512: at "PUBLIC.PKG_CALLER", line 8
+INFO:  Package backtrace: ORA-06512: at "PUBLIC.TEST_PKG.PKG_ERROR", line 3
+ORA-06512: at "PUBLIC.TEST_PKG.PKG_CALLER", line 8
 
 DROP PACKAGE test_pkg;
 -- Test 9: FORMAT_ERROR_BACKTRACE - Schema-qualified calls
@@ -218,8 +221,8 @@ EXCEPTION
 END;
 /
 CALL test_schema.schema_caller();
-INFO:  Schema-qualified backtrace: ORA-06512: at "PUBLIC.TEST_SCHEMA.SCHEMA_ERROR", line 2
-ORA-06512: at "PUBLIC.TEST_SCHEMA.SCHEMA_CALLER", line 3
+INFO:  Schema-qualified backtrace: ORA-06512: at "TEST_SCHEMA.SCHEMA_ERROR", line 2
+ORA-06512: at "TEST_SCHEMA.SCHEMA_CALLER", line 3
 
 DROP SCHEMA test_schema CASCADE;
 NOTICE:  drop cascades to 2 other objects
@@ -414,3 +417,62 @@ CALL test_all_functions_outer();
 INFO:  All three DBMS_UTILITY functions: OK
 DROP PROCEDURE test_all_functions_outer;
 DROP PROCEDURE test_all_functions_inner;
+-- Test 18: FORMAT_CALL_STACK - Package procedure. The frame for a package
+-- member must carry the exact owning-schema/package/routine triple.  The
+-- package lives in a dedicated non-public schema so the assertion can pin
+-- the schema name; a wildcard-only prefix would let a wrong or missing
+-- schema qualifier pass silently.
+CREATE SCHEMA callstack_ns;
+CREATE OR REPLACE PACKAGE callstack_ns.test_call_stack_pkg IS
+  PROCEDURE stack_caller;
+END test_call_stack_pkg;
+/
+CREATE OR REPLACE PACKAGE BODY callstack_ns.test_call_stack_pkg IS
+  PROCEDURE stack_caller IS
+    v_stack VARCHAR2(4000);
+  BEGIN
+    v_stack := DBMS_UTILITY.FORMAT_CALL_STACK;
+    IF v_stack LIKE '%CALLSTACK_NS.TEST_CALL_STACK_PKG.STACK_CALLER%'
+       AND v_stack NOT LIKE '%PUBLIC.CALLSTACK_NS%' THEN
+      RAISE INFO 'Call stack is package-qualified: OK';
+    ELSE
+      RAISE INFO 'Call stack is package-qualified: FAILED (got: %)', v_stack;
+    END IF;
+  END stack_caller;
+END test_call_stack_pkg;
+/
+CALL callstack_ns.test_call_stack_pkg.stack_caller();
+INFO:  Call stack is package-qualified: OK
+DROP PACKAGE callstack_ns.test_call_stack_pkg;
+DROP SCHEMA callstack_ns;
+-- Test 19: FORMAT_ERROR_BACKTRACE - Schema-qualified routine must not acquire a
+-- spurious PUBLIC prefix.  Regression: before fix, schema_error() appeared as
+-- PUBLIC.SCHEMA_ERROR instead of BUG_SCHEMA.SCHEMA_ERROR.
+CREATE SCHEMA bug_schema;
+CREATE OR REPLACE PROCEDURE bug_schema.schema_error IS
+BEGIN
+  RAISE EXCEPTION 'boom';
+END;
+/
+CREATE OR REPLACE PROCEDURE bug_schema.schema_caller IS
+  v_backtrace VARCHAR2(4000);
+BEGIN
+  bug_schema.schema_error();
+EXCEPTION
+  WHEN OTHERS THEN
+    v_backtrace := DBMS_UTILITY.FORMAT_ERROR_BACKTRACE;
+    IF v_backtrace LIKE '%ORA-06512: at "BUG_SCHEMA.SCHEMA_ERROR"%' THEN
+      RAISE INFO 'Backtrace has correct schema qualifier: OK';
+    ELSE
+      RAISE INFO 'Backtrace has correct schema qualifier: FAILED (got: %)', v_backtrace;
+    END IF;
+END;
+/
+CALL bug_schema.schema_caller();
+INFO:  Backtrace has correct schema qualifier: OK
+DROP SCHEMA bug_schema CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function bug_schema.schema_error()
+drop cascades to function bug_schema.schema_caller()
+RESET ivorysql.identifier_case_switch;
+RESET ivorysql.enable_case_switch;

--- a/contrib/ivorysql_ora/expected/utl_encode.out
+++ b/contrib/ivorysql_ora/expected/utl_encode.out
@@ -104,7 +104,7 @@ SELECT rawtohex(utl_encode.base64_decode(hextoraw('0A0D200A'))) IS NULL;
 -- hextoraw('5A5A5A21') = 'ZZZ!' where '!' is not a valid base64 character
 SELECT utl_encode.base64_decode(hextoraw('5A5A5A21'));
 ERROR:  UTL_ENCODE.BASE64_DECODE: invalid base64 input
-CONTEXT:  PL/iSQL function base64_decode line 8 at RETURN
+CONTEXT:  PL/iSQL function sys.utl_encode.base64_decode line 8 at RETURN
 -- PL/iSQL package interface test for decode
 DECLARE
     v_src     RAW(100) := hextoraw('48656C6C6F');

--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -15,7 +15,7 @@ end;
 ERROR:  INVALID_PATH
 DETAIL:  File location is invalid.
 HINT:  locality is not found in sys.utl_file_directory table
-CONTEXT:  PL/iSQL function fopen line 56 at assignment
+CONTEXT:  PL/iSQL function sys.utl_file.fopen line 56 at assignment
 PL/iSQL function inline_code_block line 5 at assignment
 -- test fopen, put, putf, put_line, new_line, get_line, is_open, fclose, fclose_all
 declare

--- a/contrib/ivorysql_ora/sql/dbms_utility.sql
+++ b/contrib/ivorysql_ora/sql/dbms_utility.sql
@@ -2,6 +2,10 @@
 -- Tests for DBMS_UTILITY package
 --
 
+-- Backtrace/call-stack frames are qualified per ivorysql.identifier_case_switch
+SET ivorysql.enable_case_switch = true;
+SET ivorysql.identifier_case_switch = interchange;
+
 -- Test 1: FORMAT_ERROR_BACKTRACE - Basic exception in procedure
 CREATE OR REPLACE PROCEDURE test_basic_error AS
   v_backtrace VARCHAR2(4000);
@@ -439,3 +443,67 @@ CALL test_all_functions_outer();
 
 DROP PROCEDURE test_all_functions_outer;
 DROP PROCEDURE test_all_functions_inner;
+
+-- Test 18: FORMAT_CALL_STACK - Package procedure. The frame for a package
+-- member must carry the exact owning-schema/package/routine triple.  The
+-- package lives in a dedicated non-public schema so the assertion can pin
+-- the schema name; a wildcard-only prefix would let a wrong or missing
+-- schema qualifier pass silently.
+CREATE SCHEMA callstack_ns;
+
+CREATE OR REPLACE PACKAGE callstack_ns.test_call_stack_pkg IS
+  PROCEDURE stack_caller;
+END test_call_stack_pkg;
+/
+
+CREATE OR REPLACE PACKAGE BODY callstack_ns.test_call_stack_pkg IS
+  PROCEDURE stack_caller IS
+    v_stack VARCHAR2(4000);
+  BEGIN
+    v_stack := DBMS_UTILITY.FORMAT_CALL_STACK;
+    IF v_stack LIKE '%CALLSTACK_NS.TEST_CALL_STACK_PKG.STACK_CALLER%'
+       AND v_stack NOT LIKE '%PUBLIC.CALLSTACK_NS%' THEN
+      RAISE INFO 'Call stack is package-qualified: OK';
+    ELSE
+      RAISE INFO 'Call stack is package-qualified: FAILED (got: %)', v_stack;
+    END IF;
+  END stack_caller;
+END test_call_stack_pkg;
+/
+
+CALL callstack_ns.test_call_stack_pkg.stack_caller();
+
+DROP PACKAGE callstack_ns.test_call_stack_pkg;
+DROP SCHEMA callstack_ns;
+
+-- Test 19: FORMAT_ERROR_BACKTRACE - Schema-qualified routine must not acquire a
+-- spurious PUBLIC prefix.  Regression: before fix, schema_error() appeared as
+-- PUBLIC.SCHEMA_ERROR instead of BUG_SCHEMA.SCHEMA_ERROR.
+CREATE SCHEMA bug_schema;
+
+CREATE OR REPLACE PROCEDURE bug_schema.schema_error IS
+BEGIN
+  RAISE EXCEPTION 'boom';
+END;
+/
+
+CREATE OR REPLACE PROCEDURE bug_schema.schema_caller IS
+  v_backtrace VARCHAR2(4000);
+BEGIN
+  bug_schema.schema_error();
+EXCEPTION
+  WHEN OTHERS THEN
+    v_backtrace := DBMS_UTILITY.FORMAT_ERROR_BACKTRACE;
+    IF v_backtrace LIKE '%ORA-06512: at "BUG_SCHEMA.SCHEMA_ERROR"%' THEN
+      RAISE INFO 'Backtrace has correct schema qualifier: OK';
+    ELSE
+      RAISE INFO 'Backtrace has correct schema qualifier: FAILED (got: %)', v_backtrace;
+    END IF;
+END;
+/
+
+CALL bug_schema.schema_caller();
+DROP SCHEMA bug_schema CASCADE;
+
+RESET ivorysql.identifier_case_switch;
+RESET ivorysql.enable_case_switch;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
@@ -30,7 +30,10 @@
 #include "fmgr.h"
 #include "utils/builtins.h"
 #include "utils/errcodes.h"
-#include "mb/pg_wchar.h"
+#include "utils/guc.h"
+#include "utils/ora_compatible.h"
+#include "parser/scansup.h"
+#include "port.h"
 
 #ifndef WIN32
 #include <dlfcn.h>
@@ -99,6 +102,40 @@ lookup_plisql_functions(void)
 }
 
 /*
+ * Return a copy of ident cased to match ivorysql.identifier_case_switch,
+ * mirroring the rules applied to double-quoted identifiers at every other
+ * identifier_case_switch call site in the tree (ora_scan.l, varlena.c,
+ * ri_triggers.c, backend_startup.c):
+ *
+ *   LOWERCASE:   an all-uppercase ident is downcased; anything else
+ *                (already lowercase, or mixed case) is left unchanged.
+ *   INTERCHANGE: an all-uppercase ident is downcased and an all-lowercase
+ *                ident is upcased (the two cases are "interchanged");
+ *                mixed-case idents are left unchanged.
+ *   NORMAL, or ivorysql.enable_case_switch off: unchanged (standard
+ *   PostgreSQL rules already give ident its real stored case there).
+ */
+static char *
+apply_identifier_case_switch(const char *ident)
+{
+	size_t		len = strlen(ident);
+
+	if (!enable_case_switch)
+		return pstrdup(ident);
+
+	if (identifier_case_switch == LOWERCASE)
+	{
+		if (is_all_upper(ident, len))
+			return downcase_identifier(ident, len, false, false);
+		return pstrdup(ident);
+	}
+	else if (identifier_case_switch == INTERCHANGE)
+		return identifier_case_transform(ident, len);
+
+	return pstrdup(ident);
+}
+
+/*
  * Transform a single line from PostgreSQL error context format to Oracle format.
  *
  * PostgreSQL format examples:
@@ -124,9 +161,8 @@ transform_and_append_line(StringInfo result, const char *line)
 	int line_num;
 	char *func_name;
 	char *schema_name;
-	char *func_upper;
-	char *schema_upper;
-	int i;
+	char *func_cased;
+	char *schema_cased;
 
 	/* Skip SQL statement lines */
 	if (strncmp(line, "SQL statement", 13) == 0)
@@ -187,28 +223,45 @@ transform_and_append_line(StringInfo result, const char *line)
 	line_num_start = line_marker + 6; /* Skip " line " */
 	line_num = atoi(line_num_start);
 
-	/* For now, just use PUBLIC as the default schema */
-	/* TODO: Look up the actual schema from pg_proc catalog */
-	schema_name = pstrdup("PUBLIC");
+	func_cased = apply_identifier_case_switch(func_name);
 
-	/* Convert function name to uppercase for Oracle compatibility */
-	/* Use simple ASCII uppercase conversion */
-	func_upper = pstrdup(func_name);
-	for (i = 0; func_upper[i]; i++)
-		func_upper[i] = pg_toupper((unsigned char) func_upper[i]);
+	if (strchr(func_name, '.') != NULL)
+	{
+		/*
+		 * Already schema- (or schema.package-) qualified: either a
+		 * top-level routine called with an explicit schema, or a package
+		 * member (whose context line is schema.package.routine -- see
+		 * plisql_package_qualified_signature() in pl_exec.c). Use as-is;
+		 * prepending another schema below would double it up.
+		 */
+		appendStringInfo(result, "ORA-06512: at \"%s\", line %d\n",
+						 func_cased, line_num);
+	}
+	else
+	{
+		/*
+		 * Unqualified: the routine was visible via search_path, so we
+		 * don't actually know its owning schema here.
+		 * TODO: look up the real schema from pg_proc instead of assuming
+		 * public.
+		 *
+		 * Use the real (lowercase) catalog spelling here, not "PUBLIC" --
+		 * apply_identifier_case_switch() expects its input already in
+		 * genuine stored-identifier case, same as func_name above.
+		 */
+		schema_name = pstrdup("public");
+		schema_cased = apply_identifier_case_switch(schema_name);
 
-	schema_upper = pstrdup(schema_name);
-	for (i = 0; schema_upper[i]; i++)
-		schema_upper[i] = pg_toupper((unsigned char) schema_upper[i]);
+		/* Format: ORA-06512: at "SCHEMA.FUNCTION", line N */
+		appendStringInfo(result, "ORA-06512: at \"%s.%s\", line %d\n",
+						 schema_cased, func_cased, line_num);
 
-	/* Format: ORA-06512: at "SCHEMA.FUNCTION", line N */
-	appendStringInfo(result, "ORA-06512: at \"%s.%s\", line %d\n",
-					 schema_upper, func_upper, line_num);
+		pfree(schema_cased);
+		pfree(schema_name);
+	}
 
 	pfree(func_name);
-	pfree(func_upper);
-	pfree(schema_upper);
-	pfree(schema_name);
+	pfree(func_cased);
 
 	return true;
 }
@@ -403,8 +456,7 @@ ora_format_call_stack(PG_FUNCTION_ARGS)
 		char *signature;
 		char *tab1;
 		char *tab2;
-		char *func_upper;
-		int i;
+		char *func_cased;
 
 		frame_count++;
 
@@ -435,19 +487,16 @@ ora_format_call_stack(PG_FUNCTION_ARGS)
 		lineno_str = pnstrdup(tab1 + 1, tab2 - tab1 - 1);
 		signature = tab2 + 1;
 
-		/* Convert function name to uppercase for Oracle compatibility */
-		func_upper = pstrdup(signature);
-		for (i = 0; func_upper[i]; i++)
-			func_upper[i] = pg_toupper((unsigned char) func_upper[i]);
+		func_cased = apply_identifier_case_switch(signature);
 
 		/* Format each stack frame */
 		appendStringInfo(&result, "%s  %5s  function %s\n",
-						 handle_str, lineno_str, func_upper);
+						 handle_str, lineno_str, func_cased);
 		found_any = true;
 
 		pfree(handle_str);
 		pfree(lineno_str);
-		pfree(func_upper);
+		pfree(func_cased);
 
 		line = strtok_r(NULL, "\n", &saveptr);
 	}

--- a/src/oracle_test/regress/expected/ora_package.out
+++ b/src/oracle_test/regress/expected/ora_package.out
@@ -4818,7 +4818,7 @@ LINE 1: x + 1
 DETAIL:  No operator of that name accepts the given argument types.
 HINT:  You might need to add explicit type casts.
 QUERY:  x + 1
-CONTEXT:  PL/iSQL function f1 line 3 at RETURN
+CONTEXT:  PL/iSQL function public.test_pkg.f1 line 3 at RETURN
 PL/iSQL function inline_code_block line 5 at assignment
 begin
    test_pkg.var1 := test_pkg.f1(42);

--- a/src/pl/plisql/src/expected/plisql_type_rowtype.out
+++ b/src/pl/plisql/src/expected/plisql_type_rowtype.out
@@ -1672,7 +1672,7 @@ ERROR:  invalid input syntax for type integer: "abc"
 LINE 1: var1.phone_number := 'abc'
                              ^
 QUERY:  var1.phone_number := 'abc'
-CONTEXT:  PL/iSQL function pfun line 4 at assignment
+CONTEXT:  PL/iSQL function public.pkg1.pfun line 4 at assignment
 PL/iSQL function inline_code_block line 5 at RAISE
 DROP PROCEDURE p1(v tmpe%ROWTYPE);
 DROP FUNCTION f1(v int);
@@ -1793,7 +1793,7 @@ END;
 /
 ERROR:  record "r" has no field "phone_number"
 CONTEXT:  PL/iSQL assignment "r.phone_number :=  'abc'"
-PL/iSQL function pfun line 4 at assignment
+PL/iSQL function public.pkg1.pfun line 4 at assignment
 PL/iSQL function inline_code_block line 5 at RAISE
 DROP PROCEDURE p1(v tmpe%ROWTYPE);
 DROP FUNCTION f1(v int);
@@ -1916,7 +1916,7 @@ END;
 /
 ERROR:  record "r" has no field "phone_number"
 CONTEXT:  PL/iSQL assignment "r.phone_number :=  'abc'"
-PL/iSQL function pfun line 4 at assignment
+PL/iSQL function public.pkg1.pfun line 4 at assignment
 PL/iSQL function inline_code_block line 5 at RAISE
 DROP PROCEDURE p1(v tmpe%ROWTYPE);
 DROP FUNCTION f1(v int);

--- a/src/pl/plisql/src/pl_exec.c
+++ b/src/pl/plisql/src/pl_exec.c
@@ -24,6 +24,7 @@
 #include "access/htup_details.h"
 #include "access/transam.h"
 #include "access/tupconvert.h"
+#include "catalog/pg_package.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
@@ -1415,6 +1416,56 @@ plisql_exec_event_trigger(PLiSQL_function * func, EventTriggerData *trigdata)
 }
 
 /*
+ * If func is a package member, return its package-qualified name (e.g.
+ * "schema"."package".funcname) for use in error context messages; otherwise
+ * return NULL.
+ *
+ * A package member's fn_signature is only ever the bare routine name (see
+ * quote_qualified_identifier(NULL, funcname) in
+ * plisql_build_subproc_function_internal()), because nothing else about the
+ * package is known at parse time of that string. But the compiler already
+ * resolved and attached the owning package's PackageCacheItem to the
+ * function (func->item, set in pl_subproc_function.c), so we can look the
+ * package up by oid here instead of ever needing to search package body
+ * source text for a matching declaration. Callers that walk
+ * PG_EXCEPTION_CONTEXT (e.g. contrib/pg_owa_util's who_called_me) benefit
+ * directly: the package identity is now in the text they already parse.
+ */
+static char *
+plisql_package_qualified_signature(PLiSQL_function *func)
+{
+	HeapTuple	pkgTup;
+	Form_pg_package pkgStruct;
+	char	   *nspname;
+	char	   *pkgqual;
+	char	   *result;
+
+	if (func->item == NULL)
+		return NULL;
+
+	pkgTup = SearchSysCache1(PKGOID, ObjectIdGetDatum(func->item->pkey));
+	if (!HeapTupleIsValid(pkgTup))
+		return NULL;			/* package concurrently dropped; fall back */
+
+	pkgStruct = (Form_pg_package) GETSTRUCT(pkgTup);
+	nspname = get_namespace_name(pkgStruct->pkgnamespace);
+	if (nspname == NULL)
+	{
+		ReleaseSysCache(pkgTup);
+		return NULL;			/* namespace concurrently dropped */
+	}
+
+	pkgqual = quote_qualified_identifier(nspname, NameStr(pkgStruct->pkgname));
+	ReleaseSysCache(pkgTup);
+	pfree(nspname);
+
+	result = psprintf("%s.%s", pkgqual, func->fn_signature);
+	pfree(pkgqual);
+
+	return result;
+}
+
+/*
  * error context callback to let us supply a call-stack traceback
  */
 static void
@@ -1422,6 +1473,8 @@ plisql_exec_error_callback(void *arg)
 {
 	PLiSQL_execstate *estate = (PLiSQL_execstate *) arg;
 	int			err_lineno;
+	char	   *funcname;
+	char	   *qualified_funcname;
 
 	/*
 	 * If err_var is set, report the variable's declaration line number.
@@ -1435,6 +1488,14 @@ plisql_exec_error_callback(void *arg)
 		err_lineno = estate->err_stmt->lineno;
 	else
 		err_lineno = 0;
+
+	/*
+	 * qualified_funcname, when non-NULL, is a fresh palloc'd string we own
+	 * and must free below; the fn_signature fallback is borrowed from the
+	 * long-lived function cache and must never be freed.
+	 */
+	qualified_funcname = plisql_package_qualified_signature(estate->func);
+	funcname = qualified_funcname != NULL ? qualified_funcname : estate->func->fn_signature;
 
 	if (estate->err_text != NULL)
 	{
@@ -1456,7 +1517,7 @@ plisql_exec_error_callback(void *arg)
 			 * local variable initialization"
 			 */
 			errcontext("PL/iSQL function %s line %d %s",
-					   estate->func->fn_signature,
+					   funcname,
 					   err_lineno,
 					   _(estate->err_text));
 		}
@@ -1467,7 +1528,7 @@ plisql_exec_error_callback(void *arg)
 			 * arguments into local variables"
 			 */
 			errcontext("PL/iSQL function %s %s",
-					   estate->func->fn_signature,
+					   funcname,
 					   _(estate->err_text));
 		}
 	}
@@ -1475,13 +1536,16 @@ plisql_exec_error_callback(void *arg)
 	{
 		/* translator: last %s is a plisql statement type name */
 		errcontext("PL/iSQL function %s line %d at %s",
-				   estate->func->fn_signature,
+				   funcname,
 				   err_lineno,
 				   plisql_stmt_typename(estate->err_stmt));
 	}
 	else
 		errcontext("PL/iSQL function %s",
-				   estate->func->fn_signature);
+				   funcname);
+
+	if (qualified_funcname != NULL)
+		pfree(qualified_funcname);
 }
 
 
@@ -10146,8 +10210,15 @@ plisql_get_current_exception_sqlerrcode(void)
 /*
  * plisql_get_call_stack
  *
- * Returns the current PL/iSQL call stack as a formatted string.
- * This walks the error_context_stack looking for PL/iSQL function contexts.
+ * Returns the current PL/iSQL call stack as a formatted string, one frame
+ * per line as "handle\tlineno\tsignature". Package members' signature is
+ * schema/package-qualified (see plisql_package_qualified_signature()), not
+ * just the bare routine name.
+ *
+ * This walks the error_context_stack looking for PL/iSQL function contexts,
+ * silently skipping any interleaved non-PL/iSQL (e.g. PL/pgSQL) frames --
+ * callers that need every frame in true call order regardless of language
+ * cannot use this function for that purpose.
  * Used by DBMS_UTILITY.FORMAT_CALL_STACK.
  *
  * Returns NULL if not inside any PL/iSQL function.
@@ -10170,12 +10241,28 @@ plisql_get_call_stack(void)
 		{
 			PLiSQL_execstate *estate = (PLiSQL_execstate *) context->arg;
 			int lineno = 0;
+			char *signature;
+			char *qualified_signature;
 
 			/* Get current line number */
-			if (estate->err_stmt != NULL)
-				lineno = estate->err_stmt->lineno;
-			else if (estate->err_var != NULL)
+			if (estate->err_var != NULL)
 				lineno = estate->err_var->lineno;
+			else if (estate->err_stmt != NULL)
+				lineno = estate->err_stmt->lineno;
+
+			/*
+			 * Package members' fn_signature is only ever the bare routine
+			 * name (see plisql_build_subproc_function_internal()); qualify
+			 * it with the owning package's schema/name, same as the
+			 * error-context callback above, so callers of this function
+			 * don't have to re-derive package identity themselves.
+			 *
+			 * qualified_signature, when non-NULL, is a fresh palloc'd
+			 * string we own and must free below; the fn_signature fallback
+			 * is borrowed from the long-lived function cache.
+			 */
+			qualified_signature = plisql_package_qualified_signature(estate->func);
+			signature = qualified_signature != NULL ? qualified_signature : estate->func->fn_signature;
 
 			/* Add to stack output */
 			if (found_any)
@@ -10184,8 +10271,11 @@ plisql_get_call_stack(void)
 			appendStringInfo(&buf, "%p\t%d\t%s",
 							 (void *) estate->func,
 							 lineno,
-							 estate->func->fn_signature);
+							 signature);
 			found_any = true;
+
+			if (qualified_signature != NULL)
+				pfree(qualified_signature);
 		}
 	}
 


### PR DESCRIPTION
Fixes #1472

FORMAT_ERROR_BACKTRACE unconditionally prepended a hardcoded "PUBLIC." prefix to every frame name, including package member frames whose context line already carries the full schema.package.routine path produced by plisql_package_qualified_signature(). Two bugs resulted:

Package members lost the package component: "PUBLIC.PKG_ERROR" instead of "PUBLIC.TEST_PKG.PKG_ERROR".  Schema-qualified standalone routines got an extra prefix: "PUBLIC. TEST_SCHEMA.SCHEMA_ERROR" instead of "TEST_SCHEMA.SCHEMA_ERROR".

Add test 18 to dbms_utility.sql to cover FORMAT_CALL_STACK from inside a package procedure and assert the frame is schema/package-qualified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Corrected `DBMS_UTILITY` formatting for `FORMAT_ERROR_BACKTRACE` and `FORMAT_CALL_STACK` so schema/package-qualified routine names render correctly, and eliminates unintended `PUBLIC.` prefixes in frames/lines.

- **Tests**
  - Added regression coverage for `FORMAT_CALL_STACK` using a package procedure.
  - Added regression coverage for `FORMAT_ERROR_BACKTRACE` using schema-qualified routines.
  - Updated expected outputs for `utl_encode` and `utl_file` context lines to reflect fully qualified routine names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->