### PR TITLE
Fix Ivyresult cleanup on early returns

### DIFF
--- a/src/interfaces/libpq/ivy-exec.c
+++ b/src/interfaces/libpq/ivy-exec.c
@@ -3819,6 +3819,7 @@ Ivyreplacenamebindtoposition(Ivyconn *tconn,
 		{
 			snprintf(errmsg, size_error_buf, "%s", IvyerrorMessage(tconn));
 			free(query);
+			Ivyclear(res);
 			return 0;
 		}
 
@@ -3945,7 +3946,10 @@ Ivyreplacenamebindtoposition(Ivyconn *tconn,
 		 * if no namebind, just return.
 		 */
 		if (stmtHandle->namebind == NULL)
+		{
+			Ivyclear(res);
 			return 1;
+		}
 
 		/* number of params doesn't match */
 		if (n_tuples - 1 != stmtHandle->nParams)
@@ -4107,6 +4111,7 @@ Ivyreplacenamebindtoposition2(Ivyconn *tconn,
 		{
 			snprintf(errhp->error_msg, errhp->err_buf_size, "%s", IvyerrorMessage(tconn));
 			free(query);
+			Ivyclear(res);
 			return 0;
 		}
 
@@ -4489,4 +4494,3 @@ error_handle:
 	stmtHandle->paramNames = NULL;
 	return 0;
 }
-


### PR DESCRIPTION
## Summary

- release the `Ivyresult` when parameter-description execution fails;
- release it before the successful no-namebind early return;
- apply the same error-path cleanup to the OCI-style execution helper.

Fixes #1555.

## Validation

- `make -C src/interfaces/libpq ivy-exec.o -j2`
- `git diff --check`
- audited each changed return path to ensure `res` is no longer used after `Ivyclear()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during parameter-name replacement.
  * Prevented stale or incomplete results from being returned when execution fails or no parameter bindings are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->