### PR TITLE
fix(datetime): zero fsec in ora_round to match ora_trunc behavior (1524)

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -461,6 +461,8 @@ ora_round(PG_FUNCTION_ARGS)
 
 	tm_round(tm, fmt);
 
+	fsec = 0;
+
 	if (tm2timestamp(tm, fsec, NULL, &result) != 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),


### PR DESCRIPTION
## Summary

Add `fsec = 0;` after `tm_round()` in `ora_round()` to zero fractional seconds, matching the behavior of `ora_trunc()`.

## Background / Motivation

`ora_round()` and `ora_trunc()` are Oracle-compatible date/time rounding and truncation functions in `contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c`. Both extract `fsec` (fractional seconds) from the input timestamp via `timestamp2tm()`, then call their respective `tm_*` helper to modify the `tm` struct.

However, `ora_trunc()` explicitly zeros `fsec` after `tm_trunc()`:

```c
// ora_trunc (correct):
tm_trunc(tm, fmt);
fsec = 0;                    // zeros fractional seconds
if (tm2timestamp(tm, fsec, NULL, &result) != 0)
```

While `ora_round()` does not:

```c
// ora_round (bug):
tm_round(tm, fmt);
                               // fsec NOT zeroed!
if (tm2timestamp(tm, fsec, NULL, &result) != 0)
```

The `tm_round()` function zeroes `tm->tm_sec` but never touches `fsec`. This means fractional seconds from the original timestamp are preserved in the rounded result, which is incorrect — Oracle's `ROUND` should eliminate fractional seconds.

The bug is currently latent because the SQL overload `sys.round(date, text)` only accepts PG `date` type (no fractional seconds). But the C function uses `PG_GETARG_TIMESTAMP(0)` and is designed to handle timestamps with fractional seconds. Adding a `timestamp` overload would immediately expose the bug.

Fixes #1524

## Changes

- `contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c`: Added `fsec = 0;` after `tm_round(tm, fmt);` in `ora_round()` (line ~464)

## How to Verify

1. Build with the fix: `ninja -C build -j20 && ninja -C build install`
2. Existing ROUND regression tests should still pass:
   ```
   cd build && meson test
   ```
3. Verify code consistency between `ora_round` and `ora_trunc`:
   ```c
   // Both should now have fsec = 0 after their tm_* call:
   // ora_round:  tm_round(tm, fmt);  fsec = 0;
   // ora_trunc:  tm_trunc(tm, fmt);  fsec = 0;
   ```

## Compliance

- [x] Code follows PostgreSQL coding conventions
- [x] No new compiler warnings
- [x] Regression tests pass

Assisted-by: OpenAI:gpt-5
Percentage of AI-generated code: 80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date rounding now consistently removes fractional seconds, producing timestamps with zero microseconds after rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->