### PR TITLE
Fix four datatype boundary defects

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -853,16 +853,10 @@ to_oradate3(PG_FUNCTION_ARGS)
 {
 	text	   *date_txt = PG_GETARG_TEXT_P(0);
 	text	   *fmt = PG_GETARG_TEXT_P(1);
-	text	   *nlsparam = PG_GETARG_TEXT_P(2);
 	Oid			collid = PG_GET_COLLATION();
 	Timestamp	result;
 	struct pg_tm tm;
 	fsec_t		fsec;
-
-	/* TODO */
-	char	   *p;
-
-	p = text_to_cstring(nlsparam);
 
 #if 0
 	if (strlen(p) != 0)
@@ -934,14 +928,10 @@ to_oratimestamp3(PG_FUNCTION_ARGS)
 {
 	text	   *date_txt = PG_GETARG_TEXT_P(0);
 	text	   *fmt = PG_GETARG_TEXT_P(1);
-	text	   *nlsparam = PG_GETARG_TEXT_P(2);
 	Oid			collid = PG_GET_COLLATION();
 	Timestamp	result;
 	struct pg_tm tm;
 	fsec_t		fsec;
-	char	   *p;
-
-	p = text_to_cstring(nlsparam);
 
 	/*
 	 * if (strlen(p) != 0) ereport(WARNING,
@@ -1042,16 +1032,12 @@ to_oratimestamptz3(PG_FUNCTION_ARGS)
 {
 	text	   *date_txt = PG_GETARG_TEXT_P(0);
 	text	   *fmt = PG_GETARG_TEXT_P(1);
-	text	   *nlsparam = PG_GETARG_TEXT_P(2);
 	Oid			collid = PG_GET_COLLATION();
 	Timestamp	result;
 	int			tz;
 	struct pg_tm tm;
 	fsec_t		fsec;
 	DateTimeErrorExtra extra;
-	char	   *p;
-
-	p = text_to_cstring(nlsparam);
 
 	/*
 	 * if (strlen(p) != 0) ereport(WARNING,

--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -871,10 +871,7 @@ to_oradate3(PG_FUNCTION_ARGS)
 				 errmsg("function \"to_date\" not support the parameter of \"nlsparam\".")));
 #endif
 
-	if (p && strlen(p) != 0)
-		/* make compiler quiet */
-
-		ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
+	ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
 
 	/* no timezone and no fractional second */
 	fsec = 0;
@@ -951,10 +948,7 @@ to_oratimestamp3(PG_FUNCTION_ARGS)
 	 * (errcode(ERRCODE_UNTERMINATED_C_STRING), errmsg("function \"to_date\"
 	 * not support the parameter of \"nlsparam\".")));
 	 */
-	if (p && strlen(p) != 0)
-		/* make compiler quiet */
-
-		ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
+	ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
 
 	/* no time zone */
 	if (tm2timestamp(&tm, fsec, NULL, &result) != 0)
@@ -1059,16 +1053,13 @@ to_oratimestamptz3(PG_FUNCTION_ARGS)
 
 	p = text_to_cstring(nlsparam);
 
-	if (p && strlen(p) != 0)
-		/* make compile quiet */
+	/*
+	 * if (strlen(p) != 0) ereport(WARNING,
+	 * (errcode(ERRCODE_UNTERMINATED_C_STRING), errmsg("function
+	 * \"to_date\" not support the parameter of \"nlsparam\".")));
+	 */
 
-		/*
-		 * if (strlen(p) != 0) ereport(WARNING,
-		 * (errcode(ERRCODE_UNTERMINATED_C_STRING), errmsg("function
-		 * \"to_date\" not support the parameter of \"nlsparam\".")));
-		 */
-
-		ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
+	ora_do_to_timestamp(date_txt, fmt, collid, false, &tm, &fsec, NULL, NULL, NULL, true);
 
 	if (tm.tm_zone)
 	{
@@ -1459,7 +1450,7 @@ numtoyminterval(PG_FUNCTION_ARGS)
 			interval_val = 0;
 
 		if (interval_val <= -0.5 && interval_val > -1)
-			interval_val = 1;
+			interval_val = -1;
 	}
 
 	/* round to first place after the decimal point */

--- a/contrib/ivorysql_ora/src/datatype/binary_double.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_double.c
@@ -200,6 +200,8 @@ binary_double_in_internal_opt_error(char *num, char **endptr_p,
 					return get_float8_infinity();
 				else if (val <= -HUGE_VAL)
 					return -get_float8_infinity();
+				else if (val == 0.0)
+					goto accept_underflow;
 			}
 
 			/*
@@ -235,6 +237,7 @@ binary_double_in_internal_opt_error(char *num, char **endptr_p,
 	}
 
 	/* skip trailing whitespace */
+accept_underflow:
 	while (*endptr != '\0' && isspace((unsigned char) *endptr))
 		endptr++;
 

--- a/contrib/ivorysql_ora/src/datatype/binary_double.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_double.c
@@ -201,7 +201,10 @@ binary_double_in_internal_opt_error(char *num, char **endptr_p,
 				else if (val <= -HUGE_VAL)
 					return -get_float8_infinity();
 				else if (val == 0.0)
+				{
+					val = 0.0;	/* normalize -0 to +0 */
 					goto accept_underflow;
+				}
 			}
 
 			/*

--- a/contrib/ivorysql_ora/src/datatype/binary_double.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_double.c
@@ -200,8 +200,6 @@ binary_double_in_internal_opt_error(char *num, char **endptr_p,
 					return get_float8_infinity();
 				else if (val <= -HUGE_VAL)
 					return -get_float8_infinity();
-				else if (val == 0.0)
-					return 0;
 			}
 
 			/*

--- a/contrib/ivorysql_ora/src/datatype/binary_float.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_float.c
@@ -513,7 +513,10 @@ binary_float_in(PG_FUNCTION_ARGS)
 					)
 					PG_RETURN_FLOAT4(-get_float4_infinity());
 				else if (val == 0.0)
+				{
+					val = 0.0;	/* normalize -0 to +0 */
 					goto accept_underflow;
+				}
 			}
 
 			/*

--- a/contrib/ivorysql_ora/src/datatype/binary_float.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_float.c
@@ -512,6 +512,8 @@ binary_float_in(PG_FUNCTION_ARGS)
 #endif
 					)
 					PG_RETURN_FLOAT4(-get_float4_infinity());
+				else if (val == 0.0)
+					goto accept_underflow;
 			}
 
 			/*
@@ -545,6 +547,7 @@ binary_float_in(PG_FUNCTION_ARGS)
 	}
 
 	/* skip trailing whitespace */
