### PR TITLE
fix build issues and stop exit()ing from libpq

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -86,10 +86,6 @@ ORA_REGRESS = \
 	utl_encode \
 	dbms_session
 
-ifeq ($(with_libxml),yes) 
-SHLIB_LINK += -lxml2
-endif
-
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src
 
@@ -102,6 +98,10 @@ subdir = contrib/ivorysql_ora
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+ifeq ($(with_libxml),yes)
+SHLIB_LINK += -lxml2
 endif
 
 

--- a/src/fe_utils/.gitignore
+++ b/src/fe_utils/.gitignore
@@ -1,3 +1,4 @@
 /psqlscan.c
 /ora_keywords.c
 /ora_kwlist_d.h
+/ora_string_utils.c

--- a/src/fe_utils/meson.build
+++ b/src/fe_utils/meson.build
@@ -7,6 +7,12 @@ run_command(
    '../backend/oracle_parser/ora_keywords.c'],
   check:false)
 
+run_command(
+  [ln,
+   '-s',
+   '../oracle_fe_utils/ora_string_utils.c'],
+  check:false)
+
 fe_utils_sources = files(
   'archive.c',
   'astreamer_file.c',

--- a/src/fe_utils/ora_string_utils.c
+++ b/src/fe_utils/ora_string_utils.c
@@ -1,1 +1,0 @@
-../../src/oracle_fe_utils/ora_string_utils.c

--- a/src/interfaces/libpq/.gitignore
+++ b/src/interfaces/libpq/.gitignore
@@ -1,3 +1,4 @@
 /exports.list
+/ivy_sema.c
 /libpq-refs-stamp
 /tmp_check/

--- a/src/interfaces/libpq/ivy_sema.c
+++ b/src/interfaces/libpq/ivy_sema.c
@@ -1,1 +1,0 @@
-../../../src/interfaces/libpq/posix_ivysema.c

--- a/src/interfaces/libpq/meson.build
+++ b/src/interfaces/libpq/meson.build
@@ -17,9 +17,20 @@ libpq_sources = files(
   'libpq-events.c',
   'pqexpbuffer.c',
   'ivy-exec.c',
-  'ivy_sema.c',
 )
 libpq_so_sources = [] # for shared lib, in addition to the above
+
+if cdata.has('USE_UNNAMED_POSIX_SEMAPHORES') or cdata.has('USE_NAMED_POSIX_SEMAPHORES')
+  libpq_sources += files('posix_ivysema.c')
+endif
+
+if cdata.has('USE_SYSV_SEMAPHORES')
+  libpq_sources += files('sysv_ivysema.c')
+endif
+
+if cdata.has('USE_WIN32_SEMAPHORES')
+  libpq_sources += files('win32_ivysema.c')
+endif
 
 if host_system == 'windows'
   libpq_sources += files('pthread-win32.c', 'win32.c')
@@ -27,6 +38,9 @@ if host_system == 'windows'
     '--NAME', 'libpq',
     '--FILEDESC', 'PostgreSQL Access Library',])
 endif
+
+# autoconf generates the file there, ensure we get a conflict
+generated_sources_ac += {'src/interfaces/libpq': ['ivy_sema.c']}
 
 if ssl.found()
   libpq_sources += files('fe-secure-common.c')

--- a/src/interfaces/libpq/sysv_ivysema.c
+++ b/src/interfaces/libpq/sysv_ivysema.c
@@ -16,13 +16,8 @@
 #include <unistd.h>
 #include <sys/file.h>
 
-#ifdef HAVE_SYS_IPC_H
 #include <sys/ipc.h>
-#endif
-
-#ifdef HAVE_SYS_SEM_H
 #include <sys/sem.h>
-#endif
 
 #include "ivy_sema.h"
 


### PR DESCRIPTION
Fixes #1474
 
- contrib/ivorysql_ora/Makefile: move the `ifeq ($(with_libxml),yes) SHLIB_LINK += -lxml2` block to after including Makefile.global/PGXS. $(with_libxml) isn't defined until that include runs, so the block previously always evaluated false and -lxml2 was silently never linked. Linux linker was more forgiving, but macOS is not.

- src/interfaces/libpq/.gitignore, ivy_sema.c: stop tracking the generated ivy_sema.c symlink. Ignore it instead, like pg_sema.c already is.

- src/interfaces/libpq/sysv_ivysema.c, posix_ivysema.c: replace exit()/silent-return with abort() when a semaphore primitive fails (semget/semctl/semop, sem_wait/sem_post). These files ship inside libpq, a library linked into arbitrary host applications, not the postgres backend this code was adapted from:

    * exit() terminates the entire host process on the library's own initiativ which is not great! abort() keeps the "cannot safely continue" behavior on the application side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Improved portability and consistency across Meson and Make-based builds.
  * Added automatic handling for platform-specific semaphore implementations.
  * Improved generation and tracking of required source files during builds.
  * Preserved XML library linking behavior when XML support is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->