### PR TITLE
Fix backend core: argnumbers index mixup, NLS semantics inversion, float sequence constants

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -1584,17 +1584,17 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 			{
 				newResult->args[j] = proargtypes[argnumbers[j]];
 
-				if (argtypenames != NULL && strcmp(argtypenames[argnumbers[i]], "") != 0)
+				if (argtypenames != NULL && strcmp(argtypenames[argnumbers[j]], "") != 0)
 				{
 					TypeName	*tname;
 					PkgType *pkgtype;
 
-					tname = (TypeName *) stringToNode(argtypenames[argnumbers[i]]);
+					tname = (TypeName *) stringToNode(argtypenames[argnumbers[j]]);
 
 					pkgtype = LookupPkgTypeByTypename(tname->names, false);
 					if (pkgtype != NULL)
 					{
-						newResult->args[i] = pkgtype->basetypid;
+						newResult->args[j] = pkgtype->basetypid;
 						pfree(pkgtype);
 					}
 					else
@@ -1611,7 +1611,7 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 									 errmsg("argument type %s is invalid",
 										TypeNameToString(tname))));
 
-							newResult->args[i] = typeTypeId(typtup);
+							newResult->args[j] = typeTypeId(typtup);
 							ReleaseSysCache(typtup);
 						}
 					}

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1838,15 +1838,15 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 			if ((seqform->seqtypid == INT2OID && seqform->seqmax == PG_INT16_MAX) ||
 				(seqform->seqtypid == INT4OID && seqform->seqmax == PG_INT32_MAX) ||
 				(seqform->seqtypid == INT8OID && seqform->seqmax == PG_INT64_MAX) ||
-				(seqform->seqtypid == FLOAT4OID && seqform->seqmax == PG_INT32_MAX) ||
+				(seqform->seqtypid == FLOAT4OID && seqform->seqmax == PG_INT64_MAX) ||
 				(seqform->seqtypid == FLOAT8OID && seqform->seqmax == PG_INT64_MAX) ||
 				(seqform->seqtypid == NUMBEROID && seqform->seqmax == PG_INT64_MAX))
 				reset_max_value = true;
 			if ((seqform->seqtypid == INT2OID && seqform->seqmin == PG_INT16_MIN) ||
 				(seqform->seqtypid == INT4OID && seqform->seqmin == PG_INT32_MIN) ||
 				(seqform->seqtypid == INT8OID && seqform->seqmin == PG_INT64_MIN) ||
-				(seqform->seqtypid == FLOAT4OID && seqform->seqmin == PG_INT32_MAX) ||
-				(seqform->seqtypid == FLOAT8OID && seqform->seqmin == PG_INT64_MAX) ||
+				(seqform->seqtypid == FLOAT4OID && seqform->seqmin == PG_INT64_MIN) ||
+				(seqform->seqtypid == FLOAT8OID && seqform->seqmin == PG_INT64_MIN) ||
 				(seqform->seqtypid == NUMBEROID && seqform->seqmin == PG_INT64_MIN))
 				reset_min_value = true;
 		}

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -1742,9 +1742,9 @@ select_common_type_for_nvl(ParseState *pstate, List *exprs, const char *context,
 			else if (compatible_db == ORA_PARSER)
 			{
 				if (nls_length_semantics == NLS_LENGTH_CHAR)
-					ptype = ORAVARCHARCHAROID;
-				else
 					ptype = ORAVARCHARBYTEOID;
+				else
+					ptype = ORAVARCHARCHAROID;
 			}
 		}
 		else
@@ -1777,9 +1777,9 @@ select_common_type_for_nvl(ParseState *pstate, List *exprs, const char *context,
 				else if (compatible_db == ORA_PARSER)
 				{
 					if (nls_length_semantics == NLS_LENGTH_CHAR)
-						ptype = ORAVARCHARCHAROID;
-					else
 						ptype = ORAVARCHARBYTEOID;
+					else
+						ptype = ORAVARCHARCHAROID;
 				}
 			}
 		}

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -1742,9 +1742,9 @@ select_common_type_for_nvl(ParseState *pstate, List *exprs, const char *context,
 			else if (compatible_db == ORA_PARSER)
 			{
 				if (nls_length_semantics == NLS_LENGTH_CHAR)
-					ptype = ORAVARCHARBYTEOID;
-				else
 					ptype = ORAVARCHARCHAROID;
+				else
+					ptype = ORAVARCHARBYTEOID;
 			}
 		}
 		else
@@ -1777,9 +1777,9 @@ select_common_type_for_nvl(ParseState *pstate, List *exprs, const char *context,
 				else if (compatible_db == ORA_PARSER)
 				{
 					if (nls_length_semantics == NLS_LENGTH_CHAR)
-						ptype = ORAVARCHARBYTEOID;
-					else
 						ptype = ORAVARCHARCHAROID;
+					else
+						ptype = ORAVARCHARBYTEOID;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #1652.

1. **`namespace.c` (high)**: the named/mixed-argument reorder loop used `i` (leftover from the outer `nelems` loop) instead of `j` in four places — `argnumbers[i]` read past the array and `args[i]` wrote past the argument array when a PL/iSQL function with `%TYPE`/`%ROWTYPE` parameters is called with named/mixed notation in Oracle mode.

2. **`parse_coerce.c`**: `NLS_LENGTH_SEMANTICS = CHAR` now selects `ORAVARCHARCHAROID` and `BYTE` selects `ORAVARCHARBYTEOID` (was inverted; `parse_expr.c` has the correct mapping).

3. **`sequence.c`**: FLOAT4/FLOAT8 min/max reset detection now compares against the actual defaults (`PG_INT64_MAX`/`PG_INT64_MIN`); the FLOAT4 max used `PG_INT32_MAX` and both min checks used `MAX` constants.

## Test plan

- All three translation units compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected named-argument type resolution to apply package and Oracle type substitutions to the appropriate arguments.
  * Fixed sequence default limit handling for floating-point types, including maximum and minimum values.
  * Improved Oracle NVL type resolution to respect character-length semantics settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->