### PR TITLE
Fix heap buffer overrun in named-bind query escaping

### DIFF
--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -3643,7 +3643,7 @@ get_hostvariables(const char *sql, bool *error)
 		return NULL;
 
 	/* double write quote */
-	newsql = pg_malloc0(strlen(sql) * 2);	/* enough */
+	newsql = pg_malloc0(strlen(sql) * 2 + 1);	/* doubled quotes plus NUL */
 	ptr = newsql;
 
 	while (*sql != '\0')

--- a/src/bin/psql/mainloop.c
+++ b/src/bin/psql/mainloop.c
@@ -492,7 +492,7 @@ MainLoop(FILE *source)
 		                         * init_value[0] indicates the type of missing quote: single or double quote
 		                         */
 		                        char	quote = bind_var->init_value[0];
-		                        char	*str_double_quote = pg_malloc0(strlen(bind_var->init_value) * 2);	/* Ensure enough space */
+		                        char	*str_double_quote = pg_malloc0(strlen(bind_var->init_value) * 2 + 1);	/* doubled quotes plus NUL */
 		                        char	*ptr = str_double_quote;
 		                        int		i;
 

--- a/src/interfaces/libpq/ivy-exec.c
+++ b/src/interfaces/libpq/ivy-exec.c
@@ -3797,7 +3797,13 @@ Ivyreplacenamebindtoposition(Ivyconn *tconn,
 			return 0;
 		}
 
-		newsql = malloc(stmtHandle->query_len * 2);	/* enough */
+		newsql = malloc((size_t) stmtHandle->query_len * 2 + 1);	/* doubled quotes plus NUL */
+		if (newsql == NULL)
+		{
+			free(query);
+			snprintf(errmsg, size_error_buf, "%s", "failed to allocate memory");
+			return 0;
+		}
 		ptr = newsql;
 		query_ptr = stmtHandle->query;
 		
@@ -4085,7 +4091,14 @@ Ivyreplacenamebindtoposition2(Ivyconn *tconn,
 			return 0;
 		}
 
-		newsql = malloc(strlen(stmtHandle->query) * 2);	/* enough */
+		newsql = malloc((size_t) strlen(stmtHandle->query) * 2 + 1);	/* doubled quotes plus NUL */
+		if (newsql == NULL)
+		{
+			free(query);
+			snprintf(errhp->error_msg, errhp->err_buf_size, "%s",
+					 "failed to allocate memory");
+			return 0;
+		}
 		ptr = newsql;
 		query_ptr = stmtHandle->query;
 		


### PR DESCRIPTION
## Summary

Fixes #1554: the escaped-query buffer in the named-bind path was allocated as `2 * query_length` bytes. When the input query consists entirely of single quotes, the escaping loop writes exactly `2 * query_length` bytes and the terminating NUL is then written one byte past the heap allocation.

Four sites share the same manual escaping pattern and get the same fix:

- `Ivyreplacenamebindtoposition()` in `src/interfaces/libpq/ivy-exec.c` — allocate `2 * len + 1`, compute with `size_t` arithmetic, check `malloc()` failure (previously unchecked, would crash on OOM).
- `Ivyreplacenamebindtoposition2()` in `src/interfaces/libpq/ivy-exec.c` — same fix; the `+1` also makes empty input produce a valid one-byte empty string buffer instead of a NUL write through a zero-length `malloc(0)`.
- `get_hostvariables()` in `src/bin/psql/common.c` — same buffer overrun confirmed; allocate `2 * len + 1` (empty input was already safe here because `pg_malloc0(0)` maps to a 1-byte allocation).
- `psqlplus VARIABLE` missing-termination-quote handling in `src/bin/psql/mainloop.c` — same overrun: a quote-only `init_value` fills the `2 * len` buffer and the terminating NUL lands one byte past; allocate `2 * len + 1`.

Reviewed other quote-doubling sites for the same pattern: `pg_upgrade/util.c`, `psql/command.c` and `tab-complete.in.c` already size with `+2/+3`; `fe_utils/string_utils.c` uses a growing PQExpBuffer; `fe-connect.c` and `tsearchcmds.c` are parsers, not escaping copies.

## Test plan

- `make -C src/interfaces/libpq ivy-exec.o`, `make -C src/bin/psql common.o` and `make -C src/bin/psql mainloop.o` compile cleanly with the changes.
- Full libpq link is currently blocked on this machine by a pre-existing, unrelated `ivy_sema.c` build error on macOS (separate branch `fix-ivy-sema-include-guards`); the changed translation units themselves compile cleanly.
- Recommend an AddressSanitizer run of the affected paths (prepare a query whose bytes are all single quotes, e.g. `''`) to confirm the overrun is gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL text handling to ensure duplicated quotes are safely terminated.
  * Improved query parameter escaping to prevent truncated or malformed queries.
  * Added graceful handling for memory-allocation failures during query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->