### PR TITLE
Add Oracle-compatible VSIZE function

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -71,6 +71,7 @@ ORA_REGRESS = \
 	ora_character_datatype_functions \
 	ora_datetime_datatype_functions \
 	ora_misc_functions \
+	ora_vsize \
 	ora_merge \
 	datatype_and_func_bugs \
 	ora_sysview \

--- a/contrib/ivorysql_ora/expected/ora_vsize.out
+++ b/contrib/ivorysql_ora/expected/ora_vsize.out
@@ -4,131 +4,131 @@
 -- Oracle-compatible VSIZE: number of bytes in the internal representation.
 --
 -- character data: byte length of the value (header excluded)
-SELECT sys.vsize('abc');
+SELECT vsize('abc');
  vsize 
 -------
      3
 (1 row)
 
-SELECT sys.vsize('abc'::varchar2);
+SELECT vsize(CAST('abc' AS VARCHAR2));
  vsize 
 -------
      3
 (1 row)
 
-SELECT sys.vsize('abc'::varchar);
+SELECT vsize('abc'::varchar);
  vsize 
 -------
      3
 (1 row)
 
-SELECT sys.vsize('abc'::char(10));
+SELECT vsize('abc'::char(10));
  vsize 
 -------
     10
 (1 row)
 
-SELECT sys.vsize('abc'::text) = sys.vsize('abc'::varchar2) AS same_as_varchar2;
+SELECT vsize('abc'::text) = vsize(CAST('abc' AS VARCHAR2)) AS same_as_varchar2;
  same_as_varchar2 
 ------------------
  t
 (1 row)
 
-SELECT sys.vsize('abc') = lengthb('abc') AS same_as_lengthb;
+SELECT vsize('abc') = lengthb('abc') AS same_as_lengthb;
  same_as_lengthb 
 -----------------
  t
 (1 row)
 
 -- multibyte data
-SELECT sys.vsize('你好'::text);
+SELECT vsize('你好'::text);
  vsize 
 -------
      6
 (1 row)
 
 -- numeric data
-SELECT sys.vsize(0::number);
+SELECT vsize(0::number);
  vsize 
 -------
      2
 (1 row)
 
-SELECT sys.vsize(1::number);
+SELECT vsize(1::number);
  vsize 
 -------
      4
 (1 row)
 
-SELECT sys.vsize(123::number);
+SELECT vsize(123::number);
  vsize 
 -------
      4
 (1 row)
 
-SELECT sys.vsize(1.23::number);
+SELECT vsize(1.23::number);
  vsize 
 -------
      6
 (1 row)
 
-SELECT sys.vsize(123::int4);
+SELECT vsize(123::int4);
  vsize 
 -------
      4
 (1 row)
 
-SELECT sys.vsize(123::int8);
+SELECT vsize(123::int8);
  vsize 
 -------
      8
 (1 row)
 
-SELECT sys.vsize(1.23::float8);
+SELECT vsize(1.23::float8);
  vsize 
 -------
      8
 (1 row)
 
-SELECT sys.vsize('NaN'::float8);
+SELECT vsize('NaN'::float8);
  vsize 
 -------
      8
 (1 row)
 
 -- other fixed-width types
-SELECT sys.vsize(true);
+SELECT vsize(true);
  vsize 
 -------
      1
 (1 row)
 
-SELECT sys.vsize('2024-01-01'::date);
+SELECT vsize('2024-01-01'::date);
  vsize 
 -------
      8
 (1 row)
 
-SELECT sys.vsize('2024-01-01 10:00:00'::timestamp);
+SELECT vsize('2024-01-01 10:00:00'::timestamp);
  vsize 
 -------
      8
 (1 row)
 
-SELECT sys.vsize('2024-01-01 10:00:00+08'::timestamptz);
+SELECT vsize('2024-01-01 10:00:00+08'::timestamptz);
  vsize 
 -------
      8
 (1 row)
 
 -- NULL input returns NULL
-SELECT sys.vsize(NULL::text);
+SELECT vsize(NULL::text);
  vsize 
 -------
       
 (1 row)
 
-SELECT sys.vsize(NULL::number);
+SELECT vsize(NULL::number);
  vsize 
 -------
       
