### PR TITLE
Fix ora_rowid test expectation to match sql comment

### DIFF
--- a/src/oracle_test/regress/expected/ora_rowid.out
+++ b/src/oracle_test/regress/expected/ora_rowid.out
@@ -1,5 +1,5 @@
 --
--- Test Compatible Oracle ROWID pseudo
+-- Test Oracle-Compatible ROWID Pseudo-Column
 --
 --
 --1, Support rowid feature via default_with_rowids GUC parameter


### PR DESCRIPTION
Update expected output comment to align with ora_rowid.sql, fixing the always-failing oracle_test regression check. Closes #1711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the ROWID regression test title to clarify Oracle compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->