### PR TITLE
Match ivorysql.compatible_mode case-insensitively in functioncmds

### DIFF
--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1147,7 +1147,7 @@ compute_function_attributes(ParseState *pstate,
 			VariableSetStmt *sstmt = lfirst_node(VariableSetStmt, lc);
 
 			if (sstmt->name != NULL &&
-				strcmp(sstmt->name, "ivorysql.compatible_mode") == 0)
+				pg_strcasecmp(sstmt->name, "ivorysql.compatible_mode") == 0)
 			{
 				have_explicit = true;
 				break;


### PR DESCRIPTION
## Summary

Fixes #1684. The `have_explicit` detection for `ivorysql.compatible_mode` in `src/backend/commands/functioncmds.c` used `strcmp`; GUC names are case-insensitive, so `SET IVORYSQL.COMPATIBLE_MODE = ...` in a PG-dialect extension script escaped detection and produced a redundant duplicate `proconfig` entry. Now `pg_strcasecmp`.

## Test plan

- `make -C src/backend/commands functioncmds.o` compiles cleanly.