### PR TITLE
Fix out-of-bounds read in ora_asciistr on truncated UTF-8 sequences

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -1800,11 +1800,17 @@ ora_asciistr(PG_FUNCTION_ARGS) {
             str++;
         } else if ((c & 0xE0) == 0xC0) {
             /* Two-byte UTF-8 sequence */
+            if (str + 2 > end)
+                ereport(ERROR,
+                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("Invalid bytes")));
             codePoint = ((c & 0x1F) << 6) | (str[1] & 0x3F);
             appendUTF16Escape(&output, (uint16_t) codePoint);
             str += 2;
         } else if ((c & 0xF0) == 0xE0) {
             /* Three-byte UTF-8 sequence */
+            if (str + 3 > end)
+                ereport(ERROR,
+                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("Invalid bytes")));
             codePoint = ((c & 0x0F) << 12) | ((str[1] & 0x3F) << 6) | (str[2] & 0x3F);
             appendUTF16Escape(&output, (uint16_t) codePoint);
             str += 3;
@@ -1812,6 +1818,9 @@ ora_asciistr(PG_FUNCTION_ARGS) {
             /* Four-byte UTF-8 sequence */
 			uint16_t highSurrogate, lowSurrogate;
 
+            if (str + 4 > end)
+                ereport(ERROR,
+                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("Invalid bytes")));
             codePoint = ((c & 0x07) << 18) | ((str[1] & 0x3F) << 12) | ((str[2] & 0x3F) << 6) | (str[3] & 0x3F);
             codePoint -= 0x10000;
             highSurrogate = 0xD800 | (codePoint >> 10);


### PR DESCRIPTION
## Summary

Fixes #1620: `ora_asciistr()` decoded UTF-8 by reading `str[1]`/`str[2]`/`str[3]` without checking those bytes are within the input varlena. A high byte near the end of the string (e.g. LATIN1 `é` = 0xE9 as the last character in a non-UTF8 database) matched the three-byte branch and read past the end of the data.

Each multi-byte branch now checks the remaining byte count (`str + N <= end`) and raises the existing "Invalid bytes" error for truncated sequences.

## Test plan

- `make -C contrib/ivorysql_ora src/builtin_functions/character_datatype_functions.o` compiles cleanly.
- Recommend an ASan run in a LATIN1/SQL_ASCII database: `SELECT asciistr('abc' || chr(233))`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 input validation when converting text to ASCII-style representations.
  * Truncated multi-byte characters now return a clear invalid-parameter error instead of causing unsafe reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->