### PR TITLE
Fix namespace parsing crashes and out-of-bounds reads in XML functions

### DIFF
--- a/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
+++ b/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
@@ -414,7 +414,7 @@ rv_newline(text *tv)
 
 	tmp = text_to_cstring(tv);
 	len = strlen(tmp);
-	if (tmp[len-1] == '\n')
+	if (len > 0 && tmp[len-1] == '\n')
 		tmp[len-1] = '\0';
 	ret = cstring_to_text(tmp);
 
@@ -451,7 +451,8 @@ right_trim(char *str)
 		return str;
 
 	end = str + strlen(str) - 1;
-	while (isspace(*end)) end--;
+	while (end >= str && isspace((unsigned char) *end))
+		end--;
 	*(end + 1) = '\0';
 
 	return str;
@@ -539,7 +540,7 @@ register_ns_from_csting(xmlXPathContextPtr xpathCtx, char* nsList)
 	f = strchr(nslist, (int)'=');
 	while (f != NULL)
 	{
-		if ((*(f - 1) == ' ') || (*(f + 1) != '"') || (*(f + 2) == ' '))
+		if ((f == nslist) || (*(f - 1) == ' ') || (*(f + 1) != '"') || (*(f + 2) == ' '))
 			elog(ERROR, "Invalid namespace");
 		f = strchr(f + 1, (int)'=');
 	}
@@ -557,14 +558,14 @@ register_ns_from_csting(xmlXPathContextPtr xpathCtx, char* nsList)
 		/* get the prefix */
 		start = strchr(tmp.data, (int)':');
 		end = strchr(tmp.data, (int)'=');
-		memcpy(prefix.data, start + 1, end - start);
-		prefix.data[end - start -1] = '\0';
+		if (start == NULL || end == NULL || end <= start)
+			elog(ERROR, "Invalid namespace");
+		appendBinaryStringInfo(&prefix, start + 1, end - start - 1);
 
 		/* get the url */
 		p1 = strstr(tmp.data, "=");
 		l1 = strlen(p1);
-		memcpy(url.data, p1 + 2, l1 - 3);
-		url.data[l1 - 3] = '\0';
+		appendBinaryStringInfo(&url, p1 + 2, l1 - 3);
 
 		/* do register namespace */
 		if (xmlXPathRegisterNs(xpathCtx, (xmlChar *)prefix.data, (xmlChar *)url.data) != 0)


### PR DESCRIPTION
## Summary

Fixes #1616. Four defects in `register_ns_from_csting()` / helpers in `contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c`, all reachable via the namespace argument of XML functions (EXTRACTVALUE/XMLQUERY/XMLTABLE):

1. **Backend crash (high)**: a token like `xmlns:p` passes the `IS_STR_XMLNS` prefix check but has no `=`; `end` is NULL and `end - start` is undefined pointer arithmetic feeding a huge length into the copy. Now rejected with "Invalid namespace" (`start`/`end` NULL or `end <= start`).
2. **OOB read**: `*(f - 1)` when the trimmed namespace string starts with `=` — now rejected (`f == nslist`).
3. **OOB read in `right_trim()`**: whitespace-only string walked `end` past the buffer start — loop now bounded by `end >= str`, with `(unsigned char)` cast for `isspace`.
4. **OOB read in `rv_newline()`**: `tmp[len - 1]` with `len == 0` — now guarded.

Also included (same function, previously filed as #1603): the prefix/url copies use `appendBinaryStringInfo` so tokens longer than the initial 1024-byte buffer grow instead of overrunning it. If #1606 merges first, this hunk will apply cleanly.

## Test plan

- `make -C contrib/ivorysql_ora src/xml_functions/ora_xml_functions.o` compiles cleanly.
- `SELECT extractvalue('<a>x</a>', '/a', 'xmlns:p')` now errors cleanly instead of crashing; ASan builds show no OOB reads for 2-4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML namespace parsing to reject malformed namespace declarations.
  - Added safer handling for whitespace and trailing newline removal.
  - Improved construction of namespace prefixes and URLs to prevent malformed results and improve reliability when processing XML content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->