### PR TITLE
Add Oracle-compatible TO_BINARY_FLOAT and TO_BINARY_DOUBLE functions

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_binary_double.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_double.out
@@ -571,3 +571,104 @@ select * from binaryd_tb;
 (6 rows)
 
 drop table binaryd_tb;
+-- Oracle-compatible TO_BINARY_DOUBLE function
+-- Single-argument form, text input
+SELECT sys.to_binary_double('0.0');
+ to_binary_double 
+------------------
+ 0
+(1 row)
+
+SELECT sys.to_binary_double('3.14');
+ to_binary_double 
+------------------
+ 3.14
+(1 row)
+
+SELECT sys.to_binary_double('   -34.84   ');
+ to_binary_double 
+------------------
+ -34.84
+(1 row)
+
+SELECT sys.to_binary_double('1.2345678901234e+200');
+   to_binary_double   
+----------------------
+ 1.2345678901234e+200
+(1 row)
+
+SELECT sys.to_binary_double('1.2345678901234e-200');
+   to_binary_double   
+----------------------
+ 1.2345678901234e-200
+(1 row)
+
+-- Two-argument form with a number format model
+SELECT sys.to_binary_double('1,234.5', '9,999.9');
+ to_binary_double 
+------------------
+ 1234.5
+(1 row)
+
+SELECT sys.to_binary_double('  1234.5', '9999.9');
+ to_binary_double 
+------------------
+ 1234
+(1 row)
+
+-- Oracle special values: NaN and Infinity
+SELECT sys.to_binary_double('NaN');
+ to_binary_double 
+------------------
+ Nan
+(1 row)
+
+SELECT sys.to_binary_double('nan');
+ to_binary_double 
+------------------
+ Nan
+(1 row)
+
+SELECT sys.to_binary_double('Infinity');
+ to_binary_double 
+------------------
+ Inf
+(1 row)
+
+SELECT sys.to_binary_double('inf');
+ to_binary_double 
+------------------
+ Inf
+(1 row)
+
+SELECT sys.to_binary_double('-Infinity');
+ to_binary_double 
+------------------
+ -Inf
+(1 row)
+
+SELECT sys.to_binary_double('-inf');
+ to_binary_double 
+------------------
+ -Inf
+(1 row)
+
+-- Conversion overloads from other numeric types
+SELECT sys.to_binary_double(42::numeric);
+ to_binary_double 
+------------------
+ 42
+(1 row)
+
+SELECT sys.to_binary_double(42::sys.binary_double);
+ to_binary_double 
+------------------
+ 42
+(1 row)
+
+SELECT sys.to_binary_double(42::sys.binary_float);
+ to_binary_double 
+------------------
+ 42
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_binary_double.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_double.out
@@ -573,107 +573,107 @@ select * from binaryd_tb;
 drop table binaryd_tb;
 -- Oracle-compatible TO_BINARY_DOUBLE function
 -- Single-argument form, text input
-SELECT sys.to_binary_double('0.0');
+SELECT to_binary_double('0.0');
  to_binary_double 
 ------------------
  0
 (1 row)
 
-SELECT sys.to_binary_double('3.14');
+SELECT to_binary_double('3.14');
  to_binary_double 
 ------------------
  3.14
 (1 row)
 
-SELECT sys.to_binary_double('   -34.84   ');
+SELECT to_binary_double('   -34.84   ');
  to_binary_double 
 ------------------
  -34.84
 (1 row)
 
-SELECT sys.to_binary_double('1.2345678901234e+200');
+SELECT to_binary_double('1.2345678901234e+200');
    to_binary_double   
 ----------------------
  1.2345678901234e+200
 (1 row)
 
-SELECT sys.to_binary_double('1.2345678901234e-200');
+SELECT to_binary_double('1.2345678901234e-200');
    to_binary_double   
 ----------------------
  1.2345678901234e-200
 (1 row)
 
 -- Two-argument form with a number format model
-SELECT sys.to_binary_double('1,234.5', '9,999.9');
+SELECT to_binary_double('1,234.5', '9,999.9');
  to_binary_double 
 ------------------
  1234.5
 (1 row)
 
-SELECT sys.to_binary_double('  1234.5', '9999.9');
+SELECT to_binary_double('  1234.5', '9999.9');
  to_binary_double 
 ------------------
  1234
 (1 row)
 
 -- Empty format model returns NULL instead of crashing
