### PR TITLE
libpq/psql: prevent named-bind escape buffer overruns

### DIFF
--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -3637,13 +3637,27 @@ get_hostvariables(const char *sql, bool *error)
 	HostVariable *host = NULL;
 	char		*newsql = NULL;
 	char		*ptr = NULL;
+	size_t		sql_len;
 
 	*error = false;
 	if (!sql)
 		return NULL;
 
+	/*
+	 * Each input byte may be emitted twice (quoted quotes) plus one NUL
+	 * terminator, so reject inputs whose doubled length would overflow
+	 * before pg_malloc0() sees a wrapped size.
+	 */
+	sql_len = strlen(sql);
+	if (sql_len > (SIZE_MAX - 1) / 2)
+	{
+		pg_log_error("query is too long to escape for host-variable binding");
+		*error = true;
+		return NULL;
+	}
+
 	/* double write quote */
-	newsql = pg_malloc0(strlen(sql) * 2 + 1);	/* doubled quotes plus NUL */
+	newsql = pg_malloc0(sql_len * 2 + 1);	/* doubled quotes plus NUL */
 	ptr = newsql;
 
 	while (*sql != '\0')

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -3643,7 +3643,7 @@ get_hostvariables(const char *sql, bool *error)
 		return NULL;
 
 	/* double write quote */
-	newsql = pg_malloc0(strlen(sql) * 2);	/* enough */
+	newsql = pg_malloc0(strlen(sql) * 2 + 1);	/* doubled quotes plus NUL */
 	ptr = newsql;
 
 	while (*sql != '\0')

--- a/src/interfaces/libpq/ivy-exec.c
+++ b/src/interfaces/libpq/ivy-exec.c
@@ -84,6 +84,7 @@ static int Ivyreplacenamebindtoposition3(Ivyconn *tconn,
 						IvyPreparedStatement *stmtHandle,
 						IvyError *errhp,
 						HostVariable *host);
+static char *IvyBuildParameterDescriptionQuery(const char *source);
 static int IvybindOutParameterByPosInternel(IvyPreparedStatement *stmthandle,
 						IvyBindOutInfo **bindinfo,
 						int	position,
@@ -3753,6 +3754,38 @@ ERROR_HANDLE:
 	return 0;
 }
 
+/* Build a query with source escaped as a single-quoted SQL literal. */
+static char *
+IvyBuildParameterDescriptionQuery(const char *source)
+{
+	static const char prefix[] = "select * from get_parameter_description('";
+	static const char suffix[] = "');";
+	const size_t overhead = sizeof(prefix) - 1 + sizeof(suffix);
+	size_t		source_len = strlen(source);
+	char	   *query;
+	char	   *write_ptr;
+
+	if (source_len > (SIZE_MAX - overhead) / 2)
+		return NULL;
+
+	query = malloc(source_len * 2 + overhead);
+	if (query == NULL)
+		return NULL;
+
+	write_ptr = query;
+	memcpy(write_ptr, prefix, sizeof(prefix) - 1);
+	write_ptr += sizeof(prefix) - 1;
+	while (*source != '\0')
+	{
+		if (*source == '\'')
+			*write_ptr++ = *source;
+		*write_ptr++ = *source++;
+	}
+	memcpy(write_ptr, suffix, sizeof(suffix));
+
+	return query;
+}
+
 /*
  * replace bindbyname to position
  */
