### PR TITLE
fix(oracle): honor nondeterministic CHAR byte collations

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -411,3 +411,62 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+-- Nondeterministic collations keep CHAR(n BYTE) equality and hashing aligned
+DO $$
+DECLARE
+    result boolean;
+    matches integer;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_collation WHERE collprovider = 'i') THEN
+        EXECUTE 'CREATE COLLATION ora_char_byte_ci '
+                '(provider = icu, locale = ''und-u-ks-level2'', deterministic = false)';
+
+        EXECUTE 'SELECT ''a''::char(1 byte) COLLATE ora_char_byte_ci = '
+                '''A''::char(1 byte) COLLATE ora_char_byte_ci'
+           INTO result;
+        IF NOT result THEN
+            RAISE EXCEPTION 'CHAR(n BYTE) equality ignored its nondeterministic collation';
+        END IF;
+
+        EXECUTE 'SELECT NOT (''a''::char(1 byte) COLLATE ora_char_byte_ci <> '
+                '''A''::char(1 byte) COLLATE ora_char_byte_ci)'
+           INTO result;
+        IF NOT result THEN
+            RAISE EXCEPTION 'CHAR(n BYTE) inequality ignored its nondeterministic collation';
+        END IF;
+
+        EXECUTE 'SELECT sys.oracharbytehash('
+                '''a''::char(1 byte) COLLATE ora_char_byte_ci) = '
+                'sys.oracharbytehash('
+                '''A''::char(1 byte) COLLATE ora_char_byte_ci)'
+           INTO result;
+        IF NOT result THEN
+            RAISE EXCEPTION 'equal CHAR(n BYTE) values produced different hashes';
+        END IF;
+
+        EXECUTE 'CREATE TEMP TABLE ora_char_byte_ci_test '
+                '(v char(1 byte) COLLATE ora_char_byte_ci)';
+        EXECUTE 'INSERT INTO ora_char_byte_ci_test VALUES (''a''), (''A'')';
+        PERFORM set_config('enable_sort', 'off', true);
+        EXECUTE 'SELECT count(DISTINCT v) FROM ora_char_byte_ci_test'
+           INTO matches;
+        IF matches <> 1 THEN
+            RAISE EXCEPTION 'DISTINCT did not combine equal CHAR(n BYTE) values';
+        END IF;
+
+        EXECUTE 'TRUNCATE ora_char_byte_ci_test';
+        EXECUTE 'INSERT INTO ora_char_byte_ci_test VALUES (''a'')';
+        EXECUTE 'CREATE INDEX ora_char_byte_ci_hash_idx '
+                'ON ora_char_byte_ci_test USING hash (v)';
+        PERFORM set_config('enable_seqscan', 'off', true);
+        EXECUTE 'SELECT count(*) FROM ora_char_byte_ci_test WHERE v = ''A'''
+           INTO matches;
+        IF matches <> 1 THEN
+            RAISE EXCEPTION 'hash index lookup missed an equal CHAR(n BYTE) value';
+        END IF;
+
+        EXECUTE 'DROP TABLE ora_char_byte_ci_test';
+        EXECUTE 'DROP COLLATION ora_char_byte_ci';
+    END IF;
+END
+$$;

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -177,3 +177,63 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+-- Nondeterministic collations keep CHAR(n BYTE) equality and hashing aligned
+DO $$
+DECLARE
+    result boolean;
+    matches integer;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_collation WHERE collprovider = 'i') THEN
+        EXECUTE 'CREATE COLLATION ora_char_byte_ci '
+                '(provider = icu, locale = ''und-u-ks-level2'', deterministic = false)';
+
+        EXECUTE 'SELECT ''a''::char(1 byte) COLLATE ora_char_byte_ci = '
+                '''A''::char(1 byte) COLLATE ora_char_byte_ci'
+           INTO result;
+        IF NOT result THEN
+            RAISE EXCEPTION 'CHAR(n BYTE) equality ignored its nondeterministic collation';
+        END IF;
+
+        EXECUTE 'SELECT NOT (''a''::char(1 byte) COLLATE ora_char_byte_ci <> '
+                '''A''::char(1 byte) COLLATE ora_char_byte_ci)'
+           INTO result;
+        IF NOT result THEN
+            RAISE EXCEPTION 'CHAR(n BYTE) inequality ignored its nondeterministic collation';
+        END IF;
+
+        EXECUTE 'SELECT sys.oracharbytehash('
+                '''a''::char(1 byte) COLLATE ora_char_byte_ci) = '
+                'sys.oracharbytehash('
+                '''A''::char(1 byte) COLLATE ora_char_byte_ci)'
+           INTO result;
+        IF NOT result THEN
+            RAISE EXCEPTION 'equal CHAR(n BYTE) values produced different hashes';
+        END IF;
+
+        EXECUTE 'CREATE TEMP TABLE ora_char_byte_ci_test '
+                '(v char(1 byte) COLLATE ora_char_byte_ci)';
+        EXECUTE 'INSERT INTO ora_char_byte_ci_test VALUES (''a''), (''A'')';
+        PERFORM set_config('enable_sort', 'off', true);
+        EXECUTE 'SELECT count(DISTINCT v) FROM ora_char_byte_ci_test'
+           INTO matches;
+        IF matches <> 1 THEN
+            RAISE EXCEPTION 'DISTINCT did not combine equal CHAR(n BYTE) values';
+        END IF;
+
+        EXECUTE 'TRUNCATE ora_char_byte_ci_test';
+        EXECUTE 'INSERT INTO ora_char_byte_ci_test VALUES (''a'')';
+        EXECUTE 'CREATE INDEX ora_char_byte_ci_hash_idx '
+                'ON ora_char_byte_ci_test USING hash (v)';
+        PERFORM set_config('enable_seqscan', 'off', true);
+        EXECUTE 'SELECT count(*) FROM ora_char_byte_ci_test WHERE v = ''A'''
+           INTO matches;
+        IF matches <> 1 THEN
+            RAISE EXCEPTION 'hash index lookup missed an equal CHAR(n BYTE) value';
+        END IF;
+
+        EXECUTE 'DROP TABLE ora_char_byte_ci_test';
+        EXECUTE 'DROP COLLATION ora_char_byte_ci';
+    END IF;
+END
+$$;

