### PR TITLE
Fix copy-paste errors in ivorysql GUC descriptions

### DIFF
--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1526,7 +1526,7 @@
 },
 
 { name => 'ivorysql.listen_addresses', type => 'string', context => 'PGC_POSTMASTER', group => 'CONN_AUTH_SETTINGS',
-  short_desc => 'Sets the shell command that will be called to archive a WAL file.',
+  short_desc => 'Sets the IPv4/IPv6 address(es) the Oracle-mode server listens on.',
   flags => 'GUC_LIST_INPUT',
   variable => 'OraListenAddresses',
   boot_val => '"localhost"',
@@ -1549,7 +1549,7 @@
 
 { name => 'ivorysql.rowid_seq_cache', type => 'int', context => 'PGC_USERSET', group => 'DEVELOPER_OPTIONS',
   short_desc => 'Sets rowid Sequence cache number.',
-  long_desc => '0 disables the timeout.',
+  long_desc => 'Sets the number of cached sequence values for rowid generation.',
   flags => 'GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE',
   variable => 'rowid_seq_cache',
   boot_val => '20',

--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -2437,8 +2437,7 @@
 },
 
 { name => 'nls_timestamp_tz_format', type => 'string', context => 'PGC_USERSET', group => 'COMPAT_ORACLE_OPTIONS',
-  short_desc => 'Sets the shell command that will be called to archive a WAL file.',
-  long_desc => 'An empty string means use "archive_library".',
+  short_desc => 'Compatible Oracle NLS parameter for timestamp with time zone type.',
   flags => 'GUC_NOT_IN_SAMPLE',
   variable => 'nls_timestamp_tz_format',
   boot_val => '"YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM"',


### PR DESCRIPTION
## Summary

Fixes two copy-paste errors in ivorysql GUC descriptions that are user-visible in `pg_settings` / `\dconfig+`.

Fixes #1588.

## Changes

`src/backend/utils/misc/guc_parameters.dat`:

- `ivorysql.listen_addresses` short_desc: "Sets the shell command that will be called to archive a WAL file." (copied from `archive_command`) → "Sets the IPv4/IPv6 address(es) the Oracle-mode server listens on."
- `ivorysql.rowid_seq_cache` long_desc: "0 disables the timeout." (copied from a timeout setting) → "Sets the number of cached sequence values for rowid generation."

`guc_tables.inc.c` is regenerated automatically at build time (`src/backend/utils/Makefile`), so no other files change.

## Impact

- Correct descriptions in `pg_settings`, `SHOW ALL` and `\dconfig+`
- No behavioral change (descriptions only)

## Verification

- Local build + oracle instance: `pg_settings` shows the corrected description for `ivorysql.listen_addresses`
