### PR TITLE
refactor(guc): report check hook errors via GUC_check_* instead of ereport

### DIFF
--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -459,9 +459,11 @@ check_compatible_mode(int *newval, void **extra, GucSource source)
 	int			newmode = *newval;
 
 	if (DB_PG == database_mode && newmode == ORA_PARSER)
-		ereport(ERROR,
-				(errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM),
-				 errmsg("parameter ivorysql.compatible_mode cannot be changed in native PG mode.")));
+	{
+		GUC_check_errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM);
+		GUC_check_errmsg("parameter ivorysql.compatible_mode cannot be changed in native PG mode.");
+		return false;
+	}
 
 	if (DB_ORACLE == database_mode
 		&& (IsNormalProcessingMode() || (IsUnderPostmaster && MyProcPort)))
@@ -469,15 +471,19 @@ check_compatible_mode(int *newval, void **extra, GucSource source)
 		if (newmode == ORA_PARSER)
 		{
 			if (ora_raw_parser == NULL)
-				ereport(ERROR,
-						(errcode(ERRCODE_SYSTEM_ERROR),
-						 errmsg("liboracle_parser not found!"),
-						 errhint("You must load liboracle_parser to use oracle parser.")));
+			{
+				GUC_check_errcode(ERRCODE_SYSTEM_ERROR);
+				GUC_check_errmsg("liboracle_parser not found!");
+				GUC_check_errhint("You must load liboracle_parser to use oracle parser.");
+				return false;
+			}
 			if (!ISLOADIVORYSQL_ORA)
-				ereport(ERROR,
-						(errcode(ERRCODE_SYSTEM_ERROR),
-						 errmsg("IVORYSQL_ORA library not found!"),
-						 errhint("You must load IVORYSQL_ORA to use oracle parser.")));
+			{
+				GUC_check_errcode(ERRCODE_SYSTEM_ERROR);
+				GUC_check_errmsg("IVORYSQL_ORA library not found!");
+				GUC_check_errhint("You must load IVORYSQL_ORA to use oracle parser.");
+				return false;
+			}
 		}
 	}
 	return true;
@@ -581,14 +587,18 @@ nls_length_check(char **newval, void **extra, GucSource source)
 		&& (IsNormalProcessingMode() || (IsUnderPostmaster && MyProcPort)))
 	{
 		if (strlen(*newval) > 255)
-			ereport(ERROR,
-					(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
-					 errmsg("parameter value longer than 255 characters")));
+		{
+			GUC_check_errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION);
+			GUC_check_errmsg("parameter value longer than 255 characters");
+			return false;
+		}
 		else if (isdigit(**newval))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("Cannot access NLS data files "
-							"or invalid environment specified")));
+		{
+			GUC_check_errcode(ERRCODE_INVALID_PARAMETER_VALUE);
+			GUC_check_errmsg("Cannot access NLS data files "
+							 "or invalid environment specified");
+			return false;
+		}
 		else if (identifier_case_switch == INTERCHANGE)
 			nls_case_conversion(newval, 'b');
 	}
@@ -607,10 +617,12 @@ nls_territory_check(char **newval, void **extra, GucSource source)
 		else if (pg_strcasecmp(*newval, "AMERICA") == 0)
 			memcpy(*newval, "AMERICA", 7);
 		else
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("Cannot access NLS data files "
-							"or invalid environment specified")));
+		{
+			GUC_check_errcode(ERRCODE_INVALID_PARAMETER_VALUE);
+			GUC_check_errmsg("Cannot access NLS data files "
+							 "or invalid environment specified");
+			return false;
+		}
 	}
 
 	return true;

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -444,10 +444,11 @@ static bool
 check_nls_length_semantics(int *newval, void **extra, GucSource source)
 {
 	if (IsUnderPostmaster && DB_PG == database_mode)
-		ereport(WARNING,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("Do not use this GUC variable in the current cluster (PG).")));
-
+	{
+		GUC_check_errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
+		GUC_check_errmsg("Do not use this GUC variable in the current cluster (PG).");
+		return false;
+	}
 
 	return true;
 }
@@ -495,9 +496,11 @@ check_database_mode(int *newval, void **extra, GucSource source)
 	int			newmode = *newval;
 
 	if (DB_PG == database_mode && DB_ORACLE == newmode)
-		ereport(NOTICE,
-				(errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM),
-				 errmsg("parameter ivorysql.database_mode cannot be changed")));
+	{
+		GUC_check_errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM);
+		GUC_check_errmsg("parameter ivorysql.database_mode cannot be changed");
+		return false;
+	}
 
 	return true;
 }

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -443,7 +443,8 @@ static struct config_enum Ivy_ConfigureNamesEnum[] =
 static bool
 check_nls_length_semantics(int *newval, void **extra, GucSource source)
 {
-	if (IsUnderPostmaster && DB_PG == database_mode)
+	if (source >= PGC_S_INTERACTIVE &&
+		IsUnderPostmaster && DB_PG == database_mode)
 	{
 		GUC_check_errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
 		GUC_check_errmsg("Do not use this GUC variable in the current cluster (PG).");
@@ -495,7 +496,8 @@ check_database_mode(int *newval, void **extra, GucSource source)
 {
 	int			newmode = *newval;
 
-	if (DB_PG == database_mode && DB_ORACLE == newmode)
+	if (source >= PGC_S_INTERACTIVE &&
+		DB_PG == database_mode && DB_ORACLE == newmode)
 	{
 		GUC_check_errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM);
 		GUC_check_errmsg("parameter ivorysql.database_mode cannot be changed");


### PR DESCRIPTION
check hooks in ivy_guc.c violated the GUC Implementation Notes (src/backend/utils/misc/README): they threw errors directly with ereport(ERROR), so guc.c could not attach its own context to the "invalid value for parameter" complaint.

Follow the documented pattern instead: set the error code, message and hint with GUC_check_errcode()/GUC_check_errmsg()/GUC_check_errhint() and return false to reject the proposed value. Error codes and user-visible messages are unchanged, only the reporting mechanism complies with the notes now.

Affected hooks: check_compatible_mode (3 checks), nls_length_check (2), nls_territory_check (1).

Fixes #1478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved consistency of validation errors for invalid configuration settings.
* Added clearer error messages and helpful hints when supported values fail validation.
* Validation failures now correctly prevent invalid configuration changes.
* Preserved existing validation rules and messages for compatibility mode, parser, library, language, territory, language length, and database mode settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->