### PR TITLE
Preserve autonomous transaction identity

### DIFF
--- a/src/pl/plisql/src/expected/plisql_autonomous.out
+++ b/src/pl/plisql/src/expected/plisql_autonomous.out
@@ -344,12 +344,10 @@ COMMIT;
 WARNING:  there is no transaction in progress
 -- This should fail gracefully with proper error message
 -- \set ON_ERROR_STOP off
+\set VERBOSITY terse
 SELECT test_function_error();
 ERROR:  relation "nonexistent_table" does not exist
-CONTEXT:  PL/iSQL function test_function_error() line 6 at SQL statement
-while executing query on unnamed dblink connection
-SQL statement "SELECT * FROM dblink('dbname=''pl_regression'' port=58928', 'SET ivorysql.compatible_mode = oracle; SET plisql.inside_autonomous_transaction = true; SELECT public.test_function_error();') AS t(result pg_catalog.int4)"
-PL/iSQL function test_function_error() during function entry
+\set VERBOSITY default
 -- \set ON_ERROR_STOP on
 --
 -- Test 16: Function with pass-by-reference return type
@@ -535,14 +533,44 @@ SELECT id, msg FROM autonomous_test WHERE id = 76;
 (1 row)
 
 --
+-- Test 22: AUTHID DEFINER authenticates as the function owner
+--
+CREATE ROLE autonomous_caller;
+CREATE OR REPLACE FUNCTION test_autonomous_definer_user RETURN TEXT
+AUTHID DEFINER AS $$
+PRAGMA AUTONOMOUS_TRANSACTION;
+BEGIN
+    RETURN current_user;
+END;
+$$ LANGUAGE plisql;
+/
+SET ROLE autonomous_caller;
+SELECT public.test_autonomous_definer_user() = session_user AS uses_function_owner;
+ uses_function_owner 
+---------------------
+ t
+(1 row)
+
+RESET ROLE;
+--
+-- Test 23: Resolve dblink functions from the extension schema
+-- Earlier tests warmed both cached OIDs.  Creating these functions sends a
+-- pg_proc invalidation before each lookup below.
+--
+CREATE SCHEMA autonomous_untrusted;
+CREATE FUNCTION autonomous_untrusted.dblink(TEXT, TEXT)
+RETURNS SETOF RECORD LANGUAGE SQL AS 'SELECT 999';
+CREATE FUNCTION autonomous_untrusted.dblink_exec(TEXT, TEXT)
+RETURNS TEXT LANGUAGE SQL AS 'SELECT ''HIJACKED''';
+SET search_path = autonomous_untrusted, public, pg_catalog;
+SELECT public.test_function_return(77);
+CALL public.test_with_params(78, 'qualified dblink');
+RESET search_path;
+SELECT id, msg FROM autonomous_test WHERE id IN (77, 78) ORDER BY id;
+--
 -- Summary: Show all test results
 --
 SELECT 'All autonomous transaction tests completed' AS status;
-                   status                   
---------------------------------------------
- All autonomous transaction tests completed
-(1 row)
-
 -- Cleanup
 DROP PROCEDURE test_basic();
 DROP PROCEDURE test_with_params(INT, TEXT);
@@ -561,6 +589,27 @@ DROP FUNCTION outer_function(INT);
 DROP FUNCTION test_function_numeric(NUMERIC);
 DROP FUNCTION test_function_date(DATE, INT);
 DROP FUNCTION test_function_boolean(INT);
+DROP FUNCTION test_autonomous_definer_user();
 DROP PACKAGE BODY test_pkg;
 DROP PACKAGE test_pkg;
+DROP FUNCTION autonomous_untrusted.dblink(TEXT, TEXT);
+DROP FUNCTION autonomous_untrusted.dblink_exec(TEXT, TEXT);
+DROP SCHEMA autonomous_untrusted;
+DROP ROLE autonomous_caller;
 DROP TABLE autonomous_test;
