### PR TITLE
Fix psql SERVICE prompt and NULL type descriptions

### DIFF
--- a/src/bin/psql/ora_prompt.c
+++ b/src/bin/psql/ora_prompt.c
@@ -192,7 +192,7 @@ ora_get_prompt(Ora_promptStatus_t status, ConditionalStack cstack)
 						if (service_name)
 							strlcpy(buf, service_name, sizeof(buf));
 					}
-					pg_fallthrough;
+					break;
 					/* backend pid */
 				case 'p':
 					if (pset.db)

--- a/src/bin/psql/variables.c
+++ b/src/bin/psql/variables.c
@@ -887,7 +887,7 @@ ListBindVariables(VariableSpace space, const char *name)
 				printf("\n");
 			if (ptr->name)
 				printf("variable	%s\n", ptr->name);
-			if (ptr->typoid)
+			if (ptr->typoid && typdesc)
 				printf("datatype	%s\n", typdesc);
 
 			PQclear(res);


### PR DESCRIPTION
## Summary

Fixes #1658.

- Stop the SERVICE prompt element from falling through to the backend PID case.
- Avoid passing a NULL type description to `printf`.

## Validation

- `git diff --check`