### PR TITLE
Support Oracle MODIFY column with NOT NULL

### DIFF
--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -3620,6 +3620,10 @@ set_statistics_value:
 			| DEFAULT						{ $$ = NULL; }
 		;
 
+/*
+ * Also used for Oracle MODIFY <column> <type> NOT NULL. Keeping this
+ * alternative here avoids conflicts with MODIFY <column> VISIBLE/INVISIBLE.
+ */
 identity_clause:
 		'(' identity_options ')'		{ $$ = $2; }
 		| identity_options				{ $$ = $1; }

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -3663,6 +3663,25 @@ identity_options:
 				$$ = list_make1(n);
 			}
 
+			/* ALTER TABLE <name> MODIFY [(] <colname> <typename> NOT NULL [)] */
+			| ColId Typename NOT NULL_P
+				{
+					AlterTableCmd *m = makeNode(AlterTableCmd);
+					AlterTableCmd *n = makeNode(AlterTableCmd);
+					ColumnDef *def = makeNode(ColumnDef);
+
+					m->subtype = AT_AlterColumnType;
+					m->name = $1;
+					m->def = (Node *) def;
+					/* We only use these fields of the ColumnDef node */
+					def->typeName = $2;
+					def->location = @1;
+
+					n->subtype = AT_SetNotNull;
+					n->name = $1;
+					$$ = list_make2(m, n);
+				}
+
 drop_identity:
 		ColId DROP IDENTITY_P
 			{

--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -678,7 +678,8 @@ static void determineLanguage(List *options);
 %type <node> param_mode
 %type <boolean>	opt_do_from_where
 
-%type <list>	identity_clause identity_options drop_identity
+%type <list>	modify_clause modify_column_list modify_column_item
+%type <ival>	modify_column_null
 %type <boolean>	opt_with opt_by
 
 %type <node>	json_format_clause
@@ -2619,7 +2620,7 @@ AlterTableStmt:
 alter_table_cmds:
 			alter_table_cmd							{ $$ = list_make1($1); }
 			| alter_table_cmds ',' alter_table_cmd	{ $$ = lappend($1, $3); }
-			| MODIFY identity_clause				{ $$ = $2; }
+			| MODIFY modify_clause				{ $$ = $2; }
 		;
 
 ora_alter_view_cmds:
@@ -3621,22 +3622,62 @@ set_statistics_value:
 		;
 
 /*
- * Also used for Oracle MODIFY <column> <type> NOT NULL. Keeping this
- * alternative here avoids conflicts with MODIFY <column> VISIBLE/INVISIBLE.
+ * Oracle-compatible ALTER TABLE ... MODIFY.
+ *
+ * Each item yields a List of AlterTableCmd, because a single Oracle MODIFY item
+ * can expand into more than one internal subcommand (for example a type change
+ * plus a NOT NULL constraint).
+ *
+ * Note that a bare "MODIFY <col> <type>" is not accepted here: VISIBLE and
+ * INVISIBLE are unreserved keywords and can be derived as a type name, so that
+ * form is ambiguous with "MODIFY <col> INVISIBLE" below.
  */
-identity_clause:
-		'(' identity_options ')'		{ $$ = $2; }
-		| identity_options				{ $$ = $1; }
-		| '(' drop_identity ')' 		{ $$ = $2; }
-		| drop_identity 				{ $$ = $1; }
-	;
+modify_clause:
+			'(' modify_column_list ')'		{ $$ = $2; }
+			| modify_column_item			{ $$ = $1; }
+		;
 
-identity_options:
-			ColId Typename GENERATED generated_when AS IDENTITY_P OptParenthesizedSeqOptList
+modify_column_list:
+			modify_column_item								{ $$ = $1; }
+			| modify_column_list ',' modify_column_item		{ $$ = list_concat($1, $3); }
+		;
+
+modify_column_item:
+			/* MODIFY <colname> <typename> {NOT NULL | NULL} */
+			ColId Typename modify_column_null
 				{
 					AlterTableCmd *m = makeNode(AlterTableCmd);
 					AlterTableCmd *n = makeNode(AlterTableCmd);
-					ColumnDef *def = makeNode(ColumnDef);
+					ColumnDef  *def = makeNode(ColumnDef);
+
+					m->subtype = AT_AlterColumnType;
+					m->name = $1;
+					m->def = (Node *) def;
+					/* We only use these fields of the ColumnDef node */
+					def->typeName = $2;
+					def->location = @1;
+
+					n->subtype = $3 ? AT_SetNotNull : AT_DropNotNull;
+					n->name = $1;
+
+					$$ = list_make2(m, n);
+				}
+			/* MODIFY <colname> {NOT NULL | NULL} */
+			| ColId modify_column_null
+				{
+					AlterTableCmd *n = makeNode(AlterTableCmd);
+
+					n->subtype = $2 ? AT_SetNotNull : AT_DropNotNull;
+					n->name = $1;
+					$$ = list_make1(n);
+				}
+			/* MODIFY <colname> [<typename>] GENERATED ... AS IDENTITY [(...)] */
+			| ColId Typename GENERATED generated_when AS IDENTITY_P OptParenthesizedSeqOptList
+				{
+					AlterTableCmd *m = makeNode(AlterTableCmd);
+					AlterTableCmd *n = makeNode(AlterTableCmd);
+					ColumnDef  *def = makeNode(ColumnDef);
+
 					m->subtype = AT_AlterColumnType;
 					m->name = $1;
 					m->def = (Node *) def;
@@ -3646,56 +3687,42 @@ identity_options:
 						$4 = ATTRIBUTE_ORA_IDENTITY_ALWAYS;
 					else if ($4 == ATTRIBUTE_IDENTITY_BY_DEFAULT)
 						$4 = ATTRIBUTE_ORA_IDENTITY_BY_DEFAULT;
-					n->def = (Node *)lcons(makeDefElem("generated", (Node *) makeInteger($4), @1), $7);
-
+					n->def = (Node *) lcons(makeDefElem("generated", (Node *) makeInteger($4), @1), $7);
 					n->subtype = AT_SetIdentity;
 					n->name = $1;
+
 					$$ = list_make2(m, n);
 				}
 			| ColId GENERATED generated_when AS IDENTITY_P OptParenthesizedSeqOptList
 				{
 					AlterTableCmd *n = makeNode(AlterTableCmd);
+
 					if ($3 == ATTRIBUTE_IDENTITY_ALWAYS)
 						$3 = ATTRIBUTE_ORA_IDENTITY_ALWAYS;
 					else if ($3 == ATTRIBUTE_IDENTITY_BY_DEFAULT)
 						$3 = ATTRIBUTE_ORA_IDENTITY_BY_DEFAULT;
-					n->def = (Node *)lcons(makeDefElem("generated", (Node *) makeInteger($3), @1), $6);
-
-				n->subtype = AT_SetIdentity;
-				n->name = $1;
-
-				$$ = list_make1(n);
-			}
-
-			/* ALTER TABLE <name> MODIFY [(] <colname> <typename> NOT NULL [)] */
-			| ColId Typename NOT NULL_P
-				{
-					AlterTableCmd *m = makeNode(AlterTableCmd);
-					AlterTableCmd *n = makeNode(AlterTableCmd);
-					ColumnDef *def = makeNode(ColumnDef);
-
-					m->subtype = AT_AlterColumnType;
-					m->name = $1;
-					m->def = (Node *) def;
-					/* We only use these fields of the ColumnDef node */
-					def->typeName = $2;
-					def->location = @1;
-
-					n->subtype = AT_SetNotNull;
+					n->def = (Node *) lcons(makeDefElem("generated", (Node *) makeInteger($3), @1), $6);
+					n->subtype = AT_SetIdentity;
 					n->name = $1;
-					$$ = list_make2(m, n);
-				}
 
-drop_identity:
-		ColId DROP IDENTITY_P
-			{
-				AlterTableCmd *n = makeNode(AlterTableCmd);
-				n->subtype = AT_DropIdentity;
-				n->name = $1;
-				n->missing_ok = false;
-				$$ = list_make1(n);
-			}
-	;
+					$$ = list_make1(n);
+				}
+			/* MODIFY <colname> DROP IDENTITY */
+			| ColId DROP IDENTITY_P
+				{
+					AlterTableCmd *n = makeNode(AlterTableCmd);
+
+					n->subtype = AT_DropIdentity;
+					n->name = $1;
+					n->missing_ok = false;
+					$$ = list_make1(n);
+				}
+		;
+
+modify_column_null:
+			NOT NULL_P						{ $$ = true; }
+			| NULL_P						{ $$ = false; }
+		;
 
 set_access_method_name:
 			ColId							{ $$ = $1; }

