### PR TITLE
Fix dangling DBMS_LOCK hash table built in a per-query context

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
@@ -40,6 +40,7 @@
 #include "storage/lockdefs.h"
 #include "c.h"
 #include "utils/float.h"
+#include "../../include/ivorysql_ora.h"
 
 /* Oracle compatible lock modes */
 /* we support only:
@@ -107,6 +108,19 @@ dbms_lock_init_hash_table(void)
                              DBMS_LOCK_MAX,         
                              &ctl,
                              HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
+}
+
+/*
+ * Drop the session-local lock bookkeeping on DISCARD ALL/PACKAGES.
+ */
+void
+ora_dbms_lock_reset(void)
+{
+    if (dbms_lock_hash_table != NULL)
+    {
+        hash_destroy(dbms_lock_hash_table);
+        dbms_lock_hash_table = NULL;
+    }
 }
 
 /*

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
@@ -31,6 +31,7 @@
 #include "storage/lwlock.h"
 #include "catalog/pg_type.h"
 #include "utils/elog.h"
+#include "utils/memutils.h"
 #include "utils/timeout.h"
 #include "utils/uuid.h"
 #include "access/hash.h"
@@ -100,11 +101,12 @@ dbms_lock_init_hash_table(void)
     ctl.keysize = sizeof(int64);
     ctl.entrysize = sizeof(lock_entry);
     ctl.hash = tag_hash;
+    ctl.hcxt = TopMemoryContext;
 
     dbms_lock_hash_table = hash_create("pg_dbms_lock table",
                              DBMS_LOCK_MAX,         
                              &ctl,
-                             HASH_ELEM | HASH_FUNCTION);
+                             HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 }
 
 /*

--- a/contrib/ivorysql_ora/src/include/ivorysql_ora.h
+++ b/contrib/ivorysql_ora/src/include/ivorysql_ora.h
@@ -56,4 +56,7 @@ extern void ora_dbms_output_reset(void);
 /* DBMS_SESSION */
 extern void ora_dbms_session_reset(void);
 
+/* DBMS_LOCK */
+extern void ora_dbms_lock_reset(void);
+
 #endif	/* IVORYSQL_ORA_H_ */

--- a/contrib/ivorysql_ora/src/ivorysql_ora.c
+++ b/contrib/ivorysql_ora/src/ivorysql_ora.c
@@ -188,10 +188,12 @@ ivorysql_ora_ProcessUtility(PlannedStmt *pstmt,
 		standard_ProcessUtility(pstmt, queryString, readOnlyTree,
 								context, params, queryEnv, dest, qc);
 
-	/* Reset DBMS_OUTPUT buffer and DBMS_SESSION context after DISCARD ALL/PACKAGES */
+	/* Reset DBMS_OUTPUT buffer, DBMS_SESSION context and DBMS_LOCK bookkeeping
+	 * after DISCARD ALL/PACKAGES */
 	if (is_discard_reset)
 	{
 		ora_dbms_output_reset();
 		ora_dbms_session_reset();
+		ora_dbms_lock_reset();
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1604: `dbms_lock_init_hash_table()` called `hash_create()` without `HASH_CONTEXT`, so the table was allocated in `CurrentMemoryContext`. Since the table is lazily initialized from SQL functions, that context is a per-query executor context; when the query ended the table was freed while the static `dbms_lock_hash_table` pointer kept referencing it. The next `DBMS_LOCK.REQUEST`/`RELEASE` then ran `hash_search()` on freed memory.

The fix passes `ctl.hcxt = TopMemoryContext` with `HASH_CONTEXT` (same approach as `dbms_session_init()`), and adds the missing `utils/memutils.h` include for `TopMemoryContext`.

## Test plan

- `make -C contrib/ivorysql_ora src/builtin_packages/dbms_lock/dbms_lock.o` compiles cleanly.
- Manual repro: first `CALL dbms_lock.request(...)` followed by a second `DBMS_LOCK` call in the same backend no longer touches freed memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DBMS_LOCK memory handling for greater runtime stability.
  * DBMS_LOCK session state is now properly cleared when using `DISCARD ALL` or `DISCARD PACKAGES`, preventing stale lock information from persisting across session resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->