### PR TITLE
Add Oracle-compatible UTL_URL.ESCAPE

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -33,6 +33,7 @@ OBJS = \
 	src/builtin_packages/dbms_utility/dbms_utility.o \
 	src/builtin_packages/dbms_lock/dbms_lock.o \
 	src/builtin_packages/utl_encode/utl_encode.o \
+	src/builtin_packages/utl_url/utl_url.o \
 	src/builtin_packages/dbms_session/dbms_session.o
 
 EXTENSION = ivorysql_ora
@@ -84,6 +85,7 @@ ORA_REGRESS = \
 	utl_file \
 	utl_raw \
 	utl_encode \
+	utl_url \
 	dbms_session
 
 # Include path for plisql.h (needed by dbms_utility)

--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -61,6 +61,11 @@ cleansql:
 
 # REGRESS_OPTS mainly used for installcheck or debug.
 #REGRESS_OPTS = --port=1521
+# The utl_url regression tests exercise multibyte input and charset
+# conversions, so pin the test database to UTF8 instead of relying on
+# whatever encoding initdb derives from the invoking environment's locale.
+ENCODING = UTF8
+
 ORA_REGRESS = \
 	ora_character \
 	ora_datetime \

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -187,6 +187,21 @@ SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
  a%20b     | a%20b
 (1 row)
 
