### PR TITLE
Fix duplicate sequence SESSION and GLOBAL options

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1572,7 +1572,6 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 	DefElem    *cache_value = NULL;
 	DefElem    *is_cycled = NULL;
 	DefElem	   *scale = NULL;
-	DefElem	   *session = NULL;
 	ListCell   *option;
 	bool		reset_max_value = false;
 	bool		reset_min_value = false;
@@ -1735,7 +1734,7 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 		}
 		else if(strcmp(defel->defname, "session") == 0)
 		{
-			if (session || global_flag)
+			if (session_flag || global_flag)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
@@ -1746,7 +1745,7 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 		}
 		else if(strcmp(defel->defname, "global") == 0)
 		{
-			if (session || session_flag)
+			if (session_flag || global_flag)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),

--- a/src/oracle_test/regress/expected/sequence.out
+++ b/src/oracle_test/regress/expected/sequence.out
@@ -979,6 +979,23 @@ select seq_session1.nextval from dual;
 (1 row)
 
 DROP SEQUENCE seq_session1;
+-- Reject duplicate and conflicting SESSION/GLOBAL options.
+CREATE SEQUENCE seq_dup_session SESSION SESSION;
+ERROR:  duplicate SESSION or GLOBAL specifications
+LINE 1: CREATE SEQUENCE seq_dup_session SESSION SESSION;
+                                                ^
+CREATE SEQUENCE seq_dup_global GLOBAL GLOBAL;
+ERROR:  duplicate SESSION or GLOBAL specifications
+LINE 1: CREATE SEQUENCE seq_dup_global GLOBAL GLOBAL;
+                                              ^
+CREATE SEQUENCE seq_conflict_sg SESSION GLOBAL;
+ERROR:  duplicate SESSION or GLOBAL specifications
+LINE 1: CREATE SEQUENCE seq_conflict_sg SESSION GLOBAL;
+                                                ^
+CREATE SEQUENCE seq_conflict_gs GLOBAL SESSION;
+ERROR:  duplicate SESSION or GLOBAL specifications
+LINE 1: CREATE SEQUENCE seq_conflict_gs GLOBAL SESSION;
+                                               ^
 create sequence seq start with 6 minvalue 3 maxvalue 8 cycle session nocache;
 select seq.nextval from dual;
  nextval 

--- a/src/oracle_test/regress/sql/sequence.sql
+++ b/src/oracle_test/regress/sql/sequence.sql
@@ -494,6 +494,12 @@ select seq_session1.nextval from dual;
 select seq_session1.nextval from dual;
 DROP SEQUENCE seq_session1;
 
+-- Reject duplicate and conflicting SESSION/GLOBAL options.
+CREATE SEQUENCE seq_dup_session SESSION SESSION;
+CREATE SEQUENCE seq_dup_global GLOBAL GLOBAL;
+CREATE SEQUENCE seq_conflict_sg SESSION GLOBAL;
+CREATE SEQUENCE seq_conflict_gs GLOBAL SESSION;
+
 create sequence seq start with 6 minvalue 3 maxvalue 8 cycle session nocache;
 select seq.nextval from dual;
 select seq.nextval from dual;


### PR DESCRIPTION
## What changed
- reject repeated `SESSION` and `GLOBAL` sequence options
- use the existing option flags for both duplicate and conflict checks
- remove the unused `session` pointer
- add regression coverage for duplicate and conflicting forms

## Root cause
The duplicate checks used a never-assigned `DefElem *session` and only checked the flag for the opposite option. As a result, `SESSION SESSION` and `GLOBAL GLOBAL` were accepted while mixed forms were rejected.

## Validation
- `git diff --check`
- remote `make -j16`
- remote `make oracle-check-world`: the `sequence` test passed; the temporary environment's unrelated `xml` test failed because XML support was unavailable

Closes #1638


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for sequence options to consistently reject duplicate or conflicting `SESSION` and `GLOBAL` specifications.
  - Added clearer error handling for invalid combinations regardless of option order.

- **Tests**
  - Added regression coverage for repeated and conflicting sequence options, including expected parser errors and positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->