@@ -3776,7 +3809,6 @@ Ivyreplacenamebindtoposition(Ivyconn *tconn,
 	if (stmtHandle->paramNames == NULL)
 	{
 		char	*query;
-		int	query_len;
 		int	n_tuples;
 		int	n_fields;
 		char	*first_name;
@@ -3784,35 +3816,14 @@ Ivyreplacenamebindtoposition(Ivyconn *tconn,
 		int	dostmt = 0;
 		bool	iscallstmt = false;
 		char	*convertcall = NULL;
-		char	*newsql = NULL;
-		char	*ptr = NULL;
-		const char *query_ptr = NULL;
 
-		query_len = (stmtHandle->query_len * 2) + strlen("select * from get_parameter_description(") + 5;
-		query = (char *) malloc(query_len);
+		query = IvyBuildParameterDescriptionQuery(stmtHandle->query);
 
 		if (query == NULL)
 		{
 			snprintf(errmsg, size_error_buf, "%s", "failed to allocate memory");
 			return 0;
 		}
-
-		newsql = malloc(stmtHandle->query_len * 2);	/* enough */
-		ptr = newsql;
-		query_ptr = stmtHandle->query;
-		
-		while (*query_ptr != '\0')
-		{
-			if (*query_ptr == '\'')
-				*ptr++ = *query_ptr;
-			*ptr++ = *query_ptr;
-			query_ptr++;
-		}
-		*ptr = '\0';
-
-		memset(query, 0x00, query_len);
-		snprintf(query, query_len, "select * from get_parameter_description('%s');", newsql);
-		free(newsql);
 
 		res = Ivyexec(tconn, query);
 		if (IvyresultStatus(res) != PGRES_TUPLES_OK)
@@ -4063,7 +4074,6 @@ Ivyreplacenamebindtoposition2(Ivyconn *tconn,
 	if (stmtHandle->paramNames == NULL)
 	{
 		char	*query;
-		int 	query_len;
 		int 	n_tuples;
 		int 	n_fields;
 		int	first_pos;
@@ -4071,12 +4081,8 @@ Ivyreplacenamebindtoposition2(Ivyconn *tconn,
 		int	dostmt = 0;
 		bool	iscallstmt = false;
 		char	*convertcall = NULL;
-		char	*newsql = NULL;
-		char	*ptr = NULL;
-		const char *query_ptr = NULL;
 
-		query_len = (strlen(stmtHandle->query) * 2) + strlen("select * from get_parameter_description(") + 5;
-		query = (char *) malloc(query_len);
+		query = IvyBuildParameterDescriptionQuery(stmtHandle->query);
 
 		if (query == NULL)
 		{
@@ -4084,23 +4090,6 @@ Ivyreplacenamebindtoposition2(Ivyconn *tconn,
 				"failed to allocate memory");
 			return 0;
 		}
-
-		newsql = malloc(strlen(stmtHandle->query) * 2);	/* enough */
-		ptr = newsql;
-		query_ptr = stmtHandle->query;
-		
-		while (*query_ptr != '\0')
-		{
-			if (*query_ptr == '\'')
-				*ptr++ = *query_ptr;
-			*ptr++ = *query_ptr;
-			query_ptr++;
-		}
-		*ptr = '\0';
-
-		memset(query, 0x00, query_len);
-		snprintf(query, query_len, "select * from get_parameter_description('%s');", newsql);
-		free(newsql);
 
 		res = Ivyexec(tconn, query);
 		if (IvyresultStatus(res) != PGRES_TUPLES_OK)


### PR DESCRIPTION
## Summary

- centralize construction of the libpq named-bind parameter-description query
- reserve space for worst-case quote doubling and the terminating NUL
- reject libpq size overflow and handle empty queries safely
- fix the matching quote-doubling allocation in psql's `get_hostvariables()`

## Root cause

The two libpq named-bind execution paths and psql's host-variable scanner allocated only `2 * query_length` bytes for escaped SQL text. An all-quote input can fill that allocation before the terminating NUL. The libpq path also needed an explicit overflow check and safe handling of empty input.

## Verification

- targeted compilation of `src/interfaces/libpq/ivy-exec.c`
- targeted compilation of `src/bin/psql/common.c`
- empty, quoted, and all-quote libpq boundary cases under AddressSanitizer

Fixes #1554.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SQL parameter descriptions containing quote characters.
  * Added safeguards against oversized SQL input and allocation failures.
  * Prevented potential buffer overflows when processing host variables.
  * Improved error reporting for inputs that exceed supported size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->