+-- The url_charset contract: omitting the argument and passing an explicit
+-- NULL are the same thing here -- both mean "the database encoding, do not
+-- convert".  Oracle makes them different: an omitted url_charset defaults
+-- to utl_http.body_charset (ISO-8859-1) while an explicit NULL selects the
+-- database character set.  Defaulting to the database encoding instead of
+-- ISO-8859-1 is the declared deviation of this port (ISO-8859-1 cannot
+-- represent non-Latin text; see the package documentation), and this case
+-- pins the contract so the difference stays visible.
+SELECT utl_url.escape('é') AS default_charset,
+       utl_url.escape('é', FALSE, NULL) AS explicit_null_charset;
+ default_charset | explicit_null_charset 
+-----------------+-----------------------
+ %C3%A9          | %C3%A9
+(1 row)
+
 -- An unrecognized character set is rejected
 SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
 ERROR:  UTL_URL: unrecognized URL character set "NO_SUCH_CHARSET"

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -1,0 +1,154 @@
+--
+-- utl_url.sql
+--
+-- Tests for the UTL_URL package (ESCAPE function)
+--
+-- The escaped form of a multibyte character depends on the character set the
+-- character is converted to, so the multibyte cases below pass 'UTF8'
+-- explicitly rather than relying on the database encoding.
+--
+-- ============================================================
+-- Tests for UTL_URL.ESCAPE
+-- ============================================================
+-- NULL input returns NULL
+SELECT utl_url.escape(NULL) IS NULL AS escape_null;
+ escape_null 
+-------------
+ t
+(1 row)
+
+-- Empty input
+SELECT utl_url.escape('') AS escape_empty, utl_url.escape('') IS NULL AS empty_is_null;
+ escape_empty | empty_is_null 
+--------------+---------------
+              | t
+(1 row)
+
+-- Unreserved characters are never escaped
+SELECT utl_url.escape('AZaz09-_.!~*''()') AS unreserved;
+   unreserved    
+-----------------
+ AZaz09-_.!~*'()
+(1 row)
+
+-- Space and the other illegal characters are escaped, reserved ones are not
+SELECT utl_url.escape('a b/c?d=e&f') AS default_mode;
+ default_mode  
+---------------
+ a%20b/c?d=e&f
+(1 row)
+
+-- With escape_reserved_chars = TRUE the delimiters are escaped as well
+SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
+     reserved_mode     
+-----------------------
+ a%20b%2Fc%3Fd%3De%26f
+(1 row)
+
+-- Full reserved set: passed through by default, escaped on request
+SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
+ reserved_default 
+------------------
+ ;/?:@&=+$%,#
+(1 row)
+
+SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
+           reserved_escaped           
+--------------------------------------
+ %3B%2F%3F%3A%40%26%3D%2B%24%25%2C%23
+(1 row)
+
+-- Illegal ASCII characters are always escaped
+SELECT utl_url.escape('<>"{}|\\^[]`') AS illegal_ascii;
+            illegal_ascii             
+--------------------------------------
+ %3C%3E%22%7B%7D%7C%5C%5C%5E%5B%5D%60
+(1 row)
+
+-- Control characters are escaped
+SELECT utl_url.escape('a' || chr(9) || 'b' || chr(10) || 'c') AS control_chars;
+ control_chars 
+---------------
+ a%09b%0Ac
+(1 row)
+
+-- Examples from the Oracle documentation
+SELECT utl_url.escape('http://www.acme.com/a url with space.html') AS doc_escape;
+                   doc_escape                    
+-------------------------------------------------
+ http://www.acme.com/a%20url%20with%20space.html
+(1 row)
+
+SELECT utl_url.escape('http://oracle-base.com/my page.html', TRUE) AS doc_escape_reserved;
+              doc_escape_reserved              
+-----------------------------------------------
+ http%3A%2F%2Foracle-base.com%2Fmy%20page.html
+(1 row)
+
+SELECT utl_url.escape('Is the use of the "$" sign okay?', TRUE) AS doc_escape_value;
+                    doc_escape_value                    
+--------------------------------------------------------
+ Is%20the%20use%20of%20the%20%22%24%22%20sign%20okay%3F
+(1 row)
+
+-- Multibyte characters: each byte of the converted character gets its own %XX
+SELECT utl_url.escape('中文测试', FALSE, 'UTF8') AS cjk_utf8;
+               cjk_utf8               
+--------------------------------------
+ %E4%B8%AD%E6%96%87%E6%B5%8B%E8%AF%95
+(1 row)
+
+-- Explicit character set conversion: the same characters in GB18030
+SELECT utl_url.escape('中文', FALSE, 'GB18030') AS cjk_gb18030;
+ cjk_gb18030  
+--------------
+ %D6%D0%CE%C4
+(1 row)
+
+-- The charset name may be spelled the IANA way or the PostgreSQL way
+SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
+       utl_url.escape('a b', FALSE, 'LATIN1') AS pg_name;
+ iana_name | pg_name 
+-----------+---------
+ a%20b     | a%20b
+(1 row)
+
+-- An unrecognized character set is rejected
+SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
+ERROR:  UTL_URL: unrecognized URL character set "NO_SUCH_CHARSET"
+CONTEXT:  PL/iSQL function sys.utl_url.escape line 5 at RETURN
+-- A character with no representation in the target character set is rejected
+SELECT utl_url.escape('中文', FALSE, 'LATIN1');
+ERROR:  character with byte sequence 0xe4 0xb8 0xad in encoding "UTF8" has no equivalent in encoding "LATIN1"
+CONTEXT:  PL/iSQL function sys.utl_url.escape line 5 at RETURN
+-- ============================================================
+-- PL/iSQL package interface
+-- ============================================================
+DECLARE
+    v_url     VARCHAR2(200) := 'http://example.com/a b/中文?x=1&y=2';
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape(v_url);
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+NOTICE:  escaped=http://example.com/a%20b/%E4%B8%AD%E6%96%87?x=1&y=2
+-- All three arguments through the package
+DECLARE
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape('a b$c', TRUE, 'UTF8');
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+NOTICE:  escaped=a%20b%24c

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -45,17 +45,91 @@ SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
  a%20b%2Fc%3Fd%3De%26f
 (1 row)
 
--- Full reserved set: passed through by default, escaped on request
+-- The reserved delimiters: passed through by default, escaped on request.
+-- '%' and '#' are not passthrough delimiters and are escaped even in the
+-- default mode.
 SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
  reserved_default 
 ------------------
- ;/?:@&=+$%,#
+ ;/?:@&=+$%25,%23
 (1 row)
 
 SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
            reserved_escaped           
 --------------------------------------
  %3B%2F%3F%3A%40%26%3D%2B%24%25%2C%23