@@ -139,7 +139,7 @@ CREATE TABLE vsize_tbl(a text, b number);
 INSERT INTO vsize_tbl VALUES ('hello', 12345);
 INSERT INTO vsize_tbl VALUES (NULL, NULL);
 INSERT INTO vsize_tbl VALUES ('world', 0);
-SELECT sys.vsize(a), sys.vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
+SELECT vsize(a), vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
  vsize | vsize 
 -------+-------
      5 |     6
@@ -149,13 +149,13 @@ SELECT sys.vsize(a), sys.vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
 
 DROP TABLE vsize_tbl;
 -- large values that get toasted/compressed still report the logical size
-SELECT sys.vsize(repeat('a', 100000)) = lengthb(repeat('a', 100000)) AS big_text_matches_lengthb;
+SELECT vsize(repeat('a', 100000)) = lengthb(repeat('a', 100000)) AS big_text_matches_lengthb;
  big_text_matches_lengthb 
 --------------------------
  t
 (1 row)
 
-SELECT sys.vsize(repeat('a', 100000));
+SELECT vsize(repeat('a', 100000));
  vsize  
 --------
  100000
@@ -163,7 +163,7 @@ SELECT sys.vsize(repeat('a', 100000));
 
 CREATE TABLE vsize_big(a text);
 INSERT INTO vsize_big SELECT repeat('b', 200000) FROM generate_series(1, 10);
-SELECT bool_and(sys.vsize(a) = lengthb(a)) AS toasted_matches_lengthb, min(sys.vsize(a)) AS min_size FROM vsize_big;
+SELECT bool_and(vsize(a) = lengthb(a)) AS toasted_matches_lengthb, min(vsize(a)) AS min_size FROM vsize_big;
  toasted_matches_lengthb | min_size 
 -------------------------+----------
  t                       |   200000

--- a/contrib/ivorysql_ora/expected/ora_vsize.out
+++ b/contrib/ivorysql_ora/expected/ora_vsize.out
@@ -1,0 +1,172 @@
+--
+-- VSIZE
+--
+-- Oracle-compatible VSIZE: number of bytes in the internal representation.
+--
+-- character data: byte length of the value (header excluded)
+SELECT sys.vsize('abc');
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT sys.vsize('abc'::varchar2);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT sys.vsize('abc'::varchar);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT sys.vsize('abc'::char(10));
+ vsize 
+-------
+    10
+(1 row)
+
+SELECT sys.vsize('abc'::text) = sys.vsize('abc'::varchar2) AS same_as_varchar2;
+ same_as_varchar2 
+------------------
+ t
+(1 row)
+
+SELECT sys.vsize('abc') = lengthb('abc') AS same_as_lengthb;
+ same_as_lengthb 
+-----------------
+ t
+(1 row)
+
+-- multibyte data
+SELECT sys.vsize('你好'::text);
+ vsize 
+-------
+     6
+(1 row)
+
+-- numeric data
+SELECT sys.vsize(0::number);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT sys.vsize(1::number);
+ vsize 
+-------
+     4
+(1 row)
+
+SELECT sys.vsize(123::number);
+ vsize 
+-------
+     4
+(1 row)
+
+SELECT sys.vsize(1.23::number);
+ vsize 
+-------
+     6
+(1 row)
+
+SELECT sys.vsize(123::int4);
+ vsize 
+-------
+     4
+(1 row)
+
+SELECT sys.vsize(123::int8);
+ vsize 
+-------
+     8
+(1 row)
+
+SELECT sys.vsize(1.23::float8);
+ vsize 
+-------
+     8
+(1 row)
+
+SELECT sys.vsize('NaN'::float8);
+ vsize 
+-------
+     8
+(1 row)
+
+-- other fixed-width types
+SELECT sys.vsize(true);
+ vsize 
+-------
+     1
+(1 row)
+
+SELECT sys.vsize('2024-01-01'::date);
+ vsize 
+-------
+     8
+(1 row)
+
+SELECT sys.vsize('2024-01-01 10:00:00'::timestamp);
+ vsize 
+-------
+     8
+(1 row)
+
+SELECT sys.vsize('2024-01-01 10:00:00+08'::timestamptz);
+ vsize 
+-------
+     8
+(1 row)
+
+-- NULL input returns NULL
+SELECT sys.vsize(NULL::text);
+ vsize 
+-------
+      
+(1 row)
+
+SELECT sys.vsize(NULL::number);
+ vsize 
+-------
+      
+(1 row)
+
+-- NULL values in a table
+CREATE TABLE vsize_tbl(a text, b number);
+INSERT INTO vsize_tbl VALUES ('hello', 12345);
+INSERT INTO vsize_tbl VALUES (NULL, NULL);
+INSERT INTO vsize_tbl VALUES ('world', 0);
+SELECT sys.vsize(a), sys.vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
+ vsize | vsize 
+-------+-------
+     5 |     6
+     5 |     2
+       |      
+(3 rows)
+
+DROP TABLE vsize_tbl;
+-- large values that get toasted/compressed still report the logical size
+SELECT sys.vsize(repeat('a', 100000)) = lengthb(repeat('a', 100000)) AS big_text_matches_lengthb;
+ big_text_matches_lengthb 
+--------------------------
+ t
+(1 row)
+
+SELECT sys.vsize(repeat('a', 100000));
+ vsize  
+--------
+ 100000
+(1 row)
+
+CREATE TABLE vsize_big(a text);
+INSERT INTO vsize_big SELECT repeat('b', 200000) FROM generate_series(1, 10);
+SELECT bool_and(sys.vsize(a) = lengthb(a)) AS toasted_matches_lengthb, min(sys.vsize(a)) AS min_size FROM vsize_big;
+ toasted_matches_lengthb | min_size 
+-------------------------+----------
+ t                       |   200000
+(1 row)
+
+DROP TABLE vsize_big;

