### PR TITLE
Fix oracle port probe and dependent-oids writeback

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16298,6 +16298,10 @@ RememberAllDependentForRebuilding(AlteredTableInfo *tab, AlterTableType subtype,
 
 	systable_endscan(scan);
 	table_close(depRel, NoLock);
+
+	/* write back the (possibly repalloc'd) array to the caller */
+	if (FuncPkgDepend)
+		*dependentFuncPkg = dependentFuncPkgOids;
 }
 
 /*

--- a/src/oracle_test/regress/pg_regress.c
+++ b/src/oracle_test/regress/pg_regress.c
@@ -2559,6 +2559,7 @@ regression_main(int argc, char *argv[],
 		
 		/* BEGIN - SQL oracle_test */
 		oraPort = port + 1;
+		sprintf(portstr, "%d", oraPort);	/* probe the oracle port, not the main one */
 
 		for (i = 0; i < 16; i++)
 		{


### PR DESCRIPTION
## Summary

Fixes #1674.

1. **`pg_regress.c` oracle port probe**: the first `PQpingParams` still pinged the main port (which was already known free), so the oracle port was never actually probed, a spurious "apparently in use" was printed on every oracle-mode run, and a real conflict on `port + 1` was missed. The probe now starts at the oracle port.

2. **`tablecmds.c` `RememberAllDependentForRebuilding`**: the (possibly `repalloc`'d) pending-oids array is now written back to the caller via `*dependentFuncPkg`. With more than the initial 128 dependent functions/packages in oracle mode, `ATExecAlterColumnType` previously read and `pfree`'d the stale original pointer (use-after-free / double free).

## Test plan

- Both translation units compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency handling so updated dependency information is correctly returned after scanning.
  * Fixed Oracle-compatible port detection to use the configured Oracle port instead of the main server port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->