--- a/contrib/ivorysql_ora/src/datatype/oracharbyte.c
+++ b/contrib/ivorysql_ora/src/datatype/oracharbyte.c
@@ -62,6 +62,16 @@ PG_FUNCTION_INFO_V1(oracharbyte_larger);
 PG_FUNCTION_INFO_V1(oracharbyte_smaller);
 PG_FUNCTION_INFO_V1(oracharbytehash);
 
+static void
+oracharbyte_check_collation_set(Oid collid)
+{
+	if (!OidIsValid(collid))
+		ereport(ERROR,
+				(errcode(ERRCODE_INDETERMINATE_COLLATION),
+				 errmsg("could not determine which collation to use for string comparison"),
+				 errhint("Use the COLLATE clause to set the collation explicitly.")));
+}
+
 /*******************************************************************
  * bpchar_input -- common guts of oracharbytein and oracharbyterecv
  *
@@ -375,7 +385,7 @@ oracharbyteeq(PG_FUNCTION_ARGS)
 	Oid			collid = PG_GET_COLLATION();
 	pg_locale_t mylocale;
 
-	check_collation_set(collid);
+	oracharbyte_check_collation_set(collid);
 
 	len1 = bcTruelen(arg1);
 	len2 = bcTruelen(arg2);
@@ -410,7 +420,7 @@ oracharbytene(PG_FUNCTION_ARGS)
 	Oid			collid = PG_GET_COLLATION();
 	pg_locale_t mylocale;
 
-	check_collation_set(collid);
+	oracharbyte_check_collation_set(collid);
 
 	len1 = bcTruelen(arg1);
 	len2 = bcTruelen(arg2);
@@ -625,7 +635,7 @@ oracharbytehash(PG_FUNCTION_ARGS)
 	pg_locale_t mylocale;
 	Datum		result;
 
-	check_collation_set(collid);
+	oracharbyte_check_collation_set(collid);
 
 	keydata = VARDATA_ANY(key);
 	keylen = bcTruelen(key);

--- a/contrib/ivorysql_ora/src/datatype/oracharbyte.c
+++ b/contrib/ivorysql_ora/src/datatype/oracharbyte.c
@@ -36,6 +36,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/ora_compatible.h"
+#include "utils/pg_locale.h"
 #include "utils/varlena.h"
 #include "mb/pg_wchar.h"
 #include "fmgr.h"
@@ -371,18 +372,26 @@ oracharbyteeq(PG_FUNCTION_ARGS)
 	int			len1,
 				len2;
 	bool		result;
+	Oid			collid = PG_GET_COLLATION();
+	pg_locale_t mylocale;
+
+	check_collation_set(collid);
 
 	len1 = bcTruelen(arg1);
 	len2 = bcTruelen(arg2);
 
-	/*
-	 * Since we only care about equality or not-equality, we can avoid all the
-	 * expense of strcoll() here, and just do bitwise comparison.
-	 */
-	if (len1 != len2)
-		result = false;
+	mylocale = pg_newlocale_from_collation(collid);
+
+	if (mylocale->deterministic)
+	{
+		if (len1 != len2)
+			result = false;
+		else
+			result = (memcmp(VARDATA_ANY(arg1), VARDATA_ANY(arg2), len1) == 0);
+	}
 	else
