### PR TITLE
fix(dbms_session): validate clear namespaces consistently

### DIFF
--- a/contrib/ivorysql_ora/expected/dbms_session.out
+++ b/contrib/ivorysql_ora/expected/dbms_session.out
@@ -265,17 +265,49 @@ select sys_context('rp_ns', 'key') as ctx_after_reset;
 (1 row)
 
 DROP PACKAGE rp_pkg;
--- Clear operations validate oversized namespaces even when no context exists
-call dbms_session.clear_context('rp_ns');
-call dbms_session.clear_context(repeat('n', 255));
-call dbms_session.clear_all_context(repeat('n', 255));
+-- Reconnect so oversized clears exercise the uninitialized context store
+\c -
 \set VERBOSITY terse
-call dbms_session.set_context(repeat('n', 256), 'attr', 'value');
-ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
 call dbms_session.clear_context(repeat('n', 256), 'attr');
 ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
 call dbms_session.clear_context(repeat('n', 256));
 ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
 call dbms_session.clear_all_context(repeat('n', 256));
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+\set VERBOSITY default
+-- The 255-byte namespace and attribute boundaries remain usable
+call dbms_session.set_context(repeat('n', 255), repeat('a', 255), 'value');
+select sys_context(repeat('n', 255), repeat('a', 255)) = 'value' as ok;
+ ok 
+----
+ t
+(1 row)
+
+call dbms_session.clear_context(repeat('n', 255), repeat('a', 255));
+select sys_context(repeat('n', 255), repeat('a', 255)) is null as ok;
+ ok 
+----
+ t
+(1 row)
+
+-- Namespace-wide clears exercise the fixed-size fold and comparison path
+call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.clear_context(repeat('n', 255));
+select sys_context(repeat('n', 255), 'attr') is null as ok;
+ ok 
+----
+ t
+(1 row)
+
+call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.clear_all_context(repeat('n', 255));
+select sys_context(repeat('n', 255), 'attr') is null as ok;
+ ok 
+----
+ t
+(1 row)
+
+\set VERBOSITY terse
+call dbms_session.set_context(repeat('n', 256), 'attr', 'value');
 ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
 \set VERBOSITY default

--- a/contrib/ivorysql_ora/expected/dbms_session.out
+++ b/contrib/ivorysql_ora/expected/dbms_session.out
@@ -265,3 +265,17 @@ select sys_context('rp_ns', 'key') as ctx_after_reset;
 (1 row)
 
 DROP PACKAGE rp_pkg;
+-- Clear operations validate oversized namespaces even when no context exists
+call dbms_session.clear_context('rp_ns');
+call dbms_session.clear_context(repeat('n', 255));
+call dbms_session.clear_all_context(repeat('n', 255));
+\set VERBOSITY terse
+call dbms_session.set_context(repeat('n', 256), 'attr', 'value');
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+call dbms_session.clear_context(repeat('n', 256), 'attr');
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+call dbms_session.clear_context(repeat('n', 256));
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+call dbms_session.clear_all_context(repeat('n', 256));
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+\set VERBOSITY default

--- a/contrib/ivorysql_ora/expected/dbms_session.out
+++ b/contrib/ivorysql_ora/expected/dbms_session.out
@@ -265,8 +265,8 @@ select sys_context('rp_ns', 'key') as ctx_after_reset;
 (1 row)
 
 DROP PACKAGE rp_pkg;
--- Reconnect so oversized clears exercise the uninitialized context store
-\c -
+-- Reset package state so oversized clears exercise the uninitialized context store
+DISCARD PACKAGES;
 \set VERBOSITY terse
 call dbms_session.clear_context(repeat('n', 256), 'attr');
 ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
@@ -290,8 +290,18 @@ select sys_context(repeat('n', 255), repeat('a', 255)) is null as ok;
  t
 (1 row)
 
