### PR TITLE
Fix GUC descriptions, error message name, and socket connmode matching

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1221,7 +1221,7 @@ PostmasterMain(int argc, char *argv[])
 			ereport(FATAL,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("invalid list syntax in parameter \"%s\"",
-							"listen_addresses")));
+							"ivorysql.listen_addresses")));
 		}
 
 		foreach(l, elemlist)

--- a/src/backend/tcop/backend_startup.c
+++ b/src/backend/tcop/backend_startup.c
@@ -241,15 +241,24 @@ BackendInitialize(ClientSocket *client_sock, CAC_state cac)
 	{
 		char	PostPortNumberStr[32];
 		char	OraPortNumberStr[32];
+		size_t	slen = strlen(service);
+		size_t	plen;
+		size_t	olen;
 
 		snprintf(PostPortNumberStr, sizeof(PostPortNumberStr), "%d", PostPortNumber);
 		snprintf(OraPortNumberStr, sizeof(OraPortNumberStr), "%d", OraPortNumber);
+		plen = strlen(PostPortNumberStr);
+		olen = strlen(OraPortNumberStr);
 
-		if (strstr(service, PostPortNumberStr) != NULL)
+		/* Socket names end with the port number; compare the suffix so that
+		 * e.g. an oracle port 15432 is not matched by the PG port 5432 */
+		if (slen >= plen &&
+			strcmp(service + slen - plen, PostPortNumberStr) == 0)
 		{
 			port->connmode = 'p';
 		}
-		else if (strstr(service, OraPortNumberStr) != NULL)
+		else if (slen >= olen &&
+				 strcmp(service + slen - olen, OraPortNumberStr) == 0)
 		{
 			port->connmode = 'o';
 		}

--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1526,7 +1526,7 @@
 },
 
 { name => 'ivorysql.listen_addresses', type => 'string', context => 'PGC_POSTMASTER', group => 'CONN_AUTH_SETTINGS',
-  short_desc => 'Sets the shell command that will be called to archive a WAL file.',
+  short_desc => 'Sets the host name or IP address(es) the server will listen to for Oracle connections.',
   flags => 'GUC_LIST_INPUT',
   variable => 'OraListenAddresses',
   boot_val => '"localhost"',
@@ -2437,7 +2437,7 @@
 },
 
 { name => 'nls_timestamp_tz_format', type => 'string', context => 'PGC_USERSET', group => 'COMPAT_ORACLE_OPTIONS',
-  short_desc => 'Sets the shell command that will be called to archive a WAL file.',
+  short_desc => 'Sets the default time zone format for TIMESTAMP WITH TIME ZONE values.',
   long_desc => 'An empty string means use "archive_library".',
   flags => 'GUC_NOT_IN_SAMPLE',
   variable => 'nls_timestamp_tz_format',


### PR DESCRIPTION
## Summary

Fixes #1680.

1. **`guc_parameters.dat`**: `ivorysql.listen_addresses` had the `archive_command` description; `nls_timestamp_tz_format` had the same copy-paste error and now gets a proper NLS description.
2. **`postmaster.c`**: the `ivorysql.listen_addresses` syntax-error FATAL now names `"ivorysql.listen_addresses"`.
3. **`backend_startup.c`**: Unix-socket connection-mode classification now compares the socket-path suffix (socket names always end with the port) instead of `strstr`, so an Oracle socket like `...15432` is no longer misclassified as the PG listener when the PG port is 5432.

## Test plan

- Both translation units compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the error message for invalid Oracle-mode listen-address settings.
  * Improved service-name connection detection to prevent incorrect matches when port numbers are embedded within longer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->