### PR TITLE
Guard IS_UPDATEXML against NULL args and missing hook

### DIFF
--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -4738,6 +4738,11 @@ ExecEvalXmlExpr(ExprState *state, ExprEvalStep *op)
 				ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 						errmsg("invalid number of arguments")));
 
+			/* resnull is already true; bail out on any NULL argument */
+			for (int i = 0; i < list_length(xexpr->args); i++)
+				if (op->d.xmlexpr.argnull[i])
+					return;
+
 			for (int i = 0; i < list_length(xexpr->args); i++)
 			{
 				values = lappend(values, DatumGetPointer(argvalue[i]));
@@ -4746,10 +4751,12 @@ ExecEvalXmlExpr(ExprState *state, ExprEvalStep *op)
 			if (values != NIL)
 			{
 				if (ora_updatexml_hook && compatible_db == ORA_PARSER)
+				{
 					*op->resvalue = PointerGetDatum((*ora_updatexml_hook)(values));
+					*op->resnull = false;
+				}
 				else
-					*op->resvalue = (Datum) 0;
-				*op->resnull = false;
+					*op->resnull = true;
 			}
 		}
 		break;


### PR DESCRIPTION
## Summary

Fixes #1672. In the `IS_UPDATEXML` case of `src/backend/executor/execExprInterp.c`:

1. **NULL arguments**: the code now bails out (with `resnull` already true) when any argument is NULL, instead of converting garbage `argvalue` entries into pointers and crashing in the `updatexml()` hook. This matches the sibling IS_XMLSERIALIZE / IS_DOCUMENT cases.
2. **Missing hook**: when `ora_updatexml_hook` is NULL or not in Oracle mode, the result is now NULL instead of a non-null `Datum 0` that downstream code would treat as a text pointer.

## Test plan

- `make -C src/backend/executor execExprInterp.o` compiles cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `UPDATEXML` behavior so it returns SQL `NULL` when any input is `NULL`.
  * Ensured `UPDATEXML` returns `NULL` when Oracle compatibility support is unavailable.
  * Correctly preserves non-null results when compatibility processing succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->