### PR TITLE
Fix DBMS_OUTPUT.DISABLE buffer cleanup

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -170,7 +170,6 @@ BEGIN
     dbms_output.enable();
     dbms_output.put_line('This will be cleared');
     dbms_output.disable();
-    dbms_output.enable();
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.2 - Buffer after disable: [%], Status: %', line, status;
 END;

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -169,7 +169,6 @@ BEGIN
     dbms_output.enable();
     dbms_output.put_line('This will be cleared');
     dbms_output.disable();
-    dbms_output.enable();
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.2 - Buffer after disable: [%], Status: %', line, status;
 END;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
@@ -324,13 +324,12 @@ ora_dbms_output_enable(PG_FUNCTION_ARGS)
  * ora_dbms_output_disable
  *
  * Disable output buffering.
- * Oracle behavior: buffer persists (can still GET_LINE), but PUT_LINE is ignored.
+ * Oracle behavior: purge the buffer and ignore output until re-enabled.
  */
 Datum
 ora_dbms_output_disable(PG_FUNCTION_ARGS)
 {
-	if (output_buffer != NULL)
-		output_buffer->enabled = false;
+	cleanup_output_buffer();
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
## Summary

- purge the session buffer when `DBMS_OUTPUT.DISABLE` is called
- make the existing regression exercise the state immediately after `DISABLE`
- align the native implementation comment with Oracle's documented behavior

Fixes #1544

## Testing

- confirmed the regression scenario fails before the fix: `This will be cleared|0`
- compiled the changed `dbms_output.c` object against the current IvorySQL server headers
- loaded the fixed object into an isolated test module and confirmed the same scenario returns `<NULL>|1`
- `git diff --check`

## Reference

- Oracle DBMS_OUTPUT documentation: https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_OUTPUT.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabling `DBMS_OUTPUT` now clears any buffered output.
  - Subsequent buffer reads no longer return output that was written before disabling.

- **Tests**
  - Updated coverage verifies that disabling output immediately purges the buffer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->