### PR TITLE
Preserve DBMS_OUTPUT on repeated ENABLE calls

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -175,19 +175,19 @@ BEGIN
 END;
 /
 NOTICE:  Test 3.2 - Buffer after disable: [<NULL>], Status: 1
--- Test 3.3: Re-ENABLE clears buffer
+-- Test 3.3: Re-ENABLE preserves buffer
 DECLARE
     line TEXT;
     status INTEGER;
 BEGIN
     dbms_output.enable();
     dbms_output.put_line('First enable content');
-    dbms_output.enable();  -- Re-enable should clear
+    dbms_output.enable();  -- Re-enable should preserve unread output
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.3 - After re-enable: [%], Status: %', line, status;
 END;
 /
-NOTICE:  Test 3.3 - After re-enable: [<NULL>], Status: 1
+NOTICE:  Test 3.3 - After re-enable: [First enable content], Status: 0
 -- Test 3.4: Output while disabled is silently ignored
 DECLARE
     line TEXT;

--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -176,18 +176,47 @@ END;
 /
 NOTICE:  Test 3.2 - Buffer after disable: [<NULL>], Status: 1
 -- Test 3.3: Re-ENABLE preserves buffer
+-- Full contract: unread lines and pending PUT text are preserved, and the
+-- latest size limit is applied to the active buffer.
 DECLARE
     line TEXT;
     status INTEGER;
+    i INTEGER;
+    overflow BOOLEAN := FALSE;
 BEGIN
+    -- Unread line preserved across re-enable
     dbms_output.enable();
     dbms_output.put_line('First enable content');
     dbms_output.enable();  -- Re-enable should preserve unread output
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.3 - After re-enable: [%], Status: %', line, status;
+    -- Pending PUT text preserved across re-enable
+    dbms_output.put('Pending PUT');
+    dbms_output.enable();  -- Re-enable should preserve partial output
+    dbms_output.new_line();
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 3.3 - Pending PUT preserved: [%], Status: %', line, status;
+    -- New size limit enforced: writing past the old 2000-byte limit succeeds
+    dbms_output.enable(2000);   -- small limit
+    dbms_output.enable(1000000);  -- re-enable with a larger limit
+    FOR i IN 1..60 LOOP
+        BEGIN
+            dbms_output.put_line(rpad('X', 50, 'X'));  -- 50 bytes x 60 = 3000 bytes
+        EXCEPTION WHEN OTHERS THEN
+            overflow := TRUE;
+            EXIT;
+        END;
+    END LOOP;
+    IF overflow THEN
+        RAISE NOTICE 'Test 3.3 - New size limit applied: FAILED';
+    ELSE
+        RAISE NOTICE 'Test 3.3 - New size limit applied: PASSED (3000 bytes written)';
+    END IF;
 END;
 /
 NOTICE:  Test 3.3 - After re-enable: [First enable content], Status: 0
+NOTICE:  Test 3.3 - Pending PUT preserved: [Pending PUT], Status: 0
+NOTICE:  Test 3.3 - New size limit applied: PASSED (3000 bytes written)
 -- Test 3.4: Output while disabled is silently ignored
 DECLARE
     line TEXT;

--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -278,6 +278,7 @@ NOTICE:  Test 5.1 - Overflow at line 47: ORU-10027: buffer overflow, limit of 20
 DECLARE
     v_count INTEGER := 0;
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable(2000);  -- 2000 byte content limit
     -- Write 1-byte lines until overflow
     -- Internal: 1-byte lines need 3 bytes each (2 prefix + 1 data)
@@ -308,6 +309,7 @@ DECLARE
     line TEXT;
     status INTEGER;
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable();
     dbms_output.put_line('Line A');
     dbms_output.put_line('Line B');
@@ -331,6 +333,7 @@ DECLARE
     lines TEXT[];
     numlines INTEGER := 100;  -- Request more than available
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable();
     dbms_output.put_line('Only');
     dbms_output.put_line('Three');
@@ -592,6 +595,7 @@ NOTICE:  Test 9.3 - PUT overflow error: ORU-10028: line length overflow, limit o
 -- Write in first block
 DO $$
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable(1000000);
     dbms_output.put_line('Written in block 1');
 END;

--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -223,6 +223,21 @@ BEGIN
     END;
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.3 - Shrink keeps buffered: [%], Status: %', line, status;
+    -- Drain all remaining buffered lines, checking the count and order
+    i := 0;
+    LOOP
+        dbms_output.get_line(line, status);
+        EXIT WHEN status != 0;
+        i := i + 1;
+        IF line <> rpad('X', 50, 'X') THEN
+            RAISE NOTICE 'Test 3.3 - Shrink drain order: unexpected [%]', line;
+        END IF;
+    END LOOP;
+    RAISE NOTICE 'Test 3.3 - Shrink drained: % lines, Status: %', i, status;
+    -- Usage is back below the limit: a marker write succeeds and reads back
+    dbms_output.put_line('MARKER');
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 3.3 - Shrink resumes writes: [%], Status: %', line, status;
 END;
 /
 NOTICE:  Test 3.3 - After re-enable: [First enable content], Status: 0
