### PR TITLE
Allow transaction control in Oracle AUTHID DEFINER procedures

### DIFF
--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -3116,11 +3116,15 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 	 */
 	if (((Form_pg_proc) GETSTRUCT(tp))->prosecdef)
 	{
-		GetUserIdAndSecContext(&userid, &sec_context);
 		if (compatible_db != ORA_PARSER ||
-			((Form_pg_proc) GETSTRUCT(tp))->prolang != LANG_PLISQL_OID ||
-			(sec_context & ~SECURITY_LOCAL_USERID_CHANGE) != 0)
+			((Form_pg_proc) GETSTRUCT(tp))->prolang != LANG_PLISQL_OID)
 			callcontext->atomic = true;
+		else
+		{
+			GetUserIdAndSecContext(&userid, &sec_context);
+			if ((sec_context & ~SECURITY_LOCAL_USERID_CHANGE) != 0)
+				callcontext->atomic = true;
+		}
 	}
 
 	ReleaseSysCache(tp);

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -3070,6 +3070,8 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 	HeapTuple	tp;
 	PgStat_FunctionCallUsage fcusage;
 	Datum		retval;
+	Oid			userid;
+	int			sec_context;
 
 	fexpr = stmt->funcexpr;
 	Assert(fexpr);
@@ -3105,13 +3107,21 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 		callcontext->atomic = true;
 
 	/*
-	 * In security definer procedures, we can't allow transaction commands.
-	 * StartTransaction() insists that the security context stack is empty,
-	 * and AbortTransaction() resets the security context.  This could be
-	 * reorganized, but right now it doesn't work.
+	 * In security definer procedures, we normally can't allow transaction
+	 * commands because StartTransaction() insists that the security context
+	 * stack is empty.  PL/iSQL handles the local user-ID change around a
+	 * transaction boundary in Oracle mode, where procedures are security
+	 * definer by default.  Other security restrictions must still make the
+	 * call atomic.
 	 */
 	if (((Form_pg_proc) GETSTRUCT(tp))->prosecdef)
-		callcontext->atomic = true;
+	{
+		GetUserIdAndSecContext(&userid, &sec_context);
+		if (compatible_db != ORA_PARSER ||
+			((Form_pg_proc) GETSTRUCT(tp))->prolang != LANG_PLISQL_OID ||
+			(sec_context & ~SECURITY_LOCAL_USERID_CHANGE) != 0)
+			callcontext->atomic = true;
+	}
 
 	ReleaseSysCache(tp);
 

--- a/src/pl/plisql/src/expected/plisql_call.out
+++ b/src/pl/plisql/src/expected/plisql_call.out
@@ -53,12 +53,10 @@ END;
 $$;
 /
 CALL test_proc3a();
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function test_proc3a() line 3 at COMMIT
+NOTICE:  done
 CREATE TEMP TABLE tt1(f1 int);
 CALL test_proc3a();
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function test_proc3a() line 3 at COMMIT
+NOTICE:  done
 -- nested CALL
 TRUNCATE TABLE test1;
 CREATE PROCEDURE test_proc4(y int)
@@ -217,10 +215,7 @@ END
 $$;
 /
 CALL test_proc7cc(10);
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function test_proc7c(pg_catalog.int4,pg_catalog.int4,pg_catalog.numeric) line 5 at COMMIT
-SQL statement "CALL test_proc7c(_x, _a, _b)"
-PL/iSQL function test_proc7cc(pg_catalog.int4) line 4 at CALL
+NOTICE:  _x: 10,_a: 1, _b: 5
 -- named parameters and defaults
 CREATE PROCEDURE test_proc8a(INOUT a int, INOUT b int)
 LANGUAGE plisql

