### PR TITLE
fix(libpq): include sys/ipc.h and sys/sem.h unconditionally in sysv_ivysema.c

### DIFF
--- a/src/interfaces/libpq/sysv_ivysema.c
+++ b/src/interfaces/libpq/sysv_ivysema.c
@@ -15,14 +15,8 @@
 #include <signal.h>
 #include <unistd.h>
 #include <sys/file.h>
-
-#ifdef HAVE_SYS_IPC_H
 #include <sys/ipc.h>
-#endif
-
-#ifdef HAVE_SYS_SEM_H
 #include <sys/sem.h>
-#endif
 
 #include "ivy_sema.h"
 


### PR DESCRIPTION
## Summary

`src/interfaces/libpq/sysv_ivysema.c` guarded `<sys/ipc.h>` and `<sys/sem.h>` behind `#ifdef HAVE_SYS_IPC_H` / `#ifdef HAVE_SYS_SEM_H`, but IvorySQL's `configure` never defines either macro (there is no `AC_CHECK_HEADERS` for these headers, and upstream `src/backend/port/sysv_sema.c` includes them unconditionally). The guards were therefore always false, the headers were never included, and the file failed to compile with a flood of undeclared-identifier errors — breaking the libpq build on any platform that selects System V semaphores (e.g. macOS).

This file is IvorySQL-only (`sysv_ivysema.c` + `ivy_sema.c` symlink, added for OUT-parameter support in #837), so the bug does not exist upstream.

## Root cause

```c
#ifdef HAVE_SYS_IPC_H
#include <sys/ipc.h>
#endif

#ifdef HAVE_SYS_SEM_H
#include <sys/sem.h>
#endif
```

- `src/include/pg_config.h` does **not** define `HAVE_SYS_SEM_H` or `HAVE_SYS_IPC_H`.
- `configure` / `configure.ac` contains no check that would define them (`grep -c 'HAVE_SYS_SEM_H\|HAVE_SYS_IPC_H' configure` → 0).
- Upstream `sysv_sema.c` includes the same headers **unconditionally**.

## Fix

Match upstream and include both headers unconditionally (a System V semaphore build, by definition, has these headers).

## Reproduction (before)

```sh
./configure --prefix=$PWD/build_install --with-libxml --with-icu --with-ssl=openssl --with-readline
make -j
```

```
ivy_sema.c:78:10: error: call to undeclared function 'semget'
ivy_sema.c:78:34: error: use of undeclared identifier 'IPC_CREAT'
ivy_sema.c:123:14: error: variable has incomplete type 'union semun'
ivy_sema.c:158:9: error: call to undeclared function 'semctl'
...
```

After the fix the file compiles and `make` / `make install` complete; `libpq.5.dylib` links cleanly (passes `libpq_check.pl`).

## Environment

- IvorySQL master @ d4661fb1d89 (5beta1 / PG 19devel)
- macOS 26 (Darwin 25.2.0, arm64), Apple clang 17.0.0

Fixes #1540

---

Assisted-by: Claude:Sonnet-4.6
Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for semaphore-related functionality by ensuring required System V IPC support is consistently available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->