### PR TITLE
fix(merge): fix visibility bugs in heapTupleSatisfiesUpdate4Merge (1527)

### DIFF
--- a/contrib/ivorysql_ora/src/merge/ora_merge.c
+++ b/contrib/ivorysql_ora/src/merge/ora_merge.c
@@ -1481,12 +1481,174 @@ heapTupleSatisfiesUpdate4Merge(HeapTuple htup, CommandId curcid,
 		else if (TransactionIdIsCurrentTransactionId(HeapTupleHeaderGetRawXmin(tuple)))
 		{
 			if (HeapTupleHeaderGetCmin(tuple) >= curcid)
+				return TM_Invisible;	/* inserted after scan started */
+
+			if (tuple->t_infomask & HEAP_XMAX_INVALID)	/* xid invalid */
+				return TM_Ok;
+
+			if (HEAP_XMAX_IS_LOCKED_ONLY(tuple->t_infomask))
 			{
-				 /* Only for compatible oracle MERGE */
-				return TM_Ok;	/* inserted after scan started */
+				if (tuple->t_infomask & HEAP_XMAX_IS_MULTI)
+				{
+					if (MultiXactIdIsRunning(HeapTupleHeaderGetRawXmax(tuple), true))
+						return TM_BeingModified;
+					else
+						return TM_Ok;
+				}
+
+				if (!TransactionIdIsInProgress(HeapTupleHeaderGetRawXmax(tuple)))
+					return TM_Ok;
+				return TM_BeingModified;
 			}
+
+			if (tuple->t_infomask & HEAP_XMAX_IS_MULTI)
+			{
+				TransactionId xmax;
+
+				xmax = HeapTupleGetUpdateXid(tuple);
+				Assert(TransactionIdIsValid(xmax));
+
+				if (!TransactionIdIsCurrentTransactionId(xmax))
+				{
+					if (MultiXactIdIsRunning(HeapTupleHeaderGetRawXmax(tuple),
+											 false))
+						return TM_BeingModified;
+					return TM_Ok;
+				}
+				else
+				{
+					if (HeapTupleHeaderGetCmax(tuple) >= curcid)
+						return TM_SelfModified;
+					else
+						return TM_Invisible;
+				}
+			}
+
+			if (!TransactionIdIsCurrentTransactionId(HeapTupleHeaderGetRawXmax(tuple)))
+			{
+				SetHintBits(tuple, buffer, HEAP_XMAX_INVALID,
+							InvalidTransactionId);
+				return TM_Ok;
+			}
+
+			if (HeapTupleHeaderGetCmax(tuple) >= curcid)
+				return TM_SelfModified;
+			else
+				return TM_Invisible;
+		}
+		else if (TransactionIdIsInProgress(HeapTupleHeaderGetRawXmin(tuple)))
+			return TM_Invisible;
+		else if (TransactionIdDidCommit(HeapTupleHeaderGetRawXmin(tuple)))
+			SetHintBits(tuple, buffer, HEAP_XMIN_COMMITTED,
+						HeapTupleHeaderGetRawXmin(tuple));
+		else
+		{
+			SetHintBits(tuple, buffer, HEAP_XMIN_INVALID,
+						InvalidTransactionId);
+			return TM_Invisible;
+		}
+	}
+
+	/* by here, the inserting transaction has committed */
+
+	if (tuple->t_infomask & HEAP_XMAX_INVALID)	/* xid invalid or aborted */
+		return TM_Ok;
+
+	if (tuple->t_infomask & HEAP_XMAX_COMMITTED)
+	{
+		if (HEAP_XMAX_IS_LOCKED_ONLY(tuple->t_infomask))
+			return TM_Ok;
+		if (!ItemPointerEquals(&htup->t_self, &tuple->t_ctid))
+			return TM_Updated;
+		else
+			return TM_Deleted;
+	}
+
+	if (tuple->t_infomask & HEAP_XMAX_IS_MULTI)
+	{
+		TransactionId xmax;
+
+		if (HEAP_LOCKED_UPGRADED(tuple->t_infomask))
+			return TM_Ok;
+
+		if (HEAP_XMAX_IS_LOCKED_ONLY(tuple->t_infomask))
+		{
+			if (MultiXactIdIsRunning(HeapTupleHeaderGetRawXmax(tuple), true))
+				return TM_BeingModified;
+
+			SetHintBits(tuple, buffer, HEAP_XMAX_INVALID, InvalidTransactionId);
+			return TM_Ok;
 		}
 
+		xmax = HeapTupleGetUpdateXid(tuple);
+		if (!TransactionIdIsValid(xmax))
+		{
+			if (MultiXactIdIsRunning(HeapTupleHeaderGetRawXmax(tuple), false))
+				return TM_BeingModified;
+		}
+
+		Assert(TransactionIdIsValid(xmax));
+
+		if (TransactionIdIsCurrentTransactionId(xmax))
+		{
+			if (HeapTupleHeaderGetCmax(tuple) >= curcid)
+				return TM_SelfModified;
+			else
+				return TM_Invisible;
+		}
+
+		if (MultiXactIdIsRunning(HeapTupleHeaderGetRawXmax(tuple), false))
+			return TM_BeingModified;
+
+		if (TransactionIdDidCommit(xmax))
+		{
+			if (!ItemPointerEquals(&htup->t_self, &tuple->t_ctid))
+				return TM_Updated;
+			else
+				return TM_Deleted;
+		}
+
+		if (!MultiXactIdIsRunning(HeapTupleHeaderGetRawXmax(tuple), false))
+		{
+			SetHintBits(tuple, buffer, HEAP_XMAX_INVALID,
+						InvalidTransactionId);
+			return TM_Ok;
+		}
+		else
+			return TM_BeingModified;
 	}
