### PR TITLE
Index p_argtypeNames past OUT/TABLE positions and free it

### DIFF
--- a/src/backend/utils/adt/regproc.c
+++ b/src/backend/utils/adt/regproc.c
@@ -39,6 +39,7 @@
 #include "parser/parse_type.h"
 #include "parser/scansup.h"
 #include "utils/acl.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/regproc.h"
@@ -346,7 +347,9 @@ format_procedure_extended(Oid procedure_oid, uint16 flags)
 		char	   *proname = NameStr(procform->proname);
 		int			nargs = procform->pronargs;
 		int			i;
+		int			argname_idx;
 		char	   *nspname;
+		char	   *promodes = NULL;
 		StringInfoData buf;
 		char		**p_argtypeNames = NULL;
 
@@ -371,15 +374,36 @@ format_procedure_extended(Oid procedure_oid, uint16 flags)
 			get_func_typename_info(proctup,
 						&p_argtypeNames, NULL);
 
-		for (i = 0; i < nargs; i++)
+		/* proargmodes marks OUT/TABLE positions in p_argtypeNames */
+		if (p_argtypeNames != NULL)
+		{
+			Datum		proargmodes;
+			bool		isnull;
+
+			proargmodes = SysCacheGetAttr(PROCOID, proctup,
+										  Anum_pg_proc_proargmodes,
+										  &isnull);
+			if (!isnull)
+				promodes = (char *) ARR_DATA_PTR(DatumGetArrayTypeP(proargmodes));
+		}
+
+		for (i = 0, argname_idx = 0; i < nargs; i++, argname_idx++)
 		{
 			Oid			thisargtype = procform->proargtypes.values[i];
 
+			/* skip OUT/TABLE positions in p_argtypeNames */
+			if (promodes != NULL)
+			{
+				while (promodes[argname_idx] == FUNC_PARAM_OUT ||
+					   promodes[argname_idx] == FUNC_PARAM_TABLE)
+					argname_idx++;
+			}
+
 			if (i > 0)
 				appendStringInfoChar(&buf, ',');
-			if (p_argtypeNames != NULL && strcmp(p_argtypeNames[i], "") != 0)
+			if (p_argtypeNames != NULL && strcmp(p_argtypeNames[argname_idx], "") != 0)
 			{
-				TypeName *tname = stringToNode(p_argtypeNames[i]);
+				TypeName *tname = stringToNode(p_argtypeNames[argname_idx]);
 
 				appendStringInfoString(&buf,
 								   (flags & FORMAT_PROC_FORCE_QUALIFY) != 0 ?
@@ -398,6 +422,8 @@ format_procedure_extended(Oid procedure_oid, uint16 flags)
 
 		result = buf.data;
 
+		if (p_argtypeNames != NULL)
+			pfree(p_argtypeNames);
 		ReleaseSysCache(proctup);
 	}
 	else if ((flags & FORMAT_PROC_INVALID_AS_NULL) != 0)
@@ -429,6 +455,8 @@ format_procedure_parts(Oid procedure_oid, List **objnames, List **objargs,
 	Form_pg_proc procform;
 	int			nargs;
 	int			i;
+	int			argname_idx;
+	char	   *promodes = NULL;
 	char		**p_argtypeNames = NULL;
 
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(procedure_oid));
@@ -449,15 +477,37 @@ format_procedure_parts(Oid procedure_oid, List **objnames, List **objargs,
 	if (ORA_PARSER == compatible_db)
 		get_func_typename_info(proctup,
 						&p_argtypeNames, NULL);
-	for (i = 0; i < nargs; i++)
+
+	/* proargmodes marks OUT/TABLE positions in p_argtypeNames */
+	if (p_argtypeNames != NULL)
+	{
+		Datum		proargmodes;
+		bool		isnull;
+
+		proargmodes = SysCacheGetAttr(PROCOID, proctup,
+									  Anum_pg_proc_proargmodes,
+									  &isnull);
+		if (!isnull)
+			promodes = (char *) ARR_DATA_PTR(DatumGetArrayTypeP(proargmodes));
+	}
+
+	for (i = 0, argname_idx = 0; i < nargs; i++, argname_idx++)
 	{
 		Oid			thisargtype = procform->proargtypes.values[i];
 
-		if (p_argtypeNames != NULL && strcmp(p_argtypeNames[i], "") != 0)
+		/* skip OUT/TABLE positions in p_argtypeNames */
+		if (promodes != NULL)
+		{
+			while (promodes[argname_idx] == FUNC_PARAM_OUT ||
+				   promodes[argname_idx] == FUNC_PARAM_TABLE)
+				argname_idx++;
+		}
+
+		if (p_argtypeNames != NULL && strcmp(p_argtypeNames[argname_idx], "") != 0)
 		{
 			TypeName	*tname;
 
-			tname = (TypeName *) stringToNode(p_argtypeNames[i]);
+			tname = (TypeName *) stringToNode(p_argtypeNames[argname_idx]);
 			*objargs = lappend(*objargs, TypeNameToQuoteString(tname));
 			pfree(tname);
 		}
@@ -465,6 +515,8 @@ format_procedure_parts(Oid procedure_oid, List **objnames, List **objargs,
 			*objargs = lappend(*objargs, format_type_be_qualified(thisargtype));
 	}
 
+	if (p_argtypeNames != NULL)
+		pfree(p_argtypeNames);
 	ReleaseSysCache(proctup);
 }
 

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -14961,11 +14961,24 @@ pg_get_function_arg_reference_typerowtype(PG_FUNCTION_ARGS)
 		int			numargs = form_proc->pronargs;
 		char	  **p_argtypeNames = NULL;
 		char	   *rettypename = NULL;
+		char	   *promodes = NULL;
 		int			nth_arg;
 		Datum		values[NUM_RETURN_COLUMNS];
 		bool		nulls[NUM_RETURN_COLUMNS];
 
 		get_func_typename_info(proc_tuple, &p_argtypeNames, &rettypename);
+
+		/* proargmodes marks OUT/TABLE positions in p_argtypeNames */
+		if (p_argtypeNames != NULL)
+		{
+			Datum		proargmodes;
+			bool		isnull;
+
+			proargmodes = heap_getattr(proc_tuple, Anum_pg_proc_proargmodes,
+									   proc_rel->rd_att, &isnull);
+			if (!isnull)
+				promodes = (char *) ARR_DATA_PTR(DatumGetArrayTypeP(proargmodes));
+		}
 
 		if (p_argtypeNames == NULL && rettypename == NULL)
 			continue;
@@ -14979,13 +14992,23 @@ pg_get_function_arg_reference_typerowtype(PG_FUNCTION_ARGS)
 
 		if (p_argtypeNames != NULL)
 		{
-			for (nth_arg = 0; nth_arg < numargs; nth_arg++)
+			int		argname_idx = 0;
+
+			for (nth_arg = 0; nth_arg < numargs; nth_arg++, argname_idx++)
 			{
 				MemSet(nulls, 0, sizeof(nulls));
 
-				if (strcmp(p_argtypeNames[nth_arg], "") != 0)
+				/* skip OUT/TABLE positions in p_argtypeNames */
+				if (promodes != NULL)
+				{
+					while (promodes[argname_idx] == FUNC_PARAM_OUT ||
+						   promodes[argname_idx] == FUNC_PARAM_TABLE)
+						argname_idx++;
+				}
+
+				if (strcmp(p_argtypeNames[argname_idx], "") != 0)
 					pg_get_function_arg_reference_typerowtype_internal(&tupstore, tupdesc,
-																	   p_argtypeNames[nth_arg], nth_arg + 1,
+																	   p_argtypeNames[argname_idx], nth_arg + 1,
 																	   form_proc->oid, values, nulls);
 			}
 


### PR DESCRIPTION
## Summary

Fixes #1678. `get_func_typename_info` builds `p_argtypeNames` over `proallargtypes` (including OUT parameters), but three call sites indexed it by the input-arg count:

- `format_procedure_extended` (`regproc.c`)
- `regprocedureout` (`regproc.c`)
- the `%TYPE`/`%ROWTYPE` helper in `ruleutils.c`

With `CREATE FUNCTION f(OUT a INT, b INT)` in Oracle mode, `p_argtypeNames[0]` (the OUT type name) was printed for the input parameter `b`. The loops now advance an `argname_idx` past `FUNC_PARAM_OUT`/`FUNC_PARAM_TABLE` positions via `proargmodes` (same approach as `repl_func_real_argtype`). The two `regproc` paths also now `pfree(p_argtypeNames)`.

## Test plan

- Both translation units compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected procedure and function signature formatting when definitions include `OUT` or `TABLE` arguments.
  - Fixed type and row-type references so they consistently match the correct input arguments.
  - Improved generated metadata and displayed definitions for routines combining input, output, and table parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->