### PR TITLE
build: include ora_version in liborafeutils

### DIFF
--- a/src/oracle_fe_utils/Makefile
+++ b/src/oracle_fe_utils/Makefile
@@ -33,6 +33,7 @@ include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -DFRONTEND -I$(libpq_srcdir) -I$(top_builddir)/src/include/oracle_fe_utils $(CPPFLAGS)
 
 OBJS = ora_string_utils.o \
+	ora_version.o \
 	ora_psqlscan.o
 
 all: liborafeutils.a


### PR DESCRIPTION
## Problem

The Meson definition compiles `ora_version.c` into `liborafeutils.a`, but the traditional Makefile omits `ora_version.o`. Consequently, Make installs an archive without the `get_pg_version()` implementation declared by `oracle_fe_utils/ora_version.h`, and the two build systems produce different libraries.

## Fix

Add `ora_version.o` to `src/oracle_fe_utils/Makefile` so the Make-built archive matches the Meson-built archive.

## Validation

Run on `WZU_Server`:

- clean configure and `make -C src/oracle_fe_utils`: passed
- archive contains `ora_version.o`: verified with `ar t`
- archive exports `get_pg_version`: verified with `nm -g`
- clean `make -C src/bin/psql all`: passed
- `git diff --check`: passed

Closes #1506.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the build process to ensure all required components are included in the packaged utility library.
  * Updated build and cleanup handling for more consistent development and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->