### PR TITLE
Fix TO_NUMBER trailing whitespace without a format

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_number.out
+++ b/contrib/ivorysql_ora/expected/ora_number.out
@@ -1261,6 +1261,16 @@ SELECT '' AS to_number_16, to_number('12.34','9G999D99');
 
 SELECT '' AS to_number_17, to_number('1122.34','9G999D99');
 ERROR:  invalid number format model
+-- Without a format model, trailing spaces are accepted in the integer part.
+SELECT '' AS to_number_18, to_number('123 ');
+ to_number_18 | to_number 
+--------------+-----------
+              |       123
+(1 row)
+
+-- Whitespace between digits remains invalid.
+SELECT '' AS to_number_19, to_number('123 4');
+ERROR:  invalid number format model
 --
 -- Input syntax
 --

--- a/contrib/ivorysql_ora/expected/ora_number.out
+++ b/contrib/ivorysql_ora/expected/ora_number.out
@@ -1265,7 +1265,7 @@ ERROR:  invalid number format model
 SELECT '' AS to_number_18, to_number('123 ');
  to_number_18 | to_number 
 --------------+-----------
-              |       123
+              | 123
 (1 row)
 
 -- Whitespace between digits remains invalid.

--- a/contrib/ivorysql_ora/sql/ora_number.sql
+++ b/contrib/ivorysql_ora/sql/ora_number.sql
@@ -790,6 +790,10 @@ SELECT '' AS to_number_14, to_number('12.34');
 SELECT '' AS to_number_15, to_number('-1122.34');
 SELECT '' AS to_number_16, to_number('12.34','9G999D99');
 SELECT '' AS to_number_17, to_number('1122.34','9G999D99');
+-- Without a format model, trailing spaces are accepted in the integer part.
+SELECT '' AS to_number_18, to_number('123 ');
+-- Whitespace between digits remains invalid.
+SELECT '' AS to_number_19, to_number('123 4');
 
 --
 -- Input syntax
@@ -939,4 +943,3 @@ SELECT BITAND('6','8') re FROM DUAL;
 SELECT BITAND(6,'8') re FROM DUAL;
 SELECT BITAND('6',8) re FROM DUAL;
 /* End - bug0000478 */
-

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -7435,6 +7435,18 @@ Numeric ora_to_number_internal(text *value, text *fmt)
 					precision++;
 				else if (*tem == '.')
 					isleft = false;
+				else if (*tem == ' ')
+				{
+					/* allow trailing whitespace only (same as the scale side) */
+					while (*tem == ' ')
+						tem++;
+
+					if (*tem == '\0')
+						break;
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("invalid number format model")));
+				}
 				else
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -8584,4 +8596,3 @@ float8_to_char(PG_FUNCTION_ARGS)
 	NUM_TOCHAR_finish;
 	PG_RETURN_TEXT_P(result);
 }
-


### PR DESCRIPTION
## Summary

Fixes #1688 by accepting trailing whitespace in the integer part of `TO_NUMBER` without a format, matching the existing scale-path behavior.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `TO_NUMBER()` handling of integer input with trailing spaces.
  - Whitespace between digits or followed by additional content is now correctly rejected as an invalid number format.

- **Tests**
  - Added regression coverage for accepted trailing whitespace and rejected embedded whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->