--- a/contrib/ivorysql_ora/sql/ora_vsize.sql
+++ b/contrib/ivorysql_ora/sql/ora_vsize.sql
@@ -5,48 +5,48 @@
 --
 
 -- character data: byte length of the value (header excluded)
-SELECT sys.vsize('abc');
-SELECT sys.vsize('abc'::varchar2);
-SELECT sys.vsize('abc'::varchar);
-SELECT sys.vsize('abc'::char(10));
-SELECT sys.vsize('abc'::text) = sys.vsize('abc'::varchar2) AS same_as_varchar2;
-SELECT sys.vsize('abc') = lengthb('abc') AS same_as_lengthb;
+SELECT vsize('abc');
+SELECT vsize(CAST('abc' AS VARCHAR2));
+SELECT vsize('abc'::varchar);
+SELECT vsize('abc'::char(10));
+SELECT vsize('abc'::text) = vsize(CAST('abc' AS VARCHAR2)) AS same_as_varchar2;
+SELECT vsize('abc') = lengthb('abc') AS same_as_lengthb;
 
 -- multibyte data
-SELECT sys.vsize('你好'::text);
+SELECT vsize('你好'::text);
 
 -- numeric data
-SELECT sys.vsize(0::number);
-SELECT sys.vsize(1::number);
-SELECT sys.vsize(123::number);
-SELECT sys.vsize(1.23::number);
-SELECT sys.vsize(123::int4);
-SELECT sys.vsize(123::int8);
-SELECT sys.vsize(1.23::float8);
-SELECT sys.vsize('NaN'::float8);
+SELECT vsize(0::number);
+SELECT vsize(1::number);
+SELECT vsize(123::number);
+SELECT vsize(1.23::number);
+SELECT vsize(123::int4);
+SELECT vsize(123::int8);
+SELECT vsize(1.23::float8);
+SELECT vsize('NaN'::float8);
 
 -- other fixed-width types
-SELECT sys.vsize(true);
-SELECT sys.vsize('2024-01-01'::date);
-SELECT sys.vsize('2024-01-01 10:00:00'::timestamp);
-SELECT sys.vsize('2024-01-01 10:00:00+08'::timestamptz);
+SELECT vsize(true);
+SELECT vsize('2024-01-01'::date);
+SELECT vsize('2024-01-01 10:00:00'::timestamp);
+SELECT vsize('2024-01-01 10:00:00+08'::timestamptz);
 
 -- NULL input returns NULL
