### PR TITLE
Fix pgtest -n status initialization

### DIFF
--- a/src/tools/pgtest
+++ b/src/tools/pgtest
@@ -28,6 +28,7 @@ rm -f tmp_install/log/install.log
 
 # Run "make check" and store return code in $TMP/ret.
 # Display output but also capture it in $TMP/0.
+echo 0 > "$TMP"/ret
 (
 	if [ "$CLEAN" = 'Y' ]
 	then	$MAKE "$@" clean 2>&1


### PR DESCRIPTION
## Summary

- initialize the stored command status before the optional clean stage
- allow pgtest -n to proceed to build and check without reading a missing file
- preserve the exit status of clean, build, and check failures

Fixes #1563.

## Validation

- reproduced the previous behavior in an isolated directory: exit status 255 with missing ret-file and numeric-comparison errors
- sh -n src/tools/pgtest
- isolated no-clean path with a successful make: exit status 0
- isolated no-clean path with a failing make: exit status 1
- isolated clean path with a successful make: exit status 0
- isolated clean path with a failing make: exit status 1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and check reliability by ensuring a successful status is reported when no cleanup step is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->