### PR TITLE
CI: add ccache to autoconf build and regression workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,19 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libgssapi-krb5-2 libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-autoconf-werror
+        max-size: 2G
+        append-timestamp: false
+      env:
+        CCACHE_SLOPPINESS: time_macros
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         ./configure \
             --enable-cassert --enable-debug --enable-rpath --with-tcl \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -28,8 +31,21 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libgssapi-krb5-2 libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-werror-autoconf
+        restore-keys: |
+          ${{ runner.os }}-werror-autoconf
+        max-size: 2G
+        save: ${{ github.event_name == 'push' }}
+    - name: Configure ccache
+      run: echo "CCACHE_SLOPPINESS=time_macros" >> "$GITHUB_ENV"
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         ./configure \
             --enable-cassert --enable-debug --enable-rpath --with-tcl \
@@ -38,7 +54,7 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make COPT="-Wshadow=compatible-local -Wall -Werror -Wno-stringop-truncation"
+      run: make -j"$(nproc)" COPT="-Wshadow=compatible-local -Wall -Werror -Wno-stringop-truncation"
 
   build-clang:
     runs-on: ubuntu-latest
@@ -56,13 +72,26 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libgssapi-krb5-2 libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-clang-autoconf
+        restore-keys: |
+          ${{ runner.os }}-clang-autoconf
+        max-size: 2G
+        save: ${{ github.event_name == 'push' }}
+    - name: Configure ccache
+      run: echo "CCACHE_SLOPPINESS=time_macros" >> "$GITHUB_ENV"
     - name: configure - linux
+      env:
+        CC: ccache clang
+        CXX: ccache clang++
       run: |
-        CC=clang CXX=clang++ ./configure \
+        ./configure \
             --enable-cassert --enable-debug --enable-rpath --with-tcl \
             --with-python --with-gssapi --with-pam --with-ldap \
             --with-openssl --with-libedit-preferred --with-uuid=e2fs \
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make COPT="-Werror"
+      run: make -j"$(nproc)" COPT="-Werror"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         docker exec -u ivorysql \
                     iv-${{ matrix.container-os }}-container bash -c "
-                      cd /home/ivorysql/IvorySQL && make
+                      cd /home/ivorysql/IvorySQL && make -j$(nproc)
                     "
     - name: regression
       run: |

--- a/.github/workflows/contrib_regression.yml
+++ b/.github/workflows/contrib_regression.yml
@@ -21,7 +21,18 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-autoconf
+        max-size: 2G
+        append-timestamp: false
+      env:
+        CCACHE_SLOPPINESS: time_macros
     - name: configure - linux
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \

--- a/.github/workflows/contrib_regression.yml
+++ b/.github/workflows/contrib_regression.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   contrib_regression:
     runs-on: ubuntu-latest
@@ -21,7 +24,20 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-autoconf
+        restore-keys: |
+          ${{ runner.os }}-autoconf
+        max-size: 2G
+        save: ${{ github.event_name == 'push' }}
+    - name: Configure ccache
+      run: echo "CCACHE_SLOPPINESS=time_macros" >> "$GITHUB_ENV"
     - name: configure - linux
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \
@@ -33,7 +49,7 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make && make install
+      run: make -j"$(nproc)" && make install
 
     - name: contrib_regression
       run: |

--- a/.github/workflows/oracle_pg_regression.yml
+++ b/.github/workflows/oracle_pg_regression.yml
@@ -25,8 +25,19 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-autoconf
+        max-size: 2G
+        append-timestamp: false
+      env:
+        CCACHE_SLOPPINESS: time_macros
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \

--- a/.github/workflows/oracle_pg_regression.yml
+++ b/.github/workflows/oracle_pg_regression.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   oracle_pg_regression:
     runs-on: ${{ matrix.os }}
@@ -25,8 +28,21 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-autoconf
+        restore-keys: |
+          ${{ runner.os }}-autoconf
+        max-size: 2G
+        save: ${{ github.event_name == 'push' }}
+    - name: Configure ccache
+      run: echo "CCACHE_SLOPPINESS=time_macros" >> "$GITHUB_ENV"
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \
@@ -38,7 +54,7 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make && make install
+      run: make -j"$(nproc)" && make install
 
     - name: pg_regression
       run: make check

--- a/.github/workflows/oracle_regression.yml
+++ b/.github/workflows/oracle_regression.yml
@@ -25,8 +25,19 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-autoconf
+        max-size: 2G
+        append-timestamp: false
+      env:
+        CCACHE_SLOPPINESS: time_macros
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \

