### PR TITLE
Use unique artifact names for build matrix jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,7 +94,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: results
+        name: results-${{ matrix.container-os }}
         path: ${{ github.workspace }}/regression.tar.gz
 
     - name: Cleanup


### PR DESCRIPTION
## Summary

Give each build-matrix job a platform-specific regression artifact name so concurrent `upload-artifact@v4` uploads cannot collide.

Fixes #1559.

## Validation

- parsed the workflow as YAML
- expanded the matrix expression locally and confirmed the two names are unique: `results-centos-7`, `results-centos-8`
- `git diff --check`
