### PR TITLE
fix(oracle): preserve characters in VARCHAR2 byte casts

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -27,20 +27,20 @@ CREATE TABLE TEST_ORACHAR(a char(5 byte), b char(5 char));
 CREATE TABLE TEST_ORAVARCHAR(a varchar2(5 char), b varchar2(5 byte));
 -- Explicit VARCHAR2(n BYTE) casts retain only complete characters
 SELECT '中文'::varchar2(6 byte) = '中文'
-       AND octet_length('中文'::varchar2(6 byte)) = 6;
+       AND lengthb('中文'::varchar2(6 byte)) = 6;
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT '中文'::varchar2(5 byte) = '中'
-       AND octet_length('中文'::varchar2(5 byte)) = 3;
+       AND lengthb('中文'::varchar2(5 byte)) = 3;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT coalesce(octet_length('中文'::varchar2(2 byte)), 0) = 0;
+SELECT coalesce(lengthb('中文'::varchar2(2 byte)), 0) = 0;
  ?column? 
 ----------
  t

--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -40,6 +40,13 @@ SELECT '中文'::varchar2(5 byte) = '中'
  t
 (1 row)
 
+SELECT '中文'::varchar2(2 byte) = ''
+       AND octet_length('中文'::varchar2(2 byte)) = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
  ?column? 
 ----------

--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -25,6 +25,33 @@ LINE 1: CREATE TABLE TEST_ORACHAR(a varchar2(32768 char));
 -- valid range
 CREATE TABLE TEST_ORACHAR(a char(5 byte), b char(5 char));
 CREATE TABLE TEST_ORAVARCHAR(a varchar2(5 char), b varchar2(5 byte));
+-- Explicit VARCHAR2(n BYTE) casts retain only complete characters
+SELECT '中文'::varchar2(6 byte) = '中文'
+       AND octet_length('中文'::varchar2(6 byte)) = 6;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT '中文'::varchar2(5 byte) = '中'
+       AND octet_length('中文'::varchar2(5 byte)) = 3;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT 'abc'::varchar2(4 byte) = 'abc';
+ ?column? 
+----------
+ t
+(1 row)
+
 INSERT INTO TEST_ORACHAR SELECT generate_series(1,10), generate_series(1,10);
 INSERT INTO TEST_ORAVARCHAR SELECT generate_series(1,10), generate_series(1,10);
 -- Comparison operator

--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -40,8 +40,7 @@ SELECT '中文'::varchar2(5 byte) = '中'
  t
 (1 row)
 
-SELECT '中文'::varchar2(2 byte) = ''
-       AND octet_length('中文'::varchar2(2 byte)) = 0;
+SELECT coalesce(octet_length('中文'::varchar2(2 byte)), 0) = 0;
  ?column? 
 ----------
  t

--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -26,33 +26,33 @@ LINE 1: CREATE TABLE TEST_ORACHAR(a varchar2(32768 char));
 CREATE TABLE TEST_ORACHAR(a char(5 byte), b char(5 char));
 CREATE TABLE TEST_ORAVARCHAR(a varchar2(5 char), b varchar2(5 byte));
 -- Explicit VARCHAR2(n BYTE) casts retain only complete characters
-SELECT '中文'::varchar2(6 byte) = '中文'
-       AND octet_length('中文'::varchar2(6 byte)) = 6;
+SELECT cast('中文' AS varchar2(6 byte)) = '中文'
+       AND lengthb(cast('中文' AS varchar2(6 byte))) = 6;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT '中文'::varchar2(5 byte) = '中'
-       AND octet_length('中文'::varchar2(5 byte)) = 3;
+SELECT cast('中文' AS varchar2(5 byte)) = '中'
+       AND lengthb(cast('中文' AS varchar2(5 byte))) = 3;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT coalesce(octet_length('中文'::varchar2(2 byte)), 0) = 0;
+SELECT coalesce(lengthb(cast('中文' AS varchar2(2 byte))), 0) = 0;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
+SELECT cast('abcdef' AS varchar2(4 byte)) = 'abcd';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT 'abc'::varchar2(4 byte) = 'abc';
+SELECT cast('abc' AS varchar2(4 byte)) = 'abc';
  ?column? 
 ----------
  t

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -21,10 +21,10 @@ CREATE TABLE TEST_ORAVARCHAR(a varchar2(5 char), b varchar2(5 byte));
 
 -- Explicit VARCHAR2(n BYTE) casts retain only complete characters
 SELECT '中文'::varchar2(6 byte) = '中文'
-       AND octet_length('中文'::varchar2(6 byte)) = 6;
+       AND lengthb('中文'::varchar2(6 byte)) = 6;
 SELECT '中文'::varchar2(5 byte) = '中'
-       AND octet_length('中文'::varchar2(5 byte)) = 3;
-SELECT coalesce(octet_length('中文'::varchar2(2 byte)), 0) = 0;
+       AND lengthb('中文'::varchar2(5 byte)) = 3;
+SELECT coalesce(lengthb('中文'::varchar2(2 byte)), 0) = 0;
 SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
 SELECT 'abc'::varchar2(4 byte) = 'abc';
 

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -24,8 +24,7 @@ SELECT '中文'::varchar2(6 byte) = '中文'
        AND octet_length('中文'::varchar2(6 byte)) = 6;
 SELECT '中文'::varchar2(5 byte) = '中'
        AND octet_length('中文'::varchar2(5 byte)) = 3;