+-- Oversized clears are also rejected after the context store is initialized
+\set VERBOSITY terse
+call dbms_session.clear_context(repeat('n', 256), 'attr');
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+call dbms_session.clear_context(repeat('n', 256));
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+call dbms_session.clear_all_context(repeat('n', 256));
+ERROR:  DBMS_SESSION namespace too long (max 255 bytes)
+\set VERBOSITY default
 -- Namespace-wide clears exercise the fixed-size fold and comparison path
 call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.set_context(repeat('n', 255), 'other_attr', 'value2');
 call dbms_session.clear_context(repeat('n', 255));
 select sys_context(repeat('n', 255), 'attr') is null as ok;
  ok 
@@ -299,9 +309,22 @@ select sys_context(repeat('n', 255), 'attr') is null as ok;
  t
 (1 row)
 
+select sys_context(repeat('n', 255), 'other_attr') is null as ok;
+ ok 
+----
+ t
+(1 row)
+
 call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.set_context(repeat('n', 255), 'other_attr', 'value2');
 call dbms_session.clear_all_context(repeat('n', 255));
 select sys_context(repeat('n', 255), 'attr') is null as ok;
+ ok 
+----
+ t
+(1 row)
+
+select sys_context(repeat('n', 255), 'other_attr') is null as ok;
  ok 
 ----
  t

--- a/contrib/ivorysql_ora/expected/dbms_session.out
+++ b/contrib/ivorysql_ora/expected/dbms_session.out
@@ -266,7 +266,7 @@ select sys_context('rp_ns', 'key') as ctx_after_reset;
 
 DROP PACKAGE rp_pkg;
 -- Reset package state so oversized clears exercise the uninitialized context store
-DISCARD PACKAGES;
+DISCARD PACKAGE;
 \set VERBOSITY terse
 call dbms_session.clear_context(repeat('n', 256), 'attr');
 ERROR:  DBMS_SESSION namespace too long (max 255 bytes)

--- a/contrib/ivorysql_ora/sql/dbms_session.sql
+++ b/contrib/ivorysql_ora/sql/dbms_session.sql
@@ -156,3 +156,14 @@ call dbms_session.reset_package();
 select sys_context('rp_ns', 'key') as ctx_after_reset;
 
 DROP PACKAGE rp_pkg;
+
+-- Clear operations validate oversized namespaces even when no context exists
+call dbms_session.clear_context('rp_ns');
+call dbms_session.clear_context(repeat('n', 255));
+call dbms_session.clear_all_context(repeat('n', 255));
+\set VERBOSITY terse
+call dbms_session.set_context(repeat('n', 256), 'attr', 'value');
+call dbms_session.clear_context(repeat('n', 256), 'attr');
+call dbms_session.clear_context(repeat('n', 256));
+call dbms_session.clear_all_context(repeat('n', 256));
+\set VERBOSITY default

--- a/contrib/ivorysql_ora/sql/dbms_session.sql
+++ b/contrib/ivorysql_ora/sql/dbms_session.sql
@@ -157,8 +157,8 @@ select sys_context('rp_ns', 'key') as ctx_after_reset;
 
 DROP PACKAGE rp_pkg;
 
--- Reconnect so oversized clears exercise the uninitialized context store
-\c -
+-- Reset package state so oversized clears exercise the uninitialized context store
+DISCARD PACKAGES;
 \set VERBOSITY terse
 call dbms_session.clear_context(repeat('n', 256), 'attr');
 call dbms_session.clear_context(repeat('n', 256));
@@ -171,13 +171,24 @@ select sys_context(repeat('n', 255), repeat('a', 255)) = 'value' as ok;
 call dbms_session.clear_context(repeat('n', 255), repeat('a', 255));
 select sys_context(repeat('n', 255), repeat('a', 255)) is null as ok;
 
+-- Oversized clears are also rejected after the context store is initialized
+\set VERBOSITY terse
+call dbms_session.clear_context(repeat('n', 256), 'attr');
+call dbms_session.clear_context(repeat('n', 256));
+call dbms_session.clear_all_context(repeat('n', 256));
+\set VERBOSITY default
+
 -- Namespace-wide clears exercise the fixed-size fold and comparison path
 call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.set_context(repeat('n', 255), 'other_attr', 'value2');
 call dbms_session.clear_context(repeat('n', 255));
 select sys_context(repeat('n', 255), 'attr') is null as ok;
