### PR TITLE
Fix heap overrun parsing XML namespace declarations

### DIFF
--- a/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
+++ b/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
@@ -557,14 +557,12 @@ register_ns_from_csting(xmlXPathContextPtr xpathCtx, char* nsList)
 		/* get the prefix */
 		start = strchr(tmp.data, (int)':');
 		end = strchr(tmp.data, (int)'=');
-		memcpy(prefix.data, start + 1, end - start);
-		prefix.data[end - start -1] = '\0';
+		appendBinaryStringInfo(&prefix, start + 1, end - start - 1);
 
 		/* get the url */
 		p1 = strstr(tmp.data, "=");
 		l1 = strlen(p1);
-		memcpy(url.data, p1 + 2, l1 - 3);
-		url.data[l1 - 3] = '\0';
+		appendBinaryStringInfo(&url, p1 + 2, l1 - 3);
 
 		/* do register namespace */
 		if (xmlXPathRegisterNs(xpathCtx, (xmlChar *)prefix.data, (xmlChar *)url.data) != 0)


### PR DESCRIPTION
## Summary

Fixes #1603: `register_ns_from_csting()` in `contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c` copied namespace prefix/url tokens into `StringInfo` buffers with raw `memcpy`, bypassing the growth path. A single token longer than the initial 1024-byte buffer (e.g. `xmlns:p="<5000-byte-url>"` in `EXTRACTVALUE`/`XMLQUERY` namespace arguments) wrote past the heap.

Replaced both `memcpy` + manual NUL writes with `appendBinaryStringInfo`, which grows the buffer as needed and keeps it NUL-terminated. The copied byte counts are unchanged (`end - start - 1` for the prefix, `l1 - 3` for the url).

## Test plan

- `make -C contrib/ivorysql_ora src/xml_functions/ora_xml_functions.o` compiles cleanly.
- Recommend an AddressSanitizer run with a namespace token > 1024 bytes to confirm the overrun is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of XML namespace prefixes and URLs during extraction.
  * Prevented potential string termination issues when processing XML data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->