### PR TITLE
Handle IvorySQL-specific AT_ subcommands in test_ddl_deparse

### DIFF
--- a/src/test/modules/test_ddl_deparse/test_ddl_deparse.c
+++ b/src/test/modules/test_ddl_deparse/test_ddl_deparse.c
@@ -315,6 +315,10 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 			case AT_ReAddStatistics:
 				strtype = "(re) ADD STATS";
 				break;
+				/*
+				 * These enum values are for Oracle-compatible features and would
+				 * not be hit in PG mode, but put them here to avoid build warning.
+				 */
 			case AT_AddRowids:
 				strtype = "SET WITH ROWID";
 				break;

--- a/src/test/modules/test_ddl_deparse/test_ddl_deparse.c
+++ b/src/test/modules/test_ddl_deparse/test_ddl_deparse.c
@@ -315,6 +315,24 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 			case AT_ReAddStatistics:
 				strtype = "(re) ADD STATS";
 				break;
+			case AT_AddRowids:
+				strtype = "SET WITH ROWID";
+				break;
+			case AT_AddRowidsRecurse:
+				strtype = "SET WITH ROWID (recursive)";
+				break;
+			case AT_DropRowids:
+				strtype = "SET WITHOUT ROWID";
+				break;
+			case AT_DropInvisible:
+				strtype = "ALTER COLUMN DROP INVISIBLE";
+				break;
+			case AT_SetInvisible:
+				strtype = "ALTER COLUMN SET INVISIBLE";
+				break;
+			case AT_ForceViewCompile:
+				strtype = "COMPILE FORCE VIEW";
+				break;
 		}
 
 		if (subcmd->recurse)


### PR DESCRIPTION
Add the missing cases after AT_ReAddStatistics.

About #1514 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `ALTER TABLE` command recognition for six additional operations.
  * Added clearer descriptions for row-ID changes, column visibility updates, and forced view compilation in generated output.
  * These operations now appear more accurately in deparsed SQL and related diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->