### PR TITLE
fix(datetime): handle empty NLS parameters (1531)

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -26,6 +26,14 @@ SELECT to_date(
  01-15-1989 11:00:00
 (1 row)
 
+SELECT to_char(
+	to_date('2001-02-03', 'YYYY-MM-DD', repeat('x', 0)),
+	'YYYY-MM-DD HH24:MI:SS') AS empty_nls_to_date FROM DUAL;
+  empty_nls_to_date  
+---------------------
+ 2001-02-03 00:00:00
+(1 row)
+
 /*
  * to_timestamp
  */
@@ -51,6 +59,15 @@ SELECT to_timestamp(
          to_timestamp          
 -------------------------------
  09-10-2016 14:10:10.123000000
+(1 row)
+
+SELECT to_char(
+	to_timestamp('2002-03-04 05:06:07.123',
+		'YYYY-MM-DD HH24:MI:SS.FF3', repeat('x', 0)),
+	'YYYY-MM-DD HH24:MI:SS.FF3') AS empty_nls_to_timestamp FROM DUAL;
+ empty_nls_to_timestamp  
+-------------------------
+ 2002-03-04 05:06:07.123
 (1 row)
 
 	
@@ -81,6 +98,18 @@ SELECT to_timestamp_tz(
  09-10-2016 14:10:10.123000000 -07:00
 (1 row)
 
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+SELECT to_char(
+	to_timestamp_tz('2003-04-05 06:07:08.123 +08:00',
+		'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM', repeat('x', 0)),
+	'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM') AS empty_nls_to_timestamp_tz FROM DUAL;
+   empty_nls_to_timestamp_tz    
+--------------------------------
+ 2003-04-04 22:07:08.123 +00:00
+(1 row)
+
+COMMIT;
 SELECT to_timestamp_tz('10-9-2016 14:10:10.123000 +8:30', 'DD-MM-YYYY HH24:MI:SS.FF TZH:TZM') FROM DUAL;
            to_timestamp_tz            
 --------------------------------------

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -13,6 +13,10 @@ SELECT to_date(
      'NLS_DATE_LANGUAGE = American')
      FROM DUAL;
 
+SELECT to_char(
+	to_date('2001-02-03', 'YYYY-MM-DD', repeat('x', 0)),
+	'YYYY-MM-DD HH24:MI:SS') AS empty_nls_to_date FROM DUAL;
+
 /*
  * to_timestamp
  */
@@ -26,6 +30,11 @@ SELECT to_timestamp(
 	'10-9-2016 14:10:10.123000', 
 	'DD-MM-YYYY HH24:MI:SS.FF9',
 	'NLS_DATE_LANGUAGE = American') FROM DUAL;
+
+SELECT to_char(
+	to_timestamp('2002-03-04 05:06:07.123',
+		'YYYY-MM-DD HH24:MI:SS.FF3', repeat('x', 0)),
+	'YYYY-MM-DD HH24:MI:SS.FF3') AS empty_nls_to_timestamp FROM DUAL;
 	
 /*
  * to_timestamp_tz
@@ -40,6 +49,14 @@ SELECT to_timestamp_tz(
 	'10-9-2016 14:10:10.123000', 
 	'DD-MM-YYYY HH24:MI:SS.FF9',
 	'NLS_DATE_LANGUAGE = American') FROM DUAL;
+
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+SELECT to_char(
+	to_timestamp_tz('2003-04-05 06:07:08.123 +08:00',
+		'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM', repeat('x', 0)),
+	'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM') AS empty_nls_to_timestamp_tz FROM DUAL;
+COMMIT;
 
 SELECT to_timestamp_tz('10-9-2016 14:10:10.123000 +8:30', 'DD-MM-YYYY HH24:MI:SS.FF TZH:TZM') FROM DUAL;
 SELECT to_timestamp_tz('10-9-2016 14:10:10.123000 +1:00', 'DD-MM-YYYY HH24:MI:SS.FF TZH:TZM') FROM DUAL;

--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -853,28 +853,13 @@ to_oradate3(PG_FUNCTION_ARGS)
 {
 	text	   *date_txt = PG_GETARG_TEXT_P(0);
 	text	   *fmt = PG_GETARG_TEXT_P(1);
-	text	   *nlsparam = PG_GETARG_TEXT_P(2);
 	Oid			collid = PG_GET_COLLATION();
 	Timestamp	result;
 	struct pg_tm tm;
 	fsec_t		fsec;
 
-	/* TODO */
-	char	   *p;
-
-	p = text_to_cstring(nlsparam);
-
-#if 0
-	if (strlen(p) != 0)
-		ereport(WARNING,
-				(errcode(ERRCODE_UNTERMINATED_C_STRING),
-				 errmsg("function \"to_date\" not support the parameter of \"nlsparam\".")));
-#endif
-
-	if (p && strlen(p) != 0)
-		/* make compiler quiet */
-
-		ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
+	/* nlsparam is not interpreted yet, but must not affect parsing. */
+	ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
 
 	/* no timezone and no fractional second */
 	fsec = 0;
@@ -937,24 +922,13 @@ to_oratimestamp3(PG_FUNCTION_ARGS)
 {
 	text	   *date_txt = PG_GETARG_TEXT_P(0);
 	text	   *fmt = PG_GETARG_TEXT_P(1);
-	text	   *nlsparam = PG_GETARG_TEXT_P(2);
 	Oid			collid = PG_GET_COLLATION();
 	Timestamp	result;
 	struct pg_tm tm;
 	fsec_t		fsec;
-	char	   *p;
 
-	p = text_to_cstring(nlsparam);
-
-	/*
-	 * if (strlen(p) != 0) ereport(WARNING,
-	 * (errcode(ERRCODE_UNTERMINATED_C_STRING), errmsg("function \"to_date\"
-	 * not support the parameter of \"nlsparam\".")));
-	 */
-	if (p && strlen(p) != 0)
-		/* make compiler quiet */
-
-		ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
+	/* nlsparam is not interpreted yet, but must not affect parsing. */
+	ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
 
 	/* no time zone */
 	if (tm2timestamp(&tm, fsec, NULL, &result) != 0)
@@ -1048,27 +1022,15 @@ to_oratimestamptz3(PG_FUNCTION_ARGS)
 {
 	text	   *date_txt = PG_GETARG_TEXT_P(0);
 	text	   *fmt = PG_GETARG_TEXT_P(1);
-	text	   *nlsparam = PG_GETARG_TEXT_P(2);
 	Oid			collid = PG_GET_COLLATION();
 	Timestamp	result;
 	int			tz;
 	struct pg_tm tm;
 	fsec_t		fsec;
 	DateTimeErrorExtra extra;
-	char	   *p;
 
-	p = text_to_cstring(nlsparam);
-
-	if (p && strlen(p) != 0)
-		/* make compile quiet */
-
-		/*
-		 * if (strlen(p) != 0) ereport(WARNING,
-		 * (errcode(ERRCODE_UNTERMINATED_C_STRING), errmsg("function
-		 * \"to_date\" not support the parameter of \"nlsparam\".")));
-		 */
-
-		ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
+	/* nlsparam is not interpreted yet, but must not affect parsing. */
+	ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
 
 	if (tm.tm_zone)
 	{


### PR DESCRIPTION
## Summary

- always parse input in the three-argument `to_date`, `to_timestamp`, and `to_timestamp_tz` implementations
- avoid reading uninitialized `pg_tm`/`fsec` state when `nlsparam` is an empty, non-null string
- add regression coverage for all three conversion functions with a runtime-generated empty NLS parameter

## Root cause

The conversion call was guarded by `strlen(nlsparam) != 0`. An empty `nlsparam` therefore skipped `ora_do_to_timestamp()`, while the function continued to build a result from uninitialized parse state.

## Tests

- `make -C contrib/ivorysql_ora oracle-check ORA_REGRESS=ora_datetime_datatype_functions` (pass)
- full `oracle-check`: 23/24 pass; `ora_xml_functions` requires a build configured with `--with-libxml`

Fixes #1531


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle-compatible `to_date`, `to_timestamp`, and `to_timestamp_tz` conversions when an empty NLS parameter is supplied.
  * Ensured timestamp-with-time-zone conversions correctly handle UTC output and source offsets.
  * Added regression coverage for date, timestamp, and time-zone-aware timestamp formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->