### PR TITLE
Install amcheck module for regression testing

### DIFF
--- a/src/oracle_test/regress/GNUmakefile
+++ b/src/oracle_test/regress/GNUmakefile
@@ -95,6 +95,8 @@ installdirs-tests: installdirs
 ## Run tests
 ##
 
+EXTRA_INSTALL = contrib/amcheck
+
 ORACLE_REGRESS_OPTS = --dlpath=. --max-concurrent-tests=20 \
 	$(EXTRA_REGRESS_OPTS)
 


### PR DESCRIPTION
This PR adds `contrib/amcheck` to `EXTRA_INSTALL` to ensure the module is available during Oracle compatibility regression test runs. 

This is necessary because `alter_index.sql` exercises `amcheck`'s `bt_index_check()` function, which is not included in the default installation. By including it in `EXTRA_INSTALL`, we guarantee that the module is built and available in the temporary test environment.

fix #1533 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Oracle regression test setup to include additional database integrity checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->