-SELECT sys.to_binary_double('123', '');
+SELECT to_binary_double('123', '');
  to_binary_double 
 ------------------
  
 (1 row)
 
 -- Oracle special values: NaN and Infinity
-SELECT sys.to_binary_double('NaN');
+SELECT to_binary_double('NaN');
  to_binary_double 
 ------------------
  Nan
 (1 row)
 
-SELECT sys.to_binary_double('nan');
+SELECT to_binary_double('nan');
  to_binary_double 
 ------------------
  Nan
 (1 row)
 
-SELECT sys.to_binary_double('Infinity');
+SELECT to_binary_double('Infinity');
  to_binary_double 
 ------------------
  Inf
 (1 row)
 
-SELECT sys.to_binary_double('inf');
+SELECT to_binary_double('inf');
  to_binary_double 
 ------------------
  Inf
 (1 row)
 
-SELECT sys.to_binary_double('-Infinity');
+SELECT to_binary_double('-Infinity');
  to_binary_double 
 ------------------
  -Inf
 (1 row)
 
-SELECT sys.to_binary_double('-inf');
+SELECT to_binary_double('-inf');
  to_binary_double 
 ------------------
  -Inf
 (1 row)
 
 -- Conversion overloads from other numeric types
-SELECT sys.to_binary_double(42::numeric);
+SELECT to_binary_double(42::numeric);
  to_binary_double 
 ------------------
  42
 (1 row)
 
-SELECT sys.to_binary_double(42::sys.binary_double);
+SELECT to_binary_double(42::sys.binary_double);
  to_binary_double 
 ------------------
  42
 (1 row)
 
-SELECT sys.to_binary_double(42::sys.binary_float);
+SELECT to_binary_double(42::sys.binary_float);
  to_binary_double 
 ------------------
  42

--- a/contrib/ivorysql_ora/expected/ora_binary_double.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_double.out
@@ -613,7 +613,7 @@ SELECT to_binary_double('1,234.5', '9,999.9');
 SELECT to_binary_double('  1234.5', '9999.9');
  to_binary_double 
 ------------------
- 1234
+ 1234.5
 (1 row)
 
 -- Empty format model returns NULL instead of crashing

--- a/contrib/ivorysql_ora/expected/ora_binary_double.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_double.out
@@ -616,6 +616,13 @@ SELECT sys.to_binary_double('  1234.5', '9999.9');
  1234
 (1 row)
 
+-- Empty format model returns NULL instead of crashing
+SELECT sys.to_binary_double('123', '');
+ to_binary_double 
+------------------
+ 
+(1 row)
+
 -- Oracle special values: NaN and Infinity
 SELECT sys.to_binary_double('NaN');
  to_binary_double 

--- a/contrib/ivorysql_ora/expected/ora_binary_float.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_float.out
@@ -453,107 +453,107 @@ select * from binaryf_tbtidb002145521;
 
 -- Oracle-compatible TO_BINARY_FLOAT function
 -- Single-argument form, text input
-SELECT sys.to_binary_float('0.0');
+SELECT to_binary_float('0.0');
  to_binary_float 
 -----------------
  0
 (1 row)
 
-SELECT sys.to_binary_float('1.23');
+SELECT to_binary_float('1.23');
  to_binary_float 
 -----------------
  1.23
 (1 row)
 
-SELECT sys.to_binary_float('   -34.84   ');
+SELECT to_binary_float('   -34.84   ');
  to_binary_float 
 -----------------
  -34.84
 (1 row)
 
-SELECT sys.to_binary_float('1.2345678901234e+20');
+SELECT to_binary_float('1.2345678901234e+20');
  to_binary_float 
 -----------------
  1.23457e+20
 (1 row)
 
-SELECT sys.to_binary_float('1.2345678901234e-20');
+SELECT to_binary_float('1.2345678901234e-20');
  to_binary_float 
 -----------------
  1.23457e-20
 (1 row)
 
 -- Two-argument form with a number format model
-SELECT sys.to_binary_float('1,234.5', '9,999.9');
+SELECT to_binary_float('1,234.5', '9,999.9');
  to_binary_float 
 -----------------
  1234.5
 (1 row)
 
