### PR TITLE
Remove insecure cpanm downloads from regression workflows

### DIFF
--- a/.github/workflows/contrib_regression.yml
+++ b/.github/workflows/contrib_regression.yml
@@ -23,8 +23,6 @@ jobs:
               libicu-dev libnuma-dev
     - name: configure - linux
       run: |
-        curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
-        ./cpanm --sudo IPC::Run && \
         ./configure \
             --prefix=$PWD/inst \
             --enable-cassert --enable-debug --enable-tap-tests --enable-rpath \

--- a/.github/workflows/oracle_pg_regression.yml
+++ b/.github/workflows/oracle_pg_regression.yml
@@ -28,8 +28,6 @@ jobs:
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
-        ./cpanm --sudo IPC::Run && \
         ./configure \
             --prefix=$PWD/inst \
             --enable-cassert --enable-debug --enable-tap-tests --enable-rpath \

--- a/.github/workflows/oracle_regression.yml
+++ b/.github/workflows/oracle_regression.yml
@@ -28,8 +28,6 @@ jobs:
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
-        ./cpanm --sudo IPC::Run && \
         ./configure \
             --prefix=$PWD/inst \
             --enable-cassert --enable-debug --enable-tap-tests --enable-rpath \

--- a/.github/workflows/pg_regression.yml
+++ b/.github/workflows/pg_regression.yml
@@ -28,8 +28,6 @@ jobs:
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
-        ./cpanm --sudo IPC::Run && \
         ./configure \
             --prefix=$PWD/inst \
             --enable-cassert --enable-debug --enable-tap-tests --enable-rpath \


### PR DESCRIPTION
## Summary

- stop downloading `cpanm` over plain HTTP in four regression workflows
- stop executing the downloaded script with `--sudo`
- rely on the existing `libipc-run-perl` apt dependency for `IPC::Run`

Fixes #1548

## Testing

- parsed all four changed workflow files with Ruby's YAML parser
- verified all four workflows still install `libipc-run-perl`
- verified no `cpanmin.us` or `cpanm` references remain under `.github/workflows`
- `git diff --check`

`actionlint` is not installed in the local environment; GitHub Actions provides the final workflow validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined regression test setup by removing unnecessary Perl dependency installation steps.
  - Configuration workflows now proceed directly to the project setup phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->