-		result = (memcmp(VARDATA_ANY(arg1), VARDATA_ANY(arg2), len1) == 0);
+		result = (varstr_cmp(VARDATA_ANY(arg1), len1,
+						 VARDATA_ANY(arg2), len2, collid) == 0);
 
 	PG_FREE_IF_COPY(arg1, 0);
 	PG_FREE_IF_COPY(arg2, 1);
@@ -398,18 +407,26 @@ oracharbytene(PG_FUNCTION_ARGS)
 	int			len1,
 				len2;
 	bool		result;
+	Oid			collid = PG_GET_COLLATION();
+	pg_locale_t mylocale;
+
+	check_collation_set(collid);
 
 	len1 = bcTruelen(arg1);
 	len2 = bcTruelen(arg2);
 
-	/*
-	 * Since we only care about equality or not-equality, we can avoid all the
-	 * expense of strcoll() here, and just do bitwise comparison.
-	 */
-	if (len1 != len2)
-		result = true;
+	mylocale = pg_newlocale_from_collation(collid);
+
+	if (mylocale->deterministic)
+	{
+		if (len1 != len2)
+			result = true;
+		else
+			result = (memcmp(VARDATA_ANY(arg1), VARDATA_ANY(arg2), len1) != 0);
+	}
 	else
-		result = (memcmp(VARDATA_ANY(arg1), VARDATA_ANY(arg2), len1) != 0);
+		result = (varstr_cmp(VARDATA_ANY(arg1), len1,
+						 VARDATA_ANY(arg2), len2, collid) != 0);
 
 	PG_FREE_IF_COPY(arg1, 0);
 	PG_FREE_IF_COPY(arg2, 1);
@@ -595,22 +612,43 @@ oracharbyte_sortsupport(PG_FUNCTION_ARGS)
  * orachar needs a specialized hash function because we want to ignore
  * trailing blanks in comparisons.
  *