-SELECT sys.to_binary_float('  1234.5', '9999.9');
+SELECT to_binary_float('  1234.5', '9999.9');
  to_binary_float 
 -----------------
  1234
 (1 row)
 
 -- Empty format model returns NULL instead of crashing
-SELECT sys.to_binary_float('123', '');
+SELECT to_binary_float('123', '');
  to_binary_float 
 -----------------
  
 (1 row)
 
 -- Oracle special values: NaN and Infinity
-SELECT sys.to_binary_float('NaN');
+SELECT to_binary_float('NaN');
  to_binary_float 
 -----------------
  Nan
 (1 row)
 
-SELECT sys.to_binary_float('nan');
+SELECT to_binary_float('nan');
  to_binary_float 
 -----------------
  Nan
 (1 row)
 
-SELECT sys.to_binary_float('Infinity');
+SELECT to_binary_float('Infinity');
  to_binary_float 
 -----------------
  Inf
 (1 row)
 
-SELECT sys.to_binary_float('inf');
+SELECT to_binary_float('inf');
  to_binary_float 
 -----------------
  Inf
 (1 row)
 
-SELECT sys.to_binary_float('-Infinity');
+SELECT to_binary_float('-Infinity');
  to_binary_float 
 -----------------
  -Inf
 (1 row)
 
-SELECT sys.to_binary_float('-inf');
+SELECT to_binary_float('-inf');
  to_binary_float 
 -----------------
  -Inf
 (1 row)
 
 -- Conversion overloads from other numeric types
-SELECT sys.to_binary_float(42::numeric);
+SELECT to_binary_float(42::numeric);
  to_binary_float 
 -----------------
  42
 (1 row)
 
-SELECT sys.to_binary_float(42::sys.binary_float);
+SELECT to_binary_float(42::sys.binary_float);
  to_binary_float 
 -----------------
  42
 (1 row)
 
-SELECT sys.to_binary_float(42::sys.binary_double);
+SELECT to_binary_float(42::sys.binary_double);
  to_binary_float 
 -----------------
  42

--- a/contrib/ivorysql_ora/expected/ora_binary_float.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_float.out
@@ -451,3 +451,104 @@ select * from binaryf_tbtidb002145521;
  -Inf | -Inf
 (2 rows)
 
+-- Oracle-compatible TO_BINARY_FLOAT function
+-- Single-argument form, text input
+SELECT sys.to_binary_float('0.0');
+ to_binary_float 
+-----------------
+ 0
+(1 row)
+
+SELECT sys.to_binary_float('1.23');
+ to_binary_float 
+-----------------
+ 1.23
+(1 row)
+
+SELECT sys.to_binary_float('   -34.84   ');
+ to_binary_float 
+-----------------
+ -34.84
+(1 row)
+
+SELECT sys.to_binary_float('1.2345678901234e+20');
+ to_binary_float 
+-----------------
+ 1.23457e+20
+(1 row)
+
+SELECT sys.to_binary_float('1.2345678901234e-20');
+ to_binary_float 
+-----------------
+ 1.23457e-20
+(1 row)
+
+-- Two-argument form with a number format model
+SELECT sys.to_binary_float('1,234.5', '9,999.9');
+ to_binary_float 
+-----------------
+ 1234.5
+(1 row)
+
+SELECT sys.to_binary_float('  1234.5', '9999.9');
+ to_binary_float 
+-----------------
+ 1234
+(1 row)
+
+-- Oracle special values: NaN and Infinity
+SELECT sys.to_binary_float('NaN');
+ to_binary_float 
+-----------------
+ Nan
+(1 row)
+
+SELECT sys.to_binary_float('nan');
+ to_binary_float 
+-----------------
+ Nan
+(1 row)
+
+SELECT sys.to_binary_float('Infinity');
+ to_binary_float 
+-----------------
+ Inf
+(1 row)
+
+SELECT sys.to_binary_float('inf');
+ to_binary_float 
+-----------------
+ Inf
+(1 row)
+
+SELECT sys.to_binary_float('-Infinity');
+ to_binary_float 
+-----------------
+ -Inf
+(1 row)
+
+SELECT sys.to_binary_float('-inf');
+ to_binary_float 
+-----------------
+ -Inf
+(1 row)
+
+-- Conversion overloads from other numeric types
+SELECT sys.to_binary_float(42::numeric);
+ to_binary_float 
+-----------------
+ 42
+(1 row)
+
+SELECT sys.to_binary_float(42::sys.binary_float);
+ to_binary_float 
+-----------------
+ 42
+(1 row)
+
+SELECT sys.to_binary_float(42::sys.binary_double);
+ to_binary_float 
+-----------------
+ 42
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_binary_float.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_float.out
@@ -496,6 +496,13 @@ SELECT sys.to_binary_float('  1234.5', '9999.9');
  1234
 (1 row)
 