--- a/src/pl/plisql/src/expected/plisql_transaction.out
+++ b/src/pl/plisql/src/expected/plisql_transaction.out
@@ -756,7 +756,7 @@ SELECT * FROM test1;
 -- Test transaction control in an AUTHID DEFINER procedure (Issue #1187).
 -- Verify that the procedure retains its owner's privileges after transaction
 -- boundaries and that the caller's effective user is restored on return.
-CREATE ROLE transaction_caller;
+CREATE ROLE regress_transaction_caller;
 CREATE TABLE test_definer_xact (event text, effective_user name);
 CREATE OR REPLACE PROCEDURE transaction_definer AUTHID DEFINER IS
 BEGIN
@@ -768,10 +768,10 @@ BEGIN
 END;
 /
 REVOKE EXECUTE ON PROCEDURE transaction_definer FROM PUBLIC;
-GRANT EXECUTE ON PROCEDURE transaction_definer TO transaction_caller;
-SET ROLE transaction_caller;
+GRANT EXECUTE ON PROCEDURE transaction_definer TO regress_transaction_caller;
+SET ROLE regress_transaction_caller;
 CALL transaction_definer();
-SELECT current_user = 'transaction_caller'::name AS caller_restored;
+SELECT current_user = 'regress_transaction_caller'::name AS caller_restored;
  caller_restored 
 -----------------
  t
@@ -788,14 +788,14 @@ FROM test_definer_xact ORDER BY event;
 
 DROP PROCEDURE transaction_definer;
 DROP TABLE test_definer_xact;
-DROP ROLE transaction_caller;
+DROP ROLE regress_transaction_caller;
 -- Test that transaction control in a security-definer procedure is safe even
 -- when the procedure body switches ivorysql.compatible_mode before COMMIT.
 -- compatible_db is a GUC and can be changed by EXECUTE 'SET ...' inside the
 -- procedure, so exec_transaction must restore the outer user based on the
 -- security context flag alone rather than the mutable compatible_db.  Before
 -- the fix this crashed the backend at the COMMIT statement.
-CREATE ROLE transaction_mode_switcher;
+CREATE ROLE regress_transaction_mode_switcher;
 CREATE TABLE test_definer_mode_xact (event text, effective_user name);
 CREATE OR REPLACE PROCEDURE transaction_definer_mode_switch AUTHID DEFINER IS
 BEGIN
@@ -806,10 +806,10 @@ BEGIN
 END;
 /
 REVOKE EXECUTE ON PROCEDURE transaction_definer_mode_switch FROM PUBLIC;
-GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO transaction_mode_switcher;
-SET ROLE transaction_mode_switcher;
+GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO regress_transaction_mode_switcher;
+SET ROLE regress_transaction_mode_switcher;
 CALL transaction_definer_mode_switch();
-SELECT current_user = 'transaction_mode_switcher'::name AS caller_restored;
+SELECT current_user = 'regress_transaction_mode_switcher'::name AS caller_restored;
  caller_restored 
 -----------------
  t
@@ -824,7 +824,7 @@ SELECT count(*) FROM test_definer_mode_xact;
 
 DROP PROCEDURE transaction_definer_mode_switch;
 DROP TABLE test_definer_mode_xact;
-DROP ROLE transaction_mode_switcher;
+DROP ROLE regress_transaction_mode_switcher;
 -- Test nested security-definer procedure calls with COMMIT/ROLLBACK
 -- (Issue #1007).  Oracle-syntax procedures default to AUTHID DEFINER.
 CREATE TABLE test_nested_commit (id int);

--- a/src/pl/plisql/src/expected/plisql_transaction.out
+++ b/src/pl/plisql/src/expected/plisql_transaction.out
@@ -15,12 +15,15 @@ END
 $$;
 /
 CALL transaction_test1(9, 'foo');
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function transaction_test1(pg_catalog.int4,text) line 6 at COMMIT
 SELECT * FROM test1;
- a | b 
----+---
-(0 rows)
+ a |  b  
+---+-----
+ 0 | foo
+ 2 | foo
+ 4 | foo
+ 6 | foo
+ 8 | foo
+(5 rows)
 
 TRUNCATE test1;
 DO
@@ -132,7 +135,7 @@ $$;
 CALL transaction_test5();
 ERROR:  invalid transaction termination
 CONTEXT:  PL/iSQL function transaction_test5() line 3 at COMMIT
--- SECURITY DEFINER currently disallow transaction statements
+-- SECURITY DEFINER procedures allow transaction statements in Oracle mode
 CREATE PROCEDURE transaction_test5b()
 LANGUAGE plisql
 SECURITY DEFINER
@@ -143,8 +146,6 @@ END;
 $$;
 /
 CALL transaction_test5b();
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function transaction_test5b() line 3 at COMMIT
 TRUNCATE test1;
 -- nested procedure calls
 CREATE PROCEDURE transaction_test6(c text)
@@ -156,14 +157,15 @@ END;
 $$;
 /
 CALL transaction_test6('bar');
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function transaction_test1(pg_catalog.int4,text) line 6 at COMMIT
-SQL statement "CALL transaction_test1(9, c)"
-PL/iSQL function transaction_test6(text) line 3 at CALL
 SELECT * FROM test1;
- a | b 
----+---
-(0 rows)
+ a |  b  
+---+-----
+ 0 | bar
+ 2 | bar
+ 4 | bar
+ 6 | bar
+ 8 | bar
+(5 rows)
 
 TRUNCATE test1;
 CREATE PROCEDURE transaction_test7()
@@ -175,16 +177,15 @@ END;
 $$;
 /
 CALL transaction_test7();
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function transaction_test1(pg_catalog.int4,text) line 6 at COMMIT
-SQL statement "CALL transaction_test1(9, $x$baz$x$)"
-PL/iSQL function inline_code_block line 1 at CALL
-SQL statement "DO 'BEGIN transaction_test1(9, $x$baz$x$); END;'"
-PL/iSQL function transaction_test7() line 3 at DO
 SELECT * FROM test1;
- a | b 
----+---
-(0 rows)
+ a |  b  
+---+-----
+ 0 | baz
+ 2 | baz
+ 4 | baz
+ 6 | baz
+ 8 | baz
+(5 rows)
 
 CREATE PROCEDURE transaction_test8()
 LANGUAGE plisql
@@ -545,7 +546,7 @@ $$;
 /
 TRUNCATE test1;
 CALL cursor_fail_during_commit();
-ERROR:  invalid transaction termination
+ERROR:  division by zero
 CONTEXT:  PL/iSQL function cursor_fail_during_commit() line 6 at COMMIT
 -- note that error occurs during first COMMIT, hence nothing is in test1
 SELECT count(*) FROM test1;
@@ -568,7 +569,7 @@ $$;
 /
 TRUNCATE test1;
 CALL cursor_fail_during_rollback();
-ERROR:  invalid transaction termination
+ERROR:  division by zero
 CONTEXT:  PL/iSQL function cursor_fail_during_rollback() line 6 at ROLLBACK
 SELECT count(*) FROM test1;
  count 
@@ -673,8 +674,11 @@ END;
 $$;
 /
 CALL transaction_test10a(10);
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function transaction_test10a(pg_catalog.int4) line 4 at COMMIT
+ x  
+----
+ 11
+(1 row)
+
 CREATE PROCEDURE transaction_test10b(INOUT x int)
 LANGUAGE plisql
 AS $$
@@ -685,8 +689,11 @@ END;
 $$;
 /
 CALL transaction_test10b(10);
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function transaction_test10b(pg_catalog.int4) line 4 at ROLLBACK
+ x 
+---
+ 9
+(1 row)
+
 -- transaction timestamp vs. statement timestamp
 CREATE PROCEDURE transaction_test11()
 LANGUAGE plisql
@@ -718,8 +725,6 @@ END;
 $$;
 /
 CALL transaction_test11();
-ERROR:  invalid transaction termination
-CONTEXT:  PL/iSQL function transaction_test11() line 14 at COMMIT
 -- transaction chain
 TRUNCATE test1;
 DO LANGUAGE plisql $$
@@ -748,20 +753,47 @@ SELECT * FROM test1;
  2 | 
 (2 rows)
 
--- Test nested procedure calls with COMMIT/ROLLBACK (Issue #1007)
---
--- Note: Oracle-syntax procedures (CREATE PROCEDURE ... IS) default to
--- AUTHID DEFINER (prosecdef=true), which forces atomic mode and blocks
--- COMMIT/ROLLBACK. Use AUTHID CURRENT_USER to allow transaction control.
--- This matches Oracle behavior where COMMIT is allowed regardless of AUTHID.
--- Tests below verify COMMIT/ROLLBACK in nested procedure calls
--- using AUTHID CURRENT_USER (Oracle-compatible syntax).
--- Without AUTHID CURRENT_USER, Oracle-syntax procedures default to
--- SECURITY DEFINER (prosecdef=true), which forces atomic mode and
--- blocks COMMIT/ROLLBACK. This is a known limitation (see Test 0).
+-- Test transaction control in an AUTHID DEFINER procedure (Issue #1187).
+-- Verify that the procedure retains its owner's privileges after transaction
+-- boundaries and that the caller's effective user is restored on return.
+CREATE ROLE transaction_caller;
+CREATE TABLE test_definer_xact (event text, effective_user name);
+CREATE OR REPLACE PROCEDURE transaction_definer AUTHID DEFINER IS
+BEGIN
+    INSERT INTO test_definer_xact VALUES ('before commit', current_user);
+    COMMIT;
+    INSERT INTO test_definer_xact VALUES ('before rollback', current_user);
+    ROLLBACK;
+    INSERT INTO test_definer_xact VALUES ('after rollback', current_user);
+END;
+/
+REVOKE EXECUTE ON PROCEDURE transaction_definer FROM PUBLIC;
+GRANT EXECUTE ON PROCEDURE transaction_definer TO transaction_caller;
+SET ROLE transaction_caller;
+CALL transaction_definer();
+SELECT current_user = 'transaction_caller'::name AS caller_restored;
+ caller_restored 
+-----------------
+ t
+(1 row)
+
+RESET ROLE;
+SELECT event, effective_user = current_user AS ran_as_owner
+FROM test_definer_xact ORDER BY event;
+     event      | ran_as_owner 
+----------------+--------------
+ after rollback | t
+ before commit  | t
+(2 rows)
+
+DROP PROCEDURE transaction_definer;
+DROP TABLE test_definer_xact;
+DROP ROLE transaction_caller;
+-- Test nested security-definer procedure calls with COMMIT/ROLLBACK
+-- (Issue #1007).  Oracle-syntax procedures default to AUTHID DEFINER.
 CREATE TABLE test_nested_commit (id int);
 -- Inner procedure with COMMIT
-CREATE OR REPLACE PROCEDURE nested_inner_commit AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_inner_commit IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (1);
     COMMIT;
@@ -769,7 +801,7 @@ BEGIN
 END;
 /
 -- Outer procedure calling inner with CALL keyword
-CREATE OR REPLACE PROCEDURE nested_outer_commit AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_commit IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (0);
     CALL nested_inner_commit();
@@ -789,7 +821,7 @@ SELECT * FROM test_nested_commit ORDER BY id;
 (4 rows)
 
 -- Test 2: Oracle-style call (without CALL keyword) with COMMIT
-CREATE OR REPLACE PROCEDURE nested_outer_oracle_style AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_oracle_style IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (10);
     nested_inner_commit();  -- Oracle-style call
@@ -808,28 +840,28 @@ SELECT * FROM test_nested_commit ORDER BY id;
 (4 rows)
 
 -- Test 3: Deeply nested Oracle-style calls (4 levels) with COMMIT
-CREATE OR REPLACE PROCEDURE nested_level4 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level4 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (104);
     COMMIT;
     INSERT INTO test_nested_commit VALUES (105);
 END;
 /
-CREATE OR REPLACE PROCEDURE nested_level3 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level3 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (103);
     nested_level4();  -- Oracle-style call
     INSERT INTO test_nested_commit VALUES (106);
 END;
 /
-CREATE OR REPLACE PROCEDURE nested_level2 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level2 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (102);
     nested_level3();  -- Oracle-style call
     INSERT INTO test_nested_commit VALUES (107);
 END;
 /
-CREATE OR REPLACE PROCEDURE nested_level1 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level1 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (101);
     nested_level2();  -- Oracle-style call
@@ -852,14 +884,14 @@ SELECT * FROM test_nested_commit ORDER BY id;
 (8 rows)
 
 -- Test 4: ROLLBACK in nested procedure with CALL keyword
-CREATE OR REPLACE PROCEDURE nested_inner_rollback AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_inner_rollback IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (201);
     ROLLBACK;
     INSERT INTO test_nested_commit VALUES (202);
 END;
 /
-CREATE OR REPLACE PROCEDURE nested_outer_rollback AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_rollback IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (200);
     CALL nested_inner_rollback();
@@ -876,7 +908,7 @@ SELECT * FROM test_nested_commit ORDER BY id;
 (2 rows)
 
 -- Test 5: Oracle-style call (without CALL keyword) with ROLLBACK
-CREATE OR REPLACE PROCEDURE nested_outer_rollback_oracle_style AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_rollback_oracle_style IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (300);
     nested_inner_rollback();  -- Oracle-style call

--- a/src/pl/plisql/src/expected/plisql_transaction.out
+++ b/src/pl/plisql/src/expected/plisql_transaction.out
@@ -798,17 +798,22 @@ DROP ROLE regress_transaction_caller;
 CREATE ROLE regress_transaction_mode_switcher;
 CREATE TABLE test_definer_mode_xact (event text, effective_user name);
 CREATE OR REPLACE PROCEDURE transaction_definer_mode_switch AUTHID DEFINER IS
+    i int;
 BEGIN
-    INSERT INTO test_definer_mode_xact VALUES ('before commit', current_user);
-    EXECUTE 'SET ivorysql.compatible_mode = ''pg''';
-    COMMIT;
-    EXECUTE 'SET ivorysql.compatible_mode = ''ora''';
+    FOR i IN 1..2 LOOP
+        INSERT INTO test_definer_mode_xact VALUES ('privilege check', current_user);
+        IF i = 1 THEN
+            EXECUTE 'SET ivorysql.compatible_mode = ''pg''';
+            COMMIT;
+        END IF;
+    END LOOP;
 END;
 /
 REVOKE EXECUTE ON PROCEDURE transaction_definer_mode_switch FROM PUBLIC;
 GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO regress_transaction_mode_switcher;
 SET ROLE regress_transaction_mode_switcher;
 CALL transaction_definer_mode_switch();
+SET ivorysql.compatible_mode = oracle;
 SELECT current_user = 'regress_transaction_mode_switcher'::name AS caller_restored;
  caller_restored 
 -----------------
@@ -819,7 +824,7 @@ RESET ROLE;
 SELECT count(*) FROM test_definer_mode_xact;
  count 
 -------
-     1
+     2
 (1 row)
 
 DROP PROCEDURE transaction_definer_mode_switch;
@@ -960,6 +965,56 @@ SELECT * FROM test_nested_commit ORDER BY id;
  303
 (2 rows)
 
+-- Test 6: Keep nested COMMIT coverage for AUTHID CURRENT_USER procedures.
+CREATE OR REPLACE PROCEDURE nested_invoker_inner_commit AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (401);
+    COMMIT;
+    INSERT INTO test_nested_commit VALUES (402);
+END;
+/
+CREATE OR REPLACE PROCEDURE nested_invoker_outer_commit AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (400);
+    CALL nested_invoker_inner_commit();
+    INSERT INTO test_nested_commit VALUES (403);
+END;
+/
+TRUNCATE test_nested_commit;
+CALL nested_invoker_outer_commit();
+SELECT * FROM test_nested_commit ORDER BY id;
+ id  
+-----
+ 400
+ 401
+ 402
+ 403
+(4 rows)
+
+-- Test 7: Keep nested ROLLBACK coverage for AUTHID CURRENT_USER procedures.
+CREATE OR REPLACE PROCEDURE nested_invoker_inner_rollback AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (501);
+    ROLLBACK;
+    INSERT INTO test_nested_commit VALUES (502);
+END;
+/
+CREATE OR REPLACE PROCEDURE nested_invoker_outer_rollback AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (500);
+    CALL nested_invoker_inner_rollback();
+    INSERT INTO test_nested_commit VALUES (503);
+END;
+/
+TRUNCATE test_nested_commit;
+CALL nested_invoker_outer_rollback();
+SELECT * FROM test_nested_commit ORDER BY id;
+ id  
+-----
+ 502
+ 503
+(2 rows)
+
 -- Clean up nested commit tests
 DROP PROCEDURE nested_inner_commit;
 DROP PROCEDURE nested_outer_commit;
@@ -971,6 +1026,10 @@ DROP PROCEDURE nested_level4;
 DROP PROCEDURE nested_inner_rollback;
 DROP PROCEDURE nested_outer_rollback;
 DROP PROCEDURE nested_outer_rollback_oracle_style;
+DROP PROCEDURE nested_invoker_inner_commit;
+DROP PROCEDURE nested_invoker_outer_commit;
+DROP PROCEDURE nested_invoker_inner_rollback;
+DROP PROCEDURE nested_invoker_outer_rollback;
 DROP TABLE test_nested_commit;
 DROP TABLE test1;
 DROP TABLE test2;

--- a/src/pl/plisql/src/expected/plisql_transaction.out
+++ b/src/pl/plisql/src/expected/plisql_transaction.out
@@ -789,6 +789,42 @@ FROM test_definer_xact ORDER BY event;
 DROP PROCEDURE transaction_definer;
 DROP TABLE test_definer_xact;
 DROP ROLE transaction_caller;
+-- Test that transaction control in a security-definer procedure is safe even
+-- when the procedure body switches ivorysql.compatible_mode before COMMIT.
+-- compatible_db is a GUC and can be changed by EXECUTE 'SET ...' inside the
+-- procedure, so exec_transaction must restore the outer user based on the
+-- security context flag alone rather than the mutable compatible_db.  Before
+-- the fix this crashed the backend at the COMMIT statement.
+CREATE ROLE transaction_mode_switcher;
+CREATE TABLE test_definer_mode_xact (event text, effective_user name);
+CREATE OR REPLACE PROCEDURE transaction_definer_mode_switch AUTHID DEFINER IS
+BEGIN
+    INSERT INTO test_definer_mode_xact VALUES ('before commit', current_user);
+    EXECUTE 'SET ivorysql.compatible_mode = ''pg''';
+    COMMIT;
+    EXECUTE 'SET ivorysql.compatible_mode = ''ora''';
+END;
+/
+REVOKE EXECUTE ON PROCEDURE transaction_definer_mode_switch FROM PUBLIC;
+GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO transaction_mode_switcher;
+SET ROLE transaction_mode_switcher;
+CALL transaction_definer_mode_switch();
+SELECT current_user = 'transaction_mode_switcher'::name AS caller_restored;
+ caller_restored 
+-----------------
+ t
+(1 row)
+
+RESET ROLE;
+SELECT count(*) FROM test_definer_mode_xact;
+ count 
+-------
+     1
+(1 row)
+
+DROP PROCEDURE transaction_definer_mode_switch;
+DROP TABLE test_definer_mode_xact;
+DROP ROLE transaction_mode_switcher;
 -- Test nested security-definer procedure calls with COMMIT/ROLLBACK
 -- (Issue #1007).  Oracle-syntax procedures default to AUTHID DEFINER.
 CREATE TABLE test_nested_commit (id int);

--- a/src/pl/plisql/src/pl_exec.c
+++ b/src/pl/plisql/src/pl_exec.c
@@ -5498,6 +5498,15 @@ exec_stmt_rollback(PLiSQL_execstate * estate, PLiSQL_stmt_rollback * stmt)
  * procedure's effective user.  A transaction must start with an empty
  * security context, so temporarily restore the outer user and then reinstate
  * the procedure owner after SPI has started the next transaction.
+ *
+ * We decide whether to save/restore the user from the security context flag
+ * alone.  Checking compatible_db here would be unsafe: it is a GUC that can
+ * be changed inside the procedure (for example by EXECUTE 'SET
+ * ivorysql.compatible_mode = ...'), so a transaction control statement that
+ * runs after such a change would skip the restore and commit with a non-empty
+ * security context, crashing the backend.  SECURITY_LOCAL_USERID_CHANGE is
+ * stable for the whole call, exactly matching how definer procedures are
+ * entered (see SetUserIdAndSecContext in pl_package.c and friends).
  */
 static void
 exec_transaction(bool is_commit, bool chain)
@@ -5507,8 +5516,7 @@ exec_transaction(bool is_commit, bool chain)
 	bool		restore_user;
 
 	GetUserIdAndSecContext(&save_userid, &save_sec_context);
-	restore_user = compatible_db == ORA_PARSER &&
-		save_sec_context == SECURITY_LOCAL_USERID_CHANGE;
+	restore_user = (save_sec_context & SECURITY_LOCAL_USERID_CHANGE) != 0;
 
 	if (restore_user)
 		SetUserIdAndSecContext(GetOuterUserId(), 0);

--- a/src/pl/plisql/src/pl_exec.c
+++ b/src/pl/plisql/src/pl_exec.c
@@ -356,6 +356,7 @@ static int	exec_stmt_commit(PLiSQL_execstate * estate,
 							 PLiSQL_stmt_commit * stmt);
 static int	exec_stmt_rollback(PLiSQL_execstate * estate,
 							   PLiSQL_stmt_rollback * stmt);
+static void exec_transaction(bool is_commit, bool chain);
 
 static void plisql_estate_setup(PLiSQL_execstate * estate,
 								PLiSQL_function * func,
@@ -5458,10 +5459,7 @@ exec_stmt_close(PLiSQL_execstate * estate, PLiSQL_stmt_close * stmt)
 static int
 exec_stmt_commit(PLiSQL_execstate * estate, PLiSQL_stmt_commit * stmt)
 {
-	if (stmt->chain)
-		SPI_commit_and_chain();
-	else
-		SPI_commit();
+	exec_transaction(true, stmt->chain);
 
 	/*
 	 * We need to build new simple-expression infrastructure, since the old
@@ -5482,10 +5480,7 @@ exec_stmt_commit(PLiSQL_execstate * estate, PLiSQL_stmt_commit * stmt)
 static int
 exec_stmt_rollback(PLiSQL_execstate * estate, PLiSQL_stmt_rollback * stmt)
 {
-	if (stmt->chain)
-		SPI_rollback_and_chain();
-	else
-		SPI_rollback();
+	exec_transaction(false, stmt->chain);
 
 	/*
 	 * We need to build new simple-expression infrastructure, since the old
@@ -5496,6 +5491,55 @@ exec_stmt_rollback(PLiSQL_execstate * estate, PLiSQL_stmt_rollback * stmt)
 	plisql_create_econtext(estate);
 
 	return PLISQL_RC_OK;
+}
+
+/*
+ * End the current transaction while preserving an Oracle security-definer
+ * procedure's effective user.  A transaction must start with an empty
+ * security context, so temporarily restore the outer user and then reinstate
+ * the procedure owner after SPI has started the next transaction.
+ */
+static void
+exec_transaction(bool is_commit, bool chain)
+{
+	Oid			save_userid;
+	int			save_sec_context;
+	bool		restore_user;
+
+	GetUserIdAndSecContext(&save_userid, &save_sec_context);
+	restore_user = compatible_db == ORA_PARSER &&
+		save_sec_context == SECURITY_LOCAL_USERID_CHANGE;
+
+	if (restore_user)
+		SetUserIdAndSecContext(GetOuterUserId(), 0);
+
+	PG_TRY();
+	{
+		if (is_commit)
+		{
+			if (chain)
+				SPI_commit_and_chain();
+			else
+				SPI_commit();
+		}
+		else
+		{
+			if (chain)
+				SPI_rollback_and_chain();
+			else
+				SPI_rollback();
+		}
+	}
+	PG_CATCH();
+	{
+		if (restore_user)
+			SetUserIdAndSecContext(save_userid, save_sec_context);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	if (restore_user)
+		SetUserIdAndSecContext(save_userid, save_sec_context);
 }
 
 /* ----------

--- a/src/pl/plisql/src/sql/plisql_transaction.sql
+++ b/src/pl/plisql/src/sql/plisql_transaction.sql
@@ -121,7 +121,7 @@ $$;
 CALL transaction_test5();
 
 
--- SECURITY DEFINER currently disallow transaction statements
+-- SECURITY DEFINER procedures allow transaction statements in Oracle mode
 CREATE PROCEDURE transaction_test5b()
 LANGUAGE plisql
 SECURITY DEFINER
@@ -650,23 +650,41 @@ $$;
 SELECT * FROM test1;
 
 
--- Test nested procedure calls with COMMIT/ROLLBACK (Issue #1007)
---
--- Note: Oracle-syntax procedures (CREATE PROCEDURE ... IS) default to
--- AUTHID DEFINER (prosecdef=true), which forces atomic mode and blocks
--- COMMIT/ROLLBACK. Use AUTHID CURRENT_USER to allow transaction control.
--- This matches Oracle behavior where COMMIT is allowed regardless of AUTHID.
+-- Test transaction control in an AUTHID DEFINER procedure (Issue #1187).
+-- Verify that the procedure retains its owner's privileges after transaction
+-- boundaries and that the caller's effective user is restored on return.
+CREATE ROLE transaction_caller;
+CREATE TABLE test_definer_xact (event text, effective_user name);
 
--- Tests below verify COMMIT/ROLLBACK in nested procedure calls
--- using AUTHID CURRENT_USER (Oracle-compatible syntax).
--- Without AUTHID CURRENT_USER, Oracle-syntax procedures default to
--- SECURITY DEFINER (prosecdef=true), which forces atomic mode and
--- blocks COMMIT/ROLLBACK. This is a known limitation (see Test 0).
+CREATE OR REPLACE PROCEDURE transaction_definer AUTHID DEFINER IS
+BEGIN
+    INSERT INTO test_definer_xact VALUES ('before commit', current_user);
+    COMMIT;
+    INSERT INTO test_definer_xact VALUES ('before rollback', current_user);
+    ROLLBACK;
+    INSERT INTO test_definer_xact VALUES ('after rollback', current_user);
+END;
+/
+
+REVOKE EXECUTE ON PROCEDURE transaction_definer FROM PUBLIC;
+GRANT EXECUTE ON PROCEDURE transaction_definer TO transaction_caller;
+SET ROLE transaction_caller;
+CALL transaction_definer();
+SELECT current_user = 'transaction_caller'::name AS caller_restored;
+RESET ROLE;
+SELECT event, effective_user = current_user AS ran_as_owner
+FROM test_definer_xact ORDER BY event;
+DROP PROCEDURE transaction_definer;
+DROP TABLE test_definer_xact;
+DROP ROLE transaction_caller;
+
+-- Test nested security-definer procedure calls with COMMIT/ROLLBACK
+-- (Issue #1007).  Oracle-syntax procedures default to AUTHID DEFINER.
 
 CREATE TABLE test_nested_commit (id int);
 
 -- Inner procedure with COMMIT
-CREATE OR REPLACE PROCEDURE nested_inner_commit AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_inner_commit IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (1);
     COMMIT;
@@ -675,7 +693,7 @@ END;
 /
 
 -- Outer procedure calling inner with CALL keyword
-CREATE OR REPLACE PROCEDURE nested_outer_commit AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_commit IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (0);
     CALL nested_inner_commit();
@@ -689,7 +707,7 @@ CALL nested_outer_commit();
 SELECT * FROM test_nested_commit ORDER BY id;
 
 -- Test 2: Oracle-style call (without CALL keyword) with COMMIT
-CREATE OR REPLACE PROCEDURE nested_outer_oracle_style AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_oracle_style IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (10);
     nested_inner_commit();  -- Oracle-style call
@@ -702,7 +720,7 @@ CALL nested_outer_oracle_style();
 SELECT * FROM test_nested_commit ORDER BY id;
 
 -- Test 3: Deeply nested Oracle-style calls (4 levels) with COMMIT
-CREATE OR REPLACE PROCEDURE nested_level4 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level4 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (104);
     COMMIT;
@@ -710,7 +728,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE PROCEDURE nested_level3 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level3 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (103);
     nested_level4();  -- Oracle-style call
@@ -718,7 +736,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE PROCEDURE nested_level2 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level2 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (102);
     nested_level3();  -- Oracle-style call
@@ -726,7 +744,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE PROCEDURE nested_level1 AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_level1 IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (101);
     nested_level2();  -- Oracle-style call
@@ -739,7 +757,7 @@ CALL nested_level1();
 SELECT * FROM test_nested_commit ORDER BY id;
 
 -- Test 4: ROLLBACK in nested procedure with CALL keyword
-CREATE OR REPLACE PROCEDURE nested_inner_rollback AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_inner_rollback IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (201);
     ROLLBACK;
@@ -747,7 +765,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE PROCEDURE nested_outer_rollback AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_rollback IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (200);
     CALL nested_inner_rollback();
@@ -760,7 +778,7 @@ CALL nested_outer_rollback();
 SELECT * FROM test_nested_commit ORDER BY id;
 
 -- Test 5: Oracle-style call (without CALL keyword) with ROLLBACK
-CREATE OR REPLACE PROCEDURE nested_outer_rollback_oracle_style AUTHID CURRENT_USER IS
+CREATE OR REPLACE PROCEDURE nested_outer_rollback_oracle_style IS
 BEGIN
     INSERT INTO test_nested_commit VALUES (300);
     nested_inner_rollback();  -- Oracle-style call

--- a/src/pl/plisql/src/sql/plisql_transaction.sql
+++ b/src/pl/plisql/src/sql/plisql_transaction.sql
@@ -688,11 +688,15 @@ CREATE ROLE regress_transaction_mode_switcher;
 CREATE TABLE test_definer_mode_xact (event text, effective_user name);
 
 CREATE OR REPLACE PROCEDURE transaction_definer_mode_switch AUTHID DEFINER IS
+    i int;
 BEGIN
-    INSERT INTO test_definer_mode_xact VALUES ('before commit', current_user);
-    EXECUTE 'SET ivorysql.compatible_mode = ''pg''';
-    COMMIT;
-    EXECUTE 'SET ivorysql.compatible_mode = ''ora''';
+    FOR i IN 1..2 LOOP
+        INSERT INTO test_definer_mode_xact VALUES ('privilege check', current_user);
+        IF i = 1 THEN
+            EXECUTE 'SET ivorysql.compatible_mode = ''pg''';
+            COMMIT;
+        END IF;
+    END LOOP;
 END;
 /
 
@@ -700,6 +704,7 @@ REVOKE EXECUTE ON PROCEDURE transaction_definer_mode_switch FROM PUBLIC;
 GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO regress_transaction_mode_switcher;
 SET ROLE regress_transaction_mode_switcher;
 CALL transaction_definer_mode_switch();
+SET ivorysql.compatible_mode = oracle;
 SELECT current_user = 'regress_transaction_mode_switcher'::name AS caller_restored;
 RESET ROLE;
 SELECT count(*) FROM test_definer_mode_xact;
@@ -819,6 +824,48 @@ TRUNCATE test_nested_commit;
 CALL nested_outer_rollback_oracle_style();
 SELECT * FROM test_nested_commit ORDER BY id;
 
+-- Test 6: Keep nested COMMIT coverage for AUTHID CURRENT_USER procedures.
+CREATE OR REPLACE PROCEDURE nested_invoker_inner_commit AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (401);
+    COMMIT;
+    INSERT INTO test_nested_commit VALUES (402);
+END;
+/
+
+CREATE OR REPLACE PROCEDURE nested_invoker_outer_commit AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (400);
+    CALL nested_invoker_inner_commit();
+    INSERT INTO test_nested_commit VALUES (403);
+END;
+/
+
+TRUNCATE test_nested_commit;
+CALL nested_invoker_outer_commit();
+SELECT * FROM test_nested_commit ORDER BY id;
+
+-- Test 7: Keep nested ROLLBACK coverage for AUTHID CURRENT_USER procedures.
+CREATE OR REPLACE PROCEDURE nested_invoker_inner_rollback AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (501);
+    ROLLBACK;
+    INSERT INTO test_nested_commit VALUES (502);
+END;
+/
+
+CREATE OR REPLACE PROCEDURE nested_invoker_outer_rollback AUTHID CURRENT_USER IS
+BEGIN
+    INSERT INTO test_nested_commit VALUES (500);
+    CALL nested_invoker_inner_rollback();
+    INSERT INTO test_nested_commit VALUES (503);
+END;
+/
+
+TRUNCATE test_nested_commit;
+CALL nested_invoker_outer_rollback();
+SELECT * FROM test_nested_commit ORDER BY id;
+
 -- Clean up nested commit tests
 DROP PROCEDURE nested_inner_commit;
 DROP PROCEDURE nested_outer_commit;
@@ -830,6 +877,10 @@ DROP PROCEDURE nested_level4;
 DROP PROCEDURE nested_inner_rollback;
 DROP PROCEDURE nested_outer_rollback;
 DROP PROCEDURE nested_outer_rollback_oracle_style;
+DROP PROCEDURE nested_invoker_inner_commit;
+DROP PROCEDURE nested_invoker_outer_commit;
+DROP PROCEDURE nested_invoker_inner_rollback;
+DROP PROCEDURE nested_invoker_outer_rollback;
 DROP TABLE test_nested_commit;
 
 

--- a/src/pl/plisql/src/sql/plisql_transaction.sql
+++ b/src/pl/plisql/src/sql/plisql_transaction.sql
@@ -653,7 +653,7 @@ SELECT * FROM test1;
 -- Test transaction control in an AUTHID DEFINER procedure (Issue #1187).
 -- Verify that the procedure retains its owner's privileges after transaction
 -- boundaries and that the caller's effective user is restored on return.
-CREATE ROLE transaction_caller;
+CREATE ROLE regress_transaction_caller;
 CREATE TABLE test_definer_xact (event text, effective_user name);
 
 CREATE OR REPLACE PROCEDURE transaction_definer AUTHID DEFINER IS
@@ -667,16 +667,16 @@ END;
 /
 
 REVOKE EXECUTE ON PROCEDURE transaction_definer FROM PUBLIC;
-GRANT EXECUTE ON PROCEDURE transaction_definer TO transaction_caller;
-SET ROLE transaction_caller;
+GRANT EXECUTE ON PROCEDURE transaction_definer TO regress_transaction_caller;
+SET ROLE regress_transaction_caller;
 CALL transaction_definer();
-SELECT current_user = 'transaction_caller'::name AS caller_restored;
+SELECT current_user = 'regress_transaction_caller'::name AS caller_restored;
 RESET ROLE;
 SELECT event, effective_user = current_user AS ran_as_owner
 FROM test_definer_xact ORDER BY event;
 DROP PROCEDURE transaction_definer;
 DROP TABLE test_definer_xact;
-DROP ROLE transaction_caller;
+DROP ROLE regress_transaction_caller;
 
 -- Test that transaction control in a security-definer procedure is safe even
 -- when the procedure body switches ivorysql.compatible_mode before COMMIT.
@@ -684,7 +684,7 @@ DROP ROLE transaction_caller;
 -- procedure, so exec_transaction must restore the outer user based on the
 -- security context flag alone rather than the mutable compatible_db.  Before
 -- the fix this crashed the backend at the COMMIT statement.
-CREATE ROLE transaction_mode_switcher;
+CREATE ROLE regress_transaction_mode_switcher;
 CREATE TABLE test_definer_mode_xact (event text, effective_user name);
 
 CREATE OR REPLACE PROCEDURE transaction_definer_mode_switch AUTHID DEFINER IS
@@ -697,15 +697,15 @@ END;
 /
 
 REVOKE EXECUTE ON PROCEDURE transaction_definer_mode_switch FROM PUBLIC;
-GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO transaction_mode_switcher;
-SET ROLE transaction_mode_switcher;
+GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO regress_transaction_mode_switcher;
+SET ROLE regress_transaction_mode_switcher;
 CALL transaction_definer_mode_switch();
-SELECT current_user = 'transaction_mode_switcher'::name AS caller_restored;
+SELECT current_user = 'regress_transaction_mode_switcher'::name AS caller_restored;
 RESET ROLE;
 SELECT count(*) FROM test_definer_mode_xact;
 DROP PROCEDURE transaction_definer_mode_switch;
 DROP TABLE test_definer_mode_xact;
-DROP ROLE transaction_mode_switcher;
+DROP ROLE regress_transaction_mode_switcher;
 
 -- Test nested security-definer procedure calls with COMMIT/ROLLBACK
 -- (Issue #1007).  Oracle-syntax procedures default to AUTHID DEFINER.

--- a/src/pl/plisql/src/sql/plisql_transaction.sql
+++ b/src/pl/plisql/src/sql/plisql_transaction.sql
@@ -678,6 +678,35 @@ DROP PROCEDURE transaction_definer;
 DROP TABLE test_definer_xact;
 DROP ROLE transaction_caller;
 
+-- Test that transaction control in a security-definer procedure is safe even
+-- when the procedure body switches ivorysql.compatible_mode before COMMIT.
+-- compatible_db is a GUC and can be changed by EXECUTE 'SET ...' inside the
+-- procedure, so exec_transaction must restore the outer user based on the
+-- security context flag alone rather than the mutable compatible_db.  Before
+-- the fix this crashed the backend at the COMMIT statement.
+CREATE ROLE transaction_mode_switcher;
+CREATE TABLE test_definer_mode_xact (event text, effective_user name);
+
+CREATE OR REPLACE PROCEDURE transaction_definer_mode_switch AUTHID DEFINER IS
+BEGIN
+    INSERT INTO test_definer_mode_xact VALUES ('before commit', current_user);
+    EXECUTE 'SET ivorysql.compatible_mode = ''pg''';
+    COMMIT;
+    EXECUTE 'SET ivorysql.compatible_mode = ''ora''';
+END;
+/
+
+REVOKE EXECUTE ON PROCEDURE transaction_definer_mode_switch FROM PUBLIC;
+GRANT EXECUTE ON PROCEDURE transaction_definer_mode_switch TO transaction_mode_switcher;
+SET ROLE transaction_mode_switcher;
+CALL transaction_definer_mode_switch();
+SELECT current_user = 'transaction_mode_switcher'::name AS caller_restored;
+RESET ROLE;
+SELECT count(*) FROM test_definer_mode_xact;
+DROP PROCEDURE transaction_definer_mode_switch;
+DROP TABLE test_definer_mode_xact;
+DROP ROLE transaction_mode_switcher;
+
 -- Test nested security-definer procedure calls with COMMIT/ROLLBACK
 -- (Issue #1007).  Oracle-syntax procedures default to AUTHID DEFINER.
 


### PR DESCRIPTION
## Summary

- allow Oracle-mode PL/iSQL `AUTHID DEFINER` procedures to run in a non-atomic call context
- restore the outer user while SPI ends and starts a transaction, then reinstate the procedure owner
- cover COMMIT/ROLLBACK, nested calls, and caller/owner identity restoration in regression tests

## Root cause

Oracle-syntax procedures default to `AUTHID DEFINER`, but `ExecuteCallStmt()` forced every security-definer procedure into atomic mode. That made transaction control fail before PL/iSQL could execute it.

## Testing

- `make -j4 COPT="-Wshadow=compatible-local -Wall -Werror -Wno-stringop-truncation"`
- `make -C src/pl/plisql/src oracle-check` (21 tests passed)

Fixes #1187
Fixes #985


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oracle-mode security-definer procedures can execute `COMMIT` and `ROLLBACK` while retaining required privileges.
  * Transaction control now works across nested procedure calls, cursor loops, and procedures with output parameters.
  * Compatibility-mode changes around transaction operations are handled correctly.
  * Caller security context is restored after transaction operations.

* **Bug Fixes**
  * Fixed invalid transaction termination errors during supported procedure commits and rollbacks.
  * Improved state restoration and error handling when transaction operations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->