### PR TITLE
meson: register psql prompt TAP test

### DIFF
--- a/src/bin/psql/meson.build
+++ b/src/bin/psql/meson.build
@@ -99,6 +99,7 @@ tests += {
       't/010_tab_completion.pl',
       't/020_cancel.pl',
       't/030_pager.pl',
+      't/040_prompt.pl',
     ],
   },
 }


### PR DESCRIPTION
## Problem

`src/bin/psql/t/040_prompt.pl` covers IvorySQL's `%o` prompt escape in both PostgreSQL and Oracle compatibility modes, but the Meson manifest's explicit TAP list stops at `030_pager.pl`. As a result, Meson test runs silently omit the prompt coverage.

## Fix

Register `040_prompt.pl` in the psql Meson TAP test list.

## Validation

Run on `WZU_Server` with Meson 1.0.1:

- full Ninja build: passed
- psql TAP suite plus setup: 8/8 tests passed
- `psql/040_prompt`: passed (6 subtests)
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added prompt-related coverage to the `psql` test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1505.
