### PR TITLE
Only convert empty text-format parameters to NULL; fix GUC descriptions

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -2004,8 +2004,16 @@ exec_bind_message(StringInfo input_message)
 				 * add a trailing NUL which is required for the input function
 				 * call.
 				 */
+				if (numPFormats > 1)
+					pformat = pformats[paramno];
+				else if (numPFormats > 0)
+					pformat = pformats[0];
+				else
+					pformat = 0;	/* default = text */
+
 				if (compatible_db == ORA_PARSER &&
 					enable_emptystring_to_NULL &&
+					pformat == 0 &&
 					plength == 0)
 				{
 					pbuf.data = NULL;		/* keep compiler quiet */
@@ -2026,13 +2034,6 @@ exec_bind_message(StringInfo input_message)
 				pbuf.data = NULL;	/* keep compiler quiet */
 				csave = 0;
 			}
-
-			if (numPFormats > 1)
-				pformat = pformats[paramno];
-			else if (numPFormats > 0)
-				pformat = pformats[0];
-			else
-				pformat = 0;	/* default = text */
 
 			if (compatible_db == ORA_PARSER &&
 				pmode == 'o')

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1993,6 +1993,13 @@ exec_bind_message(StringInfo input_message)
 			plength = pq_getmsgint(input_message, 4);
 			isNull = (plength == -1);
 
+			if (numPFormats > 1)
+				pformat = pformats[paramno];
+			else if (numPFormats > 0)
+				pformat = pformats[0];
+			else
+				pformat = 0;	/* default = text */
+
 			if (!isNull)
 			{
 				char	   *pvalue;
@@ -2004,13 +2011,6 @@ exec_bind_message(StringInfo input_message)
 				 * add a trailing NUL which is required for the input function
 				 * call.
 				 */
-				if (numPFormats > 1)
-					pformat = pformats[paramno];
-				else if (numPFormats > 0)
-					pformat = pformats[0];
-				else
-					pformat = 0;	/* default = text */
-
 				if (compatible_db == ORA_PARSER &&
 					enable_emptystring_to_NULL &&
 					pformat == 0 &&

--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1549,7 +1549,6 @@
 
 { name => 'ivorysql.rowid_seq_cache', type => 'int', context => 'PGC_USERSET', group => 'DEVELOPER_OPTIONS',
   short_desc => 'Sets rowid Sequence cache number.',
-  long_desc => '0 disables the timeout.',
   flags => 'GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE',
   variable => 'rowid_seq_cache',
   boot_val => '20',
@@ -2412,7 +2411,7 @@
 },
 
 { name => 'nls_length_semantics', type => 'enum', context => 'PGC_USERSET', group => 'COMPAT_ORACLE_OPTIONS',
-  short_desc => 'Compatible Oracle NLS parameter for charater data type.',
+  short_desc => 'Compatible Oracle NLS parameter for character data type.',
   long_desc => 'Valid values are CHAR, BYTE.',
   flags => 'GUC_IS_NAME | GUC_NOT_IN_SAMPLE',
   variable => 'nls_length_semantics',


### PR DESCRIPTION
## Summary

Fixes #1686.

1. **`postgres.c`**: the Oracle `'' -> NULL` conversion is now guarded by `pformat == 0` (the format is computed before the check now). An empty *binary*-format parameter (format=1) is no longer silently converted to NULL, which lost the empty value.
2. **`guc_parameters.dat`**: `ivorysql.rowid_seq_cache` drops the leftover "0 disables the timeout." long_desc (its min is 1); `nls_length_semantics` fixes the "charater" typo.

## Test plan

- `make -C src/backend/tcop postgres.o` compiles cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of parameter formats during database operations.
  * Ensured empty string values are correctly treated as `NULL` where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->