### PR TITLE
meson: fix Oracle postmaster TAP registration

### DIFF
--- a/src/oracle_test/postmaster/meson.build
+++ b/src/oracle_test/postmaster/meson.build
@@ -6,7 +6,9 @@ tests += {
   'bd': meson.current_build_dir(),
   'tap': {
     'tests': [
-      't/001_connection_limits.pl',
+      't/001_basic.pl',
+      't/002_connection_limits.pl',
+      't/003_start_stop.pl',
     ],
   },
 }


### PR DESCRIPTION
## Summary

- replace the nonexistent `t/001_connection_limits.pl` Meson entry
- register all existing Oracle postmaster TAP tests
- keep the Oracle postmaster manifest aligned with the PostgreSQL postmaster manifest

## Root cause

The Oracle postmaster Meson definition retained an outdated connection-limits filename and omitted the basic and start/stop TAP scripts. The Make-based path discovers all three scripts through `t/*.pl`, leaving the two build-system manifests inconsistent.

## Validation

- `git diff --check`
- Meson 1.11.2 setup on `WZU_Server` with `-Dtap_tests=enabled -Dcassert=true -Dinjection_points=true`
- verified every registered TAP path exists
- verified the Oracle and PostgreSQL postmaster Meson manifests match

Closes #1496


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded postmaster test coverage to include basic functionality and start/stop behavior.
  * Renamed the connection-limits test for clearer organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->