### PR TITLE
Make sys.to_number accept scientific notation and blank padding

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_number.out
+++ b/contrib/ivorysql_ora/expected/ora_number.out
@@ -1750,3 +1750,197 @@ SELECT BITAND('6',8) re FROM DUAL;
 (1 row)
 
 /* End - bug0000478 */
+/* Begin - to_number accepts scientific notation and blank padding */
+SELECT to_number('1e3') AS a;
+  a   
+------
+ 1000
+(1 row)
+
+SELECT to_number('1E3') AS b;
+  b   
+------
+ 1000
+(1 row)
+
+SELECT to_number('-1.5e-2') AS c;
+   c    
+--------
+ -0.015
+(1 row)
+
+SELECT to_number('1.5e+3') AS d;
+  d   
+------
+ 1500
+(1 row)
+
+SELECT to_number('1E-3') AS e;
+   e   
+-------
+ 0.001
+(1 row)
+
+SELECT to_number(' 1e3 ') AS f;
+  f   
+------
+ 1000
+(1 row)
+
+SELECT to_number('12 ') AS g;
+ g  
+----
+ 12
+(1 row)
+
+SELECT to_number(' 12') AS h;
+ h  
+----
+ 12
+(1 row)
+
+SELECT to_number('12.345') AS i;
+   i    
+--------
+ 12.345
+(1 row)
+
+SELECT to_number('-1122.34') AS j;
+    j     
+----------
+ -1122.34
+(1 row)
+
+/* leading zeros in the exponent must be honored, not truncated */
+SELECT to_number('1e0000000010') AS r;
+      r      
+-------------
+ 10000000000
+(1 row)
+
+SELECT to_number('1e-0000000010') AS s;
+      s       
+--------------
+ 0.0000000001
+(1 row)
+
+/* positive exponents beyond numeric's range keep raising an error */
+SELECT to_number('1e2147483648') AS t;
+ERROR:  value overflows numeric format
+SELECT to_number('1e10000000000000000000') AS v;
+ERROR:  value overflows numeric format
+/* ... but an all-zero mantissa times any exponent is still zero */
+SELECT to_number('0e2147483648') AS zero_mantissa;
+ zero_mantissa 
+---------------
+ 0
+(1 row)
+
+SELECT to_number('0e10000000000000000000') AS zero_mantissa_long;
+ zero_mantissa_long 
+--------------------
+ 0
+(1 row)
+
+SELECT to_number('1e1073741823') AS at_boundary;
+ERROR:  numeric field overflow
+DETAIL:  A field with precision 1000, scale 0 must round to an absolute value less than 10^1000.
+SELECT to_number('1e1073741824') AS one_over_boundary;
+ERROR:  value overflows numeric format
+SELECT to_number('1e2000') AS clamp_precision;
+ERROR:  numeric field overflow
+DETAIL:  A field with precision 1000, scale 0 must round to an absolute value less than 10^1000.
+/* precision-clamp path without an exponent */
+SELECT to_number(repeat('9', 1500)) AS long_int_no_exp;
+ERROR:  numeric field overflow
+DETAIL:  A field with precision 1000, scale 0 must round to an absolute value less than 10^1000.
+/* negative exponents that underflow numeric's range return zero, as in Oracle */
+SELECT to_number('1e-2147483648') AS u;
+ u 
+---
+ 0
+(1 row)
+
+SELECT to_number('1e-10000000000000000000') AS w;
+ w 
+---
+ 0
+(1 row)
+
+/* malformed input still raises an error */
+SELECT to_number('1e') AS k;
+ERROR:  invalid number format model
+SELECT to_number('1e+') AS l;
+ERROR:  invalid number format model
+SELECT to_number('e3') AS m;
+ERROR:  invalid number format model
+SELECT to_number('1.2e3.4') AS n;
+ERROR:  invalid number format model
+SELECT to_number('--1') AS o;
+ERROR:  invalid number format model
+SELECT to_number('1..2') AS p;
+ERROR:  invalid number format model
+SELECT to_number('12a') AS q;
+ERROR:  invalid number format model
+SELECT to_number('1 e3') AS space_before_e;
+ERROR:  invalid number format model
+SELECT to_number('1e 3') AS space_after_e;
+ERROR:  invalid number format model
+SELECT to_number('1e3e4') AS double_e;
+ERROR:  invalid number format model
+SELECT to_number('1e--3') AS double_sign;
+ERROR:  invalid number format model
+SELECT to_number('1e+-3') AS mixed_sign;
+ERROR:  invalid number format model
+SELECT to_number('   ') AS all_blank;
+ERROR:  invalid number format model
+SELECT to_number('-') AS bare_sign;
+ERROR:  invalid number format model
+SELECT to_number('.') AS bare_dot;
+ERROR:  invalid number format model
+SELECT to_number('NaN') AS nan_case;
+ERROR:  invalid number format model
+SELECT to_number('Infinity') AS inf_case;
+ERROR:  invalid number format model
+SELECT to_number('-Infinity') AS neg_inf_case;
+ERROR:  invalid number format model
+/* empty string is NULL under Oracle semantics, so STRICT returns NULL */
+SELECT to_number(''::varchar2) AS empty_str;
+ empty_str 
+-----------
+ 
+(1 row)
+
+/* one-sided decimal points */
+SELECT to_number('123.') AS trailing_dot;
+ trailing_dot 
+--------------
+ 123
+(1 row)
+
+SELECT to_number('.5') AS leading_dot;
+ leading_dot 
+-------------
+ 0.5
+(1 row)
+
+/* zero exponent in three spellings */
+SELECT to_number('1e0') AS exp_zero;
+ exp_zero 
+----------
+ 1
+(1 row)
+
+SELECT to_number('1e+0') AS exp_plus_zero;
+ exp_plus_zero 
+---------------
+ 1
+(1 row)
+
+SELECT to_number('1e-0') AS exp_minus_zero;
+ exp_minus_zero 
+----------------
+ 1
+(1 row)
+
+/* End - to_number scientific notation */