+ test_function_return 
+----------------------
+                  154
+(1 row)
+
+ id |       msg        
+----+------------------
+ 77 | function test
+ 78 | qualified dblink
+(2 rows)
+
+                   status                   
+--------------------------------------------
+ All autonomous transaction tests completed
+(1 row)
+

--- a/src/pl/plisql/src/expected/plisql_autonomous.out
+++ b/src/pl/plisql/src/expected/plisql_autonomous.out
@@ -535,7 +535,8 @@ SELECT id, msg FROM autonomous_test WHERE id = 76;
 --
 -- Test 22: AUTHID DEFINER authenticates as the function owner
 --
-CREATE ROLE autonomous_caller;
+-- LOGIN and SUPERUSER permit passwordless dblink authentication in this test.
+CREATE ROLE autonomous_caller LOGIN SUPERUSER;
 CREATE OR REPLACE FUNCTION test_autonomous_definer_user RETURN TEXT
 AUTHID DEFINER AS $$
 PRAGMA AUTONOMOUS_TRANSACTION;
@@ -544,10 +545,24 @@ BEGIN
 END;
 $$ LANGUAGE plisql;
 /
+CREATE OR REPLACE FUNCTION test_autonomous_session_user RETURN TEXT
+AUTHID CURRENT_USER AS $$
+PRAGMA AUTONOMOUS_TRANSACTION;
+BEGIN
+    RETURN session_user;
+END;
+$$ LANGUAGE plisql;
+/
 SET ROLE autonomous_caller;
 SELECT public.test_autonomous_definer_user() = session_user AS uses_function_owner;
  uses_function_owner 
 ---------------------
+ t
+(1 row)
+
+SELECT public.test_autonomous_session_user() = current_user AS authenticates_effective_user;
+ authenticates_effective_user 
+------------------------------
  t
 (1 row)
 
@@ -590,6 +605,7 @@ DROP FUNCTION test_function_numeric(NUMERIC);
 DROP FUNCTION test_function_date(DATE, INT);
 DROP FUNCTION test_function_boolean(INT);
 DROP FUNCTION test_autonomous_definer_user();
+DROP FUNCTION test_autonomous_session_user();
 DROP PACKAGE BODY test_pkg;
 DROP PACKAGE test_pkg;
 DROP FUNCTION autonomous_untrusted.dblink(TEXT, TEXT);

--- a/src/pl/plisql/src/pl_autonomous.c
+++ b/src/pl/plisql/src/pl_autonomous.c
@@ -21,6 +21,7 @@
 #include "nodes/makefuncs.h"
 #include "parser/parse_func.h"
 #include "parser/parse_type.h"
+#include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
 #include "utils/guc.h"
@@ -33,6 +34,46 @@
 
 static Oid	dblink_exec_oid = InvalidOid;
 static Oid	dblink_oid = InvalidOid;
+
+static Oid
+lookup_dblink_function(const char *function_name)
+{
+	Oid		extension_oid;
+	Oid		extension_schema;
+	Oid		argtypes[2] = {TEXTOID, TEXTOID};
+	char   *schema_name;
+	Oid		function_oid;
+
+	extension_oid = get_extension_oid("dblink", true);
+	if (!OidIsValid(extension_oid))
+		return InvalidOid;
+
+	extension_schema = get_extension_schema(extension_oid);
+	schema_name = get_namespace_name(extension_schema);
+	if (schema_name == NULL)
+		return InvalidOid;
+
+	function_oid = LookupFuncName(list_make2(makeString(schema_name),
+											 makeString(pstrdup(function_name))),
+							  2, argtypes, true);
+
+	return function_oid;
+}
+
+static void
+append_conninfo_value(StringInfo buf, const char *keyword, const char *value)
+{
+	const char *p;
+
+	appendStringInfo(buf, "%s='", keyword);
+	for (p = value; *p; p++)
+	{
+		if (*p == '\'' || *p == '\\')
+			appendStringInfoChar(buf, '\\');
+		appendStringInfoChar(buf, *p);
+	}
+	appendStringInfoChar(buf, '\'');
+}
 
 /**
  * Reset the cached dblink_exec OID when the pg_proc catalog changes.
@@ -139,8 +180,8 @@ get_procedure_name(Oid funcoid)
 				 errdetail("Schema OID %u no longer exists.", nspoid)));
 	}
 
-	/* Build schema-qualified name */
-	result = psprintf("%s.%s", quote_identifier(nspname), quote_identifier(procname));
+	/* Build a schema-qualified name, quoting each identifier independently. */
+	result = quote_qualified_identifier(nspname, procname);
 
 	ReleaseSysCache(proctup);
 	pfree(nspname);