--- a/src/oracle_test/regress/expected/alter_table.out
+++ b/src/oracle_test/regress/expected/alter_table.out
@@ -4872,68 +4872,44 @@ drop publication pub1;
 drop schema alter1 cascade;
 drop schema alter2 cascade;
 NOTICE:  drop cascades to table alter2.t1
-
 --
--- Oracle-compatible MODIFY column syntax
+-- Oracle-compatible ALTER TABLE ... MODIFY
 --
-create table modify_column_test
-(
-  paren_col varchar2(10),
-  plain_col varchar2(10),
-  expected_20 varchar2(20),
-  expected_30 varchar2(30)
-);
-insert into modify_column_test (paren_col, plain_col)
-values (null, 'plain data');
-alter table modify_column_test modify (paren_col varchar2(20) not null);
-ERROR:  column "paren_col" of relation "modify_column_test" contains null values
-update modify_column_test set paren_col = 'paren data';
-alter table modify_column_test modify (paren_col varchar2(20) not null);
-select modified.atttypid = expected.atttypid
-       and modified.atttypmod = expected.atttypmod as type_changed,
-       modified.attnotnull
-from pg_attribute modified
-join pg_attribute expected
-  on expected.attrelid = modified.attrelid
-where modified.attrelid = 'modify_column_test'::regclass
-  and modified.attname = 'paren_col'
-  and expected.attname = 'expected_20';
- type_changed | attnotnull
---------------+------------
- t            | t
-(1 row)
+create table modify_test (a varchar2(10), b varchar2(10), c number);
+insert into modify_test values (null, 'x', 1);
+-- type change plus NOT NULL, parenthesized form
+alter table modify_test modify (a varchar2(20) not null); -- error, a contains nulls
+ERROR:  column "a" of relation "modify_test" contains null values
+update modify_test set a = 'y';
+alter table modify_test modify (a varchar2(20) not null);
+-- same thing without the parentheses
+alter table modify_test modify b varchar2(30) not null;
+-- nullability only
+alter table modify_test modify (a null);
+alter table modify_test modify b null;
+-- several columns in one command
+alter table modify_test modify (a varchar2(40) not null, c number not null);
+\d modify_test
+               Table "public.modify_test"
+ Column |     Type     | Collation | Nullable | Default 
+--------+--------------+-----------+----------+---------
+ a      | varchar2(40) |           | not null | 
+ b      | varchar2(30) |           |          | 
+ c      | number       |           | not null | 
 
