### PR TITLE
Fix Oracle regexp newline matching semantics

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2111,6 +2111,61 @@ good', '.', 1, 'n') from dual;
            23
 (1 row)
 
+-- Newlines outside the matches must not change the count.
+select regexp_count('bX' || 'cX', '.X', 1, 'c') as no_newline,
+       regexp_count(chr(10) || 'bX' || 'cX', '.X', 1, 'c') as one_newline,
+       regexp_count(chr(10) || 'bX' || chr(10) || 'cX',
+                    '.X', 1, 'c') as two_newlines
+from dual;
+ no_newline | one_newline | two_newlines 
+------------+-------------+--------------
+          2 |           2 |            2
+(1 row)
+
+-- The m and n options control line anchors and dot matching independently.
+select regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'n') as n_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode
+from dual;
+ c_mode | n_mode | m_mode | mn_mode 
+--------+--------+--------+---------
+      0 |      1 |      0 |       1
+(1 row)
+
+-- The n option must not add newlines that are outside a match.
+select regexp_count(chr(10) || 'bX' || chr(10) || 'cX',
+                    '.X', 1, 'n') as n_mode
+from dual;
+ n_mode 
+--------
+      2
+(1 row)
+
+-- A negated bracket expression still matches a newline without the n option.
+select regexp_count('a,b' || chr(10) || 'c', '[^,]+', 1, 'c')
+       as negated_class
+from dual;
+ negated_class 
+---------------
+             2
+(1 row)
+
+-- The n option does not enable multiline anchors.
+select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'c') as c_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'n') as n_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'm') as m_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'mn') as mn_mode
+from dual;
+ c_mode | n_mode | m_mode | mn_mode 
+--------+--------+--------+---------
+      0 |      0 |      1 |       1
+(1 row)
+
 /*
  * length
  */

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2166,6 +2166,103 @@ from dual;
       0 |      0 |      1 |       1
 (1 row)
 
+-- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the m and n semantics.
+select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
+       as default_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'c'))
+       as c_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'n'))
+       as n_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'm'))
+       as m_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'mn'))
+       as mn_mode
+from dual;
+ default_mode | c_mode | n_mode | m_mode | mn_mode 
+--------------+--------+--------+--------+---------
+              |        |      2 |        |       2
+(1 row)
+
+select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1) as default_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'c') as c_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'n') as n_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'm') as m_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'mn') as mn_mode
+from dual;
+ default_mode | c_mode | n_mode | m_mode | mn_mode 
+--------------+--------+--------+--------+---------
+              |        |        | b      | b
+(1 row)
+
+select regexp_instr('X' || chr(10), 'X.', 1, 1, 0) as default_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'c') as c_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'n') as n_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode
+from dual;
+ default_mode | c_mode | n_mode | m_mode | mn_mode 
+--------------+--------+--------+--------+---------
+ 0            | 0      | 1      | 0      | 1
+(1 row)
+
+select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0) as default_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'c') as c_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'n') as n_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'm') as m_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'mn') as mn_mode
+from dual;
+ default_mode | c_mode | n_mode | m_mode | mn_mode 
+--------------+--------+--------+--------+---------
+ 0            | 0      | 0      | 3      | 3
+(1 row)
+
+select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
+       as default_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'c'))
+       as c_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'n'))
+       as n_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'm'))
+       as m_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'mn'))
+       as mn_mode
+from dual;
+ default_mode | c_mode | n_mode | m_mode | mn_mode 
+--------------+--------+--------+--------+---------
+            2 |      2 |      1 |      2 |       1
+(1 row)
+
+select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0),
+               chr(10), '|') as default_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'c'),
+               chr(10), '|') as c_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'n'),
+               chr(10), '|') as n_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'm'),
+               chr(10), '|') as m_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'mn'),
+               chr(10), '|') as mn_mode
+from dual;
+ default_mode | c_mode | n_mode | m_mode | mn_mode 
+--------------+--------+--------+--------+---------
+ x|b|y        | x|b|y  | x|b|y  | x|B|y  | x|B|y
+(1 row)
+
 /*
  * length
  */

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2122,17 +2122,15 @@ from dual;
           2 |           2 |            2
 (1 row)
 
--- The last m or n option determines the newline matching mode.
+-- Only the n option allows dot to match a newline.
 select regexp_count('X' || chr(10), 'X.', 1) as default_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'n') as n_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'nm') as nm_mode
