### PR TITLE
Fix authentication TAP Make targets

### DIFF
--- a/src/oracle_test/authentication/Makefile
+++ b/src/oracle_test/authentication/Makefile
@@ -18,10 +18,10 @@ include $(top_builddir)/src/Makefile.global
 
 EXTRA_INSTALL = src/oracle_test/modules/injection_points
 export enable_injection_points
-oracle_check:
+oracle-check:
 	$(oracle_prove_check)
 
-oracle_installcheck:
+oracle-installcheck:
 	$(oracle_prove_installcheck)
 
 clean distclean maintainer-clean:


### PR DESCRIPTION
## Summary

- Rename the authentication TAP targets to `oracle-check` and
  `oracle-installcheck`.
- Match the target names used by the recursive GNU Make rules so the
  authentication TAP suite is no longer silently skipped.

## Root cause

`src/oracle_test/Makefile` recurses into `authentication` using the standard
hyphenated target names. The authentication Makefile defined underscore
variants instead. The global Make rules supplied no-recipe hyphenated targets,
so Make returned success without invoking `prove` or reporting an unknown
target.

## Validation

- `git diff --check`
- Verified before the fix that `oracle-check` and `oracle-installcheck`
  reported `Nothing to be done`, while the underscore variants expanded the
  TAP commands.
- Verified after the fix that both standard targets expand their expected
  `prove ... t/*.pl` commands.
- Built an in-tree debug/cassert configuration with TAP tests and injection
  points enabled.
- Ran `make -C src/oracle_test/authentication oracle-check`:
  - `Files=7, Tests=316`
  - `Result: PASS`
  - `t/005_sspi.pl` skipped as expected on non-Windows platforms.

Closes #1487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed authentication test Make targets to `oracle-check` and `oracle-installcheck`.
  * Existing target commands and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->