### PR TITLE
Fix Oracle deparse command labels

### DIFF
--- a/src/oracle_test/modules/test_ddl_deparse/expected/alter_table.out
+++ b/src/oracle_test/modules/test_ddl_deparse/expected/alter_table.out
@@ -141,3 +141,36 @@ ALTER TYPE comptype ALTER ATTRIBUTE r TYPE bigint;
 NOTICE:  DDL test: type alter table, tag ALTER TYPE
 NOTICE:    subcommand: type ALTER COLUMN SET TYPE desc column r of composite type comptype
 NOTICE:    subcommand: type (re) ADD DOMAIN CONSTRAINT desc type dcomptype
+
+--
+-- IvorySQL-specific ALTER command labels
+--
+SET ivorysql.default_with_rowids = off;
+CREATE TABLE deparse_label_test (
+	a int,
+	b int
+);
+NOTICE:  DDL test: type simple, tag CREATE TABLE
+ALTER TABLE ONLY deparse_label_test SET WITH ROWID;
+NOTICE:  DDL test: type alter table, tag ALTER TABLE
+NOTICE:    subcommand: type SET WITH ROWID desc column rowid of table deparse_label_test
+CREATE TABLE deparse_no_rowid_test (
+	a int
+);
+NOTICE:  DDL test: type simple, tag CREATE TABLE
+ALTER TABLE ONLY deparse_no_rowid_test SET WITHOUT ROWID;
+NOTICE:  DDL test: type alter table, tag ALTER TABLE
+NOTICE:    subcommand: type SET WITHOUT ROWID desc <NULL>
+ALTER TABLE deparse_label_test ALTER COLUMN b SET INVISIBLE;
+NOTICE:  DDL test: type alter table, tag ALTER TABLE
+NOTICE:    subcommand: type ALTER COLUMN SET INVISIBLE desc column b of table deparse_label_test
+ALTER TABLE deparse_label_test ALTER COLUMN b DROP INVISIBLE;
+NOTICE:  DDL test: type alter table, tag ALTER TABLE
+NOTICE:    subcommand: type ALTER COLUMN DROP INVISIBLE desc column b of table deparse_label_test
+CREATE FORCE VIEW deparse_label_view AS
+	SELECT a FROM deparse_label_test;
+NOTICE:  DDL test: type simple, tag CREATE VIEW
+ALTER VIEW deparse_label_view COMPILE;
+NOTICE:  DDL test: type alter table, tag ALTER VIEW
+NOTICE:    subcommand: type COMPILE FORCE VIEW desc <NULL>
+RESET ivorysql.default_with_rowids;

--- a/src/oracle_test/modules/test_ddl_deparse/sql/alter_table.sql
+++ b/src/oracle_test/modules/test_ddl_deparse/sql/alter_table.sql
@@ -76,3 +76,31 @@ CREATE TYPE comptype AS (r float8);
 CREATE DOMAIN dcomptype AS comptype;
 ALTER DOMAIN dcomptype ADD CONSTRAINT c1 check ((value).r > 0);
 ALTER TYPE comptype ALTER ATTRIBUTE r TYPE bigint;
+
+--
+-- IvorySQL-specific ALTER command labels
+--
+SET ivorysql.default_with_rowids = off;
+
+CREATE TABLE deparse_label_test (
+	a int,
+	b int
+);
+
+ALTER TABLE ONLY deparse_label_test SET WITH ROWID;
+
+CREATE TABLE deparse_no_rowid_test (
+	a int
+);
+
+ALTER TABLE ONLY deparse_no_rowid_test SET WITHOUT ROWID;
+
+ALTER TABLE deparse_label_test ALTER COLUMN b SET INVISIBLE;
+ALTER TABLE deparse_label_test ALTER COLUMN b DROP INVISIBLE;
+
+CREATE FORCE VIEW deparse_label_view AS
+	SELECT a FROM deparse_label_test;
+
+ALTER VIEW deparse_label_view COMPILE;
+
+RESET ivorysql.default_with_rowids;

--- a/src/oracle_test/modules/test_ddl_deparse/test_ddl_deparse.c
+++ b/src/oracle_test/modules/test_ddl_deparse/test_ddl_deparse.c
@@ -295,7 +295,7 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "SET OPTIONS";
 				break;
 			case AT_ForceViewCompile:
-				strtype = "COMPILE FOIRCE VIEW";
+				strtype = "COMPILE FORCE VIEW";
 				break;
 			case AT_DetachPartition:
 				strtype = "DETACH PARTITION";
@@ -319,17 +319,17 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "(re) ADD STATS";
 				break;
 			case AT_DropInvisible:
-				strtype = "DROP INVISIBLE";
+				strtype = "ALTER COLUMN DROP INVISIBLE";
 				break;
 			case AT_SetInvisible:
-				strtype = "SET INVISIBLE";
+				strtype = "ALTER COLUMN SET INVISIBLE";
 				break;
 			case AT_AddRowids:
 			case AT_AddRowidsRecurse:
-				strtype = "ALTER COLUMN SET WITH RWOID";
+				strtype = "SET WITH ROWID";
 				break;
 			case AT_DropRowids:
-				strtype = "ALTER COLUMN SET WITHOUT RWOID";
+				strtype = "SET WITHOUT ROWID";
 				break;
 		}
 


### PR DESCRIPTION
## Summary
- correct misspelled and misleading command labels in the Oracle `test_ddl_deparse` helper
- align ROWID, invisible-column, and force-view labels with their actual SQL operations
- add Oracle regression coverage for the event-trigger `NOTICE` output

## Test plan
- added SQL coverage for `SET WITH/WITHOUT ROWID`, column visibility, and `ALTER VIEW ... COMPILE`
- added the corresponding expected `test_ddl_deparse` output
- full Oracle regression execution is left to project CI because no local IvorySQL build environment is available

Closes #1577

AI-generated contribution: 100%. The commit includes the required DCO sign-off and AI-assistance trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying DDL deparse output for rowid configuration and table rowid changes.
  * Added coverage for invisible columns, forced view creation, and view compilation.
* **Bug Fixes**
  * Corrected displayed subcommand labels, including `COMPILE FORCE VIEW`, column visibility, and rowid operations.
  * Fixed spelling errors in generated DDL notices.
* **Tests**
  * Expanded validation coverage for these Oracle-compatible DDL operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->