+       regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
-            0 |      0 |      1 |      0 |       1 |       0
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+            0 |      0 |      1 |      0
 (1 row)
 
 -- The n option must not add newlines that are outside a match.
@@ -2153,7 +2151,7 @@ from dual;
              2
 (1 row)
 
--- A trailing n keeps anchors single-line; a trailing m enables multiline.
+-- Only the m option enables multiline anchors.
 select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1) as default_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -2161,18 +2159,14 @@ select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'n') as n_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'm') as m_mode,
-       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'mn') as mn_mode,
-       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'nm') as nm_mode
+                    '^b$', 1, 'm') as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
-            0 |      0 |      0 |      1 |       0 |       1
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+            0 |      0 |      0 |      1
 (1 row)
 
--- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the last-option semantics.
+-- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share these semantics.
 select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        as default_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'c'))
@@ -2180,15 +2174,11 @@ select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'n'))
        as n_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'm'))
-       as m_mode,
-       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'mn'))
-       as mn_mode,
-       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'nm'))
-       as nm_mode
+       as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
-              |        |      2 |        |       2 |        
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+              |        |      2 |       
 (1 row)
 
 select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -2198,27 +2188,21 @@ select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
                      '^b$', 1, 1, 'n') as n_mode,
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'm') as m_mode,
-       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'mn') as mn_mode,
-       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'nm') as nm_mode
+                     '^b$', 1, 1, 'm') as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
-              |        |        | b      |         | b
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+              |        |        | b
 (1 row)
 
 select regexp_instr('X' || chr(10), 'X.', 1, 1, 0) as default_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'c') as c_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'n') as n_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'nm') as nm_mode
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
- 0            | 0      | 1      | 0      | 1       | 0
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+ 0            | 0      | 1      | 0
 (1 row)
 
 select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
@@ -2228,15 +2212,11 @@ select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
                     '^bb$', 1, 1, 0, 'n') as n_mode,
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'm') as m_mode,
-       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'mn') as mn_mode,
-       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'nm') as nm_mode
+                    '^bb$', 1, 1, 0, 'm') as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
- 0            | 0      | 0      | 3      | 0       | 3
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+ 0            | 0      | 0      | 3
 (1 row)
 
 select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
@@ -2246,15 +2226,11 @@ select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'n'))
        as n_mode,
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'm'))
-       as m_mode,
-       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'mn'))
-       as mn_mode,
-       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'nm'))
-       as nm_mode
+       as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
-            2 |      2 |      1 |      2 |       1 |       2
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+            2 |      2 |      1 |      2
 (1 row)
 
 select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -2268,17 +2244,11 @@ select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                chr(10), '|') as n_mode,
        replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                               '^b$', 'B', 1, 0, 'm'),
