### PR TITLE
Declare exit_nicely(void) and drop the ignored argument

### DIFF
--- a/src/interfaces/libpq/ivytest/testlibpq.c
+++ b/src/interfaces/libpq/ivytest/testlibpq.c
@@ -85,7 +85,7 @@ static void run_stmt(Ivyconn *tconn,IvyPreparedStatement *stmt, Ivyargmode *argm
 
 
 static void
-exit_nicely()
+exit_nicely(void)
 {
 	Ivyfinish(thread_data.tconn1);
 	Ivyfinish(thread_data.tconn3);
@@ -139,7 +139,7 @@ init_data(Ivyconn *conn)
 	{
 		fprintf(stderr, "plsql_function_out Ivyexec failed\n");
 		Ivyclear(res);
-		exit_nicely(conn);
+		exit_nicely();
 	}
 	Ivyclear(res);
 


### PR DESCRIPTION
exit_nicely() used an old-style empty parameter list, so the compiler skipped argument-count checks and the errant exit_nicely(conn) call was silently accepted. Make it a proper (void) prototype and remove the stray argument.
Closes #1707 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated internal connection cleanup handling during test data initialization.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->