### PR TITLE
fix(oracle): correct misspelled DDL deparse command strings

### DIFF
--- a/src/oracle_test/modules/test_ddl_deparse/test_ddl_deparse.c
+++ b/src/oracle_test/modules/test_ddl_deparse/test_ddl_deparse.c
@@ -295,7 +295,7 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "SET OPTIONS";
 				break;
 			case AT_ForceViewCompile:
-				strtype = "COMPILE FOIRCE VIEW";
+				strtype = "COMPILE FORCE VIEW";
 				break;
 			case AT_DetachPartition:
 				strtype = "DETACH PARTITION";
@@ -319,17 +319,17 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "(re) ADD STATS";
 				break;
 			case AT_DropInvisible:
-				strtype = "DROP INVISIBLE";
+				strtype = "ALTER COLUMN DROP INVISIBLE";
 				break;
 			case AT_SetInvisible:
-				strtype = "SET INVISIBLE";
+				strtype = "ALTER COLUMN SET INVISIBLE";
 				break;
 			case AT_AddRowids:
 			case AT_AddRowidsRecurse:
-				strtype = "ALTER COLUMN SET WITH RWOID";
+				strtype = "SET WITH ROWID";
 				break;
 			case AT_DropRowids:
-				strtype = "ALTER COLUMN SET WITHOUT RWOID";
+				strtype = "SET WITHOUT ROWID";
 				break;
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

Fix #1577.

The Oracle-mode DDL deparse test reported several misspelled or inaccurate command strings: `FOIRCE` (should be `FORCE`), `RWOID` (should be `ROWID`), invisible-column commands missing the `ALTER COLUMN` prefix, and ROWID commands incorrectly written as `ALTER COLUMN` operations.

## Brief changelog

- test_ddl_deparse.c: correct the five command strings
  - COMPILE FOIRCE VIEW -> COMPILE FORCE VIEW
  - DROP INVISIBLE -> ALTER COLUMN DROP INVISIBLE
  - SET INVISIBLE -> ALTER COLUMN SET INVISIBLE
  - ALTER COLUMN SET WITH RWOID -> SET WITH ROWID
  - ALTER COLUMN SET WITHOUT RWOID -> SET WITHOUT ROWID

## How was this patch verified

- String-only change; the corrected commands are not covered by existing expected output, so no test expectations are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected command labels for forced view compilation.
  * Updated invisible-column and row ID subcommand labels.
  * Standardized row ID options to use “SET WITH ROWID” and “SET WITHOUT ROWID” wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->