-SELECT '中文'::varchar2(2 byte) = ''
-       AND octet_length('中文'::varchar2(2 byte)) = 0;
+SELECT coalesce(octet_length('中文'::varchar2(2 byte)), 0) = 0;
 SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
 SELECT 'abc'::varchar2(4 byte) = 'abc';
 

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -20,13 +20,13 @@ CREATE TABLE TEST_ORACHAR(a char(5 byte), b char(5 char));
 CREATE TABLE TEST_ORAVARCHAR(a varchar2(5 char), b varchar2(5 byte));
 
 -- Explicit VARCHAR2(n BYTE) casts retain only complete characters
-SELECT '中文'::varchar2(6 byte) = '中文'
-       AND octet_length('中文'::varchar2(6 byte)) = 6;
-SELECT '中文'::varchar2(5 byte) = '中'
-       AND octet_length('中文'::varchar2(5 byte)) = 3;
-SELECT coalesce(octet_length('中文'::varchar2(2 byte)), 0) = 0;
-SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
-SELECT 'abc'::varchar2(4 byte) = 'abc';
+SELECT cast('中文' AS varchar2(6 byte)) = '中文'
+       AND lengthb(cast('中文' AS varchar2(6 byte))) = 6;
+SELECT cast('中文' AS varchar2(5 byte)) = '中'
+       AND lengthb(cast('中文' AS varchar2(5 byte))) = 3;
+SELECT coalesce(lengthb(cast('中文' AS varchar2(2 byte))), 0) = 0;
+SELECT cast('abcdef' AS varchar2(4 byte)) = 'abcd';
+SELECT cast('abc' AS varchar2(4 byte)) = 'abc';
 
 INSERT INTO TEST_ORACHAR SELECT generate_series(1,10), generate_series(1,10);
 

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -19,6 +19,14 @@ CREATE TABLE TEST_ORACHAR(a char(5 byte), b char(5 char));
 
 CREATE TABLE TEST_ORAVARCHAR(a varchar2(5 char), b varchar2(5 byte));
 
+-- Explicit VARCHAR2(n BYTE) casts retain only complete characters
+SELECT '中文'::varchar2(6 byte) = '中文'
+       AND octet_length('中文'::varchar2(6 byte)) = 6;
+SELECT '中文'::varchar2(5 byte) = '中'
+       AND octet_length('中文'::varchar2(5 byte)) = 3;
+SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
+SELECT 'abc'::varchar2(4 byte) = 'abc';
+
 INSERT INTO TEST_ORACHAR SELECT generate_series(1,10), generate_series(1,10);
 
 INSERT INTO TEST_ORAVARCHAR SELECT generate_series(1,10), generate_series(1,10);

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -24,6 +24,8 @@ SELECT '中文'::varchar2(6 byte) = '中文'
        AND octet_length('中文'::varchar2(6 byte)) = 6;
 SELECT '中文'::varchar2(5 byte) = '中'
        AND octet_length('中文'::varchar2(5 byte)) = 3;
+SELECT '中文'::varchar2(2 byte) = ''
+       AND octet_length('中文'::varchar2(2 byte)) = 0;
 SELECT 'abcdef'::varchar2(4 byte) = 'abcd';
 SELECT 'abc'::varchar2(4 byte) = 'abc';
 

--- a/contrib/ivorysql_ora/src/datatype/oravarcharbyte.c
+++ b/contrib/ivorysql_ora/src/datatype/oravarcharbyte.c
@@ -257,7 +257,7 @@ oravarcharbyte(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		len = maxlen;
+		len = pg_mbcliplen(s_data, len, maxlen);
 	}
 
 	result = (VarChar *) palloc(len + VARHDRSZ);


### PR DESCRIPTION
## Summary

- clip explicit `VARCHAR2(n BYTE)` casts at the last complete-character boundary
- preserve the byte limit without returning invalid server-encoding data
- use Oracle `CAST(... AS VARCHAR2(n BYTE))` syntax in the regression coverage

## Root cause

The explicit-cast path assigned the typmod byte limit directly to the copy length. In UTF8 this can stop inside a multibyte character. The fix uses `pg_mbcliplen()` to retain the longest complete-character prefix within the byte limit.

## Reproduction

Verified on GitHub Actions `ubuntu-24.04`, IvorySQL `19devel`, UTF8, with `ivorysql.compatible_mode = oracle`.

```sql
SET ivorysql.compatible_mode = oracle;
SELECT lengthb(CAST('中文' AS VARCHAR2(4 BYTE))) AS byte_length;
SELECT CAST('中文' AS VARCHAR2(4 BYTE)) = '中' AS complete_character;
SELECT encode(convert_to(CAST('中文' AS VARCHAR2(4 BYTE)), 'UTF8'), 'hex') AS utf8_hex;
```

With the original `oravarcharbyte()` implementation:

- `byte_length` is `4`
- `complete_character` is `f`
- `convert_to(..., 'UTF8')` fails with `invalid byte sequence for encoding UTF8: 0xe6`

With this patch:

- `byte_length` is `3`
- `complete_character` is `t`
- `utf8_hex` is `e4b8ad`

## Validation

- Original implementation reproduction: https://github.com/yyqdbngt/IvorySQL/actions/runs/32091868545
- Patched implementation plus focused `ora_character` Oracle regression: https://github.com/yyqdbngt/IvorySQL/actions/runs/32093105278
- `git diff --check`

Closes #1639

Assisted-by: OpenAI:Codex (GPT-5)
Assisted-by: opencode:qwen/qwen3.8-max-preview
Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `VARCHAR2(n BYTE)` casts to truncate multibyte text only at complete character boundaries.
  * Preserved expected truncation behavior for ASCII text and values already within the specified byte limit.
* **Tests**
  * Added regression coverage for multibyte and ASCII `VARCHAR2(n BYTE)` conversions, including byte-length validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->