### PR TITLE
fix(dbms_lock): avoid reacquiring owned locks

### DIFF
--- a/contrib/ivorysql_ora/expected/dbms_lock.out
+++ b/contrib/ivorysql_ora/expected/dbms_lock.out
@@ -18,10 +18,14 @@ begin
  v_rc := dbms_lock.request(v_handle, dbms_lock.s_mode, 0);  
  raise notice 'request rc=%', v_rc;
  assert v_rc = 0, format('DBMS_LOCK.request failed: rc=%s', v_rc);
+ v_rc := dbms_lock.request(v_handle, dbms_lock.s_mode, 0);
+ raise notice 'second request rc=%', v_rc;
+ assert v_rc = 4, format('DBMS_LOCK.request should report already owned: rc=%s', v_rc);
  insert into handle values(v_handle);
 end;
 /
 NOTICE:  request rc=0
+NOTICE:  second request rc=4
 do
 $$
 declare

--- a/contrib/ivorysql_ora/expected/dbms_lock.out
+++ b/contrib/ivorysql_ora/expected/dbms_lock.out
@@ -80,10 +80,14 @@ begin
  v_rc := dbms_lock.request(v_handle, dbms_lock.x_mode, 0);  
  raise notice 'request rc=%', v_rc;
  assert v_rc = 0, format('DBMS_LOCK.request failed: rc=%s', v_rc);
+ v_rc := dbms_lock.request(v_handle, dbms_lock.x_mode, 0);
+ raise notice 'second request rc=%', v_rc;
+ assert v_rc = 4, format('DBMS_LOCK.request should report already owned: rc=%s', v_rc);
  insert into handle values(v_handle);
 end;
 /
 NOTICE:  request rc=0
+NOTICE:  second request rc=4
 do
 $$
 declare

--- a/contrib/ivorysql_ora/sql/dbms_lock.sql
+++ b/contrib/ivorysql_ora/sql/dbms_lock.sql
@@ -75,6 +75,9 @@ begin
  v_rc := dbms_lock.request(v_handle, dbms_lock.x_mode, 0);  
  raise notice 'request rc=%', v_rc;
  assert v_rc = 0, format('DBMS_LOCK.request failed: rc=%s', v_rc);
+ v_rc := dbms_lock.request(v_handle, dbms_lock.x_mode, 0);
+ raise notice 'second request rc=%', v_rc;
+ assert v_rc = 4, format('DBMS_LOCK.request should report already owned: rc=%s', v_rc);
  insert into handle values(v_handle);
 end;
 /

--- a/contrib/ivorysql_ora/sql/dbms_lock.sql
+++ b/contrib/ivorysql_ora/sql/dbms_lock.sql
@@ -18,6 +18,9 @@ begin
  v_rc := dbms_lock.request(v_handle, dbms_lock.s_mode, 0);  
  raise notice 'request rc=%', v_rc;
  assert v_rc = 0, format('DBMS_LOCK.request failed: rc=%s', v_rc);
+ v_rc := dbms_lock.request(v_handle, dbms_lock.s_mode, 0);
+ raise notice 'second request rc=%', v_rc;
+ assert v_rc = 4, format('DBMS_LOCK.request should report already owned: rc=%s', v_rc);
  insert into handle values(v_handle);
 end;
 /

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
@@ -262,6 +262,9 @@ ivorysql_dbms_lock_request(PG_FUNCTION_ARGS)
     if (timeout < 0)
         PG_RETURN_INT32(DBMS_LOCK_PARAM_ERROR);
 
+	if (dbms_lock_check(key, lockmode))
+		PG_RETURN_INT32(DBMS_LOCK_ALREADY_OWNED);
+
     while (true)
     {
         if (exclusive)

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_lock/dbms_lock.c
@@ -259,8 +259,8 @@ ivorysql_dbms_lock_request(PG_FUNCTION_ARGS)
     if (dbms_lock_hash_table == NULL)
 	    dbms_lock_init_hash_table();
 
-    if (timeout < 0)
-        PG_RETURN_INT32(DBMS_LOCK_PARAM_ERROR);
+	if (timeout < 0)
+		PG_RETURN_INT32(DBMS_LOCK_PARAM_ERROR);
 
 	if (dbms_lock_check(key, lockmode))
 		PG_RETURN_INT32(DBMS_LOCK_ALREADY_OWNED);


### PR DESCRIPTION
## Summary

`DBMS_LOCK.REQUEST` currently reacquires a PostgreSQL session advisory lock when the same session requests the same handle and mode again. The package ownership table records only one entry, so one `DBMS_LOCK.RELEASE` removes that entry but leaves one underlying advisory-lock acquisition held.

This change checks the package ownership table before trying to acquire the advisory lock and returns `4` (`already_owned`) for a duplicate same-mode request. The regression covers both shared and exclusive modes, including the lock state after a single release.

Fixes #1598

## Testing

I reproduced the behavior in GitHub Actions on `ubuntu-latest` with an IvorySQL assertion-enabled debug build. Both variants ran:

```text
make -C contrib/ivorysql_ora oracle-check ORA_REGRESS=dbms_lock
```

Unpatched `dbms_lock.c` from the PR merge base (`c3529ba4789ee220caefc858e58bbe6f1563ad14`):

```text
request rc=0
second request rc=0
mode=ShareLock
release rc=0
mode=ShareLock
request rc=0
second request rc=0
mode=ExclusiveLock
release rc=0
mode=ExclusiveLock
```

[Unpatched run and raw log](https://github.com/yyqdbngt/IvorySQL/actions/runs/32091376542/job/95574042224)

Patched source (same code tree as this PR):

```text
request rc=0
second request rc=4
mode=ShareLock
release rc=0
mode=not found
request rc=0
second request rc=4
mode=ExclusiveLock
release rc=0
mode=not found
```

The patched focused regression exited `0`.

[Patched run and raw log](https://github.com/yyqdbngt/IvorySQL/actions/runs/32090919761/job/95572750352)

Assisted-by: OpenAI:GPT-5

Percentage of AI-generated code: 90%