+(1 row)
+
+-- A literal '%' is always escaped, even in default mode, so that
+-- already-escaped input is double-escaped (matching Oracle)
+SELECT utl_url.escape('a%b') AS pct_default;
+ pct_default 
+-------------
+ a%25b
+(1 row)
+
+SELECT utl_url.escape('a%b', TRUE) AS pct_reserved;
+ pct_reserved 
+--------------
+ a%25b
+(1 row)
+
+SELECT utl_url.escape('a%20b') AS preescaped_default;
+ preescaped_default 
+--------------------
+ a%2520b
+(1 row)
+
+SELECT utl_url.escape('a%20b', TRUE) AS preescaped_reserved;
+ preescaped_reserved 
+---------------------
+ a%2520b
+(1 row)
+
+-- '#' is always escaped, including default mode, matching Oracle.
+SELECT utl_url.escape('a#b') AS hash_default;
+ hash_default 
+--------------
+ a%23b
+(1 row)
+
+SELECT utl_url.escape('a#b', TRUE) AS hash_reserved;
+ hash_reserved 
+---------------
+ a%23b
+(1 row)
+
+-- A real-world URL with a pre-escaped component and a fragment
+SELECT utl_url.escape('http://h/p?q=a%20b#frag') AS url_default;
+         url_default         
+-----------------------------
+ http://h/p?q=a%2520b%23frag
+(1 row)
+
+-- '#' alone
+SELECT utl_url.escape('#') AS hash_only_default;
+ hash_only_default 
+-------------------
+ %23
+(1 row)
+
+SELECT utl_url.escape('#', TRUE) AS hash_only_reserved;
+ hash_only_reserved 
+--------------------
+ %23
+(1 row)
+
+-- a fragment/query-like string in both modes
+SELECT utl_url.escape('a#b?c=d', FALSE) AS hash_query_default;
+ hash_query_default 
+--------------------
+ a%23b?c=d
+(1 row)
+
+SELECT utl_url.escape('a#b?c=d', TRUE) AS hash_query_reserved;
+ hash_query_reserved 
+---------------------
+ a%23b%3Fc%3Dd
 (1 row)
 
 -- Illegal ASCII characters are always escaped

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -8,4 +8,5 @@ src/builtin_packages/dbms_utility/dbms_utility
 src/builtin_packages/dbms_lock/dbms_lock
 src/builtin_packages/utl_raw/utl_raw
 src/builtin_packages/utl_encode/utl_encode
+src/builtin_packages/utl_url/utl_url
 src/builtin_packages/dbms_session/dbms_session

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -32,6 +32,7 @@ ivorysql_ora_sources = files(
   'src/builtin_packages/dbms_lock/dbms_lock.c',
   'src/builtin_packages/utl_raw/utl_raw.c',
   'src/builtin_packages/utl_encode/utl_encode.c',
+  'src/builtin_packages/utl_url/utl_url.c',
   'src/builtin_packages/dbms_session/dbms_session.c'
 )
 

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -1,0 +1,91 @@
+--
+-- utl_url.sql
+--
+-- Tests for the UTL_URL package (ESCAPE function)
+--
+-- The escaped form of a multibyte character depends on the character set the
+-- character is converted to, so the multibyte cases below pass 'UTF8'
+-- explicitly rather than relying on the database encoding.
+--
+
+-- ============================================================
+-- Tests for UTL_URL.ESCAPE
+-- ============================================================
+
+-- NULL input returns NULL
+SELECT utl_url.escape(NULL) IS NULL AS escape_null;
+
+-- Empty input
+SELECT utl_url.escape('') AS escape_empty, utl_url.escape('') IS NULL AS empty_is_null;
+
+-- Unreserved characters are never escaped
+SELECT utl_url.escape('AZaz09-_.!~*''()') AS unreserved;
+
+-- Space and the other illegal characters are escaped, reserved ones are not
+SELECT utl_url.escape('a b/c?d=e&f') AS default_mode;
+
+-- With escape_reserved_chars = TRUE the delimiters are escaped as well
+SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
+
+-- Full reserved set: passed through by default, escaped on request
+SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
+SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
+
+-- Illegal ASCII characters are always escaped
+SELECT utl_url.escape('<>"{}|\\^[]`') AS illegal_ascii;
+
+-- Control characters are escaped
+SELECT utl_url.escape('a' || chr(9) || 'b' || chr(10) || 'c') AS control_chars;
+
+-- Examples from the Oracle documentation
+SELECT utl_url.escape('http://www.acme.com/a url with space.html') AS doc_escape;
+SELECT utl_url.escape('http://oracle-base.com/my page.html', TRUE) AS doc_escape_reserved;
+SELECT utl_url.escape('Is the use of the "$" sign okay?', TRUE) AS doc_escape_value;
+
+-- Multibyte characters: each byte of the converted character gets its own %XX
+SELECT utl_url.escape('中文测试', FALSE, 'UTF8') AS cjk_utf8;
+
+-- Explicit character set conversion: the same characters in GB18030
+SELECT utl_url.escape('中文', FALSE, 'GB18030') AS cjk_gb18030;
+
+-- The charset name may be spelled the IANA way or the PostgreSQL way
+SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
+       utl_url.escape('a b', FALSE, 'LATIN1') AS pg_name;
+
+-- An unrecognized character set is rejected
+SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
+
+-- A character with no representation in the target character set is rejected
+SELECT utl_url.escape('中文', FALSE, 'LATIN1');
+
+-- ============================================================
+-- PL/iSQL package interface
+-- ============================================================
+
+DECLARE
+    v_url     VARCHAR2(200) := 'http://example.com/a b/中文?x=1&y=2';
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape(v_url);
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+
+-- All three arguments through the package
+DECLARE
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape('a b$c', TRUE, 'UTF8');
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -27,9 +27,33 @@ SELECT utl_url.escape('a b/c?d=e&f') AS default_mode;
 -- With escape_reserved_chars = TRUE the delimiters are escaped as well
 SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
 
