### PR TITLE
fix(utl_raw): preserve server encoding bytes

### DIFF
--- a/contrib/ivorysql_ora/expected/utl_raw.out
+++ b/contrib/ivorysql_ora/expected/utl_raw.out
@@ -58,3 +58,19 @@ SELECT UTL_RAW.CAST_TO_RAW('\n');
  \x5c6e
 (1 row)
 
+-- CAST_TO_RAW preserves bytes in a non-UTF8 database
+CREATE DATABASE utl_raw_latin1
+    TEMPLATE template0 ENCODING 'LATIN1' LC_COLLATE 'C' LC_CTYPE 'C';
+\c utl_raw_latin1
+CREATE EXTENSION ivorysql_ora;
+SELECT pg_catalog.encode(
+    UTL_RAW.CAST_TO_RAW(pg_catalog.convert_from(pg_catalog.decode('e9', 'hex'), 'LATIN1')),
+    'hex');
+ encode 
+--------
+ e9
+(1 row)
+
+\c -
+DROP DATABASE utl_raw_latin1;
+

--- a/contrib/ivorysql_ora/expected/utl_raw.out
+++ b/contrib/ivorysql_ora/expected/utl_raw.out
@@ -59,10 +59,10 @@ SELECT UTL_RAW.CAST_TO_RAW('\n');
 (1 row)
 
 -- CAST_TO_RAW preserves bytes in a non-UTF8 database
+\set original_db :DBNAME
 CREATE DATABASE utl_raw_latin1
     TEMPLATE template0 ENCODING 'LATIN1' LC_COLLATE 'C' LC_CTYPE 'C';
 \c utl_raw_latin1
-CREATE EXTENSION ivorysql_ora;
 SELECT pg_catalog.encode(
     UTL_RAW.CAST_TO_RAW(pg_catalog.convert_from(pg_catalog.decode('e9', 'hex'), 'LATIN1')),
     'hex');
@@ -71,6 +71,6 @@ SELECT pg_catalog.encode(
  e9
 (1 row)
 
-\c -
+\c :original_db
 DROP DATABASE utl_raw_latin1;
 

--- a/contrib/ivorysql_ora/expected/utl_raw.out
+++ b/contrib/ivorysql_ora/expected/utl_raw.out
@@ -73,4 +73,3 @@ SELECT pg_catalog.encode(
 
 \c :original_db
 DROP DATABASE utl_raw_latin1;
-

--- a/contrib/ivorysql_ora/sql/utl_raw.sql
+++ b/contrib/ivorysql_ora/sql/utl_raw.sql
@@ -24,12 +24,12 @@ SELECT UTL_RAW.CAST_TO_RAW('a b c');
 SELECT UTL_RAW.CAST_TO_RAW('\n');
 
 -- CAST_TO_RAW preserves bytes in a non-UTF8 database
+\set original_db :DBNAME
 CREATE DATABASE utl_raw_latin1
     TEMPLATE template0 ENCODING 'LATIN1' LC_COLLATE 'C' LC_CTYPE 'C';
 \c utl_raw_latin1
-CREATE EXTENSION ivorysql_ora;
 SELECT pg_catalog.encode(
     UTL_RAW.CAST_TO_RAW(pg_catalog.convert_from(pg_catalog.decode('e9', 'hex'), 'LATIN1')),
     'hex');
-\c -
+\c :original_db
 DROP DATABASE utl_raw_latin1;

--- a/contrib/ivorysql_ora/sql/utl_raw.sql
+++ b/contrib/ivorysql_ora/sql/utl_raw.sql
@@ -22,3 +22,14 @@ SELECT UTL_RAW.big_endian;
 -- Special characters
 SELECT UTL_RAW.CAST_TO_RAW('a b c');
 SELECT UTL_RAW.CAST_TO_RAW('\n');
+
+-- CAST_TO_RAW preserves bytes in a non-UTF8 database
+CREATE DATABASE utl_raw_latin1
+    TEMPLATE template0 ENCODING 'LATIN1' LC_COLLATE 'C' LC_CTYPE 'C';
+\c utl_raw_latin1
+CREATE EXTENSION ivorysql_ora;
+SELECT pg_catalog.encode(
+    UTL_RAW.CAST_TO_RAW(pg_catalog.convert_from(pg_catalog.decode('e9', 'hex'), 'LATIN1')),
+    'hex');
+\c -
+DROP DATABASE utl_raw_latin1;

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_raw/utl_raw--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_raw/utl_raw--1.0.sql
@@ -22,6 +22,6 @@ END;
 CREATE OR REPLACE PACKAGE BODY UTL_RAW IS
     FUNCTION CAST_TO_RAW(c IN VARCHAR2) RETURN RAW IS
     BEGIN
-        RETURN pg_catalog.convert_to(c::text, 'UTF8');
+        RETURN pg_catalog.convert_to(c::text, pg_catalog.getdatabaseencoding());
     END;
 END;


### PR DESCRIPTION
## Summary

`UTL_RAW.CAST_TO_RAW` currently converts text to UTF-8 regardless of the database encoding. Use `convert_to` with the active server encoding so the returned raw bytes match Oracle-compatible server-encoding semantics.

The regression creates a LATIN1 database and verifies that `é` is represented as the single byte `e9`.

Fixes #1597

## Testing

- `git diff --check`
- reviewed the focused `utl_raw` expected-output update

The IvorySQL/PostgreSQL build toolchain is not available in this Windows environment, so the regression suite was not run locally.

Assisted-by: OpenAI:GPT-5
Percentage of AI-generated code: 90%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `UTL_RAW.CAST_TO_RAW` to preserve text bytes according to the database’s configured character encoding.
  - Fixed conversion behavior for non-UTF-8 databases, including LATIN1.
  - Ensured accented and other non-ASCII characters are converted consistently without unintended byte changes.

- **Tests**
  - Added regression coverage verifying byte preservation when converting accented characters in a LATIN1 database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->