### PR TITLE
Add REBUILD duplicate-option checks and MERGE validation fixes

### DIFF
--- a/contrib/ivorysql_ora/src/merge/ora_merge.c
+++ b/contrib/ivorysql_ora/src/merge/ora_merge.c
@@ -441,6 +441,10 @@ lmerge_matched:
 				goto out;
 
 			case TM_Updated:
+				if (IsolationUsesXactSnapshot())
+					ereport(ERROR,
+							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+							 errmsg("could not serialize access due to concurrent update")));
 				{
 					bool		was_matched;
 					Relation	 resultRelationDesc;
@@ -711,6 +715,9 @@ IvytransformMergeStmt(ParseState *pstate, MergeStmt *stmt)
 	{
 		MergeWhenClause *mergeWhenClause = (MergeWhenClause *) lfirst(l);
 		MergeWhenClause *delstmt = NULL;
+
+		/* delete_clause is per-clause state; reset it for this iteration */
+		delete_clause = -1;
 
 		/*
 		 * Collect permissions to check, according to action types. We require

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -2912,8 +2912,11 @@ ExecOraAlterIndexRebuild(ParseState *pstate,
 {
 	ReindexParams params = {0};
 	bool		online = false;
+	bool		has_online = false;
 	char	   *tablespacename = NULL;
+	bool		has_tablespace = false;
 	char	   *partitionname = NULL;
+	bool		has_partition = false;
 	bool		has_parallel = false;
 	bool		has_noparallel = false;
 	int			parallel_degree = 0;	/* 0 = auto; N >= 1 = explicit DOP */
@@ -2941,11 +2944,35 @@ ExecOraAlterIndexRebuild(ParseState *pstate,
 		DefElem    *opt = (DefElem *) lfirst(lc);
 
 		if (strcmp(opt->defname, "online") == 0)
+		{
+			if (has_online)
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("duplicate ONLINE option"),
+						 parser_errposition(pstate, opt->location)));
+			has_online = true;
 			online = defGetBoolean(opt);
+		}
 		else if (strcmp(opt->defname, "tablespace") == 0)
+		{
+			if (has_tablespace)
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("duplicate TABLESPACE option"),
+						 parser_errposition(pstate, opt->location)));
+			has_tablespace = true;
 			tablespacename = defGetString(opt);
+		}
 		else if (strcmp(opt->defname, "partition") == 0)
+		{
+			if (has_partition)
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("duplicate PARTITION option"),
+						 parser_errposition(pstate, opt->location)));
+			has_partition = true;
 			partitionname = defGetString(opt);
+		}
 		else if (strcmp(opt->defname, "parallel") == 0)
 		{
 			if (has_noparallel)


### PR DESCRIPTION
## Summary

Fixes #1654.

1. **`ALTER INDEX ... REBUILD` duplicate options** (`src/backend/commands/indexcmds.c`): `ONLINE`, `TABLESPACE` and `PARTITION` now reject duplicates with a syntax error, matching the existing `PARALLEL`/`NOPARALLEL` checks.

2. **MERGE `delete_clause` reset** (`contrib/ivorysql_ora/src/merge/ora_merge.c`): the flag is now reset at the top of each WHEN-clause iteration, so the `unreachable WHEN clause` validation is not silently skipped for clauses after an UPDATE..DELETE pair.

3. **MERGE `TM_Updated` serialization check** (same file): under REPEATABLE READ/SERIALIZABLE a concurrently updated target tuple now raises a serialization failure (matching the `TM_Deleted` branch and upstream `ExecMergeMatched`), instead of silently retrying via EPQ.

## Test plan

- Both translation units compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MERGE operations under serializable isolation now report an error when the target row is concurrently updated.
  * Fixed compatibility UPDATE/DELETE clause state carrying over between MERGE conditions.
  * ALTER INDEX REBUILD now reports clear syntax errors when ONLINE, TABLESPACE, or PARTITION options are repeated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->