--- Full reserved set: passed through by default, escaped on request
+-- The reserved delimiters: passed through by default, escaped on request.
+-- '%' and '#' are not passthrough delimiters and are escaped even in the
+-- default mode.
 SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
 SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
+
+-- A literal '%' is always escaped, even in default mode, so that
+-- already-escaped input is double-escaped (matching Oracle)
+SELECT utl_url.escape('a%b') AS pct_default;
+SELECT utl_url.escape('a%b', TRUE) AS pct_reserved;
+SELECT utl_url.escape('a%20b') AS preescaped_default;
+SELECT utl_url.escape('a%20b', TRUE) AS preescaped_reserved;
+
+-- '#' is always escaped, including default mode, matching Oracle.
+SELECT utl_url.escape('a#b') AS hash_default;
+SELECT utl_url.escape('a#b', TRUE) AS hash_reserved;
+
+-- A real-world URL with a pre-escaped component and a fragment
+SELECT utl_url.escape('http://h/p?q=a%20b#frag') AS url_default;
+
+-- '#' alone
+SELECT utl_url.escape('#') AS hash_only_default;
+SELECT utl_url.escape('#', TRUE) AS hash_only_reserved;
+
+-- a fragment/query-like string in both modes
+SELECT utl_url.escape('a#b?c=d', FALSE) AS hash_query_default;
+SELECT utl_url.escape('a#b?c=d', TRUE) AS hash_query_reserved;
 
 -- Illegal ASCII characters are always escaped
 SELECT utl_url.escape('<>"{}|\\^[]`') AS illegal_ascii;

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -76,6 +76,17 @@ SELECT utl_url.escape('中文', FALSE, 'GB18030') AS cjk_gb18030;
 SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
        utl_url.escape('a b', FALSE, 'LATIN1') AS pg_name;
 
+-- The url_charset contract: omitting the argument and passing an explicit
+-- NULL are the same thing here -- both mean "the database encoding, do not
+-- convert".  Oracle makes them different: an omitted url_charset defaults
+-- to utl_http.body_charset (ISO-8859-1) while an explicit NULL selects the
+-- database character set.  Defaulting to the database encoding instead of
+-- ISO-8859-1 is the declared deviation of this port (ISO-8859-1 cannot
+-- represent non-Latin text; see the package documentation), and this case
+-- pins the contract so the difference stays visible.
+SELECT utl_url.escape('é') AS default_charset,
+       utl_url.escape('é', FALSE, NULL) AS explicit_null_charset;
+
 -- An unrecognized character set is rejected
 SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
 

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -31,10 +31,11 @@ CREATE OR REPLACE PACKAGE utl_url AS
      * Unreserved characters, never escaped:
      *     A-Z  a-z  0-9  -  _  .  !  ~  *  '  (  )
      * Reserved characters, escaped only when escape_reserved_chars is TRUE:
-     *     ;  /  ?  :  @  &  =  +  $  %  ,  #
+     *     ;  /  ?  :  @  &  =  +  $  ,
      * Everything else, always escaped:
-     *     space, control characters, " < > { } | \ ^ [ ] ` and every
-     *     non-ASCII byte.
+     *     #, space, control characters, " < > { } | \ ^ [ ] ` , every
+     *     non-ASCII byte, and a literal "%" (already-escaped input is
+     *     double-escaped, matching Oracle).
      *
      * Parameters:
      *   url                    IN VARCHAR2 - the original URL
@@ -44,7 +45,15 @@ CREATE OR REPLACE PACKAGE utl_url AS
      *                                         converted to before being
      *                                         escaped.  NULL (the default)
      *                                         means the database encoding,
-     *                                         with no conversion.
+     *                                         with no conversion.  Note:
+     *                                         Oracle's documented default is
+     *                                         utl_http.body_charset
+     *                                         (ISO-8859-1); using the database
+     *                                         encoding instead is a deliberate
+     *                                         deviation, since ISO-8859-1
+     *                                         cannot represent non-Latin text
+     *                                         and UTL_HTTP is not available
+     *                                         here.
      * Returns:
      *   VARCHAR2 - the escaped URL, or NULL when url IS NULL
      */

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -1,0 +1,66 @@
+/***************************************************************
+ *
+ * UTL_URL Package
+ *
+ * Oracle-compatible URL escape utilities (RFC 2396).
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+ *
+ ***************************************************************/
+
+/*
+ * Register the C implementation in the sys schema.
+ *
+ * NOT declared STRICT on purpose: url_charset is legitimately NULL whenever
+ * the caller relies on the default, and a STRICT function would then return
+ * NULL for every call.  NULL propagation for the url argument is handled in C.
+ */
+CREATE FUNCTION sys.utl_url_escape(url text, escape_reserved_chars boolean, url_charset text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ivorysql_utl_url_escape'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- PL/iSQL package declaration
+CREATE OR REPLACE PACKAGE utl_url AS
+
+    /*
+     * ESCAPE
+     * Returns a URL with the illegal characters (and optionally the reserved
+     * characters) escaped using the %2-digit-hex-code format.
+     *
+     * Unreserved characters, never escaped:
+     *     A-Z  a-z  0-9  -  _  .  !  ~  *  '  (  )
+     * Reserved characters, escaped only when escape_reserved_chars is TRUE:
+     *     ;  /  ?  :  @  &  =  +  $  %  ,  #
+     * Everything else, always escaped:
+     *     space, control characters, " < > { } | \ ^ [ ] ` and every
+     *     non-ASCII byte.
+     *
+     * Parameters:
+     *   url                    IN VARCHAR2 - the original URL
+     *   escape_reserved_chars  IN BOOLEAN   - also escape the reserved
+     *                                         delimiters (default FALSE)
+     *   url_charset            IN VARCHAR2  - character set the characters are
+     *                                         converted to before being
+     *                                         escaped.  NULL (the default)
+     *                                         means the database encoding,
+     *                                         with no conversion.
+     * Returns:
+     *   VARCHAR2 - the escaped URL, or NULL when url IS NULL
+     */
+    FUNCTION escape(url IN VARCHAR2,
+                    escape_reserved_chars IN BOOLEAN DEFAULT FALSE,
+                    url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2;
+
+END utl_url;
+
+CREATE OR REPLACE PACKAGE BODY utl_url AS
+
+    FUNCTION escape(url IN VARCHAR2,
+                    escape_reserved_chars IN BOOLEAN DEFAULT FALSE,
+                    url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2 IS
+    BEGIN
+        RETURN sys.utl_url_escape(url, escape_reserved_chars, url_charset);
+    END;
+
+END utl_url;

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -43,17 +43,23 @@ CREATE OR REPLACE PACKAGE utl_url AS
      *                                         delimiters (default FALSE)
      *   url_charset            IN VARCHAR2  - character set the characters are
      *                                         converted to before being
-     *                                         escaped.  NULL (the default)
-     *                                         means the database encoding,
-     *                                         with no conversion.  Note:
-     *                                         Oracle's documented default is
+     *                                         escaped.  An omitted
+     *                                         url_charset and an explicit
+     *                                         NULL are equivalent here and
+     *                                         both mean the database
+     *                                         encoding, with no conversion.
+     *                                         Oracle distinguishes the two
+     *                                         forms: an omitted argument
+     *                                         defaults to
      *                                         utl_http.body_charset
-     *                                         (ISO-8859-1); using the database
-     *                                         encoding instead is a deliberate
-     *                                         deviation, since ISO-8859-1
-     *                                         cannot represent non-Latin text
-     *                                         and UTL_HTTP is not available
-     *                                         here.
+     *                                         (ISO-8859-1) while an explicit
+     *                                         NULL selects the database
+     *                                         character set.  Using the
+     *                                         database encoding for both is
+     *                                         a deliberate deviation:
+     *                                         ISO-8859-1 cannot represent
+     *                                         non-Latin text and UTL_HTTP
+     *                                         is not available here.
      * Returns:
      *   VARCHAR2 - the escaped URL, or NULL when url IS NULL
      */

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
@@ -1,0 +1,182 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Implementation of Oracle's UTL_URL package.
+ * This module is part of ivorysql_ora extension.
+ *
+ * Provides the URL escape mechanism described by RFC 2396 (which is
+ * what Oracle's UTL_URL implements).  Note that this is NOT the
+ * x-www-form-urlencoded scheme: a space becomes "%20", never "+".
+ *
+ * Portions Copyright (c) 2025-2026, IvorySQL Global Development Team
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "lib/stringinfo.h"
+#include "mb/pg_wchar.h"
+#include "utils/builtins.h"
+
+/*
+ * RFC 2396 / Oracle UTL_URL character classes.
+ *
+ * "Unreserved" characters are always passed through unescaped:
+ *		A-Z  a-z  0-9  -  _  .  !  ~  *  '  (  )
+ *
+ * "Reserved" characters are URL delimiters.  They are passed through when
+ * escape_reserved_chars is FALSE (the Oracle default) and escaped when it is
+ * TRUE:
+ *		;  /  ?  :  @  &  =  +  $  %  ,  #
+ *
+ * Everything else (space, control characters, "<", ">", quotes, braces,
+ * brackets, backslash, and every non-ASCII byte) is an "illegal" URL
+ * character and is always escaped.
+ */
+#define UTL_URL_UNRESERVED_CHARS	"-_.!~*'()"
+#define UTL_URL_RESERVED_CHARS		";/?:@&=+$%,#"
+
+static bool utl_url_is_unreserved(unsigned char c);
+static bool utl_url_is_reserved(unsigned char c);
+static int	utl_url_charset_to_encoding(text *charset);
+
+/*
+ * utl_url_is_unreserved - is c an RFC 2396 unreserved character?
+ *
+ * Only plain ASCII alphanumerics qualify, so we deliberately avoid the
+ * locale-dependent isalnum() here.
+ */
+static bool
+utl_url_is_unreserved(unsigned char c)
+{
+	if ((c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9'))
+		return true;
+
+	return (c != '\0' && strchr(UTL_URL_UNRESERVED_CHARS, c) != NULL);
+}
+
+/*
+ * utl_url_is_reserved - is c an RFC 2396 reserved (delimiter) character?
+ */
+static bool
+utl_url_is_reserved(unsigned char c)
+{
+	return (c != '\0' && strchr(UTL_URL_RESERVED_CHARS, c) != NULL);
+}
+
+/*
+ * utl_url_charset_to_encoding - resolve a url_charset argument.
+ *
+ * Accepts both IANA names ("ISO-8859-1", "UTF-8") and PostgreSQL names
+ * ("LATIN1", "UTF8"); pg_char_to_encoding() normalises case, dashes and
+ * underscores for us.
+ *
+ * Oracle raises BAD_FIXED_WIDTH_CHARSET (ORA-29274) for fixed-width multibyte
+ * character sets.  PostgreSQL has no such encoding in its catalog at all
+ * (UTF-16/UTF-32 are not supported), so that condition is unreachable here and
+ * every rejected name lands in the "unrecognized" branch below.
+ */
+static int
+utl_url_charset_to_encoding(text *charset)
+{
+	char	   *name = text_to_cstring(charset);
+	int			encoding = pg_char_to_encoding(name);
+
+	if (encoding < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("UTL_URL: unrecognized URL character set \"%s\"", name)));
+
+	pfree(name);
+
+	return encoding;
+}
+
+/*
+ * ivorysql_utl_url_escape
+ *
+ * Oracle-compatible ESCAPE implementation:
+ *   - Escapes illegal URL characters as %XX (upper-case hex)
+ *   - Escapes the reserved delimiters as well when escape_reserved_chars is
+ *     TRUE; passes them through when it is FALSE (Oracle's default)
+ *   - Multibyte characters are first converted to url_charset and then each
+ *     resulting byte is escaped separately, so a UTF-8 CJK character yields
+ *     three %XX groups
+ *   - A NULL url returns NULL
+ *   - A NULL url_charset means "use the database encoding, do not convert",
+ *     which is Oracle's documented behaviour for a NULL url_charset
+ *
+ * Oracle signature:
+ *   UTL_URL.ESCAPE(url IN VARCHAR2,
+ *                  escape_reserved_chars IN BOOLEAN DEFAULT FALSE,
+ *                  url_charset IN VARCHAR2 DEFAULT utl_http.body_charset)
+ *   RETURN VARCHAR2
+ * Maps to: (text, bool, text) -> text
+ *
+ * Not declared STRICT: url_charset is legitimately NULL in the default case,
+ * and a STRICT function would then wrongly return NULL for every call.
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_url_escape);
+Datum
+ivorysql_utl_url_escape(PG_FUNCTION_ARGS)
+{
+	text	   *url;
+	bool		escape_reserved;
+	int			target_encoding;
+	char	   *src;
+	char	   *converted;
+	int			len;
+	int			i;
+	StringInfoData buf;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	url = PG_GETARG_TEXT_PP(0);
+
+	/* A NULL boolean is treated like the default, FALSE */
+	escape_reserved = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
+
+	target_encoding = PG_ARGISNULL(2) ? GetDatabaseEncoding() :
+		utl_url_charset_to_encoding(PG_GETARG_TEXT_PP(2));
+
+	/*
+	 * Work on a NUL-terminated copy: pg_server_to_any() may hand the input
+	 * pointer straight back, and the conversion helpers expect C strings.
+	 */
+	src = text_to_cstring(url);
+	converted = pg_server_to_any(src, strlen(src), target_encoding);
+	len = strlen(converted);
+
+	initStringInfo(&buf);
+	for (i = 0; i < len; i++)
+	{
+		unsigned char c = (unsigned char) converted[i];
+
+		if (utl_url_is_unreserved(c) ||
+			(!escape_reserved && utl_url_is_reserved(c)))
+			appendStringInfoChar(&buf, (char) c);
+		else
+			appendStringInfo(&buf, "%%%02X", c);
+	}
+
+	/* The result is pure ASCII, hence valid in every server encoding */
+	PG_RETURN_TEXT_P(cstring_to_text_with_len(buf.data, buf.len));
+}

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
@@ -42,14 +42,16 @@
  * "Reserved" characters are URL delimiters.  They are passed through when
  * escape_reserved_chars is FALSE (the Oracle default) and escaped when it is
  * TRUE:
- *		;  /  ?  :  @  &  =  +  $  %  ,  #
+ *		;  /  ?  :  @  &  =  +  $  ,
  *
  * Everything else (space, control characters, "<", ">", quotes, braces,
- * brackets, backslash, and every non-ASCII byte) is an "illegal" URL
- * character and is always escaped.
+ * brackets, backslash, every non-ASCII byte, and literal "%" and "#"
+ * characters) is an "illegal" URL character and is always escaped.  Escaping
+ * "%" unconditionally means already-escaped input is double-escaped
+ * ("a%20b" becomes "a%2520b"), matching Oracle's observed behaviour.
  */
 #define UTL_URL_UNRESERVED_CHARS	"-_.!~*'()"
-#define UTL_URL_RESERVED_CHARS		";/?:@&=+$%,#"
+#define UTL_URL_RESERVED_CHARS		";/?:@&=+$,"
 
 static bool utl_url_is_unreserved(unsigned char c);
 static bool utl_url_is_reserved(unsigned char c);


### PR DESCRIPTION
## Summary

- add UTL_URL.ESCAPE to the ivorysql_ora extension, the URL
  percent-encoding half of Oracle's UTL_URL package (RFC 2396 semantics)
- register the new package in the Makefile, meson.build and
  ivorysql_ora_merge_sqls, following the existing builtin packages
  (utl_encode / utl_raw)
- new regression test contrib/ivorysql_ora/sql/utl_url.sql covering
  NULL propagation, the unreserved/reserved/illegal character sets,
  control characters, multibyte input with explicit charsets
  (UTF8 / GB18030 / LATIN1) and the PL/iSQL package interface
- pin the regression database to UTF8 (ENCODING = UTF8) so the
  multibyte cases do not depend on the invoking environment's locale
  (under LC_ALL=C the suite would otherwise come up as SQL_ASCII)

UNESCAPE, the inverse function, follows in a separate change stacked
on top of this one; splitting them keeps each issue reviewable on
its own.

Two design decisions worth calling out:

1. The Oracle documentation is internally inconsistent about the
   reserved set: the UTL_URL overview lists "%" among the reserved
   characters, while the ESCAPE usage notes list only
   "; / ? : @ & = + $ ,".  Real Oracle behaviour decides the
   question: on Oracle Database XE 11.2, 18 and 21 a literal "%" and
   a literal "#" are ALWAYS escaped, in both the default and the
   escape_reserved_chars = TRUE mode (already-escaped input is
   therefore double-escaped: "a%20b" becomes "a%2520b").  The probe
   script used for those runs is included in a follow-up comment so
   the results are reproducible.  This implementation follows that
   behaviour: the reserved set is ";/?:@&=+$," and everything else,
   including "%" and "#", is always escaped.

2. A NULL url_charset means "use the database encoding, do not
   convert".  This is a deliberate deviation from Oracle, whose
   documented default is utl_http.body_charset (ISO-8859-1): with
   the parameter omitted, Oracle converts through ISO-8859-1, which
   cannot represent non-Latin text (in our probes the CJK input came
   back as %BF%BF, one 0xBF replacement byte per character).  Since
   UTL_HTTP is not available in this extension, defaulting to a
   lossy single-byte conversion would silently corrupt non-Latin
   URLs, so the NULL case uses the database encoding and an explicit
   url_charset is required when a specific conversion is wanted.

## Testing

- oracle regression suite passes: 25/25, including the new
  escape-only utl_url test, in both a UTF8 and a C locale
- the multibyte failures under LC_ALL=C were reproduced without the
  ENCODING pin and disappear with it
- the twelve %-and-# comparison cases in the regression match real
  Oracle XE output row for row (11.2 / 18 / 21; probe script and
  outputs in the follow-up comment)

## Reference

- Oracle UTL_URL documentation:
  https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/UTL_URL.html
- RFC 2396: https://datatracker.ietf.org/doc/html/rfc2396

Fixes #1060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Oracle-compatible `UTL_URL` package support.
- Added URL escaping with optional reserved-character handling.
- Ensured percent signs and hash symbols are escaped consistently, including pre-escaped URLs.
- Added character-set conversion for URL encoding, including multibyte input support.
- Added validation for unrecognized or unsupported character sets.

## Tests
- Added comprehensive coverage for null and empty values, special characters, control characters, documentation examples, character-set conversion, and PL/iSQL integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->