+-- Empty format model returns NULL instead of crashing
+SELECT sys.to_binary_float('123', '');
+ to_binary_float 
+-----------------
+ 
+(1 row)
+
 -- Oracle special values: NaN and Infinity
 SELECT sys.to_binary_float('NaN');
  to_binary_float 

--- a/contrib/ivorysql_ora/expected/ora_binary_float.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_float.out
@@ -493,7 +493,7 @@ SELECT to_binary_float('1,234.5', '9,999.9');
 SELECT to_binary_float('  1234.5', '9999.9');
  to_binary_float 
 -----------------
- 1234
+ 1234.5
 (1 row)
 
 -- Empty format model returns NULL instead of crashing

--- a/contrib/ivorysql_ora/sql/ora_binary_double.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_double.sql
@@ -235,6 +235,9 @@ SELECT sys.to_binary_double('1.2345678901234e-200');
 SELECT sys.to_binary_double('1,234.5', '9,999.9');
 SELECT sys.to_binary_double('  1234.5', '9999.9');
 
+-- Empty format model returns NULL instead of crashing
+SELECT sys.to_binary_double('123', '');
+
 -- Oracle special values: NaN and Infinity
 SELECT sys.to_binary_double('NaN');
 SELECT sys.to_binary_double('nan');

--- a/contrib/ivorysql_ora/sql/ora_binary_double.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_double.sql
@@ -223,3 +223,28 @@ insert into binaryd_tb values (Binary_Double_Infinity);
 select * from binaryd_tb;
 drop table binaryd_tb;
 
+-- Oracle-compatible TO_BINARY_DOUBLE function
+-- Single-argument form, text input
+SELECT sys.to_binary_double('0.0');
+SELECT sys.to_binary_double('3.14');
+SELECT sys.to_binary_double('   -34.84   ');
+SELECT sys.to_binary_double('1.2345678901234e+200');
+SELECT sys.to_binary_double('1.2345678901234e-200');
+
+-- Two-argument form with a number format model
+SELECT sys.to_binary_double('1,234.5', '9,999.9');
+SELECT sys.to_binary_double('  1234.5', '9999.9');
+
+-- Oracle special values: NaN and Infinity
+SELECT sys.to_binary_double('NaN');
+SELECT sys.to_binary_double('nan');
+SELECT sys.to_binary_double('Infinity');
+SELECT sys.to_binary_double('inf');
+SELECT sys.to_binary_double('-Infinity');
+SELECT sys.to_binary_double('-inf');
+
+-- Conversion overloads from other numeric types
+SELECT sys.to_binary_double(42::numeric);
+SELECT sys.to_binary_double(42::sys.binary_double);
+SELECT sys.to_binary_double(42::sys.binary_float);
+

--- a/contrib/ivorysql_ora/sql/ora_binary_double.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_double.sql
@@ -225,29 +225,29 @@ drop table binaryd_tb;
 
 -- Oracle-compatible TO_BINARY_DOUBLE function
 -- Single-argument form, text input
-SELECT sys.to_binary_double('0.0');
-SELECT sys.to_binary_double('3.14');
-SELECT sys.to_binary_double('   -34.84   ');
-SELECT sys.to_binary_double('1.2345678901234e+200');
-SELECT sys.to_binary_double('1.2345678901234e-200');
+SELECT to_binary_double('0.0');
+SELECT to_binary_double('3.14');
+SELECT to_binary_double('   -34.84   ');
+SELECT to_binary_double('1.2345678901234e+200');
+SELECT to_binary_double('1.2345678901234e-200');
 
 -- Two-argument form with a number format model