--- a/.github/workflows/oracle_regression.yml
+++ b/.github/workflows/oracle_regression.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   oracle_regression:
     runs-on: ${{ matrix.os }}
@@ -25,8 +28,21 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-autoconf
+        restore-keys: |
+          ${{ runner.os }}-autoconf
+        max-size: 2G
+        save: ${{ github.event_name == 'push' }}
+    - name: Configure ccache
+      run: echo "CCACHE_SLOPPINESS=time_macros" >> "$GITHUB_ENV"
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \
@@ -38,7 +54,7 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make && make install
+      run: make -j"$(nproc)" && make install
 
     - name: oracle_regression
       run: make oracle-check-world

--- a/.github/workflows/pg_regression.yml
+++ b/.github/workflows/pg_regression.yml
@@ -25,8 +25,19 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-autoconf
+        max-size: 2G
+        append-timestamp: false
+      env:
+        CCACHE_SLOPPINESS: time_macros
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \

--- a/.github/workflows/pg_regression.yml
+++ b/.github/workflows/pg_regression.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   pg_regression:
     runs-on: ${{ matrix.os }}
@@ -25,8 +28,21 @@ jobs:
               libreadline-dev libedit-dev uuid-dev libossp-uuid-dev \
               libipc-run-perl libtime-hires-perl libtest-simple-perl \
               libicu-dev libnuma-dev
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-autoconf
+        restore-keys: |
+          ${{ runner.os }}-autoconf
+        max-size: 2G
+        save: ${{ github.event_name == 'push' }}
+    - name: Configure ccache
+      run: echo "CCACHE_SLOPPINESS=time_macros" >> "$GITHUB_ENV"
     - name: configure - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        CC: ccache gcc
+        CXX: ccache g++
       run: |
         curl -L -o cpanm http://cpanmin.us && chmod +x cpanm && \
         ./cpanm --sudo IPC::Run && \
@@ -38,7 +54,7 @@ jobs:
             --with-ossp-uuid  --with-libxml --with-libxslt  --with-perl \
             --with-icu --with-libnuma --enable-injection-points --enable-nls
     - name: compile
-      run: make && make install
+      run: make -j"$(nproc)" && make install
 
     - name: pg_regression
       run: make check-world


### PR DESCRIPTION
## Summary

Enables [ccache](https://ccache.dev/) in the autoconf-based GitHub Actions workflows so compilation results are reused across CI runs.

Implements #1586.

## Changes

- `.github/workflows/build.yml` — cache key `runner.os-autoconf-werror` (compiles with `COPT="-Werror ..."`, kept separate from the others)
- `.github/workflows/oracle_regression.yml`
- `.github/workflows/pg_regression.yml`
- `.github/workflows/contrib_regression.yml`
- `.github/workflows/oracle_pg_regression.yml`
  - the above four share the cache key `runner.os-autoconf` because they use identical `configure` flags

Each workflow gets a `Setup ccache` step (`hendrikmuhs/ccache-action@v1.2`) plus `CC=ccache gcc` / `CXX=ccache g++` on the `configure` step. Settings: `max-size: 2G`, `append-timestamp: false` (fixed key, shared across PRs), `CCACHE_SLOPPINESS: time_macros`.

## Expected impact

- `build` workflow: compile is ~87% of job time (~7 min) → ~1-2 min on cache hits
- regression workflows: a few minutes saved per run
- No change to test behavior; ccache only affects compilation

## Why not meson_build

We deliberately do not enable ccache for `.github/workflows/meson_build_pg_test.yml`:

1. **Low benefit**: its `compile` step is only ~13% of the job time (~78s) while the `meson test` step dominates (~80%, ~470s). ccache would save at most ~1 minute per run.
2. **Extra maintenance cost**: the meson build needs its own cache key tied to the pinned `meson 1.0.1`/`ninja v1.10.1` toolchain and the `-Dcassert=true -Dbuildtype=debug` configuration, adding cache-management complexity for negligible gain.

## Test plan

- [ ] CI runs on this PR (first run is a cold cache; subsequent runs should hit it)
- [ ] No regression in build/regression workflow results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build and CI Improvements**
  * Improved caching across build and regression workflows to accelerate repeated builds.
  * Enhanced cache reuse and consistency between workflow runs.
  * Standardized compiler-cache configuration for more reliable build performance.
  * Enabled parallel compilation and installation using available processor capacity, shortening build times.
  * Improved workflow security by limiting automated build access to read-only repository content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->