-select paren_col, plain_col
-from modify_column_test;
- paren_col  | plain_col
-------------+------------
- paren data | plain data
-(1 row)
+-- existing data is preserved and the widened types are usable
+insert into modify_test values ('012345678901234567890123456789', '0123456789012345', 2);
+select a, b, c from modify_test order by c;
+               a                |        b         | c 
+--------------------------------+------------------+---
+ y                              | x                | 1
+ 012345678901234567890123456789 | 0123456789012345 | 2
+(2 rows)
 
-alter table modify_column_test modify plain_col varchar2(30) not null;
-select modified.atttypid = expected.atttypid
-       and modified.atttypmod = expected.atttypmod as type_changed,
-       modified.attnotnull
-from pg_attribute modified
-join pg_attribute expected
-  on expected.attrelid = modified.attrelid
-where modified.attrelid = 'modify_column_test'::regclass
-  and modified.attname = 'plain_col'
-  and expected.attname = 'expected_30';
- type_changed | attnotnull
---------------+------------
- t            | t
-(1 row)
-
-insert into modify_column_test (paren_col, plain_col)
-values ('longer than ten', 'a value longer than ten');
-select count(*) = 1 as long_values_stored
-from modify_column_test
-where paren_col = 'longer than ten'
-  and plain_col = 'a value longer than ten';
- long_values_stored
---------------------
- t
-(1 row)
-
-drop table modify_column_test;
+-- a bare type change is not accepted: <type> is ambiguous with
+-- MODIFY <colname> INVISIBLE, since INVISIBLE is an unreserved keyword
+alter table modify_test modify (c number(10)); -- error
+ERROR:  syntax error at or near ")"
+LINE 1: alter table modify_test modify (c number(10));
+                                                    ^
+drop table modify_test;

