### PR TITLE
fix(guc): change check_database_mode from NOTICE to ERROR to prevent mode change (1535)

### DIFF
--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -488,7 +488,15 @@ check_database_mode(int *newval, void **extra, GucSource source)
 {
 	int			newmode = *newval;
 
-	if (DB_PG == database_mode && DB_ORACLE == newmode)
+	/*
+	 * Allow the change during startup (e.g., when xlog.c restores the
+	 * database_mode from the control file with PGC_S_OVERRIDE), but
+	 * reject user-initiated attempts to change from pg to oracle at
+	 * runtime.  Use ERROR instead of NOTICE so the change is actually
+	 * blocked, matching the behavior of check_compatible_mode().
+	 */
+	if (DB_PG == database_mode && DB_ORACLE == newmode &&
+		source != PGC_S_OVERRIDE && source != PGC_S_DEFAULT)
 		ereport(ERROR,
 				(errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM),
 				 errmsg("parameter ivorysql.database_mode cannot be changed")));

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -489,7 +489,7 @@ check_database_mode(int *newval, void **extra, GucSource source)
 	int			newmode = *newval;
 
 	if (DB_PG == database_mode && DB_ORACLE == newmode)
-		ereport(NOTICE,
+		ereport(ERROR,
 				(errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM),
 				 errmsg("parameter ivorysql.database_mode cannot be changed")));
 

--- a/src/oracle_test/regress/expected/guc.out
+++ b/src/oracle_test/regress/expected/guc.out
@@ -1,4 +1,4 @@
-﻿-- pg_regress should ensure that this default value applies; however
+-- pg_regress should ensure that this default value applies; however
 -- we can't rely on any specific default value of vacuum_cost_delay
 SHOW datestyle;
    DateStyle   

--- a/src/oracle_test/regress/expected/guc.out
+++ b/src/oracle_test/regress/expected/guc.out
@@ -1,4 +1,4 @@
--- pg_regress should ensure that this default value applies; however
+﻿-- pg_regress should ensure that this default value applies; however
 -- we can't rely on any specific default value of vacuum_cost_delay
 SHOW datestyle;
    DateStyle   
@@ -976,3 +976,9 @@ SELECT name FROM tab_settings_flags
 (0 rows)
 
 DROP TABLE tab_settings_flags;
+
+
+-- Test that ivorysql.database_mode cannot be changed from pg to oracle
+-- This should raise an ERROR, not a NOTICE
+SET ivorysql.database_mode = 'oracle';
+ERROR:  parameter ivorysql.database_mode cannot be changed

--- a/src/oracle_test/regress/sql/guc.sql
+++ b/src/oracle_test/regress/sql/guc.sql
@@ -1,4 +1,4 @@
-﻿-- pg_regress should ensure that this default value applies; however
+-- pg_regress should ensure that this default value applies; however
 -- we can't rely on any specific default value of vacuum_cost_delay
 SHOW datestyle;
 

--- a/src/oracle_test/regress/sql/guc.sql
+++ b/src/oracle_test/regress/sql/guc.sql
@@ -1,4 +1,4 @@
--- pg_regress should ensure that this default value applies; however
+﻿-- pg_regress should ensure that this default value applies; however
 -- we can't rely on any specific default value of vacuum_cost_delay
 SHOW datestyle;
 
@@ -396,3 +396,8 @@ SELECT name FROM tab_settings_flags
   WHERE no_reset AND NOT no_reset_all
   ORDER BY 1;
 DROP TABLE tab_settings_flags;
+
+
+-- Test that ivorysql.database_mode cannot be changed from pg to oracle
+-- This should raise an ERROR, not a NOTICE
+SET ivorysql.database_mode = 'oracle';


### PR DESCRIPTION
## Summary

Change `check_database_mode()` from `ereport(NOTICE, ...)` to `ereport(ERROR, ...)` to actually prevent changing `ivorysql.database_mode` from `pg` to `oracle`.

## Background / Motivation

The `check_database_mode()` function in `src/backend/utils/misc/ivy_guc.c` used `ereport(NOTICE, ...)` when attempting to change `ivorysql.database_mode` from `pg` to `oracle`. This printed a message saying the parameter "cannot be changed", but then returned `true` — allowing the change to proceed anyway.

In contrast, `check_compatible_mode()` in the same file correctly uses `ereport(ERROR, ...)` for the same kind of restriction, which actually blocks the change.

This inconsistency means that in PG mode, a user could change `database_mode` to `oracle` despite the check hook's intent to prevent it. While the GUC is `PGC_INTERNAL` (limiting who can set it), the check hook is supposed to be an additional guard that was effectively bypassed.

Fixes #1535

## Changes

- `src/backend/utils/misc/ivy_guc.c`: Changed `ereport(NOTICE, ...)` to `ereport(ERROR, ...)` in `check_database_mode()`, matching the behavior of `check_compatible_mode()`.
- `src/oracle_test/regress/sql/guc.sql`: Added regression test verifying that `SET ivorysql.database_mode = 'oracle'` raises an ERROR in PG mode.
- `src/oracle_test/regress/expected/guc.out`: Added expected output.

## How to Verify

```sql
-- On a cluster in PG mode
SHOW ivorysql.database_mode;
-- Expected: pg

SET ivorysql.database_mode = 'oracle';
-- Before fix: NOTICE printed, SET succeeds
-- After fix: ERROR raised, SET fails

SHOW ivorysql.database_mode;
-- Before fix: oracle (incorrectly changed)
-- After fix: pg (change blocked)
```

## Compliance

- [x] Code follows PostgreSQL coding conventions
- [x] No new compiler warnings
- [x] Regression tests added

Assisted-by: OpenAI:gpt-5
Percentage of AI-generated code: 60%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attempting to switch the database mode from PostgreSQL to Oracle at runtime now returns an error instead of a notice.
  * Added regression coverage to verify the updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->