### PR TITLE
fix(oracle): enforce LONG typmod in characters

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_raw_long.out
+++ b/contrib/ivorysql_ora/expected/ora_raw_long.out
@@ -175,6 +175,24 @@ SELECT * FROM LONG_TEXT ORDER BY II DESC;
 (3 rows)
 
 DROP TABLE LONG_TEXT;
+-- LONG typmods count characters, not bytes
+CREATE TABLE LONG_UTF8_TEST(a LONG(2));
+INSERT INTO LONG_UTF8_TEST VALUES ('中文');
+INSERT INTO LONG_UTF8_TEST VALUES ('中文A');
+ERROR:  value too long for type long(2)
+SELECT length(a) = 2 AND octet_length(a) = 6 FROM LONG_UTF8_TEST;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT '中文A'::LONG(2) = '中文'::text;
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP TABLE LONG_UTF8_TEST;
 -- rawtohex
 SELECT sys.rawtohex('\xDEADBEEF'::bytea);
  rawtohex 

--- a/contrib/ivorysql_ora/sql/ora_raw_long.sql
+++ b/contrib/ivorysql_ora/sql/ora_raw_long.sql
@@ -44,6 +44,14 @@ SELECT * FROM LONG_TEXT ORDER BY II DESC;
 
 DROP TABLE LONG_TEXT;
 
+-- LONG typmods count characters, not bytes
+CREATE TABLE LONG_UTF8_TEST(a LONG(2));
+INSERT INTO LONG_UTF8_TEST VALUES ('中文');
+INSERT INTO LONG_UTF8_TEST VALUES ('中文A');
+SELECT length(a) = 2 AND octet_length(a) = 6 FROM LONG_UTF8_TEST;
+SELECT '中文A'::LONG(2) = '中文'::text;
+DROP TABLE LONG_UTF8_TEST;
+
 -- rawtohex
 SELECT sys.rawtohex('\xDEADBEEF'::bytea);
 SELECT sys.rawtohex('\xFF'::raw);

--- a/contrib/ivorysql_ora/src/datatype/raw_long.c
+++ b/contrib/ivorysql_ora/src/datatype/raw_long.c
@@ -195,7 +195,8 @@ orachar_to_long_with_typmod(PG_FUNCTION_ARGS)
 	int32		maxlen = PG_GETARG_INT32(1);
 	bool		isExplicit = PG_GETARG_BOOL(2);
 	BpChar	   *result;
-	int32		len;
+	int32		len,
+				charlen;
 	char	   *r;
 	char	   *s;
 
@@ -207,26 +208,24 @@ orachar_to_long_with_typmod(PG_FUNCTION_ARGS)
 
 	len = VARSIZE_ANY_EXHDR(source);
 	s = VARDATA_ANY(source);
+	charlen = pg_mbstrlen_with_len(s, len);
 
-	/* No work if supplied data matches typmod already */
-	if (len == maxlen)
+	/* No work if supplied data fits the typmod already */
+	if (charlen <= maxlen)
 		PG_RETURN_TEXT_P(source);
 
 	/*
 	 * Report error for implicit conversion 
 	 * Truncate string for exlicit conversion 
 	 */
-	if (len > maxlen)
-	{
-		if (!isExplicit)
-			ereport(ERROR,
-					(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
-					 errmsg("value too long for type long(%d)",
-							maxlen)));
-		len = maxlen;	
-	}
+	if (!isExplicit)
+		ereport(ERROR,
+				(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
+				 errmsg("value too long for type long(%d)",
+						maxlen)));
+	len = pg_mbcharcliplen(s, len, maxlen);
 
-	Assert(maxlen >= len);
+	Assert(maxlen >= pg_mbstrlen_with_len(s, len));
 
 	result = palloc(len + VARHDRSZ);
 	SET_VARSIZE(result, len + VARHDRSZ);


### PR DESCRIPTION
## Summary

- apply `LONG(n)` typmods using character counts rather than encoded byte counts
- clip explicit casts with `pg_mbcharcliplen()` so multibyte characters remain intact
- add UTF-8 regression coverage for exact implicit input, oversized implicit input, and explicit truncation

## Root cause

`oralongtypmodin()` stores the declared length as a character count, but `orachar_to_long_with_typmod()` compared and truncated the value using its encoded byte length. In UTF-8 this rejected valid multibyte input and truncated explicit casts at a byte boundary.

## Reproduction and validation

The exact commands, SQL, and unpatched output are recorded in https://github.com/IvorySQL/IvorySQL/issues/1600#issuecomment-5322691835.

- unpatched baseline `9df72e5132`, Ubuntu 24.04.4: https://github.com/yyqdbngt/IvorySQL/actions/runs/32090511214
  - `ora_raw_long` was the only failing `ivorysql_ora` regression test
  - `INSERT ... VALUES ('中文')` incorrectly returned `value too long for type long(2)`
  - the explicit `LONG(2)` comparison returned `f`
- patched head `b1e02d361d`, same repository workflow: https://github.com/IvorySQL/IvorySQL/actions/runs/31863038178
  - `ok 7 - ora_raw_long`
  - full `oracle_regression` job passed

These runs used GitHub-hosted Ubuntu runners; they were not run on the Windows development host.

Closes #1600

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 90%