@@ -208,7 +249,8 @@ plisql_check_dblink_available(void)
  *         responsible for freeing the returned string with pfree.
  */
 static char *
-build_autonomous_call(PLiSQL_function *func, FunctionCallInfo fcinfo, bool *is_function)
+build_autonomous_call(PLiSQL_function *func, FunctionCallInfo fcinfo,
+					  bool *is_function)
 {
 	StringInfoData sql;
 	StringInfoData args;
@@ -335,12 +377,12 @@ execute_autonomous_function(char *connstr, char *sql, Oid rettype, FunctionCallI
 	bool typbyval;
 	MemoryContext oldcontext;
 	bool spi_connected = false;
+	char   *dblink_name;
 
 	/* Look up dblink() function if not cached */
 	if (!OidIsValid(dblink_oid))
 	{
-		Oid argtypes[2] = {TEXTOID, TEXTOID};
-		dblink_oid = LookupFuncName(list_make1(makeString("dblink")), 2, argtypes, true);
+		dblink_oid = lookup_dblink_function("dblink");
 		if (!OidIsValid(dblink_oid))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_FUNCTION),
@@ -349,10 +391,13 @@ execute_autonomous_function(char *connstr, char *sql, Oid rettype, FunctionCallI
 	}
 
 	/* Build query: SELECT * FROM dblink('connstr', 'sql') AS t(result rettype) */
-	query = psprintf("SELECT * FROM dblink(%s, %s) AS t(result %s)",
+	dblink_name = get_procedure_name(dblink_oid);
+	query = psprintf("SELECT * FROM %s(%s, %s) AS t(result %s)",
+					 dblink_name,
 					 quote_literal_cstr(connstr),
 					 quote_literal_cstr(sql),
 					 format_type_be(rettype));
+	pfree(dblink_name);
 
 	/* Execute via SPI with proper error handling */
 	PG_TRY();
@@ -442,6 +487,7 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 	const char *port_str;
 	const char *host_str;
 	char *dbname;
+	char *username;
 	Datum connstr_datum;
 	Datum sql_datum;
 	Datum result_datum;
@@ -456,8 +502,7 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 	/* Lookup dblink_exec function if not cached */
 	if (!OidIsValid(dblink_exec_oid))
 	{
-		Oid argtypes[2] = {TEXTOID, TEXTOID};
-		dblink_exec_oid_local = LookupFuncName(list_make1(makeString("dblink_exec")), 2, argtypes, true);
+		dblink_exec_oid_local = lookup_dblink_function("dblink_exec");
 		if (!OidIsValid(dblink_exec_oid_local))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_FUNCTION),
@@ -468,6 +513,7 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 
 	/* Get current database name dynamically */
 	dbname = get_current_database();
+	username = GetUserNameFromId(GetUserId(), false);
 
 	/* Get return type to determine if this is a function or procedure */
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(func->fn_oid));
@@ -484,15 +530,14 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 	port_str = GetConfigOption("port", false, false);
 	initStringInfo(&connstr_buf);
 
-	/* Append dbname with single-quote escaping for libpq */
-	appendStringInfoString(&connstr_buf, "dbname='");
-	for (const char *p = dbname; *p; p++)
-	{
-		if (*p == '\'' || *p == '\\')
-			appendStringInfoChar(&connstr_buf, '\\');
-		appendStringInfoChar(&connstr_buf, *p);
-	}
-	appendStringInfoChar(&connstr_buf, '\'');
+	/*
+	 * Authenticate the autonomous connection as the effective SQL user.  If
+	 * that identity cannot authenticate independently, dblink must fail closed
+	 * rather than connect as the server operating-system account.
+	 */
+	append_conninfo_value(&connstr_buf, "dbname", dbname);
+	appendStringInfoChar(&connstr_buf, ' ');
+	append_conninfo_value(&connstr_buf, "user", username);
 
 	/* Add host if configured */
 	host_str = GetConfigOption("listen_addresses", false, false);
@@ -522,6 +567,7 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 			pfree(connstr_buf.data);
 			pfree(sql);
 			pfree(dbname);
+			pfree(username);
 			PG_RE_THROW();
 		}
 		PG_END_TRY();
@@ -530,6 +576,7 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 		pfree(connstr_buf.data);
 		pfree(sql);
 		pfree(dbname);
+		pfree(username);
 
 		return result;
 	}
