### PR TITLE
Optimize ASCIISTR escape formatting

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3272,6 +3272,12 @@ SELECT INSTR('Information for the information age requires information.', 'infor
  \D83D\DE0A\D83D\DC4D
 (1 row)
 
+ select asciistr(repeat('你', 205)) = repeat(chr(92) || '4F60', 205) as buffer_growth from dual;
+ buffer_growth 
+---------------
+ t
+(1 row)
+
  -- string with mixed ascii and non-ascii
  select asciistr('ABÄCDE') from dual;
   asciistr  

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1238,6 +1238,7 @@ SELECT INSTR('Information for the information age requires information.', 'infor
  select asciistr('こんにちは') from dual;
  select asciistr('你好') from dual;
  select asciistr('😊👍') from dual;
+ select asciistr(repeat('你', 205)) = repeat(chr(92) || '4F60', 205) as buffer_growth from dual;
 
  -- string with mixed ascii and non-ascii
  select asciistr('ABÄCDE') from dual;

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -1721,14 +1721,24 @@ text_position_prev(int start_pos, TextPositionState *state)
 /*
  *	appendUTF16Escape
  *
- *	Converts a UTF-16 code unit to a Unicode escape sequence (\xxxx) 
- * 	and appends it to the output string.
+ *	Converts a UTF-16 code unit to a Unicode escape sequence (\xxxx)
+ *	and appends it to the output string.
  */
-static void 
-appendUTF16Escape(StringInfoData* outputString, uint16_t codePoint) {
-    char buffer[10];
-    snprintf(buffer, sizeof(buffer), "\\%04X", codePoint);
-    appendStringInfoString(outputString, buffer);
+static void
+appendUTF16Escape(StringInfoData *outputString, uint16_t codePoint)
+{
+	static const char hexdigits[] = "0123456789ABCDEF";
+	char	   *destination;
+
+	enlargeStringInfo(outputString, 5);
+	destination = outputString->data + outputString->len;
+	destination[0] = '\\';
+	destination[1] = hexdigits[(codePoint >> 12) & 0x0F];
+	destination[2] = hexdigits[(codePoint >> 8) & 0x0F];
+	destination[3] = hexdigits[(codePoint >> 4) & 0x0F];
+	destination[4] = hexdigits[codePoint & 0x0F];
+	outputString->len += 5;
+	outputString->data[outputString->len] = '\0';
 }
 
 /****************************************************************


### PR DESCRIPTION
## Summary

- replace per-UTF-16-code-unit `snprintf("\\%04X")` plus `strlen` with a direct five-byte write into `StringInfo`
- preserve uppercase hexadecimal output, leading zeroes, backslash handling, BMP output, and surrogate-pair output
- add a regression case that crosses the initial 1 KiB `StringInfo` allocation

## Root cause

`ASCIISTR` previously formatted every escaped UTF-16 code unit through the general-purpose `snprintf` parser. `appendStringInfoString` then scanned the fixed five-byte result again before copying it. Non-ASCII-heavy input pays this cost once per BMP character and twice per supplementary character.

The new helper reserves exactly five bytes, writes `\\XXXX` directly, advances the length, and restores the trailing NUL. It keeps the existing `StringInfo` growth policy.

## Benchmark

Environment:

- upstream `master` at `d4661fb1d8971cf27415e17361654431ba7b716e`
- IvorySQL 5beta1 / PostgreSQL 19devel, UTF-8
- GCC 11.4, `-O2 --enable-cassert`
- JIT and parallel query disabled
- same build tree, cluster, and tables; only `ivorysql_ora.so` changed
- 20,000 unlogged rows, each containing 1,000 repeated characters
- one warm-up followed by 7 measured executions; table reports the median

Query shape:

```sql
EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY ON)
SELECT sum(octet_length(sys.asciistr(s)))
FROM perf_<workload>;
```

| Workload | Baseline | Optimized | Time reduction | Throughput |
|---|---:|---:|---:|---:|
| BMP Chinese (`甲`) | 1254.708 ms | 235.440 ms | 81.2% | 5.33x |
| Supplementary emoji (`🙂`) | 2454.562 ms | 433.184 ms | 82.4% | 5.67x |
| Backslash | 1281.065 ms | 193.150 ms | 84.9% | 6.63x |
| ASCII control (`A`, helper not used) | 90.496 ms | 92.917 ms | -2.7% | 0.97x |

A reverse-order baseline spot check measured BMP at 1261.145 ms and the ASCII control at 92.571 ms, consistent with the original baseline and showing that the small ASCII difference is normal run-to-run variation.

Output-size checksums were identical before and after: `100000000 | 200000000 | 100000000 | 20000000`.

## Validation

- `make -C contrib/ivorysql_ora oracle-check ORA_REGRESS=ora_character_datatype_functions`: 1/1 passed
- `make -C contrib/ivorysql_ora oracle-check`: 24/24 passed
- long BMP, supplementary-character, and backslash equality assertions passed
- `git diff --check` passed
- independent review found no StringInfo boundary, termination, or encoding-semantic issue

## Duplicate check

Repository issue/PR searches for `ASCIISTR`, `appendUTF16Escape`, `snprintf`, and performance/optimization terms found only feature issues #609 and #1092 plus the original implementation PR #671; none addresses this hotspot.

Assisted-by: OpenAI:gpt-5  
Percentage of AI-generated code: 80%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of long non-ASCII strings to escaped representations, preventing buffer-growth errors.
  * Preserved the existing format of escaped output with uppercase hexadecimal digits.

* **Tests**
  * Added regression coverage for 205 repeated Chinese characters to verify reliable conversion and expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1539

