### PR TITLE
Fix psql leaks and dbms_utility dlsym caching

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
@@ -69,8 +69,6 @@ lookup_plisql_functions(void)
 	if (lookup_attempted)
 		return;
 
-	lookup_attempted = true;
-
 #ifndef WIN32
 	{
 		/*
@@ -95,7 +93,13 @@ lookup_plisql_functions(void)
 			get_call_stack_fn = (plisql_get_call_stack_fn) fn;
 	}
 #endif
-	/* On Windows, function pointers remain NULL - features require plisql */
+
+	/* Only cache the lookups if plisql was found; retry otherwise */
+	if (get_exception_context_fn != NULL &&
+		get_exception_message_fn != NULL &&
+		get_exception_sqlerrcode_fn != NULL &&
+		get_call_stack_fn != NULL)
+		lookup_attempted = true;
 }
 
 /*

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -3671,7 +3671,12 @@ get_hostvariables(const char *sql, bool *error)
 
 		/* No placeholders do not need to use PBE */
 		if (ntuples == 1)
+		{
+			PQclear(res);
+			destroyPQExpBuffer(query);
+			pg_free(newsql);
 			return NULL;
+		}
 
 		/* is an anonymous block and has placeholders */
 		if (ntuples > 1)
@@ -4153,7 +4158,8 @@ psql_exec_pbe(const char *sql, HostVariable *hv, struct _variable **bindvar)
 					IvyFreeHandle(stmthandle, IVY_HANDLE_STMT);
 					IvyFreeHandle(errhp, IVY_HANDLE_ERROR);
 					Ivyfinish2(conn);
-					return NULL;
+					res = NULL;
+					goto pbe_failure;
 				}
 		}
 


### PR DESCRIPTION
## Summary

Fixes #1628. Three small fixes:

1. **`get_hostvariables()` leak** (`src/bin/psql/common.c`): the no-placeholder early return (`ntuples == 1`) now frees `newsql`, the `PQExpBuffer query` and the `PGresult res` before returning NULL.

2. **`psql_exec_pbe` unsupported-type branch** (`src/bin/psql/common.c`): the `default:` case now sets `res = NULL` and jumps to `pbe_failure` so `var`/`bindinfo`/`indp`/`var_sz` and any allocated `var[i]` are freed (previously returned directly, leaking them).

3. **`dbms_utility` dlsym caching** (`contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c`): `lookup_attempted` is only set when all four plisql symbols were found; a lookup performed before `plisql.so` was loaded is now retried on later calls instead of being permanently stuck with NULL function pointers.

## Test plan

- `make -C src/bin/psql common.o` and `make -C contrib/ivorysql_ora src/builtin_packages/dbms_utility/dbms_utility.o` compile cleanly.