### PR TITLE
Fix pg_dump package ACLs, native-PG SET, and initdb dbmode case

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -3289,7 +3289,7 @@ initialize_data_directory(void)
 	fputs(_("performing post-bootstrap initialization ... "), stdout);
 	fflush(stdout);
 
-	if (strcmp(dbmode, "pg") == 0)
+	if (pg_strcasecmp(dbmode, "pg") == 0)
 	{
 		initPQExpBuffer(&cmd);
 		printfPQExpBuffer(&cmd, "\"%s\" %s %s template1 >%s",

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1001,7 +1001,21 @@ main(int argc, char **argv)
 	ConnectDatabaseAhx(fout, &dopt.cparams, false);
 	getDbCompatibleMode(((ArchiveHandle *) fout)->connection);
 	setup_connection(fout, dumpencoding, dumpsnapshot, use_role);
-	ExecuteSqlStatement(fout, "set ivorysql.identifier_case_switch = normal;");
+	/* Only set the IvorySQL-specific GUC when it exists (native-PG sources) */
+	{
+		PGresult   *res_guc;
+		bool		has_guc = false;
+
+		res_guc = ExecuteSqlQuery(fout,
+								  "SELECT 1 FROM pg_catalog.pg_settings "
+								  "WHERE name = 'ivorysql.identifier_case_switch'",
+								  PGRES_TUPLES_OK);
+		has_guc = (PQntuples(res_guc) > 0);
+		PQclear(res_guc);
+
+		if (has_guc)
+			ExecuteSqlStatement(fout, "set ivorysql.identifier_case_switch = normal;");
+	}
 
 	/*
 	 * On hot standbys, never try to dump unlogged table data, since it will
@@ -7281,6 +7295,7 @@ getPackages(Archive *fout, int *numPkgs)
 			findNamespace(atooid(PQgetvalue(res, i, i_pkgnamespace)));
 		pkginfo[i].rolname = pg_strdup(PQgetvalue(res, i, i_rolname));
 		pkginfo[i].pkgacl = pg_strdup(PQgetvalue(res, i, i_pkgacl));
+		pkginfo[i].dacl.acl = pg_strdup(PQgetvalue(res, i, i_pkgacl));
 		pkginfo[i].dacl.acldefault = pg_strdup(PQgetvalue(res, i, i_acldefault));
 		pkginfo[i].dacl.privtype = 0;
 		pkginfo[i].dacl.initprivs = NULL;
@@ -7288,10 +7303,10 @@ getPackages(Archive *fout, int *numPkgs)
 		/* Decide whether we want to dump it */
 		selectDumpableObject(&(pkginfo[i].dobj), fout);
 		/* Do not try to dump ACL if no ACL exists. */
-		if (!PQgetisnull(res, i, i_pkgacl))
+		if (PQgetisnull(res, i, i_pkgacl))
 			pkginfo[i].dobj.dump &= ~DUMP_COMPONENT_ACL;
 		if (strlen(pkginfo[i].rolname) == 0)
-			pg_log_warning("WARNING: owner of package \"%s\" appears to be invalid\n",
+			pg_log_warning("owner of package \"%s\" appears to be invalid",
 					  pkginfo[i].dobj.name);
 	}
 	PQclear(res);


### PR DESCRIPTION
## Summary

Fixes #1682.

1. **Package ACLs never dumped** (`src/bin/pg_dump/pg_dump.c`): `dacl.acl` is now assigned and the ACL component is cleared only when the ACL is NULL (the condition was inverted, and the comment already said the opposite). GRANTs on Oracle packages are now preserved on restore.
2. **Unconditional SET breaks native-PG dumps**: the `SET ivorysql.identifier_case_switch = normal` is now guarded by a `pg_settings` probe (same pattern as the `relhasrowid` runtime probe), so the PG→IvorySQL upgrade path works.
3. **`initdb --dbmode=PG`**: `strcmp` → `pg_strcasecmp`, matching the other dbmode checks.
4. Warning prefix/newline duplication removed.

## Test plan

- `pg_dump.o` and `initdb.o` compile cleanly (full link is blocked locally by the known macOS `ivy_sema.c` issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization so mode selection works regardless of letter casing.
  * Enhanced `pg_dump` compatibility with native PostgreSQL databases by safely handling optional configuration settings.
  * Preserved package access-control information only when available.
  * Improved warning messages for invalid package owners, making them clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->