### PR TITLE
fix(oracle): keep NULL line on PUT_LINE with pending PUT text

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_dbms_output.out
+++ b/contrib/ivorysql_ora/expected/ora_dbms_output.out
@@ -107,6 +107,23 @@ BEGIN
 END;
 /
 NOTICE:  Test 2.2 - PUT with NULL: [BeforeAfter], Status: 0
+-- Test 2.2b: PUT_LINE(NULL) after pending PUT text flushes pending then
+-- appends a NULL line
+DECLARE
+    line TEXT;
+    status INTEGER;
+BEGIN
+    dbms_output.enable();
+    dbms_output.put('Pending text');
+    dbms_output.put_line(NULL);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 2.2b - pending then PUT_LINE(NULL): [%], Status: %', line, status;
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 2.2b - second line after NULL: [%], Status: %', line, status;
+END;
+/
+NOTICE:  Test 2.2b - pending then PUT_LINE(NULL): [Pending text], Status: 0
+NOTICE:  Test 2.2b - second line after NULL: [<NULL>], Status: 0
 -- Test 2.3: Multiple PUT calls building one line
 DECLARE
     line TEXT;

--- a/contrib/ivorysql_ora/sql/ora_dbms_output.sql
+++ b/contrib/ivorysql_ora/sql/ora_dbms_output.sql
@@ -107,6 +107,22 @@ BEGIN
 END;
 /
 
+-- Test 2.2b: PUT_LINE(NULL) after pending PUT text flushes pending then
+-- appends a NULL line
+DECLARE
+    line TEXT;
+    status INTEGER;
+BEGIN
+    dbms_output.enable();
+    dbms_output.put('Pending text');
+    dbms_output.put_line(NULL);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 2.2b - pending then PUT_LINE(NULL): [%], Status: %', line, status;
+    dbms_output.get_line(line, status);
+    RAISE NOTICE 'Test 2.2b - second line after NULL: [%], Status: %', line, status;
+END;
+/
+
 -- Test 2.3: Multiple PUT calls building one line
 DECLARE
     line TEXT;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_output/dbms_output.c
@@ -383,6 +383,11 @@ ora_dbms_output_put_line(PG_FUNCTION_ARGS)
 		add_line_to_buffer(output_buffer->current_line->data,
 						   output_buffer->current_line->len);
 		resetStringInfo(output_buffer->current_line);
+
+		/* Oracle behavior: a NULL PUT_LINE still adds a NULL line after
+		 * flushing the pending PUT text. */
+		if (is_null)
+			add_line_to_buffer(NULL, 0);
 	}
 	else
 	{


### PR DESCRIPTION
## What is the purpose of the change

Fix #1582 (and #1584).

ora_dbms_output_put_line() flushed the pending PUT text but never appended the NULL line when the argument was NULL and pending PUT text existed. Oracle PUT_LINE(NULL) stores a NULL line after flushing the pending text.

## Brief changelog

- dbms_output.c: after flushing pending PUT text, append a NULL line when the argument is NULL
- add a regression test (Test 2.2b) covering pending PUT text followed by PUT_LINE(NULL)

## How was this patch verified

- Matches Oracle DBMS_OUTPUT.PUT_LINE(NULL) semantics
- Regression test asserts the pending line is flushed then a NULL line is appended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Re-enabling `DBMS_OUTPUT` now preserves unread output.
  - Adjusting the output buffer size while enabled no longer discards pending messages.
  - Calling `PUT_LINE(NULL)` now flushes pending text and adds a separate blank line.

- **Tests**
  - Added coverage confirming buffered output remains available after re-enabling `DBMS_OUTPUT`.
  - Added coverage verifying pending text and the blank line from `PUT_LINE(NULL)` are retrieved separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->