### PR TITLE
Remove unreachable compatible_mode dead code in guc_funcs.c

### DIFF
--- a/src/backend/utils/misc/guc_funcs.c
+++ b/src/backend/utils/misc/guc_funcs.c
@@ -33,9 +33,6 @@
 #include "utils/guc_tables.h"
 #include "utils/snapmgr.h"
 #include "utils/tuplestore.h"
-#include "executor/nodeModifyTable.h"
-#include "parser/parse_merge.h"
-#include "parser/parser.h"
 #include "utils/ora_compatible.h"
 
 static char *flatten_set_variable_args(const char *name, List *args);
@@ -87,42 +84,12 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 									errmsg("parameter \"%s\" cannot be changed", DB_MODE_PARMATER)));
 			}
 
-			if (0 == pg_strcasecmp(stmt->name, "compatible_mode")
-				&& DB_PG == database_mode)
-					ereport(ERROR,
-						(errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM),
-						errmsg("parameter \"%s\" cannot be changed in native PG mode.", stmt->name)));
-
+			/* compatible_mode is handled by check/assign hooks in ivy_guc.c */
 			(void) set_config_option(stmt->name,
 									 ExtractSetVariableArgs(stmt),
 									 (superuser() ? PGC_SUSET : PGC_USERSET),
 									 PGC_S_SESSION,
 									 action, true, 0, false);
-
-			if (0 == pg_strcasecmp(stmt->name, "compatible_mode")
-				 && DB_ORACLE == database_mode)
-			{
-				if (0 == pg_strcasecmp(ExtractSetVariableArgs(stmt), "oracle"))
-				{
-					if (ora_raw_parser == NULL)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYSTEM_ERROR),
-								 errmsg("liboracle_parser not found!"),
-								 errhint("You must load liboracle_parser to use oracle parser.")));
-
-					sql_raw_parser = ora_raw_parser;
-
-					pg_transform_merge_stmt_hook = ora_transform_merge_stmt_hook;
-					pg_exec_merge_matched_hook = ora_exec_merge_matched_hook;
-				}
-				else if (0 == pg_strcasecmp(ExtractSetVariableArgs(stmt), "pg"))
-				{
-					sql_raw_parser = standard_raw_parser;
-
-					pg_transform_merge_stmt_hook = transformMergeStmt;
-					pg_exec_merge_matched_hook = ExecMergeMatched;
-				}
-			}
 
 			break;
 		case VAR_SET_MULTI:
@@ -206,15 +173,6 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 									 (superuser() ? PGC_SUSET : PGC_USERSET),
 									 PGC_S_SESSION,
 									 action, true, 0, false);
-
-			if (0 == pg_strcasecmp(stmt->name, "compatible_mode")
-				 && DB_ORACLE == database_mode)
-			{
-				sql_raw_parser = standard_raw_parser;
-
-				pg_transform_merge_stmt_hook = transformMergeStmt;
-				pg_exec_merge_matched_hook = ExecMergeMatched;
-			}
 			break;
 		case VAR_RESET_ALL:
 			ResetAllOptions();


### PR DESCRIPTION
## Summary

Fixes #1479.

Remove three unreachable `if (pg_strcasecmp(stmt->name, "compatible_mode") ...)` blocks in `ExecSetVariableStmt()`.

The GUC is registered as `ivorysql.compatible_mode` (see `ivy_guc.c`), so comparisons against the bare name `"compatible_mode"` never match. The real behavior already lives in:

- `check_compatible_mode()` — reject changes in native PG mode / validate parser load
- `assign_compatible_mode()` — switch `sql_raw_parser` and merge hooks

Also drop includes that were only needed by this dead code (`executor/nodeModifyTable.h`, `parser/parse_merge.h`, `parser/parser.h`).

## Test plan

- [ ] Confirm `SET ivorysql.compatible_mode = oracle|pg` still works in Oracle-mode database via GUC hooks
- [ ] Confirm `SET ivorysql.compatible_mode = oracle` is still rejected in native PG mode
- [ ] Confirm `RESET ivorysql.compatible_mode` still restores parser/hooks via `assign_compatible_mode`
- [ ] Build succeeds (no missing symbols from removed includes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when setting or resetting the `compatible_mode` configuration option.
  - Configuration changes now follow the standard handling path, reducing unexpected behavior when switching compatibility settings.
  - Removed obsolete processing that could affect SQL and MERGE statement interpretation during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->