--- a/src/oracle_test/regress/expected/alter_table.out
+++ b/src/oracle_test/regress/expected/alter_table.out
@@ -4872,3 +4872,45 @@ drop publication pub1;
 drop schema alter1 cascade;
 drop schema alter2 cascade;
 NOTICE:  drop cascades to table alter2.t1
+
+--
+-- Oracle-compatible MODIFY column syntax
+--
+create table modify_column_test
+(
+  paren_col varchar2(10),
+  plain_col varchar2(10),
+  expected_20 varchar2(20),
+  expected_30 varchar2(30)
+);
+alter table modify_column_test modify (paren_col varchar2(20) not null);
+select modified.atttypid = expected.atttypid
+       and modified.atttypmod = expected.atttypmod as type_changed,
+       modified.attnotnull
+from pg_attribute modified
+join pg_attribute expected
+  on expected.attrelid = modified.attrelid
+where modified.attrelid = 'modify_column_test'::regclass
+  and modified.attname = 'paren_col'
+  and expected.attname = 'expected_20';
+ type_changed | attnotnull
+--------------+------------
+ t            | t
+(1 row)
+
+alter table modify_column_test modify plain_col varchar2(30) not null;
+select modified.atttypid = expected.atttypid
+       and modified.atttypmod = expected.atttypmod as type_changed,
+       modified.attnotnull
+from pg_attribute modified
+join pg_attribute expected
+  on expected.attrelid = modified.attrelid
+where modified.attrelid = 'modify_column_test'::regclass
+  and modified.attname = 'plain_col'
+  and expected.attname = 'expected_30';
+ type_changed | attnotnull
+--------------+------------
+ t            | t
+(1 row)
+
+drop table modify_column_test;

--- a/src/oracle_test/regress/expected/alter_table.out
+++ b/src/oracle_test/regress/expected/alter_table.out
@@ -4883,6 +4883,11 @@ create table modify_column_test
   expected_20 varchar2(20),
   expected_30 varchar2(30)
 );
+insert into modify_column_test (paren_col, plain_col)
+values (null, 'plain data');
+alter table modify_column_test modify (paren_col varchar2(20) not null);
+ERROR:  column "paren_col" of relation "modify_column_test" contains null values
+update modify_column_test set paren_col = 'paren data';
 alter table modify_column_test modify (paren_col varchar2(20) not null);
 select modified.atttypid = expected.atttypid
        and modified.atttypmod = expected.atttypmod as type_changed,
@@ -4898,6 +4903,13 @@ where modified.attrelid = 'modify_column_test'::regclass
  t            | t
 (1 row)
 
+select paren_col, plain_col
+from modify_column_test;
+ paren_col  | plain_col
+------------+------------
+ paren data | plain data
+(1 row)
+
 alter table modify_column_test modify plain_col varchar2(30) not null;
 select modified.atttypid = expected.atttypid
        and modified.atttypmod = expected.atttypmod as type_changed,
@@ -4911,6 +4923,17 @@ where modified.attrelid = 'modify_column_test'::regclass
  type_changed | attnotnull
 --------------+------------
  t            | t
