### PR TITLE
fix(ivorysql_ora): move ifeq($(with_libxml),yes) after Makefile.global include so -lxml2 is not dropped

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -86,10 +86,6 @@ ORA_REGRESS = \
 	utl_encode \
 	dbms_session
 
-ifeq ($(with_libxml),yes) 
-SHLIB_LINK += -lxml2
-endif
-
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src
 
@@ -102,6 +98,13 @@ subdir = contrib/ivorysql_ora
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+# This must come AFTER the includes above so that with_libxml is already
+# defined; otherwise the ifeq is evaluated with an empty value and -lxml2 is
+# silently dropped even on builds configured with --with-libxml.
+ifeq ($(with_libxml),yes)
+SHLIB_LINK += -lxml2
 endif
 
 


### PR DESCRIPTION
## Summary

In `contrib/ivorysql_ora/Makefile`, the block

```make
ifeq ($(with_libxml),yes)
SHLIB_LINK += -lxml2
endif
```

was placed **before** `include $(top_builddir)/src/Makefile.global` — which is what defines `with_libxml`. GNU make evaluates `ifeq` at parse time, so at that point `with_libxml` is empty, the condition is false, and `-lxml2` is never added to `SHLIB_LINK` — even on builds configured with `--with-libxml`. `ivorysql_ora` then compiles (headers found via `--with-libxml`'s CPPFLAGS) but fails to link with undefined libxml2 symbols.

This is a regression introduced by #1370, which wrapped the previously-unconditional `SHLIB_LINK += -lxml2` in the `ifeq` guard but placed the guard above the includes.

## Root cause

Makefile ordering (current master, lines ~89–105):

```make
ifeq ($(with_libxml),yes)     # evaluated NOW — with_libxml is empty
SHLIB_LINK += -lxml2          # skipped
endif

PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src

ifdef USE_PGXS
...
else
subdir = contrib/ivorysql_ora
top_builddir = ../..
include $(top_builddir)/src/Makefile.global     # with_libxml defined HERE (too late)
include $(top_srcdir)/contrib/contrib-global.mk
endif
```

`make -p` confirms the dropped flag:

```
SHLIB_LINK = $(BE_DLLLIBS)        # == -bundle_loader .../postgres, no -lxml2
with_libxml = yes                 # defined, but too late for the ifeq
```

Note: this is distinct from #1353 (an environment issue where libxml2-devel is not installed on openEuler — that report's link line *did* contain `-lxml2`, predating #1370). Here the library is available and `--with-libxml` is set; the flag is dropped by a Makefile ordering bug.

## Fix

Move only the `ifeq`/`SHLIB_LINK` block to **after** the includes, so `with_libxml` is already defined. `PG_CPPFLAGS` is left in its original position (before the includes) because `pgxs.mk` consumes it at PGXS include time (`override CPPFLAGS := $(PG_CPPFLAGS) $(CPPFLAGS)`), and moving it would break out-of-tree PGXS builds.

## Reproduction (before)

```sh
./configure --prefix=$PWD/build_install --with-libxml --with-icu --with-ssl=openssl --with-readline
make -j
make -C contrib/ivorysql_ora
```

```
Undefined symbols for architecture arm64:
  "_xmlXPathNewContext", referenced from: _ivy_xml_xpath in ora_xml_functions.o
  "_xmlXPathRegisterNs", referenced from: _register_ns_from_csting in ora_xml_functions.o
  ...
ld: symbol(s) not found for architecture arm64
```

After the fix, `-lxml2` appears in the link command and `ivorysql_ora.dylib` links cleanly.

## Environment

- IvorySQL master @ d4661fb1d89 (5beta1 / PG 19devel)
- macOS 26 (Darwin 25.2.0, arm64), Apple clang 17.0.0

Fixes #1541

---

Assisted-by: Claude:Sonnet-4.6
Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML support configuration during builds, ensuring the selected XML library setting is recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->