### PR TITLE
Fix parser: case-sensitive rowid checks, parse_func UAF, isalpha UB

### DIFF
--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -2790,7 +2790,7 @@ alter_table_cmd:
 					n->def = $2;
 					n->missing_ok = false;
 					colDef = castNode(ColumnDef, $2);
-					if (strcmp(colDef->colname, "rowid") == 0)
+					if (pg_strcasecmp(colDef->colname, "rowid") == 0)
 						elog(ERROR, "column name \"%s\" conflicts with a system column name", colDef->colname);
 					$$ = (Node *) n;
 				}
@@ -2803,7 +2803,7 @@ alter_table_cmd:
 				n->def = $3;
 				n->missing_ok = false;
 				colDef = castNode(ColumnDef, $3);
-					if (strcmp(colDef->colname, "rowid") == 0)
+					if (pg_strcasecmp(colDef->colname, "rowid") == 0)
 						elog(ERROR, "column name \"%s\" conflicts with a system column name", colDef->colname);
 				$$ = (Node *)n;
 				}
@@ -2817,7 +2817,7 @@ alter_table_cmd:
 					n->def = $5;
 					n->missing_ok = true;
 					colDef = castNode(ColumnDef, $5);
-					if (strcmp(colDef->colname, "rowid") == 0)
+					if (pg_strcasecmp(colDef->colname, "rowid") == 0)
 						elog(ERROR, "column name \"%s\" conflicts with a system column name", colDef->colname);
 					$$ = (Node *) n;
 				}
@@ -2831,7 +2831,7 @@ alter_table_cmd:
 					n->def = $3;
 					n->missing_ok = false;
 					colDef = castNode(ColumnDef, $3);
-					if (strcmp(colDef->colname, "rowid") == 0)
+					if (pg_strcasecmp(colDef->colname, "rowid") == 0)
 						elog(ERROR, "column name \"%s\" conflicts with a system column name", colDef->colname);
 					$$ = (Node *) n;
 				}
@@ -2845,7 +2845,7 @@ alter_table_cmd:
 					n->def = $6;
 					n->missing_ok = true;
 					colDef = castNode(ColumnDef, $6);
-					if (strcmp(colDef->colname, "rowid") == 0)
+					if (pg_strcasecmp(colDef->colname, "rowid") == 0)
 						elog(ERROR, "column name \"%s\" conflicts with a system column name", colDef->colname);
 					$$ = (Node *) n;
 				}
@@ -3058,7 +3058,7 @@ alter_table_cmd:
 					n->name = $5;
 					n->behavior = $6;
 					n->missing_ok = true;
-					if (strcmp(n->name, "rowid") == 0)
+					if (pg_strcasecmp(n->name, "rowid") == 0)
 						elog(ERROR, "cannot drop system column \"%s\"", n->name);
 					$$ = (Node *) n;
 				}
@@ -3071,7 +3071,7 @@ alter_table_cmd:
 					n->name = $3;
 					n->behavior = $4;
 					n->missing_ok = false;
-					if (strcmp(n->name, "rowid") == 0)
+					if (pg_strcasecmp(n->name, "rowid") == 0)
 						elog(ERROR, "cannot drop system column \"%s\"", n->name);
 					$$ = (Node *) n;
 				}

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -567,8 +567,6 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 					(procstruct->prokind == PROKIND_FUNCTION ||
 					 procstruct->prokind == PROKIND_PROCEDURE))
 				{
-					ReleaseSysCache(tup);
-
 					ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
 							 errmsg("%s %s is in invalid state",

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -304,7 +304,7 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString)
 				{
 					ColumnDef  *col = (ColumnDef *) element;
 
-					if (compatible_db == ORA_PARSER && strcmp(col->colname, "rowid") == 0)
+					if (compatible_db == ORA_PARSER && pg_strcasecmp(col->colname, "rowid") == 0)
 						elog(ERROR, "column name \"%s\" conflicts with a system column name", col->colname);
 					else
 						transformColumnDefinition(&cxt, (ColumnDef *) element);

--- a/src/port/identifier_alpha_transfor.c
+++ b/src/port/identifier_alpha_transfor.c
@@ -109,7 +109,7 @@ is_all_lower(const char *src, int len)
 
 	for (i = 0; i < len; i++)
 	{
-		if (isalpha(*s) && isupper(*s))
+		if (isalpha((unsigned char) *s) && isupper((unsigned char) *s))
 			return false;
 		s++;
 	}
@@ -130,7 +130,7 @@ is_all_upper(const char *src, int len)
 
 	for (i = 0; i < len; i++)
 	{
-		if (isalpha(*s) && islower(*s))
+		if (isalpha((unsigned char) *s) && islower((unsigned char) *s))
 			return false;
 		s++;
 	}


### PR DESCRIPTION
## Summary

Fixes #1670.

1. **rowid checks case-sensitive** (8 sites in `parse_utilcmd.c` + `ora_gram.y`): now `pg_strcasecmp`, matching the sibling ROWNUM/ROWID checks in `parse_target.c`/`parse_relation.c`. Quoted uppercase `"ROWID"` could previously bypass the system-column protection in `CREATE TABLE`/`ALTER TABLE ADD`/`DROP COLUMN`.
2. **`parse_func.c` use-after-release**: removed the `ReleaseSysCache(tup)` before the invalid-state `ereport(ERROR)` whose `errmsg` reads `procstruct` (the error path does not return; the later release is kept).
3. **`identifier_alpha_transfor.c`**: `isalpha`/`isupper`/`islower` now get `(unsigned char)` args (negative `char` values are UB with multibyte identifiers).

## Test plan

- All four translation units compile cleanly (ora_gram.y rebuilt with bison).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Oracle-compatible `ROWID` column validation now recognizes all capitalization variants when adding or removing columns.
  - Prevented inconsistent handling of `ROWID` conflicts across supported table-alteration operations.
  - Improved case detection for identifiers containing non-ASCII characters, reducing the risk of incorrect parsing or classification.
  - Streamlined error handling for invalid PL/iSQL routine definitions without changing reported errors or validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->