### PR TITLE
Fix MERGE cross-partition handling, ON-clause guard, and NULL hooks

### DIFF
--- a/contrib/ivorysql_ora/src/merge/ora_merge.c
+++ b/contrib/ivorysql_ora/src/merge/ora_merge.c
@@ -330,6 +330,11 @@ lmerge_matched:
 										 newslot, mtstate->canSetTag, &updateCxt);
 				if (result == TM_Ok)
 				{
+					if (updateCxt.crossPartUpdate)
+					{
+						mtstate->mt_merge_updated += 1;
+						goto out;
+					}
 					/* Fire row-level after update trigger */
 					ExecUpdateEpilogue(context, &updateCxt, resultRelInfo,
 										 tupleid, NULL, newslot);

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -787,7 +787,8 @@ transformColumnRefInternal(ParseState *pstate, ColumnRef *cref, bool missing_ok)
 				}
 
 				colname = strVal(field2);
-				set_merge_on_attrno(pstate, colname);
+				if (nsitem == pstate->p_target_nsitem)
+					set_merge_on_attrno(pstate, colname);
 
 				/* Try to identify as a column of the nsitem */
 				node = scanNSItemForColumn(pstate, nsitem, levels_up, colname,
@@ -855,7 +856,8 @@ transformColumnRefInternal(ParseState *pstate, ColumnRef *cref, bool missing_ok)
 				}
 
 				colname = strVal(field3);
-				set_merge_on_attrno(pstate, colname);
+				if (nsitem == pstate->p_target_nsitem)
+					set_merge_on_attrno(pstate, colname);
 
 				/* Try to identify as a column of the nsitem */
 				node = scanNSItemForColumn(pstate, nsitem, levels_up, colname,
@@ -935,7 +937,8 @@ transformColumnRefInternal(ParseState *pstate, ColumnRef *cref, bool missing_ok)
 				}
 
 				colname = strVal(field4);
-				set_merge_on_attrno(pstate, colname);
+				if (nsitem == pstate->p_target_nsitem)
+					set_merge_on_attrno(pstate, colname);
 
 				/* Try to identify as a column of the nsitem */
 				node = scanNSItemForColumn(pstate, nsitem, levels_up, colname,

--- a/src/backend/utils/misc/ivy_guc.c
+++ b/src/backend/utils/misc/ivy_guc.c
@@ -518,8 +518,10 @@ assign_compatible_mode(int newval, void *extra)
 			sql_raw_parser = ora_raw_parser;
 
 
-			pg_transform_merge_stmt_hook = ora_transform_merge_stmt_hook;
-			pg_exec_merge_matched_hook = ora_exec_merge_matched_hook;
+			pg_transform_merge_stmt_hook = ora_transform_merge_stmt_hook ?
+				ora_transform_merge_stmt_hook : transformMergeStmt;
+			pg_exec_merge_matched_hook = ora_exec_merge_matched_hook ?
+				ora_exec_merge_matched_hook : ExecMergeMatched;
 
 			assign_search_path(NULL, NULL);
 		}


### PR DESCRIPTION
## Summary

Fixes #1662.

1. **MERGE cross-partition UPDATE** (`contrib/ivorysql_ora/src/merge/ora_merge.c`): the Oracle `IvyExecMergeMatched` UPDATE branch now checks `updateCxt.crossPartUpdate` (as upstream `nodeModifyTable.c` does) and jumps to `out` — skipping the AFTER UPDATE trigger, index/WCO work, and the paired DELETE that would otherwise target the wrong partition.

2. **ON-clause column guard** (`src/backend/parser/parse_expr.c`): the three qualified-column-reference sites now call `set_merge_on_attrno` only when the reference targets the merge target table, so `MERGE ... ON (s.id = t.code)` no longer wrongly rejects `UPDATE SET id ...` when the target also has an `id` column.

3. **NULL merge hooks** (`src/backend/utils/misc/ivy_guc.c`): the oracle branch falls back to `transformMergeStmt` / `ExecMergeMatched` when `ivorysql_ora` is not loaded, so MERGE in oracle mode cannot crash on a NULL hook.

## Test plan

- All three translation units compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MERGE behavior for updates that move rows across partitions.
  * Corrected MERGE column tracking for qualified references to the target table.
  * Added safer fallback behavior when Oracle-compatible MERGE handlers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->