### PR TITLE
Close Ivy prepared statements with the libpq protocol

### DIFF
--- a/src/interfaces/libpq/ivy-exec.c
+++ b/src/interfaces/libpq/ivy-exec.c
@@ -3126,35 +3126,51 @@ IvyremoveStmtHandleRelation(IvyPreparedStatement *stmtHandle)
 	for (tmp = stmtHandle->IvyconnList; tmp != NULL; tmp = tmp->next)
 	{
 		Ivyconn *tconn = (Ivyconn *) tmp->value;
-		Ivyresult *tresult = NULL;
-		char	buf[256];
-		int	len;
+		PGresult   *presult = NULL;
+		char   *close_error = NULL;
 
-		memset(buf, 0x00, 256);
-		len = snprintf(buf, 256, "DEALLOCATE %s", stmtHandle->stmtName);
-
-		if (len >= 255)
-			fprintf(stderr, "length of stmt name is  more than 245 bytes\n");
-
-		/* deallocate stmt */
-		tresult = Ivyexec(tconn, (const char *) buf);
-		if (IvyresultStatus(tresult) != PGRES_COMMAND_OK)
-		{
-			if (tconn->conn == NULL)
-				fprintf(stderr, "deallocate stmt %s failed because connection is gone\n", buf);
-			else
-				fprintf(stderr, "deallocate stmt %s failed\n", buf);
-		}
-
-		Ivyclear(tresult);
-
-		/* conn may be null due to other threads call Ivyclean() */
+		/*
+		 * Ivyfinish() clears and frees the PGconn while holding self_lock, so
+		 * keep it locked for the complete synchronous Close operation.  A
+		 * protocol Close uses the statement name verbatim and avoids treating
+		 * it as a possibly truncated SQL identifier.
+		 */
+		PGSemaphoreLock(&tconn->self_lock);
 		if (tconn->conn != NULL)
 		{
-			PGSemaphoreLock(&tconn->lock);
-			tconn->IvystmtHandleList = IvyremoveValueFromList(tconn->IvystmtHandleList, (void *) stmtHandle);
-			PGSemaphoreUnlock(&tconn->lock);
+			presult = PQclosePrepared(tconn->conn, stmtHandle->stmtName);
+			if (presult == NULL)
+				close_error = strdup(PQerrorMessage(tconn->conn));
+			else if (PQresultStatus(presult) != PGRES_COMMAND_OK)
+			{
+				const char *message = PQresultErrorMessage(presult);
+
+				if (message == NULL || message[0] == '\0')
+					message = PQerrorMessage(tconn->conn);
+				close_error = strdup(message);
+			}
 		}
+		else
+			close_error = strdup("connection is gone");
+
+		/*
+		 * The local relation describes ownership of stmtHandle, not whether the
+		 * server accepted Close.  Remove it on every path before stmtHandle is
+		 * freed so the connection never retains a dangling handle pointer.
+		 */
+		PGSemaphoreLock(&tconn->lock);
+		tconn->IvystmtHandleList = IvyremoveValueFromList(tconn->IvystmtHandleList,
+													 (void *) stmtHandle);
+		PGSemaphoreUnlock(&tconn->lock);
+		PGSemaphoreUnlock(&tconn->self_lock);
+
+		if (close_error != NULL)
+		{
+			fprintf(stderr, "could not close prepared statement \"%s\": %s\n",
+					stmtHandle->stmtName, close_error);
+			free(close_error);
+		}
+		PQclear(presult);
 	}
 
 	return;

--- a/src/interfaces/libpq/ivytest/Makefile
+++ b/src/interfaces/libpq/ivytest/Makefile
@@ -14,7 +14,7 @@ endif
 override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 LDFLAGS_INTERNAL += $(libpq_pgport)
 
-PROGS = testlibpq testlibpqstmt2 testlibpq_nullstmt testlibpq_allout testlibpq_prepare_plsql testlibpq_prepare_dml \
+PROGS = testlibpq testlibpqstmt2 testlibpq_deallocate_name testlibpq_nullstmt testlibpq_allout testlibpq_prepare_plsql testlibpq_prepare_dml \
         testlibpq_binary_double testlibpq_binary_float testlibpq_interval testlibpq_number testlibpq_prepare_call \
 		testlibpq_call testlibpqstmt2_call
 