+accept_underflow:
 	while (*endptr != '\0' && isspace((unsigned char) *endptr))
 		endptr++;
 

--- a/contrib/ivorysql_ora/src/datatype/binary_float.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_float.c
@@ -512,8 +512,6 @@ binary_float_in(PG_FUNCTION_ARGS)
 #endif
 					)
 					PG_RETURN_FLOAT4(-get_float4_infinity());
-				else if (val == 0.0)
-					PG_RETURN_FLOAT4(0);
 			}
 
 			/*

--- a/contrib/ivorysql_ora/src/datatype/yminterval.c
+++ b/contrib/ivorysql_ora/src/datatype/yminterval.c
@@ -1425,7 +1425,7 @@ yminterval_in(PG_FUNCTION_ARGS)
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("The character string you specified is not a valid interval")));
 
-				if (abs(tm->tm_mon) < 0 || abs(tm->tm_mon) > 11)
+				if (tm->tm_mon < 0 || tm->tm_mon > 11)
 					ereport(ERROR,
 							(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 							 errmsg("month must be between 0 and 11")));


### PR DESCRIPTION
## Summary

Fixes #1630. Four small datatype fixes in `contrib/ivorysql_ora`:

1. **`numtoyminterval` sign** (`builtin_functions/datetime_datatype_functions.c`): `NUMTOYMINTERVAL(-0.7, 'month')` returned +1; the negative-fraction rounding now yields -1.
2. **Dangling nlsparam `if`** (same file, 3 sites): `ora_do_to_timestamp` was the body of `if (p && strlen(p) != 0)`; with an empty nlsparam the parse was skipped and uninitialized `struct pg_tm tm` fed `tm2timestamp`. The call now always runs.
3. **`yminterval_in` dead check** (`datatype/yminterval.c`): `abs(tm->tm_mon) < 0` is always false; replaced with a real negative-month check.
4. **binary underflow early return** (`datatype/binary_double.c`, `datatype/binary_float.c`): on ERANGE underflow the functions returned 0/Infinity immediately, skipping the trailing-garbage check; `'1e-9999abc'::binary_double` silently returned 0. They now fall through to the trailing check and only return the underflowed value for clean input.

## Test plan

- All four translation units compile cleanly.
- Manual: `SELECT numtoyminterval(-0.7, 'month')` → -1; `SELECT to_date('2024-01-01', 'YYYY-MM-DD', '')` parses instead of producing garbage; `SELECT '1e-9999abc'::binary_double` raises "invalid input syntax".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected negative year-to-month interval rounding for values between -0.5 and -1.
  - Improved validation of year-to-month intervals with invalid month values.
  - Fixed binary floating-point underflow handling so valid underflow results are processed correctly.
  - Improved consistency across timestamp conversion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->