### PR TITLE
build(meson): remove erroneous gensql.pl reference from gb18030_2022 (1523)

### DIFF
--- a/contrib/gb18030_2022/meson.build
+++ b/contrib/gb18030_2022/meson.build
@@ -10,21 +10,6 @@ if host_system == 'windows'
     '--FILEDESC', 'gb18030_2022 - support gb18030 2022 with extension',])
 endif
 
-custom_target('gb18030_2022.bc',
-  output: 'utf8_and_gb18030_2022.bc',
-  command: [perl, '../contrib/ivorysql_ora/gensql.pl', 'meson', '1.0'],
-  capture: true,
-  install: true,
-  install_dir: contrib_data_args['install_dir'],
-)
-
-foreach file : ['utf8_and_gb18030_2022.bc', 'gb18030_2022.bc']
-  run_target(
-    file,
-    command: ['touch', meson.current_build_dir() / file]
-  )
-endforeach
-
 gb18030_2022 = shared_module('gb18030_2022',
   gb18030_2022_src_files,
   kwargs: contrib_mod_args,


### PR DESCRIPTION
## Summary

Remove an erroneous `custom_target` in `contrib/gb18030_2022/meson.build` that incorrectly referenced `ivorysql_ora/gensql.pl` to generate a `.bc` file. This was a copy-paste error — `gb18030_2022` has its own simple SQL file installed via `install_data` and does not need `gensql.pl`.

## Background / Motivation

The meson build generated a truncated `ivorysql_ora--1.0.sql` (only 111 lines instead of 15027), causing `CREATE EXTENSION ivorysql_ora` to register only ~10 functions (dbms_session) instead of ~400+ (all Oracle-compatible datatypes, builtin functions, and DBMS packages).

The root cause was two `custom_target` entries both running `gensql.pl`:
1. `contrib/ivorysql_ora/meson.build` (correct) — generates `ivorysql_ora--1.0.sql`
2. `contrib/gb18030_2022/meson.build` (incorrect) — tries to generate `utf8_and_gb18030_2022.bc` using `gensql.pl`

The conflict between these two targets caused meson to truncate the first target's output.

Fixes #1523

## Changes

- `contrib/gb18030_2022/meson.build`: Removed the erroneous `custom_target('gb18030_2022.bc', ...)` that referenced `gensql.pl`
- `contrib/gb18030_2022/meson.build`: Removed the `foreach` `run_target` block that created placeholder `.bc` files

## How to Verify

1. `meson setup build --prefix=/tmp/pginstall -Dcassert=true`
2. `ninja -C build -j20`
3. `wc -l build/contrib/ivorysql_ora/ivorysql_ora--1.0.sql` — should be ~15027 lines (was 111)
4. `ninja -C build install`
5. `initdb -D /tmp/test -U ivorysql && pg_ctl -D /tmp/test start`
6. `psql -d postgres -U ivorysql -c "CREATE EXTENSION ivorysql_ora;"`
7. `psql -d postgres -U ivorysql -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON p.pronamespace=n.oid WHERE n.nspname='sys';"` — should be 400+ (was ~10)
8. `CREATE EXTENSION gb18030_2022;` should still work (SQL installed via `install_data`)

## Compliance

- [x] Code follows PostgreSQL coding conventions
- [x] No new compiler warnings
- [x] Regression tests pass

Assisted-by: OpenAI:gpt-5
Percentage of AI-generated code: 60%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete build steps related to generating and handling GB18030-2022 bytecode files.
  * Existing module installation and test coverage remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->