--- a/contrib/ivorysql_ora/sql/ora_number.sql
+++ b/contrib/ivorysql_ora/sql/ora_number.sql
@@ -943,3 +943,62 @@ SELECT BITAND('6','8') re FROM DUAL;
 SELECT BITAND(6,'8') re FROM DUAL;
 SELECT BITAND('6',8) re FROM DUAL;
 /* End - bug0000478 */
+
+
+/* Begin - to_number accepts scientific notation and blank padding */
+SELECT to_number('1e3') AS a;
+SELECT to_number('1E3') AS b;
+SELECT to_number('-1.5e-2') AS c;
+SELECT to_number('1.5e+3') AS d;
+SELECT to_number('1E-3') AS e;
+SELECT to_number(' 1e3 ') AS f;
+SELECT to_number('12 ') AS g;
+SELECT to_number(' 12') AS h;
+SELECT to_number('12.345') AS i;
+SELECT to_number('-1122.34') AS j;
+/* leading zeros in the exponent must be honored, not truncated */
+SELECT to_number('1e0000000010') AS r;
+SELECT to_number('1e-0000000010') AS s;
+/* positive exponents beyond numeric's range keep raising an error */
+SELECT to_number('1e2147483648') AS t;
+SELECT to_number('1e10000000000000000000') AS v;
+/* ... but an all-zero mantissa times any exponent is still zero */
+SELECT to_number('0e2147483648') AS zero_mantissa;
+SELECT to_number('0e10000000000000000000') AS zero_mantissa_long;
+SELECT to_number('1e1073741823') AS at_boundary;
+SELECT to_number('1e1073741824') AS one_over_boundary;
+SELECT to_number('1e2000') AS clamp_precision;
+/* precision-clamp path without an exponent */
+SELECT to_number(repeat('9', 1500)) AS long_int_no_exp;
+/* negative exponents that underflow numeric's range return zero, as in Oracle */
+SELECT to_number('1e-2147483648') AS u;
+SELECT to_number('1e-10000000000000000000') AS w;
+/* malformed input still raises an error */
+SELECT to_number('1e') AS k;
+SELECT to_number('1e+') AS l;
+SELECT to_number('e3') AS m;
+SELECT to_number('1.2e3.4') AS n;
+SELECT to_number('--1') AS o;
+SELECT to_number('1..2') AS p;
+SELECT to_number('12a') AS q;
+SELECT to_number('1 e3') AS space_before_e;
+SELECT to_number('1e 3') AS space_after_e;
+SELECT to_number('1e3e4') AS double_e;
+SELECT to_number('1e--3') AS double_sign;
+SELECT to_number('1e+-3') AS mixed_sign;
+SELECT to_number('   ') AS all_blank;
+SELECT to_number('-') AS bare_sign;
+SELECT to_number('.') AS bare_dot;
+SELECT to_number('NaN') AS nan_case;
+SELECT to_number('Infinity') AS inf_case;
+SELECT to_number('-Infinity') AS neg_inf_case;
+/* empty string is NULL under Oracle semantics, so STRICT returns NULL */
+SELECT to_number(''::varchar2) AS empty_str;
+/* one-sided decimal points */
+SELECT to_number('123.') AS trailing_dot;
+SELECT to_number('.5') AS leading_dot;
+/* zero exponent in three spellings */
+SELECT to_number('1e0') AS exp_zero;
+SELECT to_number('1e+0') AS exp_plus_zero;
+SELECT to_number('1e-0') AS exp_minus_zero;
+/* End - to_number scientific notation */

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -7399,8 +7399,6 @@ Numeric ora_to_number_internal(text *value, text *fmt)
 	Datum		result;
 	int			scale = 0,
 				precision = 0;
