### PR TITLE
Fix resource leak when freeing unprepared statement handles

### DIFF
--- a/src/interfaces/libpq/ivy-exec.c
+++ b/src/interfaces/libpq/ivy-exec.c
@@ -837,18 +837,11 @@ IvyexecPreparedStatement2(Ivyconn *tconn,
 void
 IvyFreePreparedStatement(IvyPreparedStatement *stmtHandle)
 {
-	if (stmtHandle == NULL || stmtHandle->query == NULL)
+	if (stmtHandle == NULL)
 		return;
 
 	/* get the lock */
 	PGSemaphoreLock(&stmtHandle->lock);
-
-	/* already free */
-	if (stmtHandle->query == NULL)
-	{
-		PGSemaphoreUnlock(&stmtHandle->lock);
-		return;
-	}
 
 	/* free bind info of out parameter */
 	if (stmtHandle->outbind != NULL)

--- a/src/interfaces/libpq/ivytest/Makefile
+++ b/src/interfaces/libpq/ivytest/Makefile
@@ -16,7 +16,7 @@ LDFLAGS_INTERNAL += $(libpq_pgport)
 
 PROGS = testlibpq testlibpqstmt2 testlibpq_nullstmt testlibpq_allout testlibpq_prepare_plsql testlibpq_prepare_dml \
         testlibpq_binary_double testlibpq_binary_float testlibpq_interval testlibpq_number testlibpq_prepare_call \
-		testlibpq_call testlibpqstmt2_call
+		testlibpq_call testlibpqstmt2_call testlibpq_unprepared_handle
 
 all: $(PROGS)
 

--- a/src/interfaces/libpq/ivytest/expected/testlibpq_unprepared_handle.out
+++ b/src/interfaces/libpq/ivytest/expected/testlibpq_unprepared_handle.out
@@ -1,0 +1,1 @@
+unprepared statement handle released

--- a/src/interfaces/libpq/ivytest/regression.txt
+++ b/src/interfaces/libpq/ivytest/regression.txt
@@ -10,3 +10,4 @@ testlibpq_binary_double
 testlibpq_binary_float
 testlibpq_interval
 testlibpq_number
+testlibpq_unprepared_handle

--- a/src/interfaces/libpq/ivytest/testlibpq_unprepared_handle.c
+++ b/src/interfaces/libpq/ivytest/testlibpq_unprepared_handle.c
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------
+ *
+ * testlibpq_unprepared_handle.c
+ *
+ * Test releasing an Ivy statement handle before preparing a query.
+ *
+ * Portions Copyright (c) 2025-2026, IvorySQL Global Development Team
+ *
+ * src/interfaces/libpq/ivytest/testlibpq_unprepared_handle.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include <stdio.h>
+
+#include "libpq-fe.h"
+#include "libpq-ivy.h"
+
+int
+main(void)
+{
+	IvyPreparedStatement *stmt = NULL;
+
+	if (!IvyHandleAlloc(NULL, (void **) &stmt, IVY_HANDLE_STMT, 0, NULL))
+	{
+		fprintf(stderr, "IvyHandleAlloc failed\n");
+		return 1;
+	}
+
+	IvyFreeHandle(stmt, IVY_HANDLE_STMT);
+	printf("unprepared statement handle released\n");
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #1601: `IvyFreePreparedStatement()` in `src/interfaces/libpq/ivy-exec.c` returned early when `stmtHandle->query == NULL`, so a statement handle allocated via `IvyHandleAlloc()` but never used to prepare a query leaked its sub-resources on release:

- `outbind` / `namebind` linked lists not freed
- `paramNames` array not freed
- `stmtName`, `paramTypes`, `IvyconnList` not freed
- `IvyremoveStmtHandleRelation()` skipped — the handle stays registered in the connection's relation list (dangling state after `free(stmtHandle)`)

The fix removes both early-return guards so the full cleanup path always runs; every `free()` in that path is NULL-safe.

Also adds a regression test (`testlibpq_unprepared_handle`) that allocates a statement handle, releases it without preparing any query, and verifies the release completes.

## Test plan

- `make -C src/interfaces/libpq ivy-exec.o` compiles cleanly.
- New test registered in ivytest Makefile and regression.txt.
- (Full local run of the ivytest suite on macOS is blocked by a pre-existing, unrelated `ivy_sema.c` build issue on this machine.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for statement handles that were allocated without a prepared query.
  * Prevented potential issues when releasing unprepared statement handles.

* **Tests**
  * Added regression coverage verifying that unprepared statement handles can be allocated and released successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->