### PR TITLE
Discard unread DBMS_OUTPUT lines before new output

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -376,6 +376,27 @@ NOTICE:    Line 1: [One]
 NOTICE:    Line 2: [Two]
 NOTICE:  Test 6.3b - Remaining: [Three], Status: 0
 NOTICE:  Test 6.3c - Remaining: [Four], Status: 0
+-- Test 6.4: A write after GET_LINE discards unread lines
+DECLARE
+    lines TEXT[];
+    numlines INTEGER := 10;
+    line TEXT;
+    status INTEGER;
+BEGIN
+    dbms_output.enable();
+    dbms_output.put_line('Old 1');
+    dbms_output.put_line('Old 2');
+    dbms_output.get_line(line, status);
+    dbms_output.put_line('New 1');
+    dbms_output.get_lines(lines, numlines);
+    RAISE NOTICE 'Test 6.4 - Retrieved % lines after writing', numlines;
+    FOR i IN 1..numlines LOOP
+        RAISE NOTICE '  Line %: [%]', i, lines[i];
+    END LOOP;
+END;
+/
+NOTICE:  Test 6.4 - Retrieved 1 lines after writing
+NOTICE:    Line 1: [New 1]
 -- =============================================================================
 -- Section 7: Usage in procedures and functions
 -- =============================================================================

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -370,6 +370,26 @@ BEGIN
 END;
 /
 
+-- Test 6.4: A write after GET_LINE discards unread lines
+DECLARE
+    lines TEXT[];
+    numlines INTEGER := 10;
+    line TEXT;
+    status INTEGER;
+BEGIN
+    dbms_output.enable();
+    dbms_output.put_line('Old 1');
+    dbms_output.put_line('Old 2');
+    dbms_output.get_line(line, status);
+    dbms_output.put_line('New 1');
+    dbms_output.get_lines(lines, numlines);
+    RAISE NOTICE 'Test 6.4 - Retrieved % lines after writing', numlines;
+    FOR i IN 1..numlines LOOP
+        RAISE NOTICE '  Line %: [%]', i, lines[i];
+    END LOOP;
+END;
+/
+
 -- =============================================================================
 -- Section 7: Usage in procedures and functions
 -- =============================================================================

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
@@ -77,6 +77,7 @@ typedef struct DbmsOutputBuffer
 	int64		buffer_used;	/* Content bytes only (user-perceived usage) */
 	int			line_count;		/* Number of lines currently in buffer */
 	bool		enabled;		/* Buffer enabled/disabled state */
+	bool		discard_unread_on_write;	/* A read occurred since the last write */
 	StringInfo	current_line;	/* Accumulator for PUT calls (not yet a line) */
 	MemoryContext buffer_mcxt;	/* Memory context for buffer allocations */
 } DbmsOutputBuffer;
@@ -100,6 +101,7 @@ static void init_output_buffer(int64 buffer_size);
 static void cleanup_output_buffer(void);
 static void add_line_to_buffer(const char *line, int line_len);
 static DbmsOutputLine *pop_line_from_buffer(void);
+static void discard_unread_lines(void);
 
 /* SQL-callable function declarations */
 PG_FUNCTION_INFO_V1(ora_dbms_output_enable);
@@ -287,6 +289,23 @@ pop_line_from_buffer(void)
 }
 
 /*
+ * Discard completed lines left unread by the preceding GET operation.
+ */
+static void
+discard_unread_lines(void)
+{
+	DbmsOutputLine *node;
+
+	if (!output_buffer->discard_unread_on_write)
+		return;
+
+	while ((node = pop_line_from_buffer()) != NULL)
+		pfree(node);
+
+	output_buffer->discard_unread_on_write = false;
+}
+
+/*
  * ora_dbms_output_enable
  *
  * Enable output buffering with optional size limit.
@@ -354,6 +373,8 @@ ora_dbms_output_put_line(PG_FUNCTION_ARGS)
 	if (output_buffer == NULL || !output_buffer->enabled)
 		PG_RETURN_VOID();
 
+	discard_unread_lines();
+
 	/* Handle NULL argument - Oracle stores actual NULL */
 	if (PG_ARGISNULL(0))
 	{
@@ -418,6 +439,8 @@ ora_dbms_output_put(PG_FUNCTION_ARGS)
 	if (output_buffer == NULL || !output_buffer->enabled)
 		PG_RETURN_VOID();
 
+	discard_unread_lines();
+
 	/* Handle NULL argument - treat as empty string (Oracle behavior) */
 	if (PG_ARGISNULL(0))
 		PG_RETURN_VOID();  /* NULL appends nothing */
@@ -450,6 +473,8 @@ ora_dbms_output_new_line(PG_FUNCTION_ARGS)
 	/* Silently discard if buffer not enabled */
 	if (output_buffer == NULL || !output_buffer->enabled)
 		PG_RETURN_VOID();
+
+	discard_unread_lines();
 
 	/* Flush current_line to buffer as a completed line */
 	if (output_buffer->current_line->len > 0)
@@ -493,6 +518,8 @@ ora_dbms_output_get_line(PG_FUNCTION_ARGS)
 	tupdesc = BlessTupleDesc(tupdesc);
 
 	node = pop_line_from_buffer();
+	if (output_buffer != NULL)
+		output_buffer->discard_unread_on_write = true;
 
 	if (node == NULL)
 	{
@@ -547,6 +574,8 @@ ora_dbms_output_get_lines(PG_FUNCTION_ARGS)
 	HeapTuple	tuple;
 
 	requested_lines = PG_GETARG_INT32(0);
+	if (output_buffer != NULL)
+		output_buffer->discard_unread_on_write = true;
 
 	/* Normalize negative values to 0 (Oracle behavior) */
 	if (requested_lines < 0)


### PR DESCRIPTION
## Summary

- remember when a `DBMS_OUTPUT` read has occurred
- discard completed unread lines at the next `PUT`, `PUT_LINE`, or `NEW_LINE`
- add regression coverage for a partial read followed by new output

Fixes #1546

## Testing

- confirmed the regression scenario fails before the fix with `{"Old 2","New 1"}`
- compiled the changed `dbms_output.c` object against the current IvorySQL server headers
- loaded the fixed object into an isolated test module and confirmed the same scenario returns `{"New 1"}`
- `git diff --check`

## Reference

- Oracle DBMS_OUTPUT documentation: https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_OUTPUT.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DBMS_OUTPUT behavior so writing after partially reading the buffer discards unread previous lines.
  * Ensured newly written output is available for subsequent retrieval without stale buffered lines.

* **Tests**
  * Added coverage validating buffer behavior after partial reads followed by new output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->