-SELECT sys.to_binary_double('1,234.5', '9,999.9');
-SELECT sys.to_binary_double('  1234.5', '9999.9');
+SELECT to_binary_double('1,234.5', '9,999.9');
+SELECT to_binary_double('  1234.5', '9999.9');
 
 -- Empty format model returns NULL instead of crashing
-SELECT sys.to_binary_double('123', '');
+SELECT to_binary_double('123', '');
 
 -- Oracle special values: NaN and Infinity
-SELECT sys.to_binary_double('NaN');
-SELECT sys.to_binary_double('nan');
-SELECT sys.to_binary_double('Infinity');
-SELECT sys.to_binary_double('inf');
-SELECT sys.to_binary_double('-Infinity');
-SELECT sys.to_binary_double('-inf');
+SELECT to_binary_double('NaN');
+SELECT to_binary_double('nan');
+SELECT to_binary_double('Infinity');
+SELECT to_binary_double('inf');
+SELECT to_binary_double('-Infinity');
+SELECT to_binary_double('-inf');
 
 -- Conversion overloads from other numeric types
-SELECT sys.to_binary_double(42::numeric);
-SELECT sys.to_binary_double(42::sys.binary_double);
-SELECT sys.to_binary_double(42::sys.binary_float);
+SELECT to_binary_double(42::numeric);
+SELECT to_binary_double(42::sys.binary_double);
+SELECT to_binary_double(42::sys.binary_float);
 

--- a/contrib/ivorysql_ora/sql/ora_binary_float.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_float.sql
@@ -167,28 +167,28 @@ select * from binaryf_tbtidb002145521;
 
 -- Oracle-compatible TO_BINARY_FLOAT function
 -- Single-argument form, text input
-SELECT sys.to_binary_float('0.0');
-SELECT sys.to_binary_float('1.23');
-SELECT sys.to_binary_float('   -34.84   ');
-SELECT sys.to_binary_float('1.2345678901234e+20');
-SELECT sys.to_binary_float('1.2345678901234e-20');
+SELECT to_binary_float('0.0');
+SELECT to_binary_float('1.23');
+SELECT to_binary_float('   -34.84   ');
+SELECT to_binary_float('1.2345678901234e+20');
+SELECT to_binary_float('1.2345678901234e-20');
 
 -- Two-argument form with a number format model
-SELECT sys.to_binary_float('1,234.5', '9,999.9');
-SELECT sys.to_binary_float('  1234.5', '9999.9');
+SELECT to_binary_float('1,234.5', '9,999.9');
+SELECT to_binary_float('  1234.5', '9999.9');
 
 -- Empty format model returns NULL instead of crashing
-SELECT sys.to_binary_float('123', '');
+SELECT to_binary_float('123', '');
 
 -- Oracle special values: NaN and Infinity
-SELECT sys.to_binary_float('NaN');
-SELECT sys.to_binary_float('nan');
-SELECT sys.to_binary_float('Infinity');
-SELECT sys.to_binary_float('inf');
-SELECT sys.to_binary_float('-Infinity');
-SELECT sys.to_binary_float('-inf');
+SELECT to_binary_float('NaN');
+SELECT to_binary_float('nan');
+SELECT to_binary_float('Infinity');
+SELECT to_binary_float('inf');
+SELECT to_binary_float('-Infinity');
+SELECT to_binary_float('-inf');
 
 -- Conversion overloads from other numeric types
-SELECT sys.to_binary_float(42::numeric);
-SELECT sys.to_binary_float(42::sys.binary_float);
-SELECT sys.to_binary_float(42::sys.binary_double);
+SELECT to_binary_float(42::numeric);
+SELECT to_binary_float(42::sys.binary_float);
+SELECT to_binary_float(42::sys.binary_double);

--- a/contrib/ivorysql_ora/sql/ora_binary_float.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_float.sql
@@ -177,6 +177,9 @@ SELECT sys.to_binary_float('1.2345678901234e-20');
 SELECT sys.to_binary_float('1,234.5', '9,999.9');
 SELECT sys.to_binary_float('  1234.5', '9999.9');
 
+-- Empty format model returns NULL instead of crashing
+SELECT sys.to_binary_float('123', '');
+
 -- Oracle special values: NaN and Infinity
 SELECT sys.to_binary_float('NaN');
 SELECT sys.to_binary_float('nan');