-               chr(10), '|') as m_mode,
-       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
-                              '^b$', 'B', 1, 0, 'mn'),
-               chr(10), '|') as mn_mode,
-       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
-                              '^b$', 'B', 1, 0, 'nm'),
-               chr(10), '|') as nm_mode
+               chr(10), '|') as m_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
---------------+--------+--------+--------+---------+---------
- x|b|y        | x|b|y  | x|b|y  | x|B|y  | x|b|y   | x|B|y
+ default_mode | c_mode | n_mode | m_mode 
+--------------+--------+--------+--------
+ x|b|y        | x|b|y  | x|b|y  | x|B|y
 (1 row)
 
 /*

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2122,15 +2122,17 @@ from dual;
           2 |           2 |            2
 (1 row)
 
--- The m and n options control line anchors and dot matching independently.
-select regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
+-- The last m or n option determines the newline matching mode.
+select regexp_count('X' || chr(10), 'X.', 1) as default_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'n') as n_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode
+       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'nm') as nm_mode
 from dual;
- c_mode | n_mode | m_mode | mn_mode 
---------+--------+--------+---------
-      0 |      1 |      0 |       1
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+            0 |      0 |      1 |      0 |       1 |       0
 (1 row)
 
 -- The n option must not add newlines that are outside a match.
@@ -2151,22 +2153,26 @@ from dual;
              2
 (1 row)
 
--- The n option does not enable multiline anchors.
+-- A trailing n keeps anchors single-line; a trailing m enables multiline.
 select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1) as default_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'c') as c_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'n') as n_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'm') as m_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'mn') as mn_mode
+                    '^b$', 1, 'mn') as mn_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'nm') as nm_mode
 from dual;
- c_mode | n_mode | m_mode | mn_mode 
---------+--------+--------+---------
-      0 |      0 |      1 |       1
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+            0 |      0 |      0 |      1 |       0 |       1
 (1 row)
 
--- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the m and n semantics.
+-- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the last-option semantics.
 select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        as default_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'c'))
@@ -2176,11 +2182,13 @@ select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'm'))
        as m_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'mn'))
-       as mn_mode
+       as mn_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'nm'))
+       as nm_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode 
---------------+--------+--------+--------+---------
-              |        |      2 |        |       2
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+              |        |      2 |        |       2 |        
 (1 row)
 
 select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -2192,22 +2200,25 @@ select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
                      '^b$', 1, 1, 'm') as m_mode,
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'mn') as mn_mode
+                     '^b$', 1, 1, 'mn') as mn_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'nm') as nm_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode 
---------------+--------+--------+--------+---------
-              |        |        | b      | b
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+              |        |        | b      |         | b
 (1 row)
 
 select regexp_instr('X' || chr(10), 'X.', 1, 1, 0) as default_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'c') as c_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'n') as n_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'nm') as nm_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode 
---------------+--------+--------+--------+---------
- 0            | 0      | 1      | 0      | 1
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+ 0            | 0      | 1      | 0      | 1       | 0
 (1 row)
 
 select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
@@ -2219,11 +2230,13 @@ select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
                     '^bb$', 1, 1, 0, 'm') as m_mode,
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'mn') as mn_mode
+                    '^bb$', 1, 1, 0, 'mn') as mn_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'nm') as nm_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode 
---------------+--------+--------+--------+---------
- 0            | 0      | 0      | 3      | 3
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+ 0            | 0      | 0      | 3      | 0       | 3
 (1 row)
 
 select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
@@ -2235,11 +2248,13 @@ select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'm'))
        as m_mode,
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'mn'))
-       as mn_mode
+       as mn_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'nm'))
+       as nm_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode 
---------------+--------+--------+--------+---------
-            2 |      2 |      1 |      2 |       1
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+            2 |      2 |      1 |      2 |       1 |       2
 (1 row)
 
 select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -2256,11 +2271,14 @@ select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                chr(10), '|') as m_mode,
        replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                               '^b$', 'B', 1, 0, 'mn'),
-               chr(10), '|') as mn_mode
+               chr(10), '|') as mn_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'nm'),
+               chr(10), '|') as nm_mode
 from dual;
- default_mode | c_mode | n_mode | m_mode | mn_mode 
---------------+--------+--------+--------+---------
- x|b|y        | x|b|y  | x|b|y  | x|B|y  | x|B|y
+ default_mode | c_mode | n_mode | m_mode | mn_mode | nm_mode 
+--------------+--------+--------+--------+---------+---------
+ x|b|y        | x|b|y  | x|b|y  | x|B|y  | x|b|y   | x|B|y
 (1 row)
 
 /*

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1003,6 +1003,79 @@ select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'mn') as mn_mode
 from dual;
 
+-- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the m and n semantics.
+select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
+       as default_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'c'))
+       as c_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'n'))
+       as n_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'm'))
+       as m_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'mn'))
+       as mn_mode
+from dual;
+
+select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1) as default_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'c') as c_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'n') as n_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'm') as m_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'mn') as mn_mode
+from dual;
+
+select regexp_instr('X' || chr(10), 'X.', 1, 1, 0) as default_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'c') as c_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'n') as n_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode
+from dual;
+
+select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0) as default_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'c') as c_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'n') as n_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'm') as m_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'mn') as mn_mode
+from dual;
+
+select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
+       as default_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'c'))
+       as c_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'n'))
+       as n_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'm'))
+       as m_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'mn'))
+       as mn_mode
+from dual;
+
+select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0),
+               chr(10), '|') as default_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'c'),
+               chr(10), '|') as c_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'n'),
+               chr(10), '|') as n_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'm'),
+               chr(10), '|') as m_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'mn'),
+               chr(10), '|') as mn_mode
+from dual;
+
 /*
  * length
  */

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -968,6 +968,40 @@ select regexp_count('hello
 Hello.hello
 good', '.', 1, 'n') from dual;
 
+-- Newlines outside the matches must not change the count.
+select regexp_count('bX' || 'cX', '.X', 1, 'c') as no_newline,
+       regexp_count(chr(10) || 'bX' || 'cX', '.X', 1, 'c') as one_newline,
+       regexp_count(chr(10) || 'bX' || chr(10) || 'cX',
+                    '.X', 1, 'c') as two_newlines
+from dual;
+
+-- The m and n options control line anchors and dot matching independently.
+select regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'n') as n_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode
+from dual;
+
+-- The n option must not add newlines that are outside a match.
+select regexp_count(chr(10) || 'bX' || chr(10) || 'cX',
+                    '.X', 1, 'n') as n_mode
+from dual;
+
+-- A negated bracket expression still matches a newline without the n option.
+select regexp_count('a,b' || chr(10) || 'c', '[^,]+', 1, 'c')
+       as negated_class
+from dual;
+
+-- The n option does not enable multiline anchors.
+select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'c') as c_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'n') as n_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'm') as m_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'mn') as mn_mode
+from dual;
 
 /*
  * length

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -975,13 +975,11 @@ select regexp_count('bX' || 'cX', '.X', 1, 'c') as no_newline,
                     '.X', 1, 'c') as two_newlines
 from dual;
 
--- The last m or n option determines the newline matching mode.
+-- Only the n option allows dot to match a newline.
 select regexp_count('X' || chr(10), 'X.', 1) as default_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'n') as n_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'nm') as nm_mode
+       regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode
 from dual;
 
 -- The n option must not add newlines that are outside a match.
@@ -994,7 +992,7 @@ select regexp_count('a,b' || chr(10) || 'c', '[^,]+', 1, 'c')
        as negated_class
 from dual;
 
--- A trailing n keeps anchors single-line; a trailing m enables multiline.
+-- Only the m option enables multiline anchors.
 select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1) as default_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -1002,14 +1000,10 @@ select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'n') as n_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'm') as m_mode,
-       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'mn') as mn_mode,
-       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'nm') as nm_mode
+                    '^b$', 1, 'm') as m_mode
 from dual;
 
--- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the last-option semantics.
+-- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share these semantics.
 select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        as default_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'c'))
@@ -1017,11 +1011,7 @@ select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'n'))
        as n_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'm'))
-       as m_mode,
-       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'mn'))
-       as mn_mode,
-       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'nm'))
-       as nm_mode
+       as m_mode
 from dual;
 
 select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -1031,19 +1021,13 @@ select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
                      '^b$', 1, 1, 'n') as n_mode,
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'm') as m_mode,
-       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'mn') as mn_mode,
-       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'nm') as nm_mode
+                     '^b$', 1, 1, 'm') as m_mode
 from dual;
 
 select regexp_instr('X' || chr(10), 'X.', 1, 1, 0) as default_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'c') as c_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'n') as n_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'nm') as nm_mode
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode
 from dual;
 
 select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
@@ -1053,11 +1037,7 @@ select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
                     '^bb$', 1, 1, 0, 'n') as n_mode,
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'm') as m_mode,
-       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'mn') as mn_mode,
-       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'nm') as nm_mode
+                    '^bb$', 1, 1, 0, 'm') as m_mode
 from dual;
 
 select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
@@ -1067,11 +1047,7 @@ select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'n'))
        as n_mode,
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'm'))
-       as m_mode,
-       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'mn'))
-       as mn_mode,
-       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'nm'))
-       as nm_mode
+       as m_mode
 from dual;
 
 select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -1085,13 +1061,7 @@ select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                chr(10), '|') as n_mode,
        replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                               '^b$', 'B', 1, 0, 'm'),
-               chr(10), '|') as m_mode,
-       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
-                              '^b$', 'B', 1, 0, 'mn'),
-               chr(10), '|') as mn_mode,
-       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
-                              '^b$', 'B', 1, 0, 'nm'),
-               chr(10), '|') as nm_mode
+               chr(10), '|') as m_mode
 from dual;
 
 /*

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -975,11 +975,13 @@ select regexp_count('bX' || 'cX', '.X', 1, 'c') as no_newline,
                     '.X', 1, 'c') as two_newlines
 from dual;
 
--- The m and n options control line anchors and dot matching independently.
-select regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
+-- The last m or n option determines the newline matching mode.
+select regexp_count('X' || chr(10), 'X.', 1) as default_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'c') as c_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'n') as n_mode,
        regexp_count('X' || chr(10), 'X.', 1, 'm') as m_mode,
-       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode
+       regexp_count('X' || chr(10), 'X.', 1, 'mn') as mn_mode,
+       regexp_count('X' || chr(10), 'X.', 1, 'nm') as nm_mode
 from dual;
 
 -- The n option must not add newlines that are outside a match.
@@ -992,18 +994,22 @@ select regexp_count('a,b' || chr(10) || 'c', '[^,]+', 1, 'c')
        as negated_class
 from dual;
 
--- The n option does not enable multiline anchors.
+-- A trailing n keeps anchors single-line; a trailing m enables multiline.
 select regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1) as default_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'c') as c_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'n') as n_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
                     '^b$', 1, 'm') as m_mode,
        regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
-                    '^b$', 1, 'mn') as mn_mode
+                    '^b$', 1, 'mn') as mn_mode,
+       regexp_count('x' || chr(10) || 'b' || chr(10) || 'y',
+                    '^b$', 1, 'nm') as nm_mode
 from dual;
 
--- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the m and n semantics.
+-- REGEXP_COUNT, SUBSTR, INSTR, and REPLACE share the last-option semantics.
 select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        as default_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'c'))
@@ -1013,7 +1019,9 @@ select length(regexp_substr('X' || chr(10), 'X.', 1, 1))
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'm'))
        as m_mode,
        length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'mn'))
-       as mn_mode
+       as mn_mode,
+       length(regexp_substr('X' || chr(10), 'X.', 1, 1, 'nm'))
+       as nm_mode
 from dual;
 
 select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -1025,14 +1033,17 @@ select regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
                      '^b$', 1, 1, 'm') as m_mode,
        regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
-                     '^b$', 1, 1, 'mn') as mn_mode
+                     '^b$', 1, 1, 'mn') as mn_mode,
+       regexp_substr('x' || chr(10) || 'b' || chr(10) || 'y',
+                     '^b$', 1, 1, 'nm') as nm_mode
 from dual;
 
 select regexp_instr('X' || chr(10), 'X.', 1, 1, 0) as default_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'c') as c_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'n') as n_mode,
        regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'm') as m_mode,
-       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'mn') as mn_mode,
+       regexp_instr('X' || chr(10), 'X.', 1, 1, 0, 'nm') as nm_mode
 from dual;
 
 select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
@@ -1044,7 +1055,9 @@ select regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
                     '^bb$', 1, 1, 0, 'm') as m_mode,
        regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
-                    '^bb$', 1, 1, 0, 'mn') as mn_mode
+                    '^bb$', 1, 1, 0, 'mn') as mn_mode,
+       regexp_instr('x' || chr(10) || 'bb' || chr(10) || 'y',
+                    '^bb$', 1, 1, 0, 'nm') as nm_mode
 from dual;
 
 select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
@@ -1056,7 +1069,9 @@ select length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0))
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'm'))
        as m_mode,
        length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'mn'))
-       as mn_mode
+       as mn_mode,
+       length(regexp_replace('X' || chr(10), 'X.', 'Y', 1, 0, 'nm'))
+       as nm_mode
 from dual;
 
 select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
@@ -1073,7 +1088,10 @@ select replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                chr(10), '|') as m_mode,
        replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
                               '^b$', 'B', 1, 0, 'mn'),
-               chr(10), '|') as mn_mode
+               chr(10), '|') as mn_mode,
+       replace(regexp_replace('x' || chr(10) || 'b' || chr(10) || 'y',
+                              '^b$', 'B', 1, 0, 'nm'),
+               chr(10), '|') as nm_mode
 from dual;
 
 /*

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -722,8 +722,9 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 	pg_wchar   *data;
 	size_t		data_len;
 	pg_re_flags flags;
-	int			num = 0;
-	bool		flag = false;
+	bool		dot_matches_newline = false;
+	bool		last_match_empty_at_end = false;
+	bool		multi_line = false;
 	
 	if (PG_ARGISNULL(2))
 		PG_RETURN_NULL();
@@ -745,6 +746,8 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 	else
 	{
 		char	*paramstr = NULL;
+		int			i;
+
 		match_param = PG_GETARG_TEXT_PP(3);
 		paramstr = text_to_cstring(match_param);
 		if (paramstr && paramstr[0] != '\0')
@@ -756,7 +759,23 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 								 errmsg("the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.")));
 		}
 		ora_parse_re_flags(&flags, match_param);
+
+		/* Oracle treats the m and n options as independent dimensions. */
+		for (i = 0; paramstr[i] != '\0'; i++)
+		{
+			if (paramstr[i] == 'n')
+				dot_matches_newline = true;
+			else if (paramstr[i] == 'm')
+				multi_line = true;
+		}
 	}
