### PR TITLE
Fix Docker quick start binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,12 @@ docker compose exec dev bash
 
 make -j$(nproc)
 make install
-export PATH="/home/ivorysql/ivorysql/bin:$PATH"
 
 # Initialize database in Oracle mode
-initdb -D data_ora -m oracle
+/home/ivorysql/ivorysql/bin/initdb -D data_ora -m oracle
 
 # Start the server
-pg_ctl -D data_ora start
+/home/ivorysql/ivorysql/bin/pg_ctl -D data_ora start
 
 # Run tests
 make oracle-check

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ docker compose exec dev bash
 
 make -j$(nproc)
 make install
+export PATH="/home/ivorysql/ivorysql/bin:$PATH"
 
 # Initialize database in Oracle mode
 initdb -D data_ora -m oracle


### PR DESCRIPTION
## Summary

- use the Docker quick start's configured installation prefix when invoking `initdb` and `pg_ctl`
- ensure the quick start resolves to the IvorySQL binaries built by the preceding commands without modifying the user's `PATH`

Fixes #1552

## Testing

- validated the updated quick-start shell block with `bash -n`
- confirmed the documented binary paths match `--prefix=/home/ivorysql/ivorysql`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to invoke the database initialization and server-control tools using their absolute installation paths.
  * This makes the documented workflow more reliable when those tools are not available through the system `PATH`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->