--- a/contrib/ivorysql_ora/sql/ora_binary_float.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_float.sql
@@ -164,3 +164,28 @@ create table binaryf_tbtidb002145521(a binary_float, b binary_double);
 insert into binaryf_tbtidb002145521 values(-3.40282e39, -3.40282e666);
 insert into binaryf_tbtidb002145521 values(-3.40283e38, -3.40282e666);
 select * from binaryf_tbtidb002145521;
+
+-- Oracle-compatible TO_BINARY_FLOAT function
+-- Single-argument form, text input
+SELECT sys.to_binary_float('0.0');
+SELECT sys.to_binary_float('1.23');
+SELECT sys.to_binary_float('   -34.84   ');
+SELECT sys.to_binary_float('1.2345678901234e+20');
+SELECT sys.to_binary_float('1.2345678901234e-20');
+
+-- Two-argument form with a number format model
+SELECT sys.to_binary_float('1,234.5', '9,999.9');
+SELECT sys.to_binary_float('  1234.5', '9999.9');
+
+-- Oracle special values: NaN and Infinity
+SELECT sys.to_binary_float('NaN');
+SELECT sys.to_binary_float('nan');
+SELECT sys.to_binary_float('Infinity');
+SELECT sys.to_binary_float('inf');
+SELECT sys.to_binary_float('-Infinity');
+SELECT sys.to_binary_float('-inf');
+
+-- Conversion overloads from other numeric types
+SELECT sys.to_binary_float(42::numeric);
+SELECT sys.to_binary_float(42::sys.binary_float);
+SELECT sys.to_binary_float(42::sys.binary_double);

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -924,6 +924,66 @@ LANGUAGE C
 STRICT
 IMMUTABLE;
 
+-- to_binary_float
+CREATE FUNCTION sys.to_binary_float(text,text)
+RETURNS sys.binary_float
+AS 'MODULE_PATHNAME','ora_to_binary_float'
+LANGUAGE C
+STRICT
+IMMUTABLE;
+
+CREATE FUNCTION sys.to_binary_float(text)
+RETURNS sys.binary_float
+AS 'MODULE_PATHNAME','ora_to_binary_float'
+LANGUAGE C
+STRICT
+IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION sys.to_binary_float(number)
+RETURNS sys.binary_float
+AS 'select $1::sys.binary_float'
+LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.to_binary_float(binary_float)
+RETURNS sys.binary_float
+AS 'select $1'
+LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.to_binary_float(binary_double)
+RETURNS sys.binary_float
+AS 'select $1::sys.binary_float'
+LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+-- to_binary_double
+CREATE FUNCTION sys.to_binary_double(text,text)
+RETURNS sys.binary_double
+AS 'MODULE_PATHNAME','ora_to_binary_double'
+LANGUAGE C
+STRICT
+IMMUTABLE;
+
+CREATE FUNCTION sys.to_binary_double(text)
+RETURNS sys.binary_double
+AS 'MODULE_PATHNAME','ora_to_binary_double'
+LANGUAGE C
+STRICT
+IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION sys.to_binary_double(number)
+RETURNS sys.binary_double
+AS 'select $1::sys.binary_double'
+LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.to_binary_double(binary_double)
+RETURNS sys.binary_double
+AS 'select $1'
+LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION sys.to_binary_double(binary_float)
+RETURNS sys.binary_double
+AS 'select $1::sys.binary_double'
+LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
 /***************************************************************
  *
  * RAW BLOB CLOB datatype functions.

--- a/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
@@ -90,13 +90,21 @@ ora_to_number(PG_FUNCTION_ARGS)
  * Oracle special values 'NaN', 'Infinity' (or 'INF') and their negations.
  */
 static float4
