### PR TITLE
Fix pg_dumpall plain-output GUC, dead #ifdef, and unused fields

### DIFF
--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -614,9 +614,7 @@ main(int argc, char *argv[])
 			exit_nicely(1);
 		}
 	}
-#ifdef IvorySQL
-		getDbCompatibleMode(conn);
-#endif
+	getDbCompatibleMode(conn);
 
 	/*
 	 * Get a list of database names that match the exclude patterns
@@ -775,6 +773,7 @@ main(int argc, char *argv[])
 				pg_encoding_to_char(encoding));
 		fprintf(OPF, "SET standard_conforming_strings = on;\n");
 		fprintf(OPF, "SET ivorysql.identifier_case_switch = normal;\n");
+		fprintf(OPF, "SET ivorysql.enable_emptystring_to_NULL = off;\n");
 		fprintf(OPF, "\n");
 	}
 

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -376,12 +376,10 @@ struct pg_conn
 								 * or a path to a UNIX-domain socket, or a
 								 * comma-separated list of machines and/or
 								 * paths; if NULL, use DEFAULT_PGSOCKET_DIR */
-	char       *iyhost;			/* Oracle compatible mode ENV VARIABLE */
 	char	   *pghostaddr;		/* the numeric IP address of the machine on
 								 * which the server is running, or a
 								 * comma-separated list of same.  Takes
 								 * precedence over pghost. */
-	char       *iyport;          /* Oracle compatible mdoe ENV VARIABLE */
 	char	   *pgport;			/* the server's communication port number, or
 								 * a comma-separated list of ports */
 	char	   *connect_timeout;	/* connection timeout (numeric string) */


### PR DESCRIPTION
## Summary

Fixes #1690.

1. **`pg_dumpall.c` plain output**: now also emits `SET ivorysql.enable_emptystring_to_NULL = off;` (matching `pg_restore`'s `_doSetFixedOutputState`), so restoring a plain script into a session where the GUC is on no longer stores `''` as NULL.
2. **`pg_dumpall.c` `#ifdef IvorySQL`**: the macro is never defined, so `getDbCompatibleMode(conn)` never ran; the guard is removed (every other tool calls it unconditionally).
3. **`libpq-int.h`**: removed the never-referenced `iyhost`/`iyport` fields (leftovers from a reverted change).

## Test plan

- `pg_dumpall.o` and `fe-connect.o` compile cleanly (full libpq link is blocked locally by the known macOS `ivy_sema.c` issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plain-text database dumps now consistently apply the appropriate database compatibility mode.
  * Dumps explicitly disable empty-string-to-NULL conversion, helping preserve empty-string values when restored.
  * Improved consistency of dump output across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->