### PR TITLE
Use text semantics in ora_btree_gist varchar2 opclass; fix q'…' flag

### DIFF
--- a/contrib/ora_btree_gist/btree_varcharchar.c
+++ b/contrib/ora_btree_gist/btree_varcharchar.c
@@ -101,68 +101,6 @@ static gbtree_vinfo tinfo =
 	NULL
 };
 
-/* bpchar needs its own comparison rules */
-
-static bool
-gbt_varcharchargt(const void *a, const void *b, Oid collation, FmgrInfo *flinfo)
-{
-	(void) flinfo;		/* not used */
-	return DatumGetBool(DirectFunctionCall2Coll(bpchargt,
-												collation,
-												PointerGetDatum(a),
-												PointerGetDatum(b)));
-}
-
-static bool
-gbt_varcharcharge(const void *a, const void *b, Oid collation, FmgrInfo *flinfo)
-{
-	(void) flinfo;		/* not used */
-	return DatumGetBool(DirectFunctionCall2Coll(bpcharge,
-												collation,
-												PointerGetDatum(a),
-												PointerGetDatum(b)));
-}
-
-static bool
-gbt_varcharchareq(const void *a, const void *b, Oid collation, FmgrInfo *flinfo)
-{
-	(void) flinfo;		/* not used */
-	return DatumGetBool(DirectFunctionCall2Coll(bpchareq,
-												collation,
-												PointerGetDatum(a),
-												PointerGetDatum(b)));
-}
-
-static bool
-gbt_varcharcharle(const void *a, const void *b, Oid collation, FmgrInfo *flinfo)
-{
-	(void) flinfo;		/* not used */
-	return DatumGetBool(DirectFunctionCall2Coll(bpcharle,
-												collation,
-												PointerGetDatum(a),
-												PointerGetDatum(b)));
-}
-
-static bool
-gbt_varcharcharlt(const void *a, const void *b, Oid collation, FmgrInfo *flinfo)
-{
-	(void) flinfo;		/* not used */
-	return DatumGetBool(DirectFunctionCall2Coll(bpcharlt,
-												collation,
-												PointerGetDatum(a),
-												PointerGetDatum(b)));
-}
-
-static int32
-gbt_varcharcharcmp(const void *a, const void *b, Oid collation, FmgrInfo *flinfo)
-{
-	(void) flinfo;		/* not used */
-	return DatumGetInt32(DirectFunctionCall2Coll(bpcharcmp,
-												 collation,
-												 PointerGetDatum(a),
-												 PointerGetDatum(b)));
-}
-
 static gbtree_vinfo bptinfo =
 {
 	gbt_t_text,

--- a/contrib/ora_btree_gist/btree_varcharchar.c
+++ b/contrib/ora_btree_gist/btree_varcharchar.c
@@ -165,15 +165,15 @@ gbt_varcharcharcmp(const void *a, const void *b, Oid collation, FmgrInfo *flinfo
 
 static gbtree_vinfo bptinfo =
 {
-	gbt_t_bpchar,
+	gbt_t_text,
 	0,
 	false,
-	gbt_varcharchargt,
-	gbt_varcharcharge,
-	gbt_varcharchareq,
-	gbt_varcharcharle,
-	gbt_varcharcharlt,
-	gbt_varcharcharcmp,
+	gbt_textgt,
+	gbt_textge,
+	gbt_texteq,
+	gbt_textle,
+	gbt_textlt,
+	gbt_textcmp,
 	NULL
 };
 

--- a/src/oracle_fe_utils/ora_psqlscan.l
+++ b/src/oracle_fe_utils/ora_psqlscan.l
@@ -602,7 +602,10 @@ other			.
 								if (cur_str[fir_len + i] == cur_str[last_len - tmp + i])
 									flag = true;
 								else
+								{
+									flag = false;
 									break;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
## Summary

Fixes #1666.

1. **`ora_btree_gist/btree_varcharchar.c` (high)**: `bptinfo` used the `gbt_varcharchargt/ge/eq/le/lt/cmp` (bpchar, padded) comparisons although the opclass only serves `oravarcharchar`/`oravarcharbyte`, whose operators (`varstr_cmp`) and the GIN side are non-padded. A GiST index on a varchar2 column could return wrong rows for `WHERE c = 'a '`. The existing `gbt_text*` wrappers are now used (existing indexes need a REINDEX).

2. **`src/oracle_fe_utils/ora_psqlscan.l`**: the multi-byte q'…' delimiter check left `flag` true when a later byte mismatched (only the first byte matched), closing the quote early and truncating the statement. `flag` is now cleared on mismatch.

## Test plan

- Both modules compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and consistency for variable-length character comparisons.
  * Fixed multibyte quoted-escape validation so mismatched characters are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->