@@ -230,6 +245,8 @@ NOTICE:  Test 3.3 - Pending PUT preserved: [Pending PUT], Status: 0
 NOTICE:  Test 3.3 - New size limit applied: PASSED (3000 bytes written)
 NOTICE:  Test 3.3 - Shrink write blocked: ORU-10027: buffer overflow, limit of 2000 bytes
 NOTICE:  Test 3.3 - Shrink keeps buffered: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX], Status: 0
+NOTICE:  Test 3.3 - Shrink drained: 59 lines, Status: 1
+NOTICE:  Test 3.3 - Shrink resumes writes: [MARKER], Status: 0
 -- Test 3.4: Output while disabled is silently ignored
 DECLARE
     line TEXT;

--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -212,11 +212,24 @@ BEGIN
     ELSE
         RAISE NOTICE 'Test 3.3 - New size limit applied: PASSED (3000 bytes written)';
     END IF;
+    -- Shrinking the limit below the buffered content: buffered lines stay
+    -- readable, and new writes are rejected until the buffer drains
+    dbms_output.enable(2000);  -- shrink below the 3000 bytes already buffered
+    BEGIN
+        dbms_output.put_line('Y');
+        RAISE NOTICE 'Test 3.3 - Shrink write: unexpected success';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Test 3.3 - Shrink write blocked: %', SQLERRM;
+    END;
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 3.3 - Shrink keeps buffered: [%], Status: %', line, status;
 END;
 /
 NOTICE:  Test 3.3 - After re-enable: [First enable content], Status: 0
 NOTICE:  Test 3.3 - Pending PUT preserved: [Pending PUT], Status: 0
 NOTICE:  Test 3.3 - New size limit applied: PASSED (3000 bytes written)
+NOTICE:  Test 3.3 - Shrink write blocked: ORU-10027: buffer overflow, limit of 2000 bytes
+NOTICE:  Test 3.3 - Shrink keeps buffered: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX], Status: 0
 -- Test 3.4: Output while disabled is silently ignored
 DECLARE
     line TEXT;

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -174,14 +174,14 @@ BEGIN
 END;
 /
 
--- Test 3.3: Re-ENABLE clears buffer
+-- Test 3.3: Re-ENABLE preserves buffer
 DECLARE
     line TEXT;
     status INTEGER;
 BEGIN
     dbms_output.enable();
     dbms_output.put_line('First enable content');
-    dbms_output.enable();  -- Re-enable should clear
+    dbms_output.enable();  -- Re-enable should preserve unread output
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.3 - After re-enable: [%], Status: %', line, status;
 END;

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -175,15 +175,44 @@ END;
 /
 
 -- Test 3.3: Re-ENABLE preserves buffer
+-- Full contract: unread lines and pending PUT text are preserved, and the
+-- latest size limit is applied to the active buffer.
 DECLARE
     line TEXT;
     status INTEGER;
+    i INTEGER;
+    overflow BOOLEAN := FALSE;
 BEGIN
+    -- Unread line preserved across re-enable
     dbms_output.enable();
     dbms_output.put_line('First enable content');
     dbms_output.enable();  -- Re-enable should preserve unread output
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.3 - After re-enable: [%], Status: %', line, status;
+
+    -- Pending PUT text preserved across re-enable
+    dbms_output.put('Pending PUT');
+    dbms_output.enable();  -- Re-enable should preserve partial output
+    dbms_output.new_line();
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 3.3 - Pending PUT preserved: [%], Status: %', line, status;
+
+    -- New size limit enforced: writing past the old 2000-byte limit succeeds
+    dbms_output.enable(2000);   -- small limit
+    dbms_output.enable(1000000);  -- re-enable with a larger limit
+    FOR i IN 1..60 LOOP
+        BEGIN
+            dbms_output.put_line(rpad('X', 50, 'X'));  -- 50 bytes x 60 = 3000 bytes
+        EXCEPTION WHEN OTHERS THEN
+            overflow := TRUE;
+            EXIT;
+        END;
+    END LOOP;
+    IF overflow THEN
+        RAISE NOTICE 'Test 3.3 - New size limit applied: FAILED';
+    ELSE
+        RAISE NOTICE 'Test 3.3 - New size limit applied: PASSED (3000 bytes written)';
+    END IF;
 END;
 /
 

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -281,6 +281,7 @@ END;
 DECLARE
     v_count INTEGER := 0;
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable(2000);  -- 2000 byte content limit
     -- Write 1-byte lines until overflow
     -- Internal: 1-byte lines need 3 bytes each (2 prefix + 1 data)
@@ -312,6 +313,7 @@ DECLARE
     line TEXT;
     status INTEGER;
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable();
     dbms_output.put_line('Line A');
     dbms_output.put_line('Line B');