-SELECT sys.vsize(NULL::text);
-SELECT sys.vsize(NULL::number);
+SELECT vsize(NULL::text);
+SELECT vsize(NULL::number);
 
 -- NULL values in a table
 CREATE TABLE vsize_tbl(a text, b number);
 INSERT INTO vsize_tbl VALUES ('hello', 12345);
 INSERT INTO vsize_tbl VALUES (NULL, NULL);
 INSERT INTO vsize_tbl VALUES ('world', 0);
-SELECT sys.vsize(a), sys.vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
+SELECT vsize(a), vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
 DROP TABLE vsize_tbl;
 
 -- large values that get toasted/compressed still report the logical size
-SELECT sys.vsize(repeat('a', 100000)) = lengthb(repeat('a', 100000)) AS big_text_matches_lengthb;
-SELECT sys.vsize(repeat('a', 100000));
+SELECT vsize(repeat('a', 100000)) = lengthb(repeat('a', 100000)) AS big_text_matches_lengthb;
+SELECT vsize(repeat('a', 100000));
 CREATE TABLE vsize_big(a text);
 INSERT INTO vsize_big SELECT repeat('b', 200000) FROM generate_series(1, 10);
-SELECT bool_and(sys.vsize(a) = lengthb(a)) AS toasted_matches_lengthb, min(sys.vsize(a)) AS min_size FROM vsize_big;
+SELECT bool_and(vsize(a) = lengthb(a)) AS toasted_matches_lengthb, min(vsize(a)) AS min_size FROM vsize_big;
 DROP TABLE vsize_big;

--- a/contrib/ivorysql_ora/sql/ora_vsize.sql
+++ b/contrib/ivorysql_ora/sql/ora_vsize.sql
@@ -1,0 +1,52 @@
+--
+-- VSIZE
+--
+-- Oracle-compatible VSIZE: number of bytes in the internal representation.
+--
+
+-- character data: byte length of the value (header excluded)
+SELECT sys.vsize('abc');
+SELECT sys.vsize('abc'::varchar2);
+SELECT sys.vsize('abc'::varchar);
+SELECT sys.vsize('abc'::char(10));
+SELECT sys.vsize('abc'::text) = sys.vsize('abc'::varchar2) AS same_as_varchar2;
+SELECT sys.vsize('abc') = lengthb('abc') AS same_as_lengthb;
+
+-- multibyte data
+SELECT sys.vsize('你好'::text);
+
+-- numeric data
+SELECT sys.vsize(0::number);
+SELECT sys.vsize(1::number);
+SELECT sys.vsize(123::number);
+SELECT sys.vsize(1.23::number);
+SELECT sys.vsize(123::int4);
+SELECT sys.vsize(123::int8);
+SELECT sys.vsize(1.23::float8);
+SELECT sys.vsize('NaN'::float8);
+
+-- other fixed-width types
+SELECT sys.vsize(true);
+SELECT sys.vsize('2024-01-01'::date);
+SELECT sys.vsize('2024-01-01 10:00:00'::timestamp);
+SELECT sys.vsize('2024-01-01 10:00:00+08'::timestamptz);
+
+-- NULL input returns NULL
+SELECT sys.vsize(NULL::text);
+SELECT sys.vsize(NULL::number);
+
+-- NULL values in a table
+CREATE TABLE vsize_tbl(a text, b number);
+INSERT INTO vsize_tbl VALUES ('hello', 12345);
+INSERT INTO vsize_tbl VALUES (NULL, NULL);
+INSERT INTO vsize_tbl VALUES ('world', 0);
+SELECT sys.vsize(a), sys.vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
+DROP TABLE vsize_tbl;
+
+-- large values that get toasted/compressed still report the logical size
+SELECT sys.vsize(repeat('a', 100000)) = lengthb(repeat('a', 100000)) AS big_text_matches_lengthb;
+SELECT sys.vsize(repeat('a', 100000));
+CREATE TABLE vsize_big(a text);
+INSERT INTO vsize_big SELECT repeat('b', 200000) FROM generate_series(1, 10);
+SELECT bool_and(sys.vsize(a) = lengthb(a)) AS toasted_matches_lengthb, min(sys.vsize(a)) AS min_size FROM vsize_big;
+DROP TABLE vsize_big;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1505,3 +1505,23 @@ CREATE AGGREGATE sys.stragg(text) (
     PARALLEL  = SAFE
 );
 /* End - STRAGG */