+(1 row)
+
+insert into modify_column_test (paren_col, plain_col)
+values ('longer than ten', 'a value longer than ten');
+select count(*) = 1 as long_values_stored
+from modify_column_test
+where paren_col = 'longer than ten'
+  and plain_col = 'a value longer than ten';
+ long_values_stored
+--------------------
+ t
 (1 row)
 
 drop table modify_column_test;

--- a/src/oracle_test/regress/sql/alter_table.sql
+++ b/src/oracle_test/regress/sql/alter_table.sql
@@ -3153,3 +3153,40 @@ alter table alter1.t1 set schema alter2;
 drop publication pub1;
 drop schema alter1 cascade;
 drop schema alter2 cascade;
+
+--
+-- Oracle-compatible MODIFY column syntax
+--
+create table modify_column_test
+(
+  paren_col varchar2(10),
+  plain_col varchar2(10),
+  expected_20 varchar2(20),
+  expected_30 varchar2(30)
+);
+
+alter table modify_column_test modify (paren_col varchar2(20) not null);
+
+select modified.atttypid = expected.atttypid
+       and modified.atttypmod = expected.atttypmod as type_changed,
+       modified.attnotnull
+from pg_attribute modified
+join pg_attribute expected
+  on expected.attrelid = modified.attrelid
+where modified.attrelid = 'modify_column_test'::regclass
+  and modified.attname = 'paren_col'
+  and expected.attname = 'expected_20';
+
+alter table modify_column_test modify plain_col varchar2(30) not null;
+
+select modified.atttypid = expected.atttypid
+       and modified.atttypmod = expected.atttypmod as type_changed,
+       modified.attnotnull
+from pg_attribute modified
+join pg_attribute expected
+  on expected.attrelid = modified.attrelid
+where modified.attrelid = 'modify_column_test'::regclass
+  and modified.attname = 'plain_col'
+  and expected.attname = 'expected_30';
+
+drop table modify_column_test;

--- a/src/oracle_test/regress/sql/alter_table.sql
+++ b/src/oracle_test/regress/sql/alter_table.sql
@@ -3155,55 +3155,33 @@ drop schema alter1 cascade;
 drop schema alter2 cascade;
 
 --
--- Oracle-compatible MODIFY column syntax
+-- Oracle-compatible ALTER TABLE ... MODIFY
 --
-create table modify_column_test
-(
-  paren_col varchar2(10),
-  plain_col varchar2(10),
-  expected_20 varchar2(20),
-  expected_30 varchar2(30)
-);
+create table modify_test (a varchar2(10), b varchar2(10), c number);
+insert into modify_test values (null, 'x', 1);
 
-insert into modify_column_test (paren_col, plain_col)
-values (null, 'plain data');
+-- type change plus NOT NULL, parenthesized form
+alter table modify_test modify (a varchar2(20) not null); -- error, a contains nulls
+update modify_test set a = 'y';
+alter table modify_test modify (a varchar2(20) not null);
 
-alter table modify_column_test modify (paren_col varchar2(20) not null);
+-- same thing without the parentheses
+alter table modify_test modify b varchar2(30) not null;
 
-update modify_column_test set paren_col = 'paren data';
-alter table modify_column_test modify (paren_col varchar2(20) not null);
+-- nullability only
+alter table modify_test modify (a null);
+alter table modify_test modify b null;
 
-select modified.atttypid = expected.atttypid
-       and modified.atttypmod = expected.atttypmod as type_changed,
-       modified.attnotnull
-from pg_attribute modified
-join pg_attribute expected
-  on expected.attrelid = modified.attrelid
-where modified.attrelid = 'modify_column_test'::regclass
-  and modified.attname = 'paren_col'
-  and expected.attname = 'expected_20';
+-- several columns in one command
+alter table modify_test modify (a varchar2(40) not null, c number not null);
+\d modify_test
 
-select paren_col, plain_col
-from modify_column_test;
+-- existing data is preserved and the widened types are usable
+insert into modify_test values ('012345678901234567890123456789', '0123456789012345', 2);
+select a, b, c from modify_test order by c;
 