-	char 		*tem = NULL;
-	bool 		isleft = true;
 
 	if(fmt)
 	{
@@ -7422,68 +7420,169 @@ Numeric ora_to_number_internal(text *value, text *fmt)
 	}
 	else
 	{
-		numstr = text_to_cstring(value);
-		tem = numstr;
-		precision = 0;
-		scale = 0;
-		while(*tem == ' ')
-		{
-		/* Remove leading space */
-			tem++;
-		}
-		if(*tem == '-' || *tem == '+')
-		{
-			precision++;
-			tem++;
-		}
-		for (; *tem != '\0'; tem++)
-		{
-			if (isleft)
-			{
-				if (isdigit((unsigned char) *tem))
-					precision++;
-				else if (*tem == '.')
-					isleft = false;
-				else if (*tem == ' ')
-				{
-					/* allow trailing whitespace only (same as the scale side) */
-					while (*tem == ' ')
-						tem++;
+		const char *p;
+		int			int_digits = 0;
+		int			frac_digits = 0;
+		int64		exponent = 0;
+		bool		has_exp_digit = false;
+		bool		exp_overflow = false;
+		bool		underflow_to_zero = false;
+		bool		has_dot = false;
+		bool		has_digit = false;
+		bool		has_nonzero_digit = false;
 
-					if (*tem == '\0')
-						break;
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("invalid number format model")));
-				}
+		numstr = text_to_cstring(value);
+		p = numstr;
+
+		/* Skip leading blanks (Oracle ignores them) */
+		while (*p == ' ')
+			p++;
+
+		/* Optional sign */
+		if (*p == '-' || *p == '+')
+			p++;
+
+		/*
+		 * Mantissa: digits with an optional decimal point.  Integer and
+		 * fractional digits are counted separately so that the numeric
+		 * typmod can be derived after the exponent is applied.
+		 */
+		while (*p != '\0')
+		{
+			if (isdigit((unsigned char) *p))
+			{
+				has_digit = true;
+				if (*p != '0')
+					has_nonzero_digit = true;
+				if (!has_dot)
+					int_digits++;
 				else
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("invalid number format model")));
+					frac_digits++;
+				p++;
+			}
+			else if (*p == '.' && !has_dot)
+			{
+				has_dot = true;
+				p++;
 			}
 			else
-			{
-				if (isdigit((unsigned char) *tem))
-					scale++;
-				else
-				{
-					while(*tem == ' ')
-						tem++;
-
-					if(*tem == '\0')
-						break;
-					else
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-									errmsg("invalid number format model")));
-				}
-			}
+				break;
 		}
