### PR TITLE
ci: upgrade GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: dependancy - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,7 @@ jobs:
         container-os: [centos-7, centos-8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Build ${{ matrix.container-os }} Docker
       if: ${{ matrix.container-os == 'centos-7' }}
       run: |
@@ -92,7 +92,7 @@ jobs:
                     "
     - name: upload regression files
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: results
         path: ${{ github.workspace }}/regression.tar.gz

--- a/.github/workflows/contrib_regression.yml
+++ b/.github/workflows/contrib_regression.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: dependancy
       run: |
         sudo apt-get update
@@ -47,7 +47,7 @@ jobs:
                 xargs -0 tar -czf pg_regression.tar.gz
     - name: upload pg_regression files
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: results
         path: ${{ github.workspace }}/pg_regression.tar.gz

--- a/.github/workflows/meson_build_pg_test.yml
+++ b/.github/workflows/meson_build_pg_test.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
       
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: dependency - linux
       run: |
         sudo apt-get update
@@ -89,7 +89,7 @@ jobs:
 
     - name: upload failure logs (raw directories for deep debugging)
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: postgres-test-failures-${{ github.sha }}.raw
         path: |

--- a/.github/workflows/oracle_pg_regression.yml
+++ b/.github/workflows/oracle_pg_regression.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: dependancy
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
@@ -53,7 +53,7 @@ jobs:
                 xargs -0 tar -czf oracle_pg_regression.tar.gz
     - name: upload oracle_pg_regression files
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: results
         path: ${{ github.workspace }}/oracle_pg_regression.tar.gz

--- a/.github/workflows/oracle_regression.yml
+++ b/.github/workflows/oracle_regression.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: dependancy
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
@@ -50,7 +50,7 @@ jobs:
                 xargs -0 tar -czf oracle_regression.tar.gz
     - name: upload oracle_regression files
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: results
         path: ${{ github.workspace }}/oracle_regression.tar.gz

--- a/.github/workflows/pg_regression.yml
+++ b/.github/workflows/pg_regression.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: dependancy
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
@@ -50,7 +50,7 @@ jobs:
                 xargs -0 tar -czf pg_regression.tar.gz
     - name: upload pg_regression files
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: results
         path: ${{ github.workspace }}/pg_regression.tar.gz


### PR DESCRIPTION
## What is the purpose of the change

fixes #1591

The regression workflows emit "Node.js 20 is deprecated" warnings because actions/checkout@v2/v3 and actions/upload-artifact@v4 target Node 20 and are forced onto Node 24.

## Brief changelog

- upgrade actions/checkout@v2/v3 to @v5 and actions/upload-artifact@v4 to @v6 across build.yml, build_and_test.yml, contrib_regression.yml, meson_build_pg_test.yml, oracle_pg_regression.yml, oracle_regression.yml and pg_regression.yml

## How was this patch verified

- Both action versions resolve to the node24 runtime, which removes the deprecation warning.
