### PR TITLE
Fix uninitialized copy of PG_VERSION contents

### DIFF
--- a/src/oracle_fe_utils/ora_version.c
+++ b/src/oracle_fe_utils/ora_version.c
@@ -69,10 +69,7 @@ get_pg_version(const char *datadir, char **version_str)
 	fclose(version_fd);
 
 	if (version_str)
-	{
-		*version_str = pg_malloc(PG_VERSION_MAX_SIZE);
-		memcpy(*version_str, buf, st.st_size);
-	}
+		*version_str = pg_strdup(buf);
 
 	if (v1 < 10)
 	{


### PR DESCRIPTION
## Summary

Fixes #1614: `get_pg_version()` filled `version_str` with `memcpy(*version_str, buf, st.st_size)`, copying `st.st_size` bytes from a stack buffer that `fscanf("%63s", buf)` had only partially initialized — uninitialized stack bytes ended up in the result, and the string was not guaranteed to be NUL-terminated.

`buf` is already a valid NUL-terminated C string after `fscanf`, so the fix replaces the raw copy with `pg_strdup(buf)`, which copies exactly the parsed token and terminates it. The `st`/`st.st_size` usage for the size check remains unchanged.

## Test plan

- `make -C src/oracle_fe_utils ora_version.o` compiles cleanly.
- Recommend a Valgrind run of a caller that passes a non-NULL `version_str`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL version string handling to ensure reliably parsed version information is returned without fixed-size allocation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->