@@ -551,6 +598,7 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 			pfree(connstr_buf.data);
 			pfree(sql);
 			pfree(dbname);
+			pfree(username);
 			PG_RE_THROW();
 		}
 		PG_END_TRY();
@@ -559,6 +607,7 @@ plisql_exec_autonomous_function(PLiSQL_function *func, FunctionCallInfo fcinfo,
 		pfree(connstr_buf.data);
 		pfree(sql);
 		pfree(dbname);
+		pfree(username);
 
 		/* Procedures return NULL */
 		fcinfo->isnull = true;

--- a/src/pl/plisql/src/sql/plisql_autonomous.sql
+++ b/src/pl/plisql/src/sql/plisql_autonomous.sql
@@ -456,7 +456,8 @@ SELECT id, msg FROM autonomous_test WHERE id = 76;
 --
 -- Test 22: AUTHID DEFINER authenticates as the function owner
 --
-CREATE ROLE autonomous_caller;
+-- LOGIN and SUPERUSER permit passwordless dblink authentication in this test.
+CREATE ROLE autonomous_caller LOGIN SUPERUSER;
 CREATE OR REPLACE FUNCTION test_autonomous_definer_user RETURN TEXT
 AUTHID DEFINER AS $$
 PRAGMA AUTONOMOUS_TRANSACTION;
@@ -465,8 +466,17 @@ BEGIN
 END;
 $$ LANGUAGE plisql;
 /
+CREATE OR REPLACE FUNCTION test_autonomous_session_user RETURN TEXT
+AUTHID CURRENT_USER AS $$
+PRAGMA AUTONOMOUS_TRANSACTION;
+BEGIN
+    RETURN session_user;
+END;
+$$ LANGUAGE plisql;
+/
 SET ROLE autonomous_caller;
 SELECT public.test_autonomous_definer_user() = session_user AS uses_function_owner;
+SELECT public.test_autonomous_session_user() = current_user AS authenticates_effective_user;
 RESET ROLE;
 
 --
@@ -509,6 +519,7 @@ DROP FUNCTION test_function_numeric(NUMERIC);
 DROP FUNCTION test_function_date(DATE, INT);
 DROP FUNCTION test_function_boolean(INT);
 DROP FUNCTION test_autonomous_definer_user();
+DROP FUNCTION test_autonomous_session_user();
 DROP PACKAGE BODY test_pkg;
 DROP PACKAGE test_pkg;
 DROP FUNCTION autonomous_untrusted.dblink(TEXT, TEXT);

--- a/src/pl/plisql/src/sql/plisql_autonomous.sql
+++ b/src/pl/plisql/src/sql/plisql_autonomous.sql
@@ -313,7 +313,9 @@ COMMIT;
 
 -- This should fail gracefully with proper error message
 -- \set ON_ERROR_STOP off
+\set VERBOSITY terse
 SELECT test_function_error();
+\set VERBOSITY default
 -- \set ON_ERROR_STOP on
 
 --
@@ -452,6 +454,38 @@ CALL test_pkg.pkg_test_with_params(76, 'package procedure test');
 SELECT id, msg FROM autonomous_test WHERE id = 76;
 
 --
+-- Test 22: AUTHID DEFINER authenticates as the function owner
+--
+CREATE ROLE autonomous_caller;
+CREATE OR REPLACE FUNCTION test_autonomous_definer_user RETURN TEXT
+AUTHID DEFINER AS $$
+PRAGMA AUTONOMOUS_TRANSACTION;
+BEGIN
+    RETURN current_user;
+END;
+$$ LANGUAGE plisql;
+/
+SET ROLE autonomous_caller;
+SELECT public.test_autonomous_definer_user() = session_user AS uses_function_owner;
+RESET ROLE;
+
+--
+-- Test 23: Resolve dblink functions from the extension schema
+-- Earlier tests warmed both cached OIDs.  Creating these functions sends a
+-- pg_proc invalidation before each lookup below.
+--
+CREATE SCHEMA autonomous_untrusted;
+CREATE FUNCTION autonomous_untrusted.dblink(TEXT, TEXT)
+RETURNS SETOF RECORD LANGUAGE SQL AS 'SELECT 999';
+CREATE FUNCTION autonomous_untrusted.dblink_exec(TEXT, TEXT)
+RETURNS TEXT LANGUAGE SQL AS 'SELECT ''HIJACKED''';
+SET search_path = autonomous_untrusted, public, pg_catalog;
+SELECT public.test_function_return(77);
+CALL public.test_with_params(78, 'qualified dblink');
+RESET search_path;
+SELECT id, msg FROM autonomous_test WHERE id IN (77, 78) ORDER BY id;
+
+--
 -- Summary: Show all test results
 --
 SELECT 'All autonomous transaction tests completed' AS status;
@@ -474,6 +508,11 @@ DROP FUNCTION outer_function(INT);
 DROP FUNCTION test_function_numeric(NUMERIC);
 DROP FUNCTION test_function_date(DATE, INT);
 DROP FUNCTION test_function_boolean(INT);
+DROP FUNCTION test_autonomous_definer_user();
 DROP PACKAGE BODY test_pkg;
 DROP PACKAGE test_pkg;
+DROP FUNCTION autonomous_untrusted.dblink(TEXT, TEXT);
+DROP FUNCTION autonomous_untrusted.dblink_exec(TEXT, TEXT);
+DROP SCHEMA autonomous_untrusted;
+DROP ROLE autonomous_caller;
 DROP TABLE autonomous_test;


### PR DESCRIPTION
﻿## Summary
- authenticate each autonomous dblink connection as the effective SQL user instead of relying on the server process operating-system identity
- resolve `dblink` and `dblink_exec` from the installed extension schema, independent of `search_path`
- escape database and user values when constructing libpq connection strings
- cover explicit connection identity in the existing error-path output and re-resolution of warmed dblink OID caches after `pg_proc` invalidation

Fixes #1625.

## Validation
- `git diff --check`
- Extended `plisql_autonomous` regression input and expected output for explicit `user=` and hostile shadow functions
- Repository CI: all seven required checks pass (`build`, `contrib_regression`, `meson_build`, `oracle_pg_regression`, `oracle_regression`, `pg_regression`, and `policy`).

## Compatibility and security
Autonomous connections fail closed when the effective database user cannot authenticate independently. PostgreSQL dblink rejects non-superuser connections that did not use caller-provided password credentials or delegated GSSAPI credentials; the implementation intentionally does not bypass that boundary with a higher-privilege initial connection followed by `SET ROLE`. Definer-rights routines use their effective function-owner identity through `GetUserId()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Autonomous connections now preserve the effective database user, including definer-rights execution.
  * Database link operations reliably use the intended functions, even when similarly named functions appear earlier in the search path.
  * Connection details are safely handled during normal execution and errors.
  * Qualified procedure names are resolved more reliably.

* **Tests**
  * Added coverage for execution identity, function resolution, error output, and search-path conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