-alter table modify_column_test modify plain_col varchar2(30) not null;
+-- a bare type change is not accepted: <type> is ambiguous with
+-- MODIFY <colname> INVISIBLE, since INVISIBLE is an unreserved keyword
+alter table modify_test modify (c number(10)); -- error
 
-select modified.atttypid = expected.atttypid
-       and modified.atttypmod = expected.atttypmod as type_changed,
-       modified.attnotnull
-from pg_attribute modified
-join pg_attribute expected
-  on expected.attrelid = modified.attrelid
-where modified.attrelid = 'modify_column_test'::regclass
-  and modified.attname = 'plain_col'
-  and expected.attname = 'expected_30';
-
-insert into modify_column_test (paren_col, plain_col)
-values ('longer than ten', 'a value longer than ten');
-
-select count(*) = 1 as long_values_stored
-from modify_column_test
-where paren_col = 'longer than ten'
-  and plain_col = 'a value longer than ten';
-
-drop table modify_column_test;
+drop table modify_test;

--- a/src/oracle_test/regress/sql/alter_table.sql
+++ b/src/oracle_test/regress/sql/alter_table.sql
@@ -3165,6 +3165,12 @@ create table modify_column_test
   expected_30 varchar2(30)
 );
 
+insert into modify_column_test (paren_col, plain_col)
+values (null, 'plain data');
+
+alter table modify_column_test modify (paren_col varchar2(20) not null);
+
+update modify_column_test set paren_col = 'paren data';
 alter table modify_column_test modify (paren_col varchar2(20) not null);
 
 select modified.atttypid = expected.atttypid
@@ -3177,6 +3183,9 @@ where modified.attrelid = 'modify_column_test'::regclass
   and modified.attname = 'paren_col'
   and expected.attname = 'expected_20';
 
+select paren_col, plain_col
+from modify_column_test;
+
 alter table modify_column_test modify plain_col varchar2(30) not null;
 
 select modified.atttypid = expected.atttypid
@@ -3188,5 +3197,13 @@ join pg_attribute expected
 where modified.attrelid = 'modify_column_test'::regclass
   and modified.attname = 'plain_col'
   and expected.attname = 'expected_30';
+
+insert into modify_column_test (paren_col, plain_col)
+values ('longer than ten', 'a value longer than ten');
+
+select count(*) = 1 as long_values_stored
+from modify_column_test
+where paren_col = 'longer than ten'
+  and plain_col = 'a value longer than ten';
 
 drop table modify_column_test;


### PR DESCRIPTION
## Summary
- support Oracle-compatible `ALTER TABLE ... MODIFY` column definitions with `NOT NULL`
- translate the syntax into separate type-change and nullability actions
- cover both parenthesized and unparenthesized forms in Oracle regression tests

## Problem
IvorySQL currently accepts `MODIFY` for identity and visibility operations, but rejects column definitions such as:

```sql
ALTER TABLE employees MODIFY (last_name VARCHAR2(50) NOT NULL);
```

The type change and `NOT NULL` constraint require separate internal `AlterTableCmd` nodes; storing the constraint only in a `ColumnDef` would not apply it.

## Testing
- [x] verified the patch is based on current `master`
- [x] verified the change is limited to the Oracle grammar and `alter_table` regression files
- [x] checked existing identity and `INVISIBLE`/`VISIBLE` grammar paths for ambiguity
- [ ] Linux parser generation and Oracle regression suite (CI)

## AI assistance
- `Assisted-by: Cursor:GPT-5.6-Sol`
- `Percentage of AI-generated code: 90%`
- the commit was reviewed and signed off by the human contributor

Fixes #678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oracle-compatible `ALTER TABLE ... MODIFY` support for single or multiple columns.
  * Supports column type changes, length increases, nullability updates, visibility changes, identity alterations, and dropping identity.
  * Supports parenthesized and unparenthesized syntax, including commands combined with other table alterations.
  * Preserves existing data and allows longer values after widening columns.

* **Tests**
  * Added regression coverage for type and nullability changes, identity options, multi-column modifications, data preservation, and widened values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->