### PR TITLE
Use vault repositories for CentOS 7 CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,8 +17,14 @@ jobs:
       run: |
         docker build -t ivorysql-${{ matrix.container-os }}:latest -<<EOF
         FROM    centos:7
-        RUN     rpm --import http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+        RUN     sed -i -e 's|^mirrorlist=|#mirrorlist=|g' \
+                       -e 's|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=http://vault.centos.org/7.9.2009|g' \
+                       /etc/yum.repos.d/CentOS-Base.repo
+        RUN     rpm --import https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
         RUN     yum install -y epel-release centos-release-scl
+        RUN     sed -i -e 's|^mirrorlist=|#mirrorlist=|g' \
+                       -e 's|^# *baseurl=http://mirror.centos.org/centos/7/sclo|baseurl=http://vault.centos.org/centos/7/sclo|g' \
+                       /etc/yum.repos.d/CentOS-SCLo-*.repo
         RUN     yum groups mark install "Development Tools"
         RUN     yum groupinstall -y "Development Tools"
         RUN     yum install -y \


### PR DESCRIPTION
## Summary

- point the CentOS 7 base repositories at the archived 7.9.2009 vault;
- point the installed Software Collections repositories at their vault location;
- fetch the EPEL 7 signing key over HTTPS.

Fixes #1557.

## Validation

- parsed `.github/workflows/build_and_test.yml` with Ruby YAML
- built the extracted CentOS 7 Dockerfile successfully as `linux/amd64`
- verified the full dependency set, including `llvm-toolset-7-llvm-devel`, installs from the vault-backed repositories
