### PR TITLE
fix(oracle): mark NLS-dependent TO_CHAR overloads stable

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -204,6 +204,36 @@ SELECT to_char(
 (1 row)
 
 DROP TABLE to_char_tbl;
+-- TO_CHAR volatility must reflect its session NLS and timezone dependencies.
+SELECT count(*) AS stable_to_char_overloads
+FROM pg_proc
+WHERE oid = ANY (ARRAY[
+    'sys.to_char(sys.oradate)'::regprocedure,
+    'sys.to_char(sys.oradate,text)'::regprocedure,
+    'sys.to_char(sys.oradate,text,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamp)'::regprocedure,
+    'sys.to_char(sys.oratimestamp,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamp,text,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamptz)'::regprocedure,
+    'sys.to_char(sys.oratimestamptz,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamptz,text,text)'::regprocedure,
+    'sys.to_char(sys.oratimestampltz)'::regprocedure,
+    'sys.to_char(sys.oratimestampltz,text)'::regprocedure,
+    'sys.to_char(sys.oratimestampltz,text,text)'::regprocedure
+])
+AND provolatile = 's';
+ stable_to_char_overloads 
+--------------------------
+                       12
+(1 row)
+
+CREATE TABLE to_char_volatility_tbl(d sys.oradate);
+CREATE INDEX to_char_volatility_idx
+    ON to_char_volatility_tbl (sys.to_char(d));
+ERROR:  functions in index expression must be marked IMMUTABLE
+LINE 2:     ON to_char_volatility_tbl (sys.to_char(d));
+                                       ^
+DROP TABLE to_char_volatility_tbl;
 -- oracle sys date func
 --bug#0000857
 SET nls_timestamp_format = 'DD-MON-YY HH24:MI:SS.US';

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -97,6 +97,30 @@ SELECT to_char(
 
 DROP TABLE to_char_tbl;
 
+-- TO_CHAR volatility must reflect its session NLS and timezone dependencies.
+SELECT count(*) AS stable_to_char_overloads
+FROM pg_proc
+WHERE oid = ANY (ARRAY[
+    'sys.to_char(sys.oradate)'::regprocedure,
+    'sys.to_char(sys.oradate,text)'::regprocedure,
+    'sys.to_char(sys.oradate,text,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamp)'::regprocedure,
+    'sys.to_char(sys.oratimestamp,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamp,text,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamptz)'::regprocedure,
+    'sys.to_char(sys.oratimestamptz,text)'::regprocedure,
+    'sys.to_char(sys.oratimestamptz,text,text)'::regprocedure,
+    'sys.to_char(sys.oratimestampltz)'::regprocedure,
+    'sys.to_char(sys.oratimestampltz,text)'::regprocedure,
+    'sys.to_char(sys.oratimestampltz,text,text)'::regprocedure
+])
+AND provolatile = 's';
+
+CREATE TABLE to_char_volatility_tbl(d sys.oradate);
+CREATE INDEX to_char_volatility_idx
+    ON to_char_volatility_tbl (sys.to_char(d));
+DROP TABLE to_char_volatility_tbl;
+
 -- oracle sys date func
 --bug#0000857
 SET nls_timestamp_format = 'DD-MON-YY HH24:MI:SS.US';

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -789,7 +789,7 @@ AS 'MODULE_PATHNAME','oradate_to_char1'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 
 CREATE FUNCTION sys.to_char(sys.oradate, text)
@@ -798,7 +798,7 @@ AS 'MODULE_PATHNAME','oradate_to_char2'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oradate, text, text)
 RETURNS varchar2
@@ -806,7 +806,7 @@ AS 'MODULE_PATHNAME','oradate_to_char3'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestamp)
 RETURNS varchar2
@@ -814,7 +814,7 @@ AS 'MODULE_PATHNAME','oratimestamp_to_char1'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestamp, text)
 RETURNS varchar2
@@ -822,7 +822,7 @@ AS 'MODULE_PATHNAME','oratimestamp_to_char2'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestamp, text, text)
 RETURNS varchar2
@@ -830,7 +830,7 @@ AS 'MODULE_PATHNAME','oratimestamp_to_char3'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestamptz)
 RETURNS varchar2
@@ -838,7 +838,7 @@ AS 'MODULE_PATHNAME','oratimestamptz_to_char1'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestamptz, text)
 RETURNS varchar2
@@ -846,7 +846,7 @@ AS 'MODULE_PATHNAME','oratimestamptz_to_char2'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestamptz, text, text)
 RETURNS varchar2
@@ -854,7 +854,7 @@ AS 'MODULE_PATHNAME','oratimestamptz_to_char3'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestampltz)
 RETURNS varchar2
@@ -862,7 +862,7 @@ AS 'MODULE_PATHNAME','oratimestampltz_to_char1'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestampltz, text)
 RETURNS varchar2
@@ -870,7 +870,7 @@ AS 'MODULE_PATHNAME','oratimestampltz_to_char2'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.oratimestampltz, text, text)
 RETURNS varchar2
@@ -878,7 +878,7 @@ AS 'MODULE_PATHNAME','oratimestampltz_to_char3'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.to_char(sys.dsinterval)
 RETURNS varchar2


### PR DESCRIPTION
## What changed

- mark all 12 Oracle-compatible `TO_CHAR` overloads for `DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` as `STABLE`
- add catalog coverage for every affected overload
- verify that PostgreSQL rejects expression indexes using the session-dependent one-argument overload

## Root cause

These overloads were declared `IMMUTABLE`, although their results depend on session NLS format/language and timezone settings. That allowed PostgreSQL to accept expression indexes whose stored keys could become inconsistent after the session settings changed.

The issue was reproduced by building an index on `sys.to_char(d)` under `nls_date_format = 'YYYY-MM-DD'`, changing it to `DD/MM/YYYY`, and observing that an index scan returned a different order from a sequential scan plus sort.

## Validation

Run on `WZU_Server` with the same configure options used by the Oracle regression workflow:

- `make -j16`
- `make -C contrib/ivorysql_ora oracle-check ORA_REGRESS=ora_datetime_datatype_functions`
- `make oracle-check-world`
- `git diff --check`

All completed successfully. The focused regression confirms all 12 overloads are `STABLE` and that the unsafe expression index is rejected.

Closes #1696


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date and timestamp formatting functions to accurately reflect their stability when results may depend on session settings.
  * Prevented these formatting expressions from being used where immutable behavior is required, such as index expressions.

* **Tests**
  * Added regression coverage for all supported date and timestamp formatting overloads.
  * Added verification that these expressions cannot be used in indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->