### PR TITLE
Fix missing owner check for CREATE PACKAGE BODY (#1708)

### DIFF
--- a/src/backend/commands/packagecmds.c
+++ b/src/backend/commands/packagecmds.c
@@ -362,6 +362,12 @@ CreatePackageBody_internal(const char *pkgname,
 	if (pkg_editable != editable)
 		elog(ERROR, "The EDITIONABLE property of a TYPE or PACKAGE specification and its"
 					" body must match");
+    /*
+     * Permission check: must own package or superuser
+     */
+	if (!pg_package_ownercheck(pkgOid, GetUserId()))
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_PACKAGE_BODY,
+					pkgname);
 
 	/*
 	 * All seems OK; prepare the data to be inserted into sys_package_body.
@@ -391,10 +397,6 @@ CreatePackageBody_internal(const char *pkgname,
 
 		if (!replace)
 			elog(ERROR, "package \"%s\" body already exists", pkgname);
-
-		if (!pg_package_ownercheck(pkgOid, GetUserId()))
-			aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_PACKAGE_BODY,
-						   pkgname);
 
 		bodydatum = SysCacheGetAttr(PKGBODYOID, oldtup,
 								  Anum_pg_package_body_bodysrc, &isnull);

--- a/src/oracle_test/regress/expected/ora_package.out
+++ b/src/oracle_test/regress/expected/ora_package.out
@@ -6376,8 +6376,60 @@ END;
 $$;
 NOTICE:  pkg_const_repeat_test: all checks passed
 DROP PACKAGE pkg_const_repeat_test;
+CREATE SCHEMA shared_ns;
+CREATE ROLE role_owner LOGIN;
+CREATE ROLE role_attacker LOGIN;
+GRANT CREATE, USAGE ON SCHEMA shared_ns TO role_owner, role_attacker;
+SET ROLE role_owner;
+SELECT current_user;
+ current_user 
+--------------
+ role_owner
+(1 row)
+
+CREATE PACKAGE shared_ns.victim_pkg IS
+  FUNCTION get_secret RETURN INTEGER;
+END victim_pkg;
+/
+SET ROLE role_attacker;
+SELECT current_user;
+ current_user  
+---------------
+ role_attacker
+(1 row)
+
+CREATE PACKAGE BODY shared_ns.victim_pkg IS
+  FUNCTION get_secret RETURN INTEGER IS
+  BEGIN
+    RETURN 1337;
+  END;
+END victim_pkg;
+/
+ERROR:  must be owner of package body victim_pkg
+CREATE OR REPLACE PACKAGE BODY shared_ns.victim_pkg IS
+  FUNCTION get_secret RETURN INTEGER IS
+  BEGIN
+    RETURN 1337;
+  END;
+END victim_pkg;
+/
+ERROR:  must be owner of package body victim_pkg
+SET ROLE role_owner;
+SELECT current_user;
+ current_user 
+--------------
+ role_owner
+(1 row)
+
+SELECT shared_ns.victim_pkg.get_secret();
+ERROR:  package "victim_pkg" has no body
+RESET ROLE;
 --clean data
 RESET ivorysql.allow_out_parameter_const;
 DROP FUNCTION test_event_trigger;
 DROP TABLE mds;
 DROP TABLE mdss;
+DROP SCHEMA shared_ns cascade;
+NOTICE:  drop cascades to package shared_ns.victim_pkg
+DROP ROLE role_owner;
+DROP ROLE role_attacker;

--- a/src/oracle_test/regress/sql/ora_package.sql
+++ b/src/oracle_test/regress/sql/ora_package.sql
@@ -6187,9 +6187,44 @@ $$;
 
 DROP PACKAGE pkg_const_repeat_test;
 
+CREATE SCHEMA shared_ns;
+CREATE ROLE role_owner LOGIN;
+CREATE ROLE role_attacker LOGIN;
+GRANT CREATE, USAGE ON SCHEMA shared_ns TO role_owner, role_attacker;
+
+SET ROLE role_owner;
+SELECT current_user;
+CREATE PACKAGE shared_ns.victim_pkg IS
+  FUNCTION get_secret RETURN INTEGER;
+END victim_pkg;
+/
+
+SET ROLE role_attacker;
+SELECT current_user;
+CREATE PACKAGE BODY shared_ns.victim_pkg IS
+  FUNCTION get_secret RETURN INTEGER IS
+  BEGIN
+    RETURN 1337;
+  END;
+END victim_pkg;
+/
+
+CREATE OR REPLACE PACKAGE BODY shared_ns.victim_pkg IS
+  FUNCTION get_secret RETURN INTEGER IS
+  BEGIN
+    RETURN 1337;
+  END;
+END victim_pkg;
+/
+SET ROLE role_owner;
+SELECT current_user;
+SELECT shared_ns.victim_pkg.get_secret();
+RESET ROLE;
 --clean data
 RESET ivorysql.allow_out_parameter_const;
 DROP FUNCTION test_event_trigger;
 DROP TABLE mds;
 DROP TABLE mdss;
-
+DROP SCHEMA shared_ns cascade;
+DROP ROLE role_owner;
+DROP ROLE role_attacker;


### PR DESCRIPTION

Fixes #1708
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved package ownership validation when creating or replacing package bodies.
- Prevented unauthorized roles from creating or replacing another role’s package body.
- Preserved package owners’ control over package implementations in shared schemas.

## Tests
- Added regression coverage for cross-role package ownership.
- Verified unauthorized package-body changes are rejected.
- Confirmed package owners can access packages that remain without an unauthorized body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->