- * Note: currently there is no need for locale-specific behavior here,
- * but if we ever change the semantics of orachar comparison to trust
- * strcoll() completely, we'd need to do something different in non-C locales.
+ * Nondeterministic collations hash the transformed sort key so values that
+ * compare equal also produce equal hash values.
  */
 Datum
 oracharbytehash(PG_FUNCTION_ARGS)
 {
 	BpChar	   *key = PG_GETARG_BPCHAR_PP(0);
+	Oid			collid = PG_GET_COLLATION();
 	char	   *keydata;
 	int			keylen;
+	pg_locale_t mylocale;
 	Datum		result;
+
+	check_collation_set(collid);
 
 	keydata = VARDATA_ANY(key);
 	keylen = bcTruelen(key);
 
-	result = hash_any((unsigned char *) keydata, keylen);
+	mylocale = pg_newlocale_from_collation(collid);
+
+	if (mylocale->deterministic)
+		result = hash_any((unsigned char *) keydata, keylen);
+	else
+	{
+		Size		bsize;
+		Size		rsize;
+		char	   *buf;
+
+		bsize = pg_strnxfrm(NULL, 0, keydata, keylen, mylocale);
+		buf = palloc(bsize + 1);
+		rsize = pg_strnxfrm(buf, bsize + 1, keydata, keylen, mylocale);
+		if (rsize > bsize)
+			elog(ERROR, "pg_strnxfrm() returned unexpected result");
+
+		result = hash_any((unsigned char *) buf, bsize + 1);
+		pfree(buf);
+	}
 
 	/* Avoid leaking memory for toasted inputs */
 	PG_FREE_IF_COPY(key, 0);

--- a/src/oracle_test/regress/expected/collate.icu.utf8.out
+++ b/src/oracle_test/regress/expected/collate.icu.utf8.out
@@ -1803,15 +1803,15 @@ SELECT x FROM test3bpci WHERE x = 'abc';
   x  
 -----
  abc
-(1 row)
+ ABC
+(2 rows)
 
 SELECT x FROM test3bpci WHERE x <> 'abc';
   x  
 -----
- ABC
  def
  ghi
-(3 rows)
+(2 rows)
 
 SELECT x FROM test3bpci WHERE x LIKE 'a%';
   x  
@@ -1830,74 +1830,70 @@ SELECT x FROM test1bpci UNION SELECT x FROM test2bpci ORDER BY x;
   x  
 -----
  abc
- ABC
  def
  ghi
-(4 rows)
+(3 rows)
 
 SELECT x FROM test2bpci UNION SELECT x FROM test1bpci ORDER BY x;
   x  
 -----
  ABC
- abc
  def
  ghi
-(4 rows)
+(3 rows)
 
 SELECT x FROM test1bpci INTERSECT SELECT x FROM test2bpci ORDER BY x;
   x  
 -----
+ abc
  ghi
-(1 row)
+(2 rows)
 
 SELECT x FROM test2bpci INTERSECT SELECT x FROM test1bpci ORDER BY x;
   x  
 -----
+ ABC
  ghi
-(1 row)
+(2 rows)
 
 SELECT x FROM test1bpci EXCEPT SELECT x FROM test2bpci;
   x  
 -----
- abc
  def
-(2 rows)
+(1 row)
 
 SELECT x FROM test2bpci EXCEPT SELECT x FROM test1bpci;
-  x  
------
- ABC
-(1 row)
+ x 
+---
+(0 rows)
 
 SELECT DISTINCT x FROM test3bpci ORDER BY x;
   x  
 -----
- ABC
  abc
  def
  ghi
-(4 rows)
+(3 rows)
 
 SELECT count(DISTINCT x) FROM test3bpci;
  count 
 -------
-     4
+     3
 (1 row)
 
 SELECT x, count(*) FROM test3bpci GROUP BY x ORDER BY x;
   x  | count 
 -----+-------
- ABC |     1
- abc |     1
+ abc |     2
  def |     1
  ghi |     1
-(4 rows)
+(3 rows)
 
 SELECT x, row_number() OVER (ORDER BY x), rank() OVER (ORDER BY x) FROM test3bpci ORDER BY x;
   x  | row_number | rank 
 -----+------------+------
  abc |          1 |    1
- ABC |          2 |    2
+ ABC |          2 |    1
  def |          3 |    3
  ghi |          4 |    4
 (4 rows)


### PR DESCRIPTION
## Summary

- use the active collation for `CHAR(n BYTE)` equality and inequality when it is nondeterministic
- hash nondeterministic values through their collation sort keys so equal values produce equal hashes
- retain the bytewise fast path for deterministic collations
- conditionally cover ICU equality, inequality, DISTINCT/hash aggregation, and hash-index lookup

## Root cause

Ordering already used `varstr_cmp()`, while equality and hashing always compared or hashed the original bytes. Under nondeterministic collations those definitions could disagree.

## Validation

- implementation follows the current core `bpchar` deterministic/nondeterministic pattern
- `git diff --check`
- added focused `ora_character` regression assertions that safely skip when ICU is unavailable
- full regression execution was not available on the Windows-only local host; repository CI is expected to run the build and regression suite

Closes #1599

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 90%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collation-aware comparisons and hashing for `CHAR(n BYTE)` values.
  * Case-insensitive collations now support equality checks, `DISTINCT`, grouping, ranking, set operations, and hash-index lookups.
  * Differently cased equivalent values are correctly treated as equal across these operations.

* **Tests**
  * Added regression coverage for ICU collation behavior, including comparisons, hashing, duplicate elimination, and indexed lookups.
  * Tests skip automatically when ICU collation support is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Deterministic collation regression follow-up

Added an ICU collation with the same `und-u-ks-level2` locale and `deterministic = true`. The regression asserts that CHAR(1 BYTE) equality between `a` and `A` is false and inequality is true, protecting both deterministic comparison paths. The temporary collation is removed, and the case remains inside the existing ICU availability guard.

For this follow-up, `git diff --check` passed and the SQL DO block was checked to match its expected echo exactly. No local database regression was run: this Windows environment has no runnable IvorySQL test installation. Earlier runtime results apply to the preceding revision; the new regression still needs CI validation.