### PR TITLE
Fix parser/GUC defects: mask array OOB, WITH-clause syscache, NLS memcpy, isdigit UB

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -551,7 +551,7 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 	 */
 	if (fdresult == FUNCDETAIL_NORMAL || fdresult == FUNCDETAIL_PROCEDURE)
 	{
-		if (ORA_PARSER == compatible_db)
+		if (ORA_PARSER == compatible_db && function_from != FUNC_FROM_WITH_CLAUSE)
 		{
 			HeapTuple	tup;
 			Form_pg_proc procstruct;

--- a/src/backend/parser/parse_param.c
+++ b/src/backend/parser/parse_param.c
@@ -2638,7 +2638,7 @@ calculate_oraparamname_position(Node *parsetree, char ***paramnames)
 	 * Check if the parameter is correct,
 	 * make sure all the parameters should have a name.
 	 */
-	for (i = 1; i < state.maxparams; i++)
+	for (i = 1; i <= state.numParams; i++)
 	{
 		if (state.paramNames[i] == NULL)
 			elog(ERROR, "placeholdvar at the position %d has no name", i);

--- a/src/backend/parser/parse_param.c
+++ b/src/backend/parser/parse_param.c
@@ -224,6 +224,11 @@ variable_paramref_hook(ParseState *pstate, ParamRef *pref)
 													*parstate->numParams, paramno);
 		else
 			*parstate->paramTypes = palloc0_array(Oid, paramno);
+		if (parstate->paramTypeWithMask)
+			parstate->paramTypeWithMask = repalloc0_array(parstate->paramTypeWithMask, Oid,
+														  *parstate->numParams, paramno);
+		else
+			parstate->paramTypeWithMask = palloc0_array(Oid, paramno);
 		*parstate->numParams = paramno;
 	}
 
@@ -2633,7 +2638,7 @@ calculate_oraparamname_position(Node *parsetree, char ***paramnames)
 	 * Check if the parameter is correct,
 	 * make sure all the parameters should have a name.
 	 */
-	for (i = 1; i <= state.numParams; i++)
+	for (i = 1; i < state.maxparams; i++)
 	{
 		if (state.paramNames[i] == NULL)
 			elog(ERROR, "placeholdvar at the position %d has no name", i);

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -597,7 +597,7 @@ nls_length_check(char **newval, void **extra, GucSource source)
 			GUC_check_errmsg("parameter value longer than 255 characters");
 			return false;
 		}
-		else if (isdigit(**newval))
+		else if (isdigit((unsigned char) **newval))
 		{
 			GUC_check_errcode(ERRCODE_INVALID_PARAMETER_VALUE);
 			GUC_check_errmsg("Cannot access NLS data files "
@@ -618,9 +618,9 @@ nls_territory_check(char **newval, void **extra, GucSource source)
 		&& (IsNormalProcessingMode() || (IsUnderPostmaster && MyProcPort)))
 	{
 		if (pg_strcasecmp(*newval, "CHINA") == 0)
-			memcpy(*newval, "CHINA", 5);
+			memcpy(*newval, "CHINA", sizeof("CHINA"));
 		else if (pg_strcasecmp(*newval, "AMERICA") == 0)
-			memcpy(*newval, "AMERICA", 7);
+			memcpy(*newval, "AMERICA", sizeof("AMERICA"));
 		else
 		{
 			GUC_check_errcode(ERRCODE_INVALID_PARAMETER_VALUE);


### PR DESCRIPTION
## Summary

Fixes #1634. Four defects:

1. **`paramTypeWithMask` OOB read** (`src/backend/parser/parse_param.c`): `variable_paramref_hook` now grows `paramTypeWithMask` alongside `paramTypes` (with `repalloc0_array`/`palloc0_array`), so `variable_coerce_param_hook` cannot index past the allocation when a higher `$N` appears than the initial USING count. The name-check loop also now scans up to `maxparams` instead of `numParams` (defensive for sparse numbering).

2. **WITH-clause funcid used as syscache OID** (`src/backend/parser/parse_func.c`): the `SearchSysCache1(PROCOID, ...)` block is skipped for `FUNC_FROM_WITH_CLAUSE` functions, whose `funcid` is a 0-based index — previously index 0 queried OID 0, and an index colliding with an invalid plisql OID raised a spurious "is in invalid state" error.

3. **`nls_territory_check` memcpy without NUL** (`src/backend/utils/misc/ivy_guc.c`): copies now use `sizeof("CHINA")` / `sizeof("AMERICA")` so the terminator is included.

4. **`isdigit` UB** (same file): the argument is cast to `unsigned char`.

## Test plan

- `make -C src/backend/parser parse_func.o parse_param.o` and `make -C src/backend/utils/misc ivy_guc.o` compile cleanly.
- Manual: `EXECUTE 'SELECT $1+$2' USING a` in plisql no longer reads OOB; `SET nls_territory = 'china'` stores a properly terminated value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Oracle-style routines defined in `WITH` clauses.
  * Fixed parameter metadata handling when variable parameters expand.
  * Improved NLS configuration validation for certain character values.
  * Increased portability and reliability when processing regional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->