### PR TITLE
Fix Oracle UPDATE target-list subscripts and strVal crash

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3030,7 +3030,10 @@ transformUpdateTargetList(ParseState *pstate, List *origTlist, ForPortionOfExpr 
 		{
 			if (origTarget->indirection)
 			{
-				colname_temp = strVal(lfirst(list_head(origTarget->indirection)));
+				Node	   *ind0 = linitial(origTarget->indirection);
+
+				if (IsA(ind0, String))
+					colname_temp = strVal(ind0);
 				alias_temp = lfirst(list_head(pstate->p_rtable));
 
 				if (alias_temp->alias)
@@ -3115,7 +3118,7 @@ transformUpdateTargetList(ParseState *pstate, List *origTlist, ForPortionOfExpr 
 		{
 			updateTargetListEntry(pstate, tle, colname_temp,
 								  attrno,
-								  NULL,
+								  list_copy_tail(origTarget->indirection, 1),
 								  origTarget->location);
 		}
 		else

--- a/src/oracle_test/regress/expected/update.out
+++ b/src/oracle_test/regress/expected/update.out
@@ -44,6 +44,24 @@ SELECT * FROM update_test;
  10 | 20 | 
 (2 rows)
 
+-- Oracle permits a table alias in a SET target.  Preserve the remaining
+-- indirection so that a qualified array element is updated, not the array.
+CREATE TABLE update_subscript_test (id int PRIMARY KEY, a int[]);
+INSERT INTO update_subscript_test VALUES (1, ARRAY[10, 20, 30]);
+UPDATE update_subscript_test u SET u.a[2] = 99 WHERE u.id = 1;
+SELECT id, a FROM update_subscript_test;
+ id |     a      
+----+------------
+  1 | {10,99,30}
+(1 row)
+
+-- A non-column first indirection must report an error, rather than treating
+-- an A_Indices node as a String node.
+UPDATE update_subscript_test u SET u[1] = 5;
+ERROR:  cannot assign to system column "u"
+LINE 1: UPDATE update_subscript_test u SET u[1] = 5;
+                                           ^
+DROP TABLE update_subscript_test;
 --
 -- Test VALUES in FROM
 --

--- a/src/oracle_test/regress/expected/update.out
+++ b/src/oracle_test/regress/expected/update.out
@@ -56,10 +56,14 @@ SELECT id, a FROM update_subscript_test;
 (1 row)
 
 -- A non-column first indirection must report an error, rather than treating
--- an A_Indices node as a String node.
+-- it as a String node.
 UPDATE update_subscript_test u SET u[1] = 5;
 ERROR:  cannot assign to system column "u"
 LINE 1: UPDATE update_subscript_test u SET u[1] = 5;
+                                           ^
+UPDATE update_subscript_test u SET u.* = 5;
+ERROR:  cannot assign to system column "u"
+LINE 1: UPDATE update_subscript_test u SET u.* = 5;
                                            ^
 DROP TABLE update_subscript_test;
 --

--- a/src/oracle_test/regress/sql/update.sql
+++ b/src/oracle_test/regress/sql/update.sql
@@ -39,8 +39,9 @@ UPDATE update_subscript_test u SET u.a[2] = 99 WHERE u.id = 1;
 SELECT id, a FROM update_subscript_test;
 
 -- A non-column first indirection must report an error, rather than treating
--- an A_Indices node as a String node.
+-- it as a String node.
 UPDATE update_subscript_test u SET u[1] = 5;
+UPDATE update_subscript_test u SET u.* = 5;
 DROP TABLE update_subscript_test;
 
 --

--- a/src/oracle_test/regress/sql/update.sql
+++ b/src/oracle_test/regress/sql/update.sql
@@ -31,6 +31,18 @@ UPDATE update_test t SET b = t.b + 10 WHERE t.a = 10;
 
 SELECT * FROM update_test;
 
+-- Oracle permits a table alias in a SET target.  Preserve the remaining
+-- indirection so that a qualified array element is updated, not the array.
+CREATE TABLE update_subscript_test (id int PRIMARY KEY, a int[]);
+INSERT INTO update_subscript_test VALUES (1, ARRAY[10, 20, 30]);
+UPDATE update_subscript_test u SET u.a[2] = 99 WHERE u.id = 1;
+SELECT id, a FROM update_subscript_test;
+
+-- A non-column first indirection must report an error, rather than treating
+-- an A_Indices node as a String node.
+UPDATE update_subscript_test u SET u[1] = 5;
+DROP TABLE update_subscript_test;
+
 --
 -- Test VALUES in FROM
 --


### PR DESCRIPTION
## Summary

Fixes #1692.

- Preserve the remaining indirection for table-qualified array updates.
- Guard strVal so non-String indirection reports a normal error instead of crashing.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Oracle-compatible `UPDATE` statements that target array elements through table aliases.
  * Ensured qualified array references preserve their details, so assignments update only the intended element.
  * Invalid non-column indirection targets now produce the expected assignment error.

* **Tests**
  * Added regression coverage for alias-qualified array-element updates.
  * Added validation confirming that only the selected array element changes and invalid targets are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->