-	return TM_Invisible;
+
+	if (TransactionIdIsCurrentTransactionId(HeapTupleHeaderGetRawXmax(tuple)))
+	{
+		if (HEAP_XMAX_IS_LOCKED_ONLY(tuple->t_infomask))
+			return TM_BeingModified;
+		if (HeapTupleHeaderGetCmax(tuple) >= curcid)
+			return TM_SelfModified;
+		else
+			return TM_Invisible;
+	}
+
+	if (TransactionIdIsInProgress(HeapTupleHeaderGetRawXmax(tuple)))
+		return TM_BeingModified;
+
+	if (!TransactionIdDidCommit(HeapTupleHeaderGetRawXmax(tuple)))
+	{
+		SetHintBits(tuple, buffer, HEAP_XMAX_INVALID,
+					InvalidTransactionId);
+		return TM_Ok;
+	}
+
+	if (HEAP_XMAX_IS_LOCKED_ONLY(tuple->t_infomask))
+	{
+		SetHintBits(tuple, buffer, HEAP_XMAX_INVALID,
+					InvalidTransactionId);
+		return TM_Ok;
+	}
+
+	SetHintBits(tuple, buffer, HEAP_XMAX_COMMITTED,
+				HeapTupleHeaderGetRawXmax(tuple));
+	if (!ItemPointerEquals(&htup->t_self, &tuple->t_ctid))
+		return TM_Updated;
+	else
+		return TM_Deleted;
 }


### PR DESCRIPTION
## Summary

Fix three critical visibility bugs in heapTupleSatisfiesUpdate4Merge() by aligning its logic with PostgreSQL's HeapTupleSatisfiesUpdate().

## Background / Motivation

The custom \heapTupleSatisfiesUpdate4Merge()\ in \contrib/ivorysql_ora/src/merge/ora_merge.c\ had three bugs:

1. **cmin >= curcid returned TM_Ok** (should be TM_Invisible) — MERGE DELETE deleted tuples inserted after scan started, violating snapshot isolation.
2. **Committed tuples returned TM_Invisible** (should check xmax and return TM_Ok) — MERGE DELETE silently skipped all committed rows.
3. **No xmax handling** — could not detect already-deleted, self-modified, or locked tuples.

Fixes #1527

## Changes

- \contrib/ivorysql_ora/src/merge/ora_merge.c\: Fixed \heapTupleSatisfiesUpdate4Merge()\ to handle all visibility cases correctly:
  - \cmin >= curcid\ now returns \TM_Invisible\
  - Current-transaction tuples now check \HEAP_XMAX_INVALID\, locked-only, multixact, and self-modified cases
  - Added handling for in-progress xmin, committed xmin, and aborted xmin
  - Added full xmax handling after the committed-xmin fallthrough: \HEAP_XMAX_INVALID\, \HEAP_XMAX_COMMITTED\, multixact, current-transaction xmax, in-progress xmax, and committed xmax
  - Returns \TM_Ok\, \TM_Updated\, \TM_Deleted\, \TM_SelfModified\, \TM_BeingModified\, or \TM_Invisible\ as appropriate

## How to Verify

\\\sql
SET ivorysql.compatible_mode = oracle;
CREATE TABLE merge_target (id NUMBER, val VARCHAR2);
CREATE TABLE merge_source (id NUMBER, val VARCHAR2);
INSERT INTO merge_target VALUES (1, 'old');
INSERT INTO merge_source VALUES (1, 'new');
MERGE INTO merge_target t USING merge_source s ON (t.id = s.id) WHEN MATCHED THEN DELETE;
SELECT count(*) FROM merge_target; -- Expected: 0
\\\

## Compliance

- [x] Code follows PostgreSQL coding conventions
- [x] No new compiler warnings
- [x] Regression tests pass

Assisted-by: OpenAI:gpt-5
Percentage of AI-generated code: 70%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MERGE operation handling for tuples affected by active, committed, aborted, or multitransaction inserts and deletes.
  * Correctly distinguishes invisible, modified, updated, deleted, and successfully processable rows.
  * Improved handling of rows inserted after a scan and transaction status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->