+
+	/* By default, a period does not match a newline in Oracle. */
+	flags.cflags &= ~REG_NEWLINE;
+	if (!dot_matches_newline)
+		flags.cflags |= REG_NLDOT;
+	if (multi_line)
+		flags.cflags |= REG_NLANCH;
 
 	if (PG_ARGISNULL(0) || 
 		PG_ARGISNULL(1))
@@ -765,20 +784,7 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 	s = PG_GETARG_TEXT_PP(0);
 	p = PG_GETARG_TEXT_PP(1);
 	src_text_len = VARSIZE_ANY_EXHDR(s);
-	
-	if (PG_NARGS() == 4)
-	{
-		char   *str = VARDATA_ANY(s);
-		int     i;
 
-		for (i = 0; i < src_text_len; i++)
-		{
-			if (str[i] == '\n')
-				num++;
-		}
-		if (src_text_len > 0 && str[src_text_len - 1] == '\n')
-			flag = true;
-	}
 	/* Compile RE */
 	re = RE_compile_and_cache(p, flags.cflags, PG_GET_COLLATION());
 
@@ -818,6 +824,9 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 
 		/* Count the number of matches */
 		occurrence_cnt++;
+		last_match_empty_at_end =
+			pmatch[0].rm_so == pmatch[0].rm_eo &&
+			pmatch[0].rm_eo == (pg_regoff_t) data_len;
 
 		/*
 		 * Advance search position.  Normally we start the next search at the
@@ -830,23 +839,15 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 			search_start++;
 	}
 
-	if (flags.cflags == (REG_ICASE | REG_ADVANCED) || (flags.cflags == REG_ADVANCED))
-	{
-		if (!strncmp(p->vl_dat ,".",1))
-			occurrence_cnt -= num;
-	}	
-	if (flags.cflags == (REG_NEWLINE | REG_ADVANCED) && !strncmp(p->vl_dat ,".",1))
-		occurrence_cnt += num;
-	if (flags.cflags == (REG_NEWLINE | REG_ADVANCED) && !strncmp(p->vl_dat ,"^",1))
-	{
-		if (num)
-			occurrence_cnt = num;
-	}
-	if (flags.cflags ==  REG_ADVANCED && !strncmp(p->vl_dat ,"^",1) && flag)
-	{
-		if (num > 1)
-			occurrence_cnt += 1;
-	}
+	/* Do not count the empty line after a trailing newline for a bare ^. */
+	if ((flags.cflags & REG_NLANCH) != 0 &&
+		VARSIZE_ANY_EXHDR(p) == 1 &&
+		*VARDATA_ANY(p) == '^' &&
+		data_len > 0 && data[data_len - 1] == '\n' &&
+		last_match_empty_at_end &&
+		occurrence_cnt > 0)
+		occurrence_cnt--;
+
 	pfree(data);
 
 	PG_RETURN_INT32(occurrence_cnt);

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -722,9 +722,7 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 	pg_wchar   *data;
 	size_t		data_len;
 	pg_re_flags flags;
