### PR TITLE
Fix regexp_instr single-char matches and RR/RRRR century direction

### DIFF
--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -2157,8 +2157,14 @@ adjust_partial_year_to_2020RR(int year)
 		{
 			sprintf(year1, "%d%02d", prenum, year);
 		}
+		else if (sufnum >= 50 && year <= 49)
+		{
+			/* current 50-99, input 00-49: next century */
+			sprintf(year1, "%d%02d", prenum + 1, year);
+		}
 		else
 		{
+			/* current 00-49, input 50-99: previous century */
 			sprintf(year1, "%d%02d", prenum - 1, year);
 		}
 	}

--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -1687,8 +1687,6 @@ ora_build_regexp_instr_matches_result(regexp_matches_ctx *matchctx ,int ret_opt,
 			eo = matchctx->match_locs[loc + matchctx->npatterns * 2 -1] - 1;
 			if(eo < 0)
 				eo = 0;
-			if(so == eo)
-				return false;
 		}
 
 		if (so < 0 || eo < 0)


### PR DESCRIPTION
## Summary

Fixes #1656.

1. **`regexp_instr` single-char / zero-length matches** (`src/backend/utils/adt/regexp.c`): the `so == eo` early return made a 1-char match look like a zero-length match (`eo` is decremented by one), so `regexp_instr('abc', 'b')` returned 0 instead of 2, and zero-length matches returned 0 instead of the position. Removed; the `so < 0 || eo < 0` check below already handles the no-match case.

2. **RR/RRRR century adjustment** (`src/backend/utils/adt/formatting.c`): when the current year's last two digits are 50-99 and the input is 00-49, Oracle maps to the next century; the code subtracted one. Now `prenum + 1` in that case, `prenum - 1` only for the other cross-century case.

## Test plan

- Both translation units compile cleanly.
- Manual: `regexp_instr('abc', 'b')` → 2; with current year 2075, `to_date('10','RR')` → 2110.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected partial-year interpretation for two-digit years spanning century boundaries.
  * Improved regular expression matching so zero-length subexpression matches are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->