+select sys_context(repeat('n', 255), 'other_attr') is null as ok;
 call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.set_context(repeat('n', 255), 'other_attr', 'value2');
 call dbms_session.clear_all_context(repeat('n', 255));
 select sys_context(repeat('n', 255), 'attr') is null as ok;
+select sys_context(repeat('n', 255), 'other_attr') is null as ok;
 
 \set VERBOSITY terse
 call dbms_session.set_context(repeat('n', 256), 'attr', 'value');

--- a/contrib/ivorysql_ora/sql/dbms_session.sql
+++ b/contrib/ivorysql_ora/sql/dbms_session.sql
@@ -157,13 +157,28 @@ select sys_context('rp_ns', 'key') as ctx_after_reset;
 
 DROP PACKAGE rp_pkg;
 
--- Clear operations validate oversized namespaces even when no context exists
-call dbms_session.clear_context('rp_ns');
-call dbms_session.clear_context(repeat('n', 255));
-call dbms_session.clear_all_context(repeat('n', 255));
+-- Reconnect so oversized clears exercise the uninitialized context store
+\c -
 \set VERBOSITY terse
-call dbms_session.set_context(repeat('n', 256), 'attr', 'value');
 call dbms_session.clear_context(repeat('n', 256), 'attr');
 call dbms_session.clear_context(repeat('n', 256));
 call dbms_session.clear_all_context(repeat('n', 256));
+\set VERBOSITY default
+
+-- The 255-byte namespace and attribute boundaries remain usable
+call dbms_session.set_context(repeat('n', 255), repeat('a', 255), 'value');
+select sys_context(repeat('n', 255), repeat('a', 255)) = 'value' as ok;
+call dbms_session.clear_context(repeat('n', 255), repeat('a', 255));
+select sys_context(repeat('n', 255), repeat('a', 255)) is null as ok;
+
+-- Namespace-wide clears exercise the fixed-size fold and comparison path
+call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.clear_context(repeat('n', 255));
+select sys_context(repeat('n', 255), 'attr') is null as ok;
+call dbms_session.set_context(repeat('n', 255), 'attr', 'value');
+call dbms_session.clear_all_context(repeat('n', 255));
+select sys_context(repeat('n', 255), 'attr') is null as ok;
+
+\set VERBOSITY terse
+call dbms_session.set_context(repeat('n', 256), 'attr', 'value');
 \set VERBOSITY default

--- a/contrib/ivorysql_ora/sql/dbms_session.sql
+++ b/contrib/ivorysql_ora/sql/dbms_session.sql
@@ -158,7 +158,7 @@ select sys_context('rp_ns', 'key') as ctx_after_reset;
 DROP PACKAGE rp_pkg;
 
 -- Reset package state so oversized clears exercise the uninitialized context store
-DISCARD PACKAGES;
+DISCARD PACKAGE;
 \set VERBOSITY terse
 call dbms_session.clear_context(repeat('n', 256), 'attr');
 call dbms_session.clear_context(repeat('n', 256));

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_session/dbms_session.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_session/dbms_session.c
@@ -73,6 +73,7 @@ static MemoryContext DbmsSessionContext = NULL;
 
 /* Internal helpers */
 static void dbms_session_init(void);
+static void check_context_name(const char *name, const char *kind);
 static void make_key(CtxKey *key, const char *ns, const char *attr);
 static void clear_namespace(const char *ns);
 
@@ -111,29 +112,32 @@ dbms_session_init(void)
 						   HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 }
 