-	bool		dot_matches_newline = false;
 	bool		last_match_empty_at_end = false;
-	bool		multi_line = false;
 	
 	if (PG_ARGISNULL(2))
 		PG_RETURN_NULL();
@@ -746,7 +744,6 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 	else
 	{
 		char	*paramstr = NULL;
-		int			i;
 
 		match_param = PG_GETARG_TEXT_PP(3);
 		paramstr = text_to_cstring(match_param);
@@ -758,24 +755,9 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 							 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 								 errmsg("the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.")));
 		}
-		ora_parse_re_flags(&flags, match_param);
-
-		/* Oracle treats the m and n options as independent dimensions. */
-		for (i = 0; paramstr[i] != '\0'; i++)
-		{
-			if (paramstr[i] == 'n')
-				dot_matches_newline = true;
-			else if (paramstr[i] == 'm')
-				multi_line = true;
-		}
 	}
 
-	/* By default, a period does not match a newline in Oracle. */
-	flags.cflags &= ~REG_NEWLINE;
-	if (!dot_matches_newline)
-		flags.cflags |= REG_NLDOT;
-	if (multi_line)
-		flags.cflags |= REG_NLANCH;
+	ora_parse_re_flags(&flags, match_param);
 
 	if (PG_ARGISNULL(0) || 
 		PG_ARGISNULL(1))