+
+/* VSIZE */
+/*
+ * VSIZE: Oracle-compatible function returning the number of bytes in the
+ * internal representation of the argument.  Returns NULL for NULL input.
+ * For varlena types the logical (decompressed) data size, excluding the
+ * varlena header, is returned; for fixed-width types the storage width is
+ * returned.
+ *
+ * The anycompatible pseudo-type accepts a value of any data type, and an
+ * untyped string literal is resolved to text, so VSIZE('abc') works just
+ * like in Oracle.
+ */
+CREATE FUNCTION sys.vsize(anycompatible)
+RETURNS int4
+AS 'MODULE_PATHNAME', 'ora_vsize'
+LANGUAGE C
+STRICT
+IMMUTABLE;
+/* End - VSIZE */

--- a/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
@@ -30,7 +30,9 @@
 #include "postgres.h"
 #include "fmgr.h"
 #include "miscadmin.h"
+#include "access/detoast.h"
 #include "utils/formatting.h"
+#include "utils/lsyscache.h"
 #include "utils/numeric.h"
 #include "varatt.h"
 #include "lib/stringinfo.h"
@@ -38,6 +40,69 @@
 
 PG_FUNCTION_INFO_V1(uid);
 PG_FUNCTION_INFO_V1(stragg_transfn);
+PG_FUNCTION_INFO_V1(ora_vsize);
+
+
+/*
+ * ora_vsize
+ *
+ * Oracle-compatible VSIZE function.
+ * Returns the number of bytes in the internal representation of the
+ * argument.  NULL input yields NULL (the function is declared STRICT).
+ *
+ * For varlena types the logical (decompressed) data size is returned,
+ * excluding the varlena header, so that VSIZE('abc') is 3, matching
+ * Oracle's behavior for character data.  For fixed-width types the
+ * type's storage width is returned.
+ */
+Datum
+ora_vsize(PG_FUNCTION_ARGS)
+{
+	Datum		value = PG_GETARG_DATUM(0);
+	int32		result;
+	int			typlen;
+
+	/* On first call, get the input type's typlen, and save at *fn_extra */
+	if (fcinfo->flinfo->fn_extra == NULL)
+	{
+		/* Lookup the datatype of the supplied argument */
+		Oid			argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+
+		typlen = get_typlen(argtypeid);
+		if (typlen == 0)		/* should not happen */
+			elog(ERROR, "cache lookup failed for type %u", argtypeid);
+
+		fcinfo->flinfo->fn_extra = MemoryContextAlloc(fcinfo->flinfo->fn_mcxt,
+													  sizeof(int));
+		*((int *) fcinfo->flinfo->fn_extra) = typlen;
+	}
+	else
+		typlen = *((int *) fcinfo->flinfo->fn_extra);
+
+	if (typlen == -1)
+	{
+		/*
+		 * varlena type.  toast_raw_datum_size() normalizes 1-byte/4-byte
+		 * headers, compression and external (toasted) storage to the
+		 * logical (decompressed) size using the 4-byte header convention,
+		 * so subtracting VARHDRSZ yields the payload byte count in every
+		 * case -- the same pattern octet_length() uses.
+		 */
+		result = toast_raw_datum_size(value) - VARHDRSZ;
+	}
+	else if (typlen == -2)
+	{
+		/* cstring */
+		result = strlen(DatumGetCString(value)) + 1;
+	}
+	else
+	{
+		/* ordinary fixed-width type */
+		result = typlen;
+	}
+
+	PG_RETURN_INT32(result);
+}
 
 
 Datum


### PR DESCRIPTION
VSIZE returns the number of bytes in the internal representation of an argument, matching Oracle semantics: character data reports its byte length (VSIZE('abc') = 3), fixed-width types report their storage width, and NULL input yields NULL.

releated to #1565 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oracle-compatible `sys.vsize`, which reports the byte size of compatible values.
  * Supports character, multibyte, numeric, Boolean, date, timestamp, fixed-width, table-column, NULL, and large text values.
  * Handles VARCHAR2 values and compressed or toasted large values consistently.

* **Tests**
  * Added comprehensive regression coverage validating byte lengths, NULL handling, varied data types, and consistency with `lengthb`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->