@@ -332,6 +334,7 @@ DECLARE
     lines TEXT[];
     numlines INTEGER := 100;  -- Request more than available
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable();
     dbms_output.put_line('Only');
     dbms_output.put_line('Three');
@@ -577,6 +580,7 @@ END;
 -- Write in first block
 DO $$
 BEGIN
+    dbms_output.disable();  -- Ensure a clean buffer: re-ENABLE preserves unread output
     dbms_output.enable(1000000);
     dbms_output.put_line('Written in block 1');
 END;

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -213,6 +213,18 @@ BEGIN
     ELSE
         RAISE NOTICE 'Test 3.3 - New size limit applied: PASSED (3000 bytes written)';
     END IF;
+
+    -- Shrinking the limit below the buffered content: buffered lines stay
+    -- readable, and new writes are rejected until the buffer drains
+    dbms_output.enable(2000);  -- shrink below the 3000 bytes already buffered
+    BEGIN
+        dbms_output.put_line('Y');
+        RAISE NOTICE 'Test 3.3 - Shrink write: unexpected success';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Test 3.3 - Shrink write blocked: %', SQLERRM;
+    END;
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 3.3 - Shrink keeps buffered: [%], Status: %', line, status;
 END;
 /
 

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -225,6 +225,23 @@ BEGIN
     END;
     dbms_output.get_line(line, status);
     RAISE NOTICE 'Test 3.3 - Shrink keeps buffered: [%], Status: %', line, status;
+
+    -- Drain all remaining buffered lines, checking the count and order
+    i := 0;
+    LOOP
+        dbms_output.get_line(line, status);
+        EXIT WHEN status != 0;
+        i := i + 1;
+        IF line <> rpad('X', 50, 'X') THEN
+            RAISE NOTICE 'Test 3.3 - Shrink drain order: unexpected [%]', line;
+        END IF;
+    END LOOP;
+    RAISE NOTICE 'Test 3.3 - Shrink drained: % lines, Status: %', i, status;
+
+    -- Usage is back below the limit: a marker write succeeds and reads back
+    dbms_output.put_line('MARKER');
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 3.3 - Shrink resumes writes: [%], Status: %', line, status;
 END;
 /
 

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
@@ -114,20 +114,24 @@ PG_FUNCTION_INFO_V1(ora_dbms_output_get_lines);
 /*
  * init_output_buffer
  *
- * Initialize or re-initialize the output buffer.
+ * Initialize the output buffer or update its size when already enabled.
  *
  * buffer_size: user-specified content limit in bytes, or -1 for unlimited.
  *
- * IvorySQL behavior: ENABLE always clears existing buffer.
- * Note: Oracle preserves buffer on re-ENABLE; this is an intentional
- * IvorySQL simplification.
+ * Re-enabling an active buffer preserves unread output and applies the latest
+ * size limit.  Enabling a disabled buffer starts with an empty buffer.
  */
 static void
 init_output_buffer(int64 buffer_size)
 {
 	MemoryContext oldcontext;
 
-	/* IvorySQL behavior: ENABLE clears existing buffer (differs from Oracle) */
+	if (output_buffer != NULL && output_buffer->enabled)
+	{
+		output_buffer->buffer_size = buffer_size;
+		return;
+	}
+
 	if (output_buffer != NULL)
 		cleanup_output_buffer();
 
@@ -163,7 +167,7 @@ init_output_buffer(int64 buffer_size)
  * cleanup_output_buffer
  *
  * Free all buffer resources and reset to NULL.
- * Called when ENABLE is called to re-initialize the buffer.
+ * Called when buffer state needs to be discarded.
  */
 static void
 cleanup_output_buffer(void)
@@ -314,7 +318,7 @@ ora_dbms_output_enable(PG_FUNCTION_ARGS)
 			buffer_size = DBMS_OUTPUT_MIN_BUFFER_SIZE;
 	}
 
-	/* Initialize buffer (clears existing if present) */
+	/* Initialize the buffer or update the active buffer's size limit */
 	init_output_buffer(buffer_size);
 
 	PG_RETURN_VOID();


### PR DESCRIPTION
## Summary

- preserve unread lines and partial output when `DBMS_OUTPUT.ENABLE` is called on an active buffer;
- apply the newest size limit without reallocating the active buffer;
- retain the current disable/enable-cycle behavior and update the regression expectation.

Fixes #1561.

## Validation

- reproduced the old behavior: repeated `ENABLE` returned `NULL`, status `1`
- compiled `dbms_output.o`
- loaded the patched object into a live IvorySQL backend and confirmed repeated `ENABLE` returns `First enable content`, status `0`
- confirmed `DISABLE` followed by `ENABLE` still starts with an empty buffer and returns only new output
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabling DBMS_OUTPUT now preserves unread messages and pending output text.
  * Buffer size settings update correctly while output remains enabled.
  * Reduced limits prevent new writes when buffered content exceeds the limit, while preserving readable output.
  * Disabling output before re-enabling provides a clean buffer when needed.

* **Tests**
  * Added coverage for preserved buffered content, pending text, buffer limits, and clean-buffer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->