+/* Reject names that do not fit the fixed-size key buffer. */
+static void
+check_context_name(const char *name, const char *kind)
+{
+	if (strlen(name) >= DBMS_SESSION_NAME_LEN)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("DBMS_SESSION %s too long (max %d bytes)",
+						kind, DBMS_SESSION_NAME_LEN - 1)));
+}
+
 /*
  * make_key - build a zero-filled hash key from namespace/attribute names.
  *
  * Oracle treats namespace and attribute names case-insensitively (it folds
  * them to upper case internally), so we upper-case both while copying.  This
  * makes SET_CONTEXT('app', 'usr', ...) readable via SYS_CONTEXT('APP', 'USR'),
- * matching Oracle.  Rejects names that do not fit the fixed-size key buffer.
+ * matching Oracle.
  */
 static void
 make_key(CtxKey *key, const char *ns, const char *attr)
 {
 	int			i;
 
-	if (strlen(ns) >= DBMS_SESSION_NAME_LEN)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("DBMS_SESSION namespace too long (max %d bytes)",
-						DBMS_SESSION_NAME_LEN - 1)));
-	if (strlen(attr) >= DBMS_SESSION_NAME_LEN)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("DBMS_SESSION attribute too long (max %d bytes)",
-						DBMS_SESSION_NAME_LEN - 1)));
+	check_context_name(ns, "namespace");
+	check_context_name(attr, "attribute");
 
 	/* MemSet first: HASH_BLOBS compares the whole struct as bytes. */
 	MemSet(key, 0, sizeof(CtxKey));
@@ -160,6 +164,8 @@ clear_namespace(const char *ns)
 	char		ns_up[DBMS_SESSION_NAME_LEN];
 	int			i;
 
+	check_context_name(ns, "namespace");
+
 	if (DbmsSessionHash == NULL)
 		return;
 
@@ -167,13 +173,7 @@ clear_namespace(const char *ns)
 	if (nentries == 0)
 		return;
 
-	/*
-	 * Stored keys are upper-cased (see make_key), so upper-case the namespace
-	 * here too before comparing.  An over-long namespace cannot match any
-	 * stored key (those are length-checked at insert time).
-	 */
-	if (strlen(ns) >= DBMS_SESSION_NAME_LEN)
-		return;
+	/* Stored keys are upper-cased (see make_key), so fold before comparing. */
 	for (i = 0; ns[i] != '\0'; i++)
 		ns_up[i] = pg_toupper((unsigned char) ns[i]);
 	ns_up[i] = '\0';
@@ -271,9 +271,6 @@ ora_dbms_session_clear_context(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				 errmsg("DBMS_SESSION.CLEAR_CONTEXT namespace must not be NULL")));
 
-	if (DbmsSessionHash == NULL)
-		PG_RETURN_VOID();
-
 	ns = text_to_cstring(PG_GETARG_TEXT_PP(0));
 
 	if (PG_ARGISNULL(1))
@@ -288,6 +285,8 @@ ora_dbms_session_clear_context(PG_FUNCTION_ARGS)
 		bool		found;
 
 		make_key(&key, ns, attr);
+		if (DbmsSessionHash == NULL)
+			PG_RETURN_VOID();
 		entry = (CtxEntry *) hash_search(DbmsSessionHash, &key, HASH_FIND, &found);
 		if (found)
 		{
@@ -314,9 +313,6 @@ ora_dbms_session_clear_all_context(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				 errmsg("DBMS_SESSION.CLEAR_ALL_CONTEXT namespace must not be NULL")));
-
-	if (DbmsSessionHash == NULL)
-		PG_RETURN_VOID();
 
 	ns = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	clear_namespace(ns);


### PR DESCRIPTION
## Summary

- centralize DBMS_SESSION context-name length validation
- validate clear-operation arguments before treating an empty context store as a no-op
- cover the valid 255-byte boundary and consistent 256-byte errors for set, single-attribute clear, and whole-namespace clear operations

## Root cause

The clear functions returned before converting or validating their namespace when the context hash was absent or empty, so the same invalid argument behaved differently depending on session history.

## Validation

- `git diff --check`
- added focused `dbms_session` regression cases
- full regression execution was not available on the Windows-only local host; repository CI is expected to run the build and regression suite

Closes #1640

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 90%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session context clearing for valid and missing namespaces.
  * Corrected attribute clearing when no session context store exists.
  * Standardized validation for namespace and attribute name lengths.
  * Names up to 255 bytes are supported; 256-byte names are rejected consistently.
  * Namespace-wide clearing now removes multiple attributes correctly at the 255-byte boundary.

* **Tests**
  * Expanded coverage for setting, reading, clearing, and clearing all session context values, including boundary lengths and uninitialized context stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->