-		precision += scale;
-		if (precision == 0)
+
+		/*
+		 * Optional exponent (scientific notation), e.g. '1e3' or '-1.5E-2'.
+		 * Oracle's TO_NUMBER accepts these.
+		 */
+		if (*p == 'e' || *p == 'E')
+		{
+			int			exp_sign = 1;
+
+			p++;
+
+			if (*p == '-')
+			{
+				exp_sign = -1;
+				p++;
+			}
+			else if (*p == '+')
+				p++;
+
+			while (isdigit((unsigned char) *p))
+			{
+				/*
+				 * Consume every exponent digit rather than stopping after a
+				 * fixed number of them, so that '1e0000000010' is not misread
+				 * as '1e1'.  Accumulate the magnitude in int64 and apply the
+				 * same bound as numeric_in() (PG_INT32_MAX / 2) to spot
+				 * exponents that can no longer be represented.  Past that
+				 * bound the outcome is already fixed: a positive exponent
+				 * overflows numeric, while a negative one underflows to zero
+				 * (matching Oracle's TO_NUMBER).  Keep scanning so the rest of
+				 * the input is still validated, but stop accumulating.
+				 */
+				has_exp_digit = true;
+				if (!exp_overflow)
+				{
+					if (exponent > PG_INT32_MAX / 2)
+						exp_overflow = true;
+					else
+					{
+						exponent = exponent * 10 + (*p - '0');
+						if (exponent > PG_INT32_MAX / 2)
+							exp_overflow = true;
+					}
+				}
+				p++;
+			}
+
+			/* An exponent must have at least one digit */
+			if (!has_exp_digit)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("invalid number format model")));
+
+			if (exp_overflow)
+			{
+				if (exp_sign > 0 && has_nonzero_digit)
+					ereport(ERROR,
+							(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+							 errmsg("value overflows numeric format")));
+
+				/*
+				 * An oversized exponent times an all-zero mantissa is still
+				 * zero, and a negative exponent that large underflows to
+				 * zero as well -- both match Oracle's TO_NUMBER.  numeric_in()
+				 * would instead raise an out-of-range error, so parse a
+				 * plain "0" below.
+				 */
+				underflow_to_zero = true;
+				exponent = 0;
+			}
+			else
+				exponent *= exp_sign;
+		}
+
+		/* Skip trailing blanks (Oracle ignores them) */
+		while (*p == ' ')
+			p++;
+
+		if (*p != '\0')
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("invalid number format model")));
+					 errmsg("invalid number format model")));
+
+		if (!has_digit)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid number format model")));
+
+		/*
+		 * Derive the numeric typmod from the mantissa digits and the
+		 * exponent: scale = max(0, frac_digits - exponent), precision =
+		 * mantissa digits shifted by the exponent (never less than the
+		 * scale).  Values beyond numeric's limits are rejected by
+		 * numeric_in() with an overflow error.
+		 */
+		scale = Max(0, frac_digits - (int) exponent);
+		precision = Max(int_digits + frac_digits +
+						Max(0, (int) exponent - frac_digits), scale);
+
+		/* Keep the typmod within numeric's valid range */
+		if (precision > NUMERIC_MAX_PRECISION)
+			precision = NUMERIC_MAX_PRECISION;
+		if (scale > precision)
+			scale = precision;
+
+		/*
+		 * A negative exponent that underflows numeric's range yields zero
+		 * (as Oracle's TO_NUMBER does), so hand numeric_in() a plain "0"
+		 * instead of the original string, which would overflow.
+		 */
+		if (underflow_to_zero)
+		{
+			pfree(numstr);
+			numstr = pstrdup("0");
+		}
 	}
 
 	result = DirectFunctionCall3(numeric_in,


### PR DESCRIPTION
ora_to_number_internal()'s unformatted branch only accepted digits, a single decimal point and a leading sign, so inputs like '1e3' (which Oracle's TO_NUMBER accepts and PostgreSQL's numeric input already parses) were rejected with "invalid number format model".  Trailing blanks were also rejected in the integer part while accepted after the decimal point.

Parse an optional exponent ('e'/'E' followed by an optional sign and digits) and skip leading and trailing blanks, matching Oracle.  Derive the numeric typmod from the mantissa digits adjusted by the exponent so the result keeps the right scale (e.g. '1e3' -> numeric(4,0) -> 1000, '-1.5e-2' -> numeric(3,3) -> -0.015).

Add regression coverage for scientific notation, blank padding and malformed exponents in ora_number.sql.

Closed #1703 

Assisted-by: Cursor
Percentage of AI-generated code: 95%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved numeric conversion for scientific notation, signed exponents, decimal values, optional signs, and surrounding whitespace.
  - Leading zeros in exponents are handled correctly, including positive and negative exponent values.

- **Bug Fixes**
  - Numeric conversions now handle precision, scale, overflow, and underflow consistently.
  - Malformed, incomplete, empty, and unsupported numeric inputs return appropriate errors.

- **Tests**
  - Expanded regression coverage for whitespace, special values, decimal variants, zero exponents, exponent boundaries, and malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->