### PR TITLE
Guard against NULL outbind entry in DO statement parameter setup

### DIFF
--- a/src/interfaces/libpq/ivy-exec.c
+++ b/src/interfaces/libpq/ivy-exec.c
@@ -1895,6 +1895,16 @@ IvyHandleDostmt(Ivyconn *tconn,
 						break;
 				}
 
+				if (info == NULL)
+				{
+					snprintf(errmsg, err_buf_size, "%s",
+							 "outbind position not found");
+					free(stmtHandle->paramTypes);
+					stmtHandle->paramTypes = NULL;
+					destroyPQExpBuffer(query_buf);
+					return 0;
+				}
+
 				stmtHandle->paramTypes[i] = (Oid) info->dtype;
 
 				switch(UnSetModeOut(info->dtype))


### PR DESCRIPTION
## Summary

Fixes #1617: in the DO-statement parameter setup of `IvyStmtExecute` (`src/interfaces/libpq/ivy-exec.c`), the inner loop searches `outbind` for `info->position == i + 1` and then dereferences `info` unconditionally. If the caller bound non-contiguous positions (e.g. 1 and 3, skipping 2), `info` is NULL and `info->dtype` crashes the client process.

The fix reports "outbind position not found" and cleans up (`paramTypes` + `query_buf`) before returning 0, matching the error style of the same function.

## Test plan

- `make -C src/interfaces/libpq ivy-exec.o` compiles cleanly.
- Manual: bind positions 1 and 3 of a 3-placeholder statement and execute a DO statement — the client now gets an error instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for missing output parameter bindings.
  * Improved error handling to prevent failures when an output parameter has no corresponding bind entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->