--- a/src/interfaces/libpq/ivytest/expected/testlibpq_deallocate_name.out
+++ b/src/interfaces/libpq/ivytest/expected/testlibpq_deallocate_name.out
@@ -1,0 +1,1 @@
+long quoted prepared statement deallocated

--- a/src/interfaces/libpq/ivytest/regression.txt
+++ b/src/interfaces/libpq/ivytest/regression.txt
@@ -1,5 +1,6 @@
 testlibpq
 testlibpqstmt2
+testlibpq_deallocate_name
 testlibpqstmt2_call
 testlibpq_nullstmt
 testlibpq_allout

--- a/src/interfaces/libpq/ivytest/testlibpq_deallocate_name.c
+++ b/src/interfaces/libpq/ivytest/testlibpq_deallocate_name.c
@@ -1,0 +1,81 @@
+/*-------------------------------------------------------------------------
+ *
+ * testlibpq_deallocate_name.c
+ *		Exercise Ivy prepared-statement names that require SQL quoting.
+ *
+ * Portions Copyright (c) 2026, IvorySQL Global Development Team
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libpq-fe.h"
+#include "libpq-ivy.h"
+
+static void
+fail(Ivyconn *conn, const char *message)
+{
+	fprintf(stderr, "%s: %s", message, IvyerrorMessage(conn));
+	Ivyfinish(conn);
+	exit(EXIT_FAILURE);
+}
+
+int
+main(void)
+{
+	const char *stmt_name =
+		"statement with \"quotes\"; and spaces: "
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+	IvyPreparedStatement *statement;
+	Ivyconn    *conn;
+	Ivyresult  *result;
+	Oid		param_types[1] = {23};
+	const char *param_values[1] = {"1"};
+	int		param_lengths[1] = {1};
+	int		param_formats[1] = {0};
+	char		errmsg[256];
+
+	conn = Ivyconnectdb("user=system dbname=postgres port=1521");
+	if (Ivystatus(conn) == CONNECTION_BAD)
+		fail(conn, "connection failed");
+
+	statement = IvyCreatePreparedStatement(stmt_name, "SELECT $1::int", 1,
+											 param_types);
+	if (statement == NULL)
+		fail(conn, "statement allocation failed");
+
+	result = IvyexecPreparedStatement(conn, statement, 1, param_values,
+									param_lengths, param_formats, NULL, 0,
+									errmsg, sizeof(errmsg));
+	if (IvyresultStatus(result) != PGRES_TUPLES_OK)
+	{
+		Ivyclear(result);
+		fail(conn, "prepare or execute failed");
+	}
+	Ivyclear(result);
+
+	IvyFreePreparedStatement(statement);
+
+	result = Ivyexec(conn,
+				 "SELECT count(*) FROM pg_prepared_statements "
+				 "WHERE name = 'statement with \"quotes\"; and spaces: ' || "
+				 "repeat('x', 320)");
+	if (IvyresultStatus(result) != PGRES_TUPLES_OK ||
+		Ivyntuples(result) != 1 ||
+		Ivygetvalue(result, 0, 0)[0] != '0')
+	{
+		Ivyclear(result);
+		fail(conn, "long quoted statement was not deallocated");
+	}
+
+	printf("long quoted prepared statement deallocated\n");
+	Ivyclear(result);
+	Ivyfinish(conn);
+	return 0;
+}

--- a/src/interfaces/libpq/ivytest/testlibpq_deallocate_name.c
+++ b/src/interfaces/libpq/ivytest/testlibpq_deallocate_name.c
@@ -1,0 +1,95 @@
+/*-------------------------------------------------------------------------
+ *
+ * testlibpq_deallocate_name.c
+ *		Exercise Ivy prepared-statement names that require SQL quoting.
+ *
+ * Portions Copyright (c) 2026, IvorySQL Global Development Team
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libpq-fe.h"
+#include "libpq-ivy.h"
+
+static void
+fail(Ivyconn *conn, const char *message)
+{
+	fprintf(stderr, "%s: %s", message, IvyerrorMessage(conn));
+	Ivyfinish(conn);
+	exit(EXIT_FAILURE);
+}
+
+int
+main(void)
+{
+	const char *stmt_name =
+		"statement with \"quotes\"; and spaces: "
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+	IvyPreparedStatement *statement;
+	Ivyconn    *conn;
+	Ivyresult  *result;
+	Oid		param_types[1] = {23};
+	const char *param_values[1] = {"1"};
+	int		param_lengths[1] = {1};
+	int		param_formats[1] = {0};
+	char		errmsg[256];
+
+	conn = Ivyconnectdb("user=system dbname=postgres port=1521");
+	if (Ivystatus(conn) == CONNECTION_BAD)
+		fail(conn, "connection failed");
+
+	statement = IvyCreatePreparedStatement(stmt_name, "SELECT $1::int", 1,
+											 param_types);
+	if (statement == NULL)
+		fail(conn, "statement allocation failed");
+
+	result = IvyexecPreparedStatement(conn, statement, 1, param_values,
+									param_lengths, param_formats, NULL, 0,
+									errmsg, sizeof(errmsg));
+	if (IvyresultStatus(result) != PGRES_TUPLES_OK)
+	{
+		Ivyclear(result);
+		fail(conn, "prepare or execute failed");
+	}
+	Ivyclear(result);
+
+	IvyFreePreparedStatement(statement);
+
+	/*
+	 * The server stores prepared-statement names truncated to NAMEDATALEN - 1
+	 * bytes, so pg_prepared_statements never holds the full client-side name.
+	 * Match the name prefix instead: while the old DEALLOCATE <name> path was
+	 * in use this query still lists the statement, because the server rejected
+	 * that truncated, unquoted statement and kept the prepared one.
+	 */
+	result = Ivyexec(conn,
+					 "SELECT name FROM pg_prepared_statements "
+					 "WHERE name LIKE 'statement with%'");
+	if (IvyresultStatus(result) != PGRES_TUPLES_OK)
+	{
+		Ivyclear(result);
+		fail(conn, "could not list pg_prepared_statements");
+	}
+	if (Ivyntuples(result) != 0)
+	{
+		fprintf(stderr,
+				"long quoted prepared statement was not deallocated: "
+				"the server still has \"%s\"\n",
+				Ivygetvalue(result, 0, 0));
+		Ivyclear(result);
+		Ivyfinish(conn);
+		exit(EXIT_FAILURE);
+	}
+
+	printf("long quoted prepared statement deallocated\n");
+	Ivyclear(result);
+	Ivyfinish(conn);
+	return 0;
+}


### PR DESCRIPTION
﻿## Summary
- close Ivy prepared statements with libpq's protocol-level `PQclosePrepared` API, preserving the full statement name without SQL identifier parsing or truncation
- hold the connection lifetime lock through the synchronous Close and always remove the local statement relation, even when the connection is gone or Close fails
- cover a statement name longer than 255 bytes containing quotes, a semicolon, and spaces

Fixes #1627.

## Validation
- `git diff --check`
- Added `testlibpq_deallocate_name` to the Ivy regression driver
- Repository CI: all seven required checks pass (`build`, `contrib_regression`, `meson_build`, `oracle_pg_regression`, `oracle_regression`, `pg_regression`, and `policy`).

## Cleanup semantics
Server cleanup and local ownership cleanup are independent: a protocol Close failure is reported, but the connection-side list is still detached before the statement handle is freed so it cannot retain a dangling pointer.

## Risk
The change is limited to cleanup of prepared statements already associated with an Ivy connection. Successful cleanup now uses the same protocol-level name semantics as prepare/execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved prepared-statement cleanup for names containing quotes, spaces, semicolons, and other special characters.
* Prevented cleanup failures caused by overly long or improperly escaped statement identifiers.
* Ensured cleanup safely handles unavailable connections and consistently releases resources.

## Tests

* Added regression coverage confirming that prepared statements with complex names are successfully deallocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