--- a/src/backend/regex/README
+++ b/src/backend/regex/README
@@ -280,9 +280,9 @@ and it also typically adds lots of follow-on arc-splitting work for the
 color splitting logic.  Now we handle this case by generating a single arc
 labeled with the special color RAINBOW, meaning all colors.  Such arcs
 never need to be split, so they help keep NFAs small in this common case.
-(Note: this optimization doesn't help in REG_NLSTOP mode, where "." is
-not supposed to match newline.  In that case we still handle "." by
-generating an almost-rainbow of all colors except newline's color.)
+(Note: this optimization doesn't help in REG_NLSTOP or REG_NLDOT mode,
+where "." is not supposed to match newline.  In that case we still handle "."
+by generating an almost-rainbow of all colors except newline's color.)
 
 Given this summary, we can see we need the following operations for
 colors:

--- a/src/backend/regex/regcomp.c
+++ b/src/backend/regex/regcomp.c
@@ -452,7 +452,7 @@ pg_regcomp(regex_t *re,
 
 	/* parsing */
 	lexstart(v);				/* also handles prefixes */
-	if ((v->cflags & REG_NLSTOP) || (v->cflags & REG_NLANCH))
+	if (v->cflags & (REG_NLSTOP | REG_NLANCH | REG_NLDOT))
 	{
 		/* assign newline a unique color */
 		v->nlcolor = subcolor(v->cm, newline());
@@ -1002,7 +1002,8 @@ parseqatom(struct vars *v,
 			break;
 		case '.':
 			rainbow(v->nfa, v->cm, PLAIN,
-					(v->cflags & REG_NLSTOP) ? v->nlcolor : COLORLESS,
+					(v->cflags & (REG_NLSTOP | REG_NLDOT)) ?
+					v->nlcolor : COLORLESS,
 					lp, rp);
 			NEXT();
 			break;

--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -462,7 +462,31 @@ parse_re_flags(pg_re_flags *flags, text *opts)
 void
 ora_parse_re_flags(pg_re_flags *flags, text *opts)
 {
-	parse_re_flags(flags,opts);
+	parse_re_flags(flags, opts);
+
+	/*
+	 * Oracle treats m and n as independent options: m changes the behavior of
+	 * line anchors, while n allows dot to match a newline.  PostgreSQL's
+	 * parser treats the two options as synonyms, so replace its newline flags
+	 * with the Oracle semantics after parsing the other options.
+	 */
+	flags->cflags &= ~REG_NEWLINE;
+	flags->cflags |= REG_NLDOT;
+
+	if (opts)
+	{
+		char	   *opt_p = VARDATA_ANY(opts);
+		int			opt_len = VARSIZE_ANY_EXHDR(opts);
+		int			i;
+
+		for (i = 0; i < opt_len; i++)
+		{
+			if (opt_p[i] == 'n')
+				flags->cflags &= ~REG_NLDOT;
+			else if (opt_p[i] == 'm')
+				flags->cflags |= REG_NLANCH;
+		}
+	}
 }
 
 /*

--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -465,8 +465,10 @@ ora_parse_re_flags(pg_re_flags *flags, text *opts)
 	parse_re_flags(flags, opts);
 
 	/*
-	 * Oracle treats m and n as independent options: m changes the behavior of
-	 * line anchors, while n allows dot to match a newline.  PostgreSQL's
+	 * Oracle treats m and n as distinct, mutually overriding newline modes.
+	 * The m mode enables multiline anchors while keeping dot from matching a
+	 * newline; the n mode keeps single-line anchors while allowing dot to
+	 * match a newline.  When both occur, the last one wins.  PostgreSQL's
 	 * parser treats the two options as synonyms, so replace its newline flags
 	 * with the Oracle semantics after parsing the other options.
 	 */
@@ -482,9 +484,9 @@ ora_parse_re_flags(pg_re_flags *flags, text *opts)
 		for (i = 0; i < opt_len; i++)
 		{
 			if (opt_p[i] == 'n')
-				flags->cflags &= ~REG_NLDOT;
+				flags->cflags &= ~(REG_NLANCH | REG_NLDOT);
 			else if (opt_p[i] == 'm')
-				flags->cflags |= REG_NLANCH;
+				flags->cflags |= REG_NLANCH | REG_NLDOT;
 		}
 	}
 }

--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -465,10 +465,8 @@ ora_parse_re_flags(pg_re_flags *flags, text *opts)
 	parse_re_flags(flags, opts);
 
 	/*
-	 * Oracle treats m and n as distinct, mutually overriding newline modes.
-	 * The m mode enables multiline anchors while keeping dot from matching a
-	 * newline; the n mode keeps single-line anchors while allowing dot to
-	 * match a newline.  When both occur, the last one wins.  PostgreSQL's
+	 * Oracle treats m and n as independent options: m changes the behavior of
+	 * line anchors, while n allows dot to match a newline.  PostgreSQL's
 	 * parser treats the two options as synonyms, so replace its newline flags
 	 * with the Oracle semantics after parsing the other options.
 	 */
@@ -484,9 +482,9 @@ ora_parse_re_flags(pg_re_flags *flags, text *opts)
 		for (i = 0; i < opt_len; i++)
 		{
 			if (opt_p[i] == 'n')
-				flags->cflags &= ~(REG_NLANCH | REG_NLDOT);
+				flags->cflags &= ~REG_NLDOT;
 			else if (opt_p[i] == 'm')
-				flags->cflags |= REG_NLANCH | REG_NLDOT;
+				flags->cflags |= REG_NLANCH;
 		}
 	}
 }

--- a/src/include/regex/regex.h
+++ b/src/include/regex/regex.h
@@ -80,6 +80,7 @@
 #undef REG_DUMP
 #undef REG_FAKE
 #undef REG_PROGRESS
+#undef REG_NLDOT
 #undef REG_NOTBOL
 #undef REG_NOTEOL
 #undef REG_STARTEND
@@ -196,6 +197,7 @@ typedef struct
 #define REG_DUMP	004000		/* none of your business :-) */
 #define REG_FAKE	010000		/* none of your business :-) */
 #define REG_PROGRESS	020000	/* none of your business :-) */
+#define REG_NLDOT	040000		/* \n doesn't match . */
 
 
 


### PR DESCRIPTION
## Summary

- Stop changing `REGEXP_COUNT` totals based on newlines outside the matched
  substrings.
- Add `REG_NLDOT`, which excludes newline from `.` without excluding it from
  negated bracket expressions.
- Handle Oracle's documented `m` and `n` behaviors centrally in
  `ora_parse_re_flags()`: `m` enables multiline anchors, while `n` allows dot
  to match newline.
- Share the behavior across `REGEXP_COUNT`, `REGEXP_SUBSTR`, `REGEXP_INSTR`,
  and `REGEXP_REPLACE`, with regression coverage for default, `c`, `n`, and
  `m` modes.

## Root cause

`ora_regexp_count()` counted every newline in the complete source and adjusted
the regex engine's result when the pattern began with `.` or `^`. Newlines
outside the matched substrings therefore changed the returned count.

PostgreSQL's newline-sensitive regex mode combines dot, bracket-expression,
and anchor behavior. Oracle's `m` and `n` options control multiline anchors
and dot-newline matching separately. The existing `REG_NLSTOP` flag could not
provide the required dot-only behavior because it also prevents negated
bracket expressions from matching newline.

This change adds a dot-specific regex flag and applies the Oracle option
semantics in the shared Oracle flag parser used by all four functions.

## Review update

- Removed the unsupported last-option-wins interpretation and the associated
  combined-option assertions and regression cases.
- Kept `m` and `n` as independent controls for their documented behaviors.
- Rechecked all callers and the adjacent regex-engine flag handling; no other
  PostgreSQL, HBA, JSONPath, or `REGEXP_LIKE` path is changed by the new flag.

## Validation

Run in the Docker development environment:

- `make -j2 -C contrib/ivorysql_ora oracle-check ORA_REGRESS=ora_character_datatype_functions`
  - 1/1 test passed
- `make -j2 -C contrib/ivorysql_ora oracle-check`
  - 24/24 tests passed
- `make -j2 -C src/test/modules/test_regex check`
  - 2/2 tests passed
- `make -j2 check`
  - 244/244 tests passed
- `make -j2 oracle-check ORA_REGRESS=alter_index EXTRA_INSTALL=contrib/amcheck`
  - 254/254 tests passed
- Manual Oracle-mode checks covered Unicode text, unrelated leading/middle/
  trailing newlines, negated classes, regex-cache isolation, the original
  issue reproduction, and a 1,000-match stress case.
- `git diff --check`

Closes #1481
