### PR TITLE
Use a supported runner for Build and Test workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   regression:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         container-os: [centos-7, centos-8]


### PR DESCRIPTION
## Summary

- replace the removed `ubuntu-18.04` hosted runner label with the supported, pinned `ubuntu-22.04` label
- restore schedulability of the manually dispatched CentOS container regression matrix

Fixes #1550

## Testing

- parsed `.github/workflows/build_and_test.yml` with Ruby's YAML parser
- checked the label against GitHub's current hosted-runners reference
- `git diff --check`

## Reference

- https://docs.github.com/en/actions/reference/runners/github-hosted-runners


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the regression workflow environment to Ubuntu 22.04.
  * Build, testing, artifact collection, and cleanup processes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->