-ora_to_binary_float_internal(text *value, text *fmt)
+ora_to_binary_float_internal(text *value, text *fmt, bool *isnull)
 {
 	Datum		result;
+
+	*isnull = false;
 
 	if (fmt)
 	{
 		Numeric		num = ora_to_number_internal(value, fmt);
+
+		if (num == NULL)
+		{
+			*isnull = true;
+			return (float4) 0;
+		}
 
 		result = DirectFunctionCall1(number_binary_float,
 									 NumericGetDatum(num));
@@ -123,13 +131,21 @@ ora_to_binary_float_internal(text *value, text *fmt)
  * ora_to_binary_float_internal().
  */
 static float8
-ora_to_binary_double_internal(text *value, text *fmt)
+ora_to_binary_double_internal(text *value, text *fmt, bool *isnull)
 {
 	Datum		result;
+
+	*isnull = false;
 
 	if (fmt)
 	{
 		Numeric		num = ora_to_number_internal(value, fmt);
+
+		if (num == NULL)
+		{
+			*isnull = true;
+			return (float8) 0;
+		}
 
 		result = DirectFunctionCall1(number_binary_double,
 									 NumericGetDatum(num));
@@ -159,11 +175,18 @@ ora_to_binary_float(PG_FUNCTION_ARGS)
 {
 	text	   *value = PG_GETARG_TEXT_P(0);
 	text	   *fmt = NULL;
+	float4		result;
+	bool		isnull;
 
 	if (PG_NARGS() > 1)
 		fmt = PG_GETARG_TEXT_P(1);
 
-	PG_RETURN_FLOAT4(ora_to_binary_float_internal(value, fmt));
+	result = ora_to_binary_float_internal(value, fmt, &isnull);
+
+	if (isnull)
+		PG_RETURN_NULL();
+
+	PG_RETURN_FLOAT4(result);
 }
 
 /*
@@ -179,9 +202,16 @@ ora_to_binary_double(PG_FUNCTION_ARGS)
 {
 	text	   *value = PG_GETARG_TEXT_P(0);
 	text	   *fmt = NULL;
+	float8		result;
+	bool		isnull;
 
 	if (PG_NARGS() > 1)
 		fmt = PG_GETARG_TEXT_P(1);
 
-	PG_RETURN_FLOAT8(ora_to_binary_double_internal(value, fmt));
+	result = ora_to_binary_double_internal(value, fmt, &isnull);
+
+	if (isnull)
+		PG_RETURN_NULL();
+
+	PG_RETURN_FLOAT8(result);
 }

--- a/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
@@ -33,7 +33,7 @@
 #include "utils/formatting.h"
 #include "utils/numeric.h"
 
-/* Functions implemented in src/datatype/binary_float.c and binary_double.c */
+/* Functions implemented in contrib/ivorysql_ora/src/datatype/binary_float.c and contrib/ivorysql_ora/src/datatype/binary_double.c */
 extern Datum binary_float_in(PG_FUNCTION_ARGS);
 extern Datum binary_double_in(PG_FUNCTION_ARGS);
 extern Datum number_binary_float(PG_FUNCTION_ARGS);

--- a/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
@@ -29,11 +29,20 @@
 
 #include "postgres.h"
 #include "fmgr.h"
+#include "utils/builtins.h"
 #include "utils/formatting.h"
 #include "utils/numeric.h"
 
+/* Functions implemented in src/datatype/binary_float.c and binary_double.c */
+extern Datum binary_float_in(PG_FUNCTION_ARGS);
+extern Datum binary_double_in(PG_FUNCTION_ARGS);
+extern Datum number_binary_float(PG_FUNCTION_ARGS);
+extern Datum number_binary_double(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(number_bitand);
 PG_FUNCTION_INFO_V1(ora_to_number);
+PG_FUNCTION_INFO_V1(ora_to_binary_float);
+PG_FUNCTION_INFO_V1(ora_to_binary_double);
 
 
 Datum
@@ -66,4 +75,113 @@ ora_to_number(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 	else
 		PG_RETURN_NUMERIC(result);
+}
+
+/*
+ * ora_to_binary_float_internal
+ * Convert a character string, with an optional number format model, to a
+ * single-precision floating-point value in the same manner as Oracle's
+ * TO_BINARY_FLOAT function.
+ *
+ * When a format model is supplied, the string is first converted to a
+ * NUMBER value using the same number format model logic as TO_NUMBER,
+ * and then that value is converted to BINARY_FLOAT.  Otherwise the string
+ * is parsed directly as a floating-point literal, which also accepts the
+ * Oracle special values 'NaN', 'Infinity' (or 'INF') and their negations.
+ */
+static float4
+ora_to_binary_float_internal(text *value, text *fmt)
+{
+	Datum		result;
+
+	if (fmt)
+	{
+		Numeric		num = ora_to_number_internal(value, fmt);
+
+		result = DirectFunctionCall1(number_binary_float,
+									 NumericGetDatum(num));
+	}
+	else
+	{
+		char	   *numstr = text_to_cstring(value);
+
+		result = DirectFunctionCall1(binary_float_in,
+									 CStringGetDatum(numstr));
+		pfree(numstr);
+	}
+
+	return DatumGetFloat4(result);
+}
+
+/*
+ * ora_to_binary_double_internal
+ * Convert a character string, with an optional number format model, to a
+ * double-precision floating-point value in the same manner as Oracle's
+ * TO_BINARY_DOUBLE function.
+ *
+ * This is the double-precision counterpart of
+ * ora_to_binary_float_internal().
+ */
+static float8
+ora_to_binary_double_internal(text *value, text *fmt)
+{
+	Datum		result;
+
+	if (fmt)
+	{
+		Numeric		num = ora_to_number_internal(value, fmt);
+
+		result = DirectFunctionCall1(number_binary_double,
+									 NumericGetDatum(num));
+	}
+	else
+	{
+		char	   *numstr = text_to_cstring(value);
+
+		result = DirectFunctionCall1(binary_double_in,
+									 CStringGetDatum(numstr));
+		pfree(numstr);
+	}
+
+	return DatumGetFloat8(result);
+}
+
+/*
+ * ora_to_binary_float
+ * Oracle compatible TO_BINARY_FLOAT function.
+ *
+ * Converts a character string to a value of BINARY_FLOAT data type.
+ * The optional second argument is a number format model that describes
+ * how the character string should be interpreted.
+ */
+Datum
+ora_to_binary_float(PG_FUNCTION_ARGS)
+{
+	text	   *value = PG_GETARG_TEXT_P(0);
+	text	   *fmt = NULL;
+
+	if (PG_NARGS() > 1)
+		fmt = PG_GETARG_TEXT_P(1);
+
+	PG_RETURN_FLOAT4(ora_to_binary_float_internal(value, fmt));
+}
+
+/*
+ * ora_to_binary_double
+ * Oracle compatible TO_BINARY_DOUBLE function.
+ *
+ * Converts a character string to a value of BINARY_DOUBLE data type.
+ * The optional second argument is a number format model that describes
+ * how the character string should be interpreted.
+ */
+Datum
+ora_to_binary_double(PG_FUNCTION_ARGS)
+{
+	text	   *value = PG_GETARG_TEXT_P(0);
+	text	   *fmt = NULL;
+
+	if (PG_NARGS() > 1)
+		fmt = PG_GETARG_TEXT_P(1);
+
+	PG_RETURN_FLOAT8(ora_to_binary_double_internal(value, fmt));
 }

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -6406,7 +6406,16 @@ NUM_numpart_from_char(NUMProc *Np, int id, size_t input_len)
 	if (OVERLOAD_TEST)
 		return;
 
-	if (*Np->inout_p == ' ')
+	/*
+	 * Skip leading blanks in the input.  Oracle ignores leading blanks
+	 * before the numeric content, so they must not consume 9 positions.
+	 * Otherwise a digit can be pushed onto the decimal-node position and
+	 * the fractional part (e.g. TO_BINARY_DOUBLE('  1234.5', '9999.9'))
+	 * would be lost.  Only skip before any content has been read, so that
+	 * blanks belonging to literal spaces inside the format are preserved.
+	 */
+	while (*Np->inout_p == ' ' && Np->read_pre == 0 && Np->read_post == 0 &&
+		   *Np->number == ' ' && !OVERLOAD_TEST)
 		Np->inout_p++;
 
 	if (OVERLOAD_TEST)


### PR DESCRIPTION
Implement TO_BINARY_FLOAT/TO_BINARY_DOUBLE in ivorysql_ora, supporting an optional number format model and Oracle special values (NaN, Infinity).

fix  #1498 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Oracle-compatible `TO_BINARY_FLOAT` and `TO_BINARY_DOUBLE` conversion functions.
- Supports text, numeric, and floating-point inputs.
- Text conversions accept optional number formats and special values such as `NaN` and infinity.
- Empty format models return `NULL`.

## Tests
- Added coverage for supported input types, format models, empty formats, and special floating-point values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->