### PR TITLE
Fix numtodsinterval error message and ora_ascii multibyte handling

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -60,6 +60,8 @@ cleansql:
 
 # REGRESS_OPTS mainly used for installcheck or debug.
 #REGRESS_OPTS = --port=1521
+# ora_ascii includes a UTF-8 code-point regression test.
+ORACLE_REGRESS_OPTS += --encoding=UTF8
 ORA_REGRESS = \
 	ora_character \
 	ora_datetime \
@@ -103,6 +105,5 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
-
 
 

--- a/contrib/ivorysql_ora/expected/ora_ascii.out
+++ b/contrib/ivorysql_ora/expected/ora_ascii.out
@@ -32,6 +32,13 @@ select ascii('xyz') from dual;
    120
 (1 row)
 
+-- UTF-8 multibyte characters return their Unicode code point, not the first byte.
+select ascii('日') from dual;
+ ascii 
+-------
+ 26085
+(1 row)
+
 select ascii(to_char('2026-01-01'::date,'DD-MON-YYYY HH24:MI:SS')) from dual;
  ascii 
 -------
@@ -55,4 +62,3 @@ select ascii('') is null from dual;
 ----------
  t
 (1 row)
-

--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -464,6 +464,9 @@ select * from datetest;
 (4 rows)
 
 drop table datetest;
+-- The invalid-unit error must identify NUMTODSINTERVAL, not NUMTOYMINTERVAL.
+select numtodsinterval(1, 'xxx');
+ERROR:  illegal argument for function numtodsinterval
 --NUMTOYMINTERVAL
 create table datetest (aa interval year(3) to month);
 insert into datetest values (NUMTOYMINTERVAL(123,'year'));

--- a/contrib/ivorysql_ora/sql/ora_ascii.sql
+++ b/contrib/ivorysql_ora/sql/ora_ascii.sql
@@ -12,6 +12,9 @@ select ascii('abc') from dual;
 
 select ascii('xyz') from dual;
 
+-- UTF-8 multibyte characters return their Unicode code point, not the first byte.
+select ascii('日') from dual;
+
 select ascii(to_char('2026-01-01'::date,'DD-MON-YYYY HH24:MI:SS')) from dual;
 
 select ascii(to_char('2026-01-11 01:02:03.00'::timestamp,'DD-MON-YYYY HH24:MI:SS.FF6')) from dual;

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -257,6 +257,9 @@ insert into datetest values (NUMTODSINTERVAL(678,'second'));
 select * from datetest;
 drop table datetest;
 
+-- The invalid-unit error must identify NUMTODSINTERVAL, not NUMTOYMINTERVAL.
+select numtodsinterval(1, 'xxx');
+
 --NUMTOYMINTERVAL
 create table datetest (aa interval year(3) to month);
 

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -2343,6 +2343,7 @@ ora_to_single_byte(PG_FUNCTION_ARGS)
  */
 extern Datum binary_float_out(PG_FUNCTION_ARGS);
 extern Datum binary_double_out(PG_FUNCTION_ARGS);
+extern Datum ascii(PG_FUNCTION_ARGS);
 
 Datum
 ora_ascii(PG_FUNCTION_ARGS)
@@ -2378,10 +2379,16 @@ ora_ascii(PG_FUNCTION_ARGS)
         }
 		case  ORACHARCHAROID: 
 		case  ORAVARCHARCHAROID : {
-			/* char, varchar, varchar2 */
+			/* char, varchar, varchar2: empty string is NULL (Oracle), else
+			 * return the code point of the first character */
 			text *txt = PG_GETARG_TEXT_PP(0);
-            str = text_to_cstring(txt);
-            break;
+
+			if (VARSIZE_ANY_EXHDR(txt) == 0)
+			{
+				fcinfo->isnull = true;
+				PG_RETURN_VOID();
+			}
+			PG_RETURN_DATUM(DirectFunctionCall1(ascii, PG_GETARG_DATUM(0)));
 		}
 		case ORADATEOID: {
 			Timestamp	timestamp = PG_GETARG_TIMESTAMP(0);

--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -1554,7 +1554,7 @@ numtodsinterval(PG_FUNCTION_ARGS)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("illegal argument for function numtoyminterval")));
+				 errmsg("illegal argument for function numtodsinterval")));
 	}
 
 	result = (Interval *) palloc(sizeof(Interval));


### PR DESCRIPTION
## Summary

Fixes #1668.

1. **`numtodsinterval` error message** (`contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c:1557`): the invalid-unit error said "numtoyminterval"; now "numtodsinterval".

2. **`ora_ascii` multibyte handling** (same module, `character_datatype_functions.c`): the `oracharchar`/`oravarcharchar` cases returned the leading byte of a multibyte character (`ASCII('日')` → 230). They now keep the Oracle empty-string-is-NULL behavior and otherwise delegate to the core `ascii()`, which decodes the code point (`ASCII('日')` → 26085).

## Test plan

- Both translation units compile cleanly.
- Manual: `SELECT ascii('日')` in a UTF-8 database → 26085; `ascii('')` → NULL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Oracle-compatible `LENGTHC` support for counting Unicode characters, including normalization and handling for supported character data types.
  - Updated `ASCII` behavior for character input to return Unicode code points, including multibyte characters; empty strings return `NULL`.

- **Bug Fixes**
  - Corrected `NUMTODSINTERVAL` error messages so invalid units identify the correct function.

- **Tests**
  - Added coverage for Unicode `ASCII` results, empty-string behavior, `LENGTHC`, and invalid datetime interval units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->