### PR TITLE
Fix plisql runtime: PACKAGE_DATUM type recursion and speculative check

### DIFF
--- a/src/pl/plisql/src/pl_exec.c
+++ b/src/pl/plisql/src/pl_exec.c
@@ -6074,7 +6074,7 @@ plisql_exec_get_datum_type(PLiSQL_execstate * estate,
 		case PLISQL_DTYPE_PACKAGE_DATUM:
 			{
 				datum = plisql_get_datum(estate, datum);
-				plisql_exec_get_datum_type(estate, datum);
+				typeid = plisql_exec_get_datum_type(estate, datum);
 				break;
 			}
 
@@ -7054,7 +7054,7 @@ plisql_param_fetch(ParamListInfo params,
 	 * If the access is speculative, we prefer to return no data rather than
 	 * to fail in exec_eval_datum().  Check the likely failure cases.
 	 */
-	else if (speculative)
+	if (speculative)
 	{
 		switch (datum->dtype)
 		{


### PR DESCRIPTION
## Summary

Fixes #1660.

1. **`plisql_exec_get_datum_type`** (`src/pl/plisql/src/pl_exec.c:6074`): the `PACKAGE_DATUM` case discarded the recursive result, so package variables returned `InvalidOid`. `exec_stmt_foreach_a` then misreported "must be of an array type" for `FOREACH pkg.v IN ARRAY ... SLICE`, and the exported API returned the wrong type. Now `typeid = plisql_exec_get_datum_type(...)` (matching the `type_info` and `exec_eval_datum` variants).

2. **`plisql_param_fetch`** (`pl_exec.c:7045`): `else if (speculative)` became `if (speculative)`, so package datums also run the speculative safety check like upstream plpgsql — an unassigned package record used as a query parameter now returns a dummy NULL at plan time instead of raising "record is not yet assigned".

## Test plan

- `make -C src/pl/plisql/src pl_exec.o` compiles cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of package-defined data types so they resolve consistently in all applicable contexts.
  * Strengthened validation of speculative parameters, ensuring safety checks are performed even when parameters are otherwise unused.
  * These changes improve reliability and consistency when working with packaged procedures and parameter declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->