### PR TITLE
add Oracle-Compatible package DBMS_TRANSACTION

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -33,7 +33,8 @@ OBJS = \
 	src/builtin_packages/dbms_utility/dbms_utility.o \
 	src/builtin_packages/dbms_lock/dbms_lock.o \
 	src/builtin_packages/utl_encode/utl_encode.o \
-	src/builtin_packages/dbms_session/dbms_session.o
+	src/builtin_packages/dbms_session/dbms_session.o \
+	src/builtin_packages/dbms_transaction/dbms_transaction.o
 
 EXTENSION = ivorysql_ora
 
@@ -85,7 +86,8 @@ ORA_REGRESS = \
 	utl_file \
 	utl_raw \
 	utl_encode \
-	dbms_session
+	dbms_session \
+	dbms_transaction
 
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src

--- a/contrib/ivorysql_ora/expected/dbms_transaction.out
+++ b/contrib/ivorysql_ora/expected/dbms_transaction.out
@@ -1,0 +1,605 @@
+--
+-- dbms_transaction.sql
+--
+-- tests for DBMS_TRANSACTION:
+--   COMMIT / ROLLBACK, SAVEPOINT / ROLLBACK_SAVEPOINT,
+--   READ_ONLY / READ_WRITE, LOCAL_TRANSACTION_ID,
+--   legacy no-ops, and the documented-unsupported distributed
+--   transaction recovery subprograms.
+--
+create table dbms_tx_t (id int, val varchar2(100));
+--
+-- COMMIT / ROLLBACK: valid only when the package procedure is invoked as a
+-- top-level CALL (non-atomic context) -- same restriction as a bare
+-- COMMIT/ROLLBACK statement inside a PL/iSQL procedure.
+-- AUTOCOMMIT is default ON in psql
+\set AUTOCOMMIT off
+insert into dbms_tx_t values (0, 'committed');
+call dbms_transaction.commit();
+ERROR:  invalid transaction termination
+CONTEXT:  PL/iSQL function sys.dbms_transaction.commit line 3 at COMMIT
+\set AUTOCOMMIT on
+COMMIT;
+insert into dbms_tx_t values (1, 'committed');
+call dbms_transaction.commit();
+select * from dbms_tx_t order by id;
+ id |    val    
+----+-----------
+  1 | committed
+(1 row)
+
+insert into dbms_tx_t values (2, 'rolled back');
+call dbms_transaction.rollback();
+select * from dbms_tx_t order by id;
+ id |     val     
+----+-------------
+  1 | committed
+  2 | rolled back
+(2 rows)
+
+BEGIN
+    insert into dbms_tx_t values (3, 'committed');
+    dbms_transaction.commit();
+    insert into dbms_tx_t values (4, 'rolled back');
+    dbms_transaction.rollback();
+END;
+/
+select * from dbms_tx_t order by id;
+ id |     val     
+----+-------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+(3 rows)
+
+--
+-- SAVEPOINT / ROLLBACK_SAVEPOINT: unlike COMMIT/ROLLBACK, these require an
+-- explicit transaction block, same as a bare SQL SAVEPOINT statement.
+--
+call dbms_transaction.savepoint('sp_outside');
+ERROR:  SAVEPOINT can only be used in transaction blocks
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+-- PG starts transactions explicitly while Oracle starts transactions implicityly
+BEGIN;
+    insert into dbms_tx_t values (5, 'before sp1');
+    call dbms_transaction.savepoint('sp1');
+    insert into dbms_tx_t values (6, 'after sp1, will be rolled back');
+    call dbms_transaction.rollback_savepoint('sp1');
+    insert into dbms_tx_t values (7, 'after rollback to sp1');
+COMMIT;
+select * from dbms_tx_t order by id;
+ id |          val          
+----+-----------------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+  5 | before sp1
+  7 | after rollback to sp1
+(5 rows)
+
+-- nested savepoints: rolling back to the outer one undoes both
+BEGIN;
+    call dbms_transaction.savepoint('a');
+    insert into dbms_tx_t values (8, 'a');
+    call dbms_transaction.savepoint('b');
+    insert into dbms_tx_t values (9, 'b');
+    call dbms_transaction.rollback_savepoint('a');
+    insert into dbms_tx_t values (10, 'after rollback to a');
+COMMIT;
+select * from dbms_tx_t order by id;
+ id |          val          
+----+-----------------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+  5 | before sp1
+  7 | after rollback to sp1
+ 10 | after rollback to a
+(6 rows)
+
+-- rollback to a savepoint that does not exist
+BEGIN;
+    call dbms_transaction.savepoint('a');
+    insert into dbms_tx_t values (8, 'a');
+    call dbms_transaction.savepoint('b');
+    insert into dbms_tx_t values (9, 'b');
+    call dbms_transaction.rollback_savepoint('a');
+    insert into dbms_tx_t values (10, 'after rollback to a');
+    call dbms_transaction.rollback_savepoint('b');
+ERROR:  savepoint "b" does not exist
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+COMMIT;
+select * from dbms_tx_t order by id;
+ id |          val          
+----+-----------------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+  5 | before sp1
+  7 | after rollback to sp1
+ 10 | after rollback to a
+(6 rows)
+
+BEGIN;
+    call dbms_transaction.rollback_savepoint('does_not_exist');
+ERROR:  savepoint "does_not_exist" does not exist
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+ROLLBACK;
+-- SAVEPOINT/ROLLBACK_SAVEPOINT also accept Oracle's named-parameter call
+-- syntax now that the parameter is named "savept" (matching Oracle's
+-- documented signature) instead of the "sp" name used previously.
+begin;
+insert into dbms_tx_t values (11, 'before named-param savepoint');
+call dbms_transaction.savepoint(savept => 'sp_named');
+insert into dbms_tx_t values (12, 'after named-param savepoint, will be rolled back');
+call dbms_transaction.rollback_savepoint(savept => 'sp_named');
+insert into dbms_tx_t values (13, 'after named-param rollback_savepoint');
+commit;
+select * from dbms_tx_t where id between 11 and 13 order by id;
+ id |                 val                  
+----+--------------------------------------
+ 11 | before named-param savepoint
+ 13 | after named-param rollback_savepoint
+(2 rows)
+
+--
+-- READ_ONLY / READ_WRITE
+--
+BEGIN;
+    call dbms_transaction.read_only();
+    insert into dbms_tx_t values (14, 'blocked by read only');
+ERROR:  cannot execute INSERT in a read-only transaction
+ROLLBACK;
+-- READ_WRITE as the first statement of a transaction is a no-op that must
+-- not block subsequent writes.  (Switching a transaction back from read-only
+-- to read-write after another statement has already run is a PostgreSQL
+-- restriction -- "transaction read-write mode must be set before any
+-- query" -- so that sequence is intentionally not exercised here.)
+BEGIN;
+    call dbms_transaction.read_write();
+    insert into dbms_tx_t values (15, 'allowed with read_write');
+COMMIT;
+select * from dbms_tx_t where id = 15;
+ id |           val           
+----+-------------------------
+ 15 | allowed with read_write
+(1 row)
+
+-- LOCAL_TRANSACTION_ID
+select dbms_transaction.local_transaction_id() is null as no_xid_without_create from dual;
+ no_xid_without_create 
+-----------------------
+ t
+(1 row)
+
+BEGIN;
+    select dbms_transaction.local_transaction_id(true) is not null as xid_created from dual;
+ xid_created 
+-------------
+ t
+(1 row)
+
+    select dbms_transaction.local_transaction_id() is not null as xid_now_visible from dual;
+ xid_now_visible 
+-----------------
+ t
+(1 row)
+
+    -- calling again with create_transaction=true on an already-assigned
+    -- transaction just returns the existing id, it does not assign a new one
+    select dbms_transaction.local_transaction_id(true) = dbms_transaction.local_transaction_id() as xid_stable from dual;
+ xid_stable 
+------------
+ t
+(1 row)
+
+COMMIT;
+-- the transaction (and its id) ends with the commit above -- a fresh
+-- transaction has no id again until something assigns one
+select dbms_transaction.local_transaction_id() is null as no_xid_in_new_transaction from dual;
+ no_xid_in_new_transaction 
+---------------------------
+ t
+(1 row)
+
+--
+-- SAVEPOINT / ROLLBACK_SAVEPOINT: additional boundary conditions
+--
+-- NULL savepoint name is rejected explicitly by the C bridge, for both
+-- SAVEPOINT and ROLLBACK_SAVEPOINT.
+begin;
+call dbms_transaction.savepoint(NULL);
+ERROR:  DBMS_TRANSACTION savepoint name must not be NULL
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+rollback;
+begin;
+call dbms_transaction.rollback_savepoint(NULL);
+ERROR:  DBMS_TRANSACTION savepoint name must not be NULL
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+rollback;
+-- savepoint name length boundary: 255 bytes is accepted, 256 is rejected
+-- (DBMS_TRANSACTION_SAVEPOINT_NAME_LEN in dbms_transaction.c is 256, so the
+-- longest accepted name is 255 bytes).
+begin;
+call dbms_transaction.savepoint(repeat('x', 255));
+call dbms_transaction.rollback_savepoint(repeat('x', 255));
+rollback;
+begin;
+call dbms_transaction.savepoint(repeat('x', 256));
+ERROR:  DBMS_TRANSACTION savepoint name too long (max 255 bytes)
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+rollback;
+-- an empty-string savepoint name hits the same "must not be NULL" error as
+-- an explicit NULL: VARCHAR2 treats '' as NULL, and savept is declared
+-- VARCHAR2, so the C bridge never sees a non-NULL empty string here.
+begin;
+call dbms_transaction.savepoint('');
+ERROR:  DBMS_TRANSACTION savepoint name must not be NULL
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+rollback;
+-- redefining the same savepoint name rolls back to the most recently
+-- defined one, matching plain SQL SAVEPOINT semantics -- the first
+-- definition's row is unaffected, only the row inserted after the second
+-- "a" is undone.
+begin;
+insert into dbms_tx_t values (20, 'before first a');
+call dbms_transaction.savepoint('a');
+insert into dbms_tx_t values (21, 'after first a');
+call dbms_transaction.savepoint('a');
+insert into dbms_tx_t values (22, 'after second a, will be rolled back');
+call dbms_transaction.rollback_savepoint('a');
+commit;
+select * from dbms_tx_t where id between 20 and 22 order by id;
+ id |      val       
+----+----------------
+ 20 | before first a
+ 21 | after first a
+(2 rows)
+
+-- rolling back to the same savepoint repeatedly is allowed each time --
+-- ROLLBACK_SAVEPOINT does not release/consume the savepoint, so it can be
+-- targeted again.
+begin;
+call dbms_transaction.savepoint('rep');
+insert into dbms_tx_t values (23, 'first attempt, will be rolled back');
+call dbms_transaction.rollback_savepoint('rep');
+insert into dbms_tx_t values (23, 'second attempt, will also be rolled back');
+call dbms_transaction.rollback_savepoint('rep');
+commit;
+select * from dbms_tx_t where id = 23;
+ id | val 
+----+-----
+(0 rows)
+
+-- ROLLBACK_SAVEPOINT called entirely outside a transaction block (no
+-- enclosing BEGIN at all, unlike the "does_not_exist" case above which was
+-- inside an explicit BEGIN) must raise the same kind of ordinary error as
+-- ROLLBACK TO SAVEPOINT would, not crash the backend.
+call dbms_transaction.rollback_savepoint('never_defined');
+ERROR:  ROLLBACK TO SAVEPOINT can only be used in transaction blocks
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+-- savepoint names are opaque text, not SQL identifiers -- whitespace is
+-- accepted without quoting games.
+begin;
+call dbms_transaction.savepoint('sp with space');
+insert into dbms_tx_t values (24, 'will be rolled back');
+call dbms_transaction.rollback_savepoint('sp with space');
+commit;
+select * from dbms_tx_t where id = 24;
+ id | val 
+----+-----
+(0 rows)
+
+--
+-- READ_ONLY / READ_WRITE: switching modes within one transaction
+--
+-- switching from read-only back to read-write in the same transaction hits
+-- PostgreSQL's "must be set before any query" restriction, because
+-- READ_ONLY's own SET TRANSACTION READ ONLY already counts as a query.
+begin;
+call dbms_transaction.read_only();
+call dbms_transaction.read_write();
+ERROR:  transaction read-write mode must be set before any query
+CONTEXT:  SQL statement "SET TRANSACTION READ WRITE"
+PL/iSQL function sys.dbms_transaction.read_write line 28 at EXECUTE
+rollback;
+-- the reverse direction -- read-write down to read-only -- is always
+-- allowed, since it only narrows what the transaction can do.
+begin;
+call dbms_transaction.read_write();
+call dbms_transaction.read_only();
+select current_setting('transaction_read_only');
+ current_setting 
+-----------------
+ on
+(1 row)
+
+rollback;
+--
+-- COMMIT/ROLLBACK: atomic context (nested inside another procedure's CALL)
+--
+-- COMMIT/ROLLBACK are only valid as the top-level CALL; invoking them from
+-- inside a procedure that is itself being CALLed (so the whole thing runs
+-- atomically) must raise an error instead of silently no-op'ing.
+create or replace procedure dbms_tx_wrapper_commit() as
+begin
+    dbms_transaction.commit();
+end;
+/
+begin;
+call dbms_tx_wrapper_commit();
+ERROR:  invalid transaction termination
+CONTEXT:  PL/iSQL function sys.dbms_transaction.commit line 3 at COMMIT
+SQL statement "CALL dbms_transaction.commit()"
+PL/iSQL function dbms_tx_wrapper_commit() line 2 at CALL
+rollback;
+drop procedure dbms_tx_wrapper_commit();
+-- SAVEPOINT/ROLLBACK_SAVEPOINT: the nested-call guard must not be bypassable
+-- by setting plisql.inside_autonomous_transaction directly.  That GUC is
+-- PGC_USERSET (dblink's own connection has to be able to set it), so an
+-- ordinary session can set it to "on" without ever going through the
+-- autonomous-transaction machinery -- the guard must still reject a nested
+-- SAVEPOINT/ROLLBACK_SAVEPOINT call in that case, not fall through to
+-- DefineSavepoint()/RollbackToSavepoint().
+create or replace procedure dbms_tx_wrapper_savepoint() as
+begin
+    dbms_transaction.savepoint('should_not_be_reached');
+end;
+/
+set plisql.inside_autonomous_transaction = true;
+begin;
+call dbms_tx_wrapper_savepoint();
+ERROR:  DBMS_TRANSACTION.SAVEPOINT cannot be called from within another PL/iSQL routine
+DETAIL:  It must be the direct result of a top-level CALL, the same way a bare SQL SAVEPOINT/ROLLBACK TO SAVEPOINT statement must be its own complete statement.
+HINT:  Move the call to DBMS_TRANSACTION.SAVEPOINT out to its own top-level CALL statement.
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+SQL statement "CALL dbms_transaction.savepoint('should_not_be_reached')"
+PL/iSQL function dbms_tx_wrapper_savepoint() line 2 at CALL
+rollback;
+reset plisql.inside_autonomous_transaction;
+drop procedure dbms_tx_wrapper_savepoint();
+--
+-- Skip the autonomous-transaction section entirely if dblink isn't even
+-- installable in this environment, instead of letting CREATE EXTENSION
+-- error out and cascade into a wall of unrelated failures below.
+--
+SELECT count(*) > 0 AS have_dblink
+FROM pg_available_extensions WHERE name = 'dblink' \gset
+\if :have_dblink
+    --
+    -- The autonomous-transaction tests below run PRAGMA AUTONOMOUS_TRANSACTION
+    -- procedures via dblink.  dblink's connection string (built in
+    -- pl_autonomous.c) has no explicit "user=", so libpq falls back to
+    -- whatever OS user the postgres server process itself is running as --
+    -- if no role of that name exists, every autonomous-transaction test below
+    -- would fail with an unrelated connection error instead of testing what
+    -- it's meant to.  Probe the same loopback connection here and create the
+    -- missing role up front if that's the problem.
+    --
+    CREATE EXTENSION IF NOT EXISTS dblink;
+    DO $$
+    DECLARE
+        missing_role text;
+        probe_connstr text;
+        err_detail    text;
+    BEGIN
+        -- mirror pl_autonomous.c's own connection string exactly: dbname + port,
+        -- no user=
+        probe_connstr := 'dbname=' || current_database()
+                        || ' port=' || current_setting('port');
+                        
+        PERFORM dblink_connect('dbms_tx_probe', probe_connstr);
+        PERFORM dblink_disconnect('dbms_tx_probe');
+    EXCEPTION
+        WHEN OTHERS THEN
+            GET STACKED DIAGNOSTICS err_detail = PG_EXCEPTION_DETAIL;
+            missing_role := substring(err_detail FROM 'role "([^"]+)" does not exist');
+            IF missing_role IS NOT NULL THEN
+                EXECUTE format('CREATE ROLE %I LOGIN SUPERUSER', missing_role);
+                -- record it so the cleanup block below knows to drop it again
+                PERFORM set_config('dbms_tx_test.created_role', missing_role, false);
+            ELSE
+                RAISE;  -- some other, unrelated connection problem -- don't hide it
+            END IF;
+    END;    
+    $$;
+    -- LOCAL_TRANSACTION_ID: an autonomous transaction gets its own transaction
+    -- id, distinct from (and independent of) the calling transaction's id --
+    -- and the autonomous insert is visible immediately, before the outer
+    -- transaction commits.
+    create table dbms_tx_autonomous (which text, xid text);
+    create or replace procedure dbms_tx_autonomous_xid() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_autonomous values ('inner', dbms_transaction.local_transaction_id(true));
+    end;
+    /
+    begin;
+    insert into dbms_tx_autonomous values ('outer', dbms_transaction.local_transaction_id(true));
+    call dbms_tx_autonomous_xid();
+    select which, xid is not null as has_xid from dbms_tx_autonomous order by which;
+    commit;
+    select count(distinct xid) = 2 as outer_and_inner_xids_differ from dbms_tx_autonomous;
+    -- the autonomous insert survives even though the calling transaction rolls
+    -- back -- COMMIT/ROLLBACK of the outer transaction have no effect on it.
+    truncate dbms_tx_autonomous;
+    begin;
+    insert into dbms_tx_autonomous values ('outer_rolled_back', dbms_transaction.local_transaction_id(true));
+    call dbms_tx_autonomous_xid();
+    rollback;
+    select which from dbms_tx_autonomous order by which;
+    drop procedure dbms_tx_autonomous_xid();
+    drop table dbms_tx_autonomous;
+    --
+    -- SAVEPOINT / ROLLBACK_SAVEPOINT / COMMIT / ROLLBACK inside an autonomous
+    -- transaction: the dblink call that executes the autonomous procedure is a
+    -- single bare "CALL proc();" with no surrounding BEGIN, so from that
+    -- session's point of view there is no explicit transaction block --
+    -- SAVEPOINT/ROLLBACK_SAVEPOINT there fail the same way a bare top-level
+    -- SAVEPOINT statement would (see "call dbms_transaction.savepoint('sp_outside')"
+    -- above).  COMMIT/ROLLBACK are still invoked from within the autonomous
+    -- procedure's own body (a nested CALL to dbms_transaction.commit()/rollback()),
+    -- so they hit the same "invalid transaction termination" restriction as any
+    -- other nested CALL -- PRAGMA AUTONOMOUS_TRANSACTION does not change either
+    -- restriction.
+    --
+    create or replace procedure dbms_tx_autonomous_savepoint() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.savepoint('autosp');
+    end;
+    /
+    call dbms_tx_autonomous_savepoint();
+    drop procedure dbms_tx_autonomous_savepoint();
+    create or replace procedure dbms_tx_autonomous_rbsp() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.rollback_savepoint('autosp');
+    end;
+    /
+    call dbms_tx_autonomous_rbsp();
+    drop procedure dbms_tx_autonomous_rbsp();
+    create or replace procedure dbms_tx_autonomous_commit() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_t values (900, 'should not be committed');
+        dbms_transaction.commit();
+    end;
+    /
+    call dbms_tx_autonomous_commit();
+    select * from dbms_tx_t where id = 900;
+    drop procedure dbms_tx_autonomous_commit();
+    create or replace procedure dbms_tx_autonomous_rollback() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_t values (901, 'should error before rollback runs');
+        dbms_transaction.rollback();
+    end;
+    /
+    call dbms_tx_autonomous_rollback();
+    select * from dbms_tx_t where id = 901;
+    drop procedure dbms_tx_autonomous_rollback();
+    --
+    -- READ_ONLY / READ_WRITE inside an autonomous transaction: these are plain
+    -- SET TRANSACTION statements and do not need an explicit transaction block,
+    -- so (unlike SAVEPOINT/COMMIT above) they work the same as at the top level.
+    --
+    create or replace procedure dbms_tx_autonomous_readonly() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.read_only();
+        insert into dbms_tx_t values (902, 'blocked by autonomous read_only');
+    end;
+    /
+    call dbms_tx_autonomous_readonly();
+    select * from dbms_tx_t where id = 902;
+    drop procedure dbms_tx_autonomous_readonly();
+    create or replace procedure dbms_tx_autonomous_readwrite() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.read_write();
+        insert into dbms_tx_t values (903, 'allowed by autonomous read_write, autocommitted');
+    end;
+    /
+    call dbms_tx_autonomous_readwrite();
+    select * from dbms_tx_t where id = 903;
+    drop procedure dbms_tx_autonomous_readwrite();
+    --
+    -- Clean up: drop the role again, but only if this script is the one that
+    -- created it -- never drop a role that already existed before we got here.
+    -- Note: no "<> ''" check alongside IS NOT NULL -- Oracle-compat mode's
+    -- empty-string-is-NULL semantics turns such a comparison into NULL, which
+    -- IF treats as not-satisfied, silently skipping the DROP.
+    --
+    DO $$
+    DECLARE
+        r text := current_setting('dbms_tx_test.created_role', true);
+    BEGIN 
+        IF r IS NOT NULL THEN
+            EXECUTE format('DROP ROLE %I', r);
+        END IF;
+    END;
+    $$;
+\else
+    \echo 'dblink is not available in this environment, skipping DBMS_TRANSACTION autonomous-transaction tests'
+dblink is not available in this environment, skipping DBMS_TRANSACTION autonomous-transaction tests
+\endif
+--
+-- Cross-user execution: the package must be callable by any role, not just
+-- the owner/superuser that ran CREATE EXTENSION, and it must run with the
+-- caller's own privileges (AUTHID CURRENT_USER) rather than the package
+-- owner's -- this is what Oracle's own documentation for DBMS_TRANSACTION
+-- promises ("all subprograms ... run with the privileges of the calling
+-- user, rather than the package owner SYS").
+--
+create role regress_dbms_tx_other_user login;
+create table regress_dbms_tx_other_user_t (id int);
+grant all on regress_dbms_tx_other_user_t to regress_dbms_tx_other_user;
+set session authorization regress_dbms_tx_other_user;
+select current_user;
+        current_user        
+----------------------------
+ regress_dbms_tx_other_user
+(1 row)
+
+-- no explicit GRANT needed: EXECUTE on the package is granted to PUBLIC
+-- when dbms_transaction is installed
+select dbms_transaction.local_transaction_id() is null as no_xid_without_create;
+ no_xid_without_create 
+-----------------------
+ t
+(1 row)
+
+begin;
+select dbms_transaction.local_transaction_id(true) is not null as xid_created;
+ xid_created 
+-------------
+ t
+(1 row)
+
+call dbms_transaction.savepoint('other_user_sp');
+call dbms_transaction.rollback_savepoint('other_user_sp');
+commit;
+-- COMMIT/ROLLBACK also work for a non-owner role, same as for the owner
+insert into regress_dbms_tx_other_user_t values (1);
+call dbms_transaction.commit();
+insert into regress_dbms_tx_other_user_t values (2);
+call dbms_transaction.rollback();
+select * from regress_dbms_tx_other_user_t order by id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+-- READ_ONLY/READ_WRITE also work for a non-owner role
+begin;
+call dbms_transaction.read_only();
+insert into regress_dbms_tx_other_user_t values (3);
+ERROR:  cannot execute INSERT in a read-only transaction
+rollback;
+begin;
+call dbms_transaction.read_write();
+insert into regress_dbms_tx_other_user_t values (4);
+commit;
+select * from regress_dbms_tx_other_user_t order by id;
+ id 
+----
+  1
+  2
+  4
+(3 rows)
+
+reset session authorization;
+drop table regress_dbms_tx_other_user_t;
+drop role regress_dbms_tx_other_user;
+drop table dbms_tx_t;

--- a/contrib/ivorysql_ora/expected/dbms_transaction.out
+++ b/contrib/ivorysql_ora/expected/dbms_transaction.out
@@ -3,7 +3,7 @@
 --
 -- tests for DBMS_TRANSACTION:
 --   COMMIT / ROLLBACK, SAVEPOINT / ROLLBACK_SAVEPOINT,
---   READ_ONLY / READ_WRITE, LOCAL_TRANSACTION_ID,
+--   READ_ONLY / READ_WRITE,
 --   legacy no-ops, and the documented-unsupported distributed
 --   transaction recovery subprograms.
 --
@@ -166,43 +166,6 @@ select * from dbms_tx_t where id = 15;
  id |           val           
 ----+-------------------------
  15 | allowed with read_write
-(1 row)
-
--- LOCAL_TRANSACTION_ID
-select dbms_transaction.local_transaction_id() is null as no_xid_without_create from dual;
- no_xid_without_create 
------------------------
- t
-(1 row)
-
-BEGIN;
-    select dbms_transaction.local_transaction_id(true) is not null as xid_created from dual;
- xid_created 
--------------
- t
-(1 row)
-
-    select dbms_transaction.local_transaction_id() is not null as xid_now_visible from dual;
- xid_now_visible 
------------------
- t
-(1 row)
-
-    -- calling again with create_transaction=true on an already-assigned
-    -- transaction just returns the existing id, it does not assign a new one
-    select dbms_transaction.local_transaction_id(true) = dbms_transaction.local_transaction_id() as xid_stable from dual;
- xid_stable 
-------------
- t
-(1 row)
-
-COMMIT;
--- the transaction (and its id) ends with the commit above -- a fresh
--- transaction has no id again until something assigns one
-select dbms_transaction.local_transaction_id() is null as no_xid_in_new_transaction from dual;
- no_xid_in_new_transaction 
----------------------------
- t
 (1 row)
 
 --
@@ -412,33 +375,6 @@ FROM pg_available_extensions WHERE name = 'dblink' \gset
             END IF;
     END;    
     $$;
-    -- LOCAL_TRANSACTION_ID: an autonomous transaction gets its own transaction
-    -- id, distinct from (and independent of) the calling transaction's id --
-    -- and the autonomous insert is visible immediately, before the outer
-    -- transaction commits.
-    create table dbms_tx_autonomous (which text, xid text);
-    create or replace procedure dbms_tx_autonomous_xid() as
-    pragma autonomous_transaction;
-    begin
-        insert into dbms_tx_autonomous values ('inner', dbms_transaction.local_transaction_id(true));
-    end;
-    /
-    begin;
-    insert into dbms_tx_autonomous values ('outer', dbms_transaction.local_transaction_id(true));
-    call dbms_tx_autonomous_xid();
-    select which, xid is not null as has_xid from dbms_tx_autonomous order by which;
-    commit;
-    select count(distinct xid) = 2 as outer_and_inner_xids_differ from dbms_tx_autonomous;
-    -- the autonomous insert survives even though the calling transaction rolls
-    -- back -- COMMIT/ROLLBACK of the outer transaction have no effect on it.
-    truncate dbms_tx_autonomous;
-    begin;
-    insert into dbms_tx_autonomous values ('outer_rolled_back', dbms_transaction.local_transaction_id(true));
-    call dbms_tx_autonomous_xid();
-    rollback;
-    select which from dbms_tx_autonomous order by which;
-    drop procedure dbms_tx_autonomous_xid();
-    drop table dbms_tx_autonomous;
     --
     -- SAVEPOINT / ROLLBACK_SAVEPOINT / COMMIT / ROLLBACK inside an autonomous
     -- transaction: the dblink call that executes the autonomous procedure is a
@@ -553,19 +489,7 @@ select current_user;
 
 -- no explicit GRANT needed: EXECUTE on the package is granted to PUBLIC
 -- when dbms_transaction is installed
-select dbms_transaction.local_transaction_id() is null as no_xid_without_create;
- no_xid_without_create 
------------------------
- t
-(1 row)
-
 begin;
-select dbms_transaction.local_transaction_id(true) is not null as xid_created;
- xid_created 
--------------
- t
-(1 row)
-
 call dbms_transaction.savepoint('other_user_sp');
 call dbms_transaction.rollback_savepoint('other_user_sp');
 commit;

--- a/contrib/ivorysql_ora/expected/dbms_transaction_1.out
+++ b/contrib/ivorysql_ora/expected/dbms_transaction_1.out
@@ -1,0 +1,672 @@
+--
+-- dbms_transaction.sql
+--
+-- tests for DBMS_TRANSACTION:
+--   COMMIT / ROLLBACK, SAVEPOINT / ROLLBACK_SAVEPOINT,
+--   READ_ONLY / READ_WRITE, LOCAL_TRANSACTION_ID,
+--   legacy no-ops, and the documented-unsupported distributed
+--   transaction recovery subprograms.
+--
+create table dbms_tx_t (id int, val varchar2(100));
+--
+-- COMMIT / ROLLBACK: valid only when the package procedure is invoked as a
+-- top-level CALL (non-atomic context) -- same restriction as a bare
+-- COMMIT/ROLLBACK statement inside a PL/iSQL procedure.
+-- AUTOCOMMIT is default ON in psql
+\set AUTOCOMMIT off
+insert into dbms_tx_t values (0, 'committed');
+call dbms_transaction.commit();
+ERROR:  invalid transaction termination
+CONTEXT:  PL/iSQL function sys.dbms_transaction.commit line 3 at COMMIT
+\set AUTOCOMMIT on
+COMMIT;
+insert into dbms_tx_t values (1, 'committed');
+call dbms_transaction.commit();
+select * from dbms_tx_t order by id;
+ id |    val    
+----+-----------
+  1 | committed
+(1 row)
+
+insert into dbms_tx_t values (2, 'rolled back');
+call dbms_transaction.rollback();
+select * from dbms_tx_t order by id;
+ id |     val     
+----+-------------
+  1 | committed
+  2 | rolled back
+(2 rows)
+
+BEGIN
+    insert into dbms_tx_t values (3, 'committed');
+    dbms_transaction.commit();
+    insert into dbms_tx_t values (4, 'rolled back');
+    dbms_transaction.rollback();
+END;
+/
+select * from dbms_tx_t order by id;
+ id |     val     
+----+-------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+(3 rows)
+
+--
+-- SAVEPOINT / ROLLBACK_SAVEPOINT: unlike COMMIT/ROLLBACK, these require an
+-- explicit transaction block, same as a bare SQL SAVEPOINT statement.
+--
+call dbms_transaction.savepoint('sp_outside');
+ERROR:  SAVEPOINT can only be used in transaction blocks
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+-- PG starts transactions explicitly while Oracle starts transactions implicityly
+BEGIN;
+    insert into dbms_tx_t values (5, 'before sp1');
+    call dbms_transaction.savepoint('sp1');
+    insert into dbms_tx_t values (6, 'after sp1, will be rolled back');
+    call dbms_transaction.rollback_savepoint('sp1');
+    insert into dbms_tx_t values (7, 'after rollback to sp1');
+COMMIT;
+select * from dbms_tx_t order by id;
+ id |          val          
+----+-----------------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+  5 | before sp1
+  7 | after rollback to sp1
+(5 rows)
+
+-- nested savepoints: rolling back to the outer one undoes both
+BEGIN;
+    call dbms_transaction.savepoint('a');
+    insert into dbms_tx_t values (8, 'a');
+    call dbms_transaction.savepoint('b');
+    insert into dbms_tx_t values (9, 'b');
+    call dbms_transaction.rollback_savepoint('a');
+    insert into dbms_tx_t values (10, 'after rollback to a');
+COMMIT;
+select * from dbms_tx_t order by id;
+ id |          val          
+----+-----------------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+  5 | before sp1
+  7 | after rollback to sp1
+ 10 | after rollback to a
+(6 rows)
+
+-- rollback to a savepoint that does not exist
+BEGIN;
+    call dbms_transaction.savepoint('a');
+    insert into dbms_tx_t values (8, 'a');
+    call dbms_transaction.savepoint('b');
+    insert into dbms_tx_t values (9, 'b');
+    call dbms_transaction.rollback_savepoint('a');
+    insert into dbms_tx_t values (10, 'after rollback to a');
+    call dbms_transaction.rollback_savepoint('b');
+ERROR:  savepoint "b" does not exist
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+COMMIT;
+select * from dbms_tx_t order by id;
+ id |          val          
+----+-----------------------
+  1 | committed
+  2 | rolled back
+  3 | committed
+  5 | before sp1
+  7 | after rollback to sp1
+ 10 | after rollback to a
+(6 rows)
+
+BEGIN;
+    call dbms_transaction.rollback_savepoint('does_not_exist');
+ERROR:  savepoint "does_not_exist" does not exist
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+ROLLBACK;
+-- SAVEPOINT/ROLLBACK_SAVEPOINT also accept Oracle's named-parameter call
+-- syntax now that the parameter is named "savept" (matching Oracle's
+-- documented signature) instead of the "sp" name used previously.
+begin;
+insert into dbms_tx_t values (11, 'before named-param savepoint');
+call dbms_transaction.savepoint(savept => 'sp_named');
+insert into dbms_tx_t values (12, 'after named-param savepoint, will be rolled back');
+call dbms_transaction.rollback_savepoint(savept => 'sp_named');
+insert into dbms_tx_t values (13, 'after named-param rollback_savepoint');
+commit;
+select * from dbms_tx_t where id between 11 and 13 order by id;
+ id |                 val                  
+----+--------------------------------------
+ 11 | before named-param savepoint
+ 13 | after named-param rollback_savepoint
+(2 rows)
+
+--
+-- READ_ONLY / READ_WRITE
+--
+BEGIN;
+    call dbms_transaction.read_only();
+    insert into dbms_tx_t values (14, 'blocked by read only');
+ERROR:  cannot execute INSERT in a read-only transaction
+ROLLBACK;
+-- READ_WRITE as the first statement of a transaction is a no-op that must
+-- not block subsequent writes.  (Switching a transaction back from read-only
+-- to read-write after another statement has already run is a PostgreSQL
+-- restriction -- "transaction read-write mode must be set before any
+-- query" -- so that sequence is intentionally not exercised here.)
+BEGIN;
+    call dbms_transaction.read_write();
+    insert into dbms_tx_t values (15, 'allowed with read_write');
+COMMIT;
+select * from dbms_tx_t where id = 15;
+ id |           val           
+----+-------------------------
+ 15 | allowed with read_write
+(1 row)
+
+-- LOCAL_TRANSACTION_ID
+select dbms_transaction.local_transaction_id() is null as no_xid_without_create from dual;
+ no_xid_without_create 
+-----------------------
+ t
+(1 row)
+
+BEGIN;
+    select dbms_transaction.local_transaction_id(true) is not null as xid_created from dual;
+ xid_created 
+-------------
+ t
+(1 row)
+
+    select dbms_transaction.local_transaction_id() is not null as xid_now_visible from dual;
+ xid_now_visible 
+-----------------
+ t
+(1 row)
+
+    -- calling again with create_transaction=true on an already-assigned
+    -- transaction just returns the existing id, it does not assign a new one
+    select dbms_transaction.local_transaction_id(true) = dbms_transaction.local_transaction_id() as xid_stable from dual;
+ xid_stable 
+------------
+ t
+(1 row)
+
+COMMIT;
+-- the transaction (and its id) ends with the commit above -- a fresh
+-- transaction has no id again until something assigns one
+select dbms_transaction.local_transaction_id() is null as no_xid_in_new_transaction from dual;
+ no_xid_in_new_transaction 
+---------------------------
+ t
+(1 row)
+
+--
+-- SAVEPOINT / ROLLBACK_SAVEPOINT: additional boundary conditions
+--
+-- NULL savepoint name is rejected explicitly by the C bridge, for both
+-- SAVEPOINT and ROLLBACK_SAVEPOINT.
+begin;
+call dbms_transaction.savepoint(NULL);
+ERROR:  DBMS_TRANSACTION savepoint name must not be NULL
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+rollback;
+begin;
+call dbms_transaction.rollback_savepoint(NULL);
+ERROR:  DBMS_TRANSACTION savepoint name must not be NULL
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+rollback;
+-- savepoint name length boundary: 255 bytes is accepted, 256 is rejected
+-- (DBMS_TRANSACTION_SAVEPOINT_NAME_LEN in dbms_transaction.c is 256, so the
+-- longest accepted name is 255 bytes).
+begin;
+call dbms_transaction.savepoint(repeat('x', 255));
+call dbms_transaction.rollback_savepoint(repeat('x', 255));
+rollback;
+begin;
+call dbms_transaction.savepoint(repeat('x', 256));
+ERROR:  DBMS_TRANSACTION savepoint name too long (max 255 bytes)
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+rollback;
+-- an empty-string savepoint name hits the same "must not be NULL" error as
+-- an explicit NULL: VARCHAR2 treats '' as NULL, and savept is declared
+-- VARCHAR2, so the C bridge never sees a non-NULL empty string here.
+begin;
+call dbms_transaction.savepoint('');
+ERROR:  DBMS_TRANSACTION savepoint name must not be NULL
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+rollback;
+-- redefining the same savepoint name rolls back to the most recently
+-- defined one, matching plain SQL SAVEPOINT semantics -- the first
+-- definition's row is unaffected, only the row inserted after the second
+-- "a" is undone.
+begin;
+insert into dbms_tx_t values (20, 'before first a');
+call dbms_transaction.savepoint('a');
+insert into dbms_tx_t values (21, 'after first a');
+call dbms_transaction.savepoint('a');
+insert into dbms_tx_t values (22, 'after second a, will be rolled back');
+call dbms_transaction.rollback_savepoint('a');
+commit;
+select * from dbms_tx_t where id between 20 and 22 order by id;
+ id |      val       
+----+----------------
+ 20 | before first a
+ 21 | after first a
+(2 rows)
+
+-- rolling back to the same savepoint repeatedly is allowed each time --
+-- ROLLBACK_SAVEPOINT does not release/consume the savepoint, so it can be
+-- targeted again.
+begin;
+call dbms_transaction.savepoint('rep');
+insert into dbms_tx_t values (23, 'first attempt, will be rolled back');
+call dbms_transaction.rollback_savepoint('rep');
+insert into dbms_tx_t values (23, 'second attempt, will also be rolled back');
+call dbms_transaction.rollback_savepoint('rep');
+commit;
+select * from dbms_tx_t where id = 23;
+ id | val 
+----+-----
+(0 rows)
+
+-- ROLLBACK_SAVEPOINT called entirely outside a transaction block (no
+-- enclosing BEGIN at all, unlike the "does_not_exist" case above which was
+-- inside an explicit BEGIN) must raise the same kind of ordinary error as
+-- ROLLBACK TO SAVEPOINT would, not crash the backend.
+call dbms_transaction.rollback_savepoint('never_defined');
+ERROR:  ROLLBACK TO SAVEPOINT can only be used in transaction blocks
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+-- savepoint names are opaque text, not SQL identifiers -- whitespace is
+-- accepted without quoting games.
+begin;
+call dbms_transaction.savepoint('sp with space');
+insert into dbms_tx_t values (24, 'will be rolled back');
+call dbms_transaction.rollback_savepoint('sp with space');
+commit;
+select * from dbms_tx_t where id = 24;
+ id | val 
+----+-----
+(0 rows)
+
+--
+-- READ_ONLY / READ_WRITE: switching modes within one transaction
+--
+-- switching from read-only back to read-write in the same transaction hits
+-- PostgreSQL's "must be set before any query" restriction, because
+-- READ_ONLY's own SET TRANSACTION READ ONLY already counts as a query.
+begin;
+call dbms_transaction.read_only();
+call dbms_transaction.read_write();
+ERROR:  transaction read-write mode must be set before any query
+CONTEXT:  SQL statement "SET TRANSACTION READ WRITE"
+PL/iSQL function sys.dbms_transaction.read_write line 28 at EXECUTE
+rollback;
+-- the reverse direction -- read-write down to read-only -- is always
+-- allowed, since it only narrows what the transaction can do.
+begin;
+call dbms_transaction.read_write();
+call dbms_transaction.read_only();
+select current_setting('transaction_read_only');
+ current_setting 
+-----------------
+ on
+(1 row)
+
+rollback;
+--
+-- COMMIT/ROLLBACK: atomic context (nested inside another procedure's CALL)
+--
+-- COMMIT/ROLLBACK are only valid as the top-level CALL; invoking them from
+-- inside a procedure that is itself being CALLed (so the whole thing runs
+-- atomically) must raise an error instead of silently no-op'ing.
+create or replace procedure dbms_tx_wrapper_commit() as
+begin
+    dbms_transaction.commit();
+end;
+/
+begin;
+call dbms_tx_wrapper_commit();
+ERROR:  invalid transaction termination
+CONTEXT:  PL/iSQL function sys.dbms_transaction.commit line 3 at COMMIT
+SQL statement "CALL dbms_transaction.commit()"
+PL/iSQL function dbms_tx_wrapper_commit() line 2 at CALL
+rollback;
+drop procedure dbms_tx_wrapper_commit();
+-- SAVEPOINT/ROLLBACK_SAVEPOINT: the nested-call guard must not be bypassable
+-- by setting plisql.inside_autonomous_transaction directly.  That GUC is
+-- PGC_USERSET (dblink's own connection has to be able to set it), so an
+-- ordinary session can set it to "on" without ever going through the
+-- autonomous-transaction machinery -- the guard must still reject a nested
+-- SAVEPOINT/ROLLBACK_SAVEPOINT call in that case, not fall through to
+-- DefineSavepoint()/RollbackToSavepoint().
+create or replace procedure dbms_tx_wrapper_savepoint() as
+begin
+    dbms_transaction.savepoint('should_not_be_reached');
+end;
+/
+set plisql.inside_autonomous_transaction = true;
+begin;
+call dbms_tx_wrapper_savepoint();
+ERROR:  DBMS_TRANSACTION.SAVEPOINT cannot be called from within another PL/iSQL routine
+DETAIL:  It must be the direct result of a top-level CALL, the same way a bare SQL SAVEPOINT/ROLLBACK TO SAVEPOINT statement must be its own complete statement.
+HINT:  Move the call to DBMS_TRANSACTION.SAVEPOINT out to its own top-level CALL statement.
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+SQL statement "CALL dbms_transaction.savepoint('should_not_be_reached')"
+PL/iSQL function dbms_tx_wrapper_savepoint() line 2 at CALL
+rollback;
+reset plisql.inside_autonomous_transaction;
+drop procedure dbms_tx_wrapper_savepoint();
+--
+-- Skip the autonomous-transaction section entirely if dblink isn't even
+-- installable in this environment, instead of letting CREATE EXTENSION
+-- error out and cascade into a wall of unrelated failures below.
+--
+SELECT count(*) > 0 AS have_dblink
+FROM pg_available_extensions WHERE name = 'dblink' \gset
+\if :have_dblink
+    --
+    -- The autonomous-transaction tests below run PRAGMA AUTONOMOUS_TRANSACTION
+    -- procedures via dblink.  dblink's connection string (built in
+    -- pl_autonomous.c) has no explicit "user=", so libpq falls back to
+    -- whatever OS user the postgres server process itself is running as --
+    -- if no role of that name exists, every autonomous-transaction test below
+    -- would fail with an unrelated connection error instead of testing what
+    -- it's meant to.  Probe the same loopback connection here and create the
+    -- missing role up front if that's the problem.
+    --
+    CREATE EXTENSION IF NOT EXISTS dblink;
+    DO $$
+    DECLARE
+        missing_role text;
+        probe_connstr text;
+        err_detail    text;
+    BEGIN
+        -- mirror pl_autonomous.c's own connection string exactly: dbname + port,
+        -- no user=
+        probe_connstr := 'dbname=' || current_database()
+                        || ' port=' || current_setting('port');
+                        
+        PERFORM dblink_connect('dbms_tx_probe', probe_connstr);
+        PERFORM dblink_disconnect('dbms_tx_probe');
+    EXCEPTION
+        WHEN OTHERS THEN
+            GET STACKED DIAGNOSTICS err_detail = PG_EXCEPTION_DETAIL;
+            missing_role := substring(err_detail FROM 'role "([^"]+)" does not exist');
+            IF missing_role IS NOT NULL THEN
+                EXECUTE format('CREATE ROLE %I LOGIN SUPERUSER', missing_role);
+                -- record it so the cleanup block below knows to drop it again
+                PERFORM set_config('dbms_tx_test.created_role', missing_role, false);
+            ELSE
+                RAISE;  -- some other, unrelated connection problem -- don't hide it
+            END IF;
+    END;    
+    $$;
+    -- LOCAL_TRANSACTION_ID: an autonomous transaction gets its own transaction
+    -- id, distinct from (and independent of) the calling transaction's id --
+    -- and the autonomous insert is visible immediately, before the outer
+    -- transaction commits.
+    create table dbms_tx_autonomous (which text, xid text);
+    create or replace procedure dbms_tx_autonomous_xid() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_autonomous values ('inner', dbms_transaction.local_transaction_id(true));
+    end;
+    /
+    begin;
+    insert into dbms_tx_autonomous values ('outer', dbms_transaction.local_transaction_id(true));
+    call dbms_tx_autonomous_xid();
+    select which, xid is not null as has_xid from dbms_tx_autonomous order by which;
+ which | has_xid 
+-------+---------
+ inner | t
+ outer | t
+(2 rows)
+
+    commit;
+    select count(distinct xid) = 2 as outer_and_inner_xids_differ from dbms_tx_autonomous;
+ outer_and_inner_xids_differ 
+-----------------------------
+ t
+(1 row)
+
+    -- the autonomous insert survives even though the calling transaction rolls
+    -- back -- COMMIT/ROLLBACK of the outer transaction have no effect on it.
+    truncate dbms_tx_autonomous;
+    begin;
+    insert into dbms_tx_autonomous values ('outer_rolled_back', dbms_transaction.local_transaction_id(true));
+    call dbms_tx_autonomous_xid();
+    rollback;
+    select which from dbms_tx_autonomous order by which;
+ which 
+-------
+ inner
+(1 row)
+
+    drop procedure dbms_tx_autonomous_xid();
+    drop table dbms_tx_autonomous;
+    --
+    -- SAVEPOINT / ROLLBACK_SAVEPOINT / COMMIT / ROLLBACK inside an autonomous
+    -- transaction: the dblink call that executes the autonomous procedure is a
+    -- single bare "CALL proc();" with no surrounding BEGIN, so from that
+    -- session's point of view there is no explicit transaction block --
+    -- SAVEPOINT/ROLLBACK_SAVEPOINT there fail the same way a bare top-level
+    -- SAVEPOINT statement would (see "call dbms_transaction.savepoint('sp_outside')"
+    -- above).  COMMIT/ROLLBACK are still invoked from within the autonomous
+    -- procedure's own body (a nested CALL to dbms_transaction.commit()/rollback()),
+    -- so they hit the same "invalid transaction termination" restriction as any
+    -- other nested CALL -- PRAGMA AUTONOMOUS_TRANSACTION does not change either
+    -- restriction.
+    --
+    create or replace procedure dbms_tx_autonomous_savepoint() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.savepoint('autosp');
+    end;
+    /
+    call dbms_tx_autonomous_savepoint();
+ERROR:  DBMS_TRANSACTION.SAVEPOINT cannot be called from within another PL/iSQL routine
+DETAIL:  It must be the direct result of a top-level CALL, the same way a bare SQL SAVEPOINT/ROLLBACK TO SAVEPOINT statement must be its own complete statement.
+HINT:  Move the call to DBMS_TRANSACTION.SAVEPOINT out to its own top-level CALL statement.
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.savepoint line 13 at PERFORM
+SQL statement "CALL dbms_transaction.savepoint('autosp')"
+PL/iSQL function dbms_tx_autonomous_savepoint() line 3 at CALL
+while executing command on unnamed dblink connection
+PL/iSQL function dbms_tx_autonomous_savepoint() during function entry
+    drop procedure dbms_tx_autonomous_savepoint();
+    create or replace procedure dbms_tx_autonomous_rbsp() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.rollback_savepoint('autosp');
+    end;
+    /
+    call dbms_tx_autonomous_rbsp();
+ERROR:  DBMS_TRANSACTION.ROLLBACK_SAVEPOINT cannot be called from within another PL/iSQL routine
+DETAIL:  It must be the direct result of a top-level CALL, the same way a bare SQL SAVEPOINT/ROLLBACK TO SAVEPOINT statement must be its own complete statement.
+HINT:  Move the call to DBMS_TRANSACTION.ROLLBACK_SAVEPOINT out to its own top-level CALL statement.
+CONTEXT:  SQL statement "SELECT sys.ora_dbms_transaction_rollback_savepoint(savept)"
+PL/iSQL function sys.dbms_transaction.rollback_savepoint line 18 at PERFORM
+SQL statement "CALL dbms_transaction.rollback_savepoint('autosp')"
+PL/iSQL function dbms_tx_autonomous_rbsp() line 3 at CALL
+while executing command on unnamed dblink connection
+PL/iSQL function dbms_tx_autonomous_rbsp() during function entry
+    drop procedure dbms_tx_autonomous_rbsp();
+    create or replace procedure dbms_tx_autonomous_commit() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_t values (900, 'should not be committed');
+        dbms_transaction.commit();
+    end;
+    /
+    call dbms_tx_autonomous_commit();
+ERROR:  invalid transaction termination
+CONTEXT:  PL/iSQL function sys.dbms_transaction.commit line 3 at COMMIT
+SQL statement "CALL dbms_transaction.commit()"
+PL/iSQL function dbms_tx_autonomous_commit() line 4 at CALL
+while executing command on unnamed dblink connection
+PL/iSQL function dbms_tx_autonomous_commit() during function entry
+    select * from dbms_tx_t where id = 900;
+ id | val 
+----+-----
+(0 rows)
+
+    drop procedure dbms_tx_autonomous_commit();
+    create or replace procedure dbms_tx_autonomous_rollback() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_t values (901, 'should error before rollback runs');
+        dbms_transaction.rollback();
+    end;
+    /
+    call dbms_tx_autonomous_rollback();
+ERROR:  invalid transaction termination
+CONTEXT:  PL/iSQL function sys.dbms_transaction.rollback line 8 at ROLLBACK
+SQL statement "CALL dbms_transaction.rollback()"
+PL/iSQL function dbms_tx_autonomous_rollback() line 4 at CALL
+while executing command on unnamed dblink connection
+PL/iSQL function dbms_tx_autonomous_rollback() during function entry
+    select * from dbms_tx_t where id = 901;
+ id | val 
+----+-----
+(0 rows)
+
+    drop procedure dbms_tx_autonomous_rollback();
+    --
+    -- READ_ONLY / READ_WRITE inside an autonomous transaction: these are plain
+    -- SET TRANSACTION statements and do not need an explicit transaction block,
+    -- so (unlike SAVEPOINT/COMMIT above) they work the same as at the top level.
+    --
+    create or replace procedure dbms_tx_autonomous_readonly() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.read_only();
+        insert into dbms_tx_t values (902, 'blocked by autonomous read_only');
+    end;
+    /
+    call dbms_tx_autonomous_readonly();
+ERROR:  cannot execute INSERT in a read-only transaction
+CONTEXT:  SQL statement "insert into dbms_tx_t values (902, 'blocked by autonomous read_only')"
+PL/iSQL function dbms_tx_autonomous_readonly() line 4 at SQL statement
+while executing command on unnamed dblink connection
+PL/iSQL function dbms_tx_autonomous_readonly() during function entry
+    select * from dbms_tx_t where id = 902;
+ id | val 
+----+-----
+(0 rows)
+
+    drop procedure dbms_tx_autonomous_readonly();
+    create or replace procedure dbms_tx_autonomous_readwrite() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.read_write();
+        insert into dbms_tx_t values (903, 'allowed by autonomous read_write, autocommitted');
+    end;
+    /
+    call dbms_tx_autonomous_readwrite();
+    select * from dbms_tx_t where id = 903;
+ id  |                       val                       
+-----+-------------------------------------------------
+ 903 | allowed by autonomous read_write, autocommitted
+(1 row)
+
+    drop procedure dbms_tx_autonomous_readwrite();
+    --
+    -- Clean up: drop the role again, but only if this script is the one that
+    -- created it -- never drop a role that already existed before we got here.
+    -- Note: no "<> ''" check alongside IS NOT NULL -- Oracle-compat mode's
+    -- empty-string-is-NULL semantics turns such a comparison into NULL, which
+    -- IF treats as not-satisfied, silently skipping the DROP.
+    --
+    DO $$
+    DECLARE
+        r text := current_setting('dbms_tx_test.created_role', true);
+    BEGIN 
+        IF r IS NOT NULL THEN
+            EXECUTE format('DROP ROLE %I', r);
+        END IF;
+    END;
+    $$;
+\else
+    \echo 'dblink is not available in this environment, skipping DBMS_TRANSACTION autonomous-transaction tests'
+\endif
+--
+-- Cross-user execution: the package must be callable by any role, not just
+-- the owner/superuser that ran CREATE EXTENSION, and it must run with the
+-- caller's own privileges (AUTHID CURRENT_USER) rather than the package
+-- owner's -- this is what Oracle's own documentation for DBMS_TRANSACTION
+-- promises ("all subprograms ... run with the privileges of the calling
+-- user, rather than the package owner SYS").
+--
+create role regress_dbms_tx_other_user login;
+create table regress_dbms_tx_other_user_t (id int);
+grant all on regress_dbms_tx_other_user_t to regress_dbms_tx_other_user;
+set session authorization regress_dbms_tx_other_user;
+select current_user;
+        current_user        
+----------------------------
+ regress_dbms_tx_other_user
+(1 row)
+
+-- no explicit GRANT needed: EXECUTE on the package is granted to PUBLIC
+-- when dbms_transaction is installed
+select dbms_transaction.local_transaction_id() is null as no_xid_without_create;
+ no_xid_without_create 
+-----------------------
+ t
+(1 row)
+
+begin;
+select dbms_transaction.local_transaction_id(true) is not null as xid_created;
+ xid_created 
+-------------
+ t
+(1 row)
+
+call dbms_transaction.savepoint('other_user_sp');
+call dbms_transaction.rollback_savepoint('other_user_sp');
+commit;
+-- COMMIT/ROLLBACK also work for a non-owner role, same as for the owner
+insert into regress_dbms_tx_other_user_t values (1);
+call dbms_transaction.commit();
+insert into regress_dbms_tx_other_user_t values (2);
+call dbms_transaction.rollback();
+select * from regress_dbms_tx_other_user_t order by id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+-- READ_ONLY/READ_WRITE also work for a non-owner role
+begin;
+call dbms_transaction.read_only();
+insert into regress_dbms_tx_other_user_t values (3);
+ERROR:  cannot execute INSERT in a read-only transaction
+rollback;
+begin;
+call dbms_transaction.read_write();
+insert into regress_dbms_tx_other_user_t values (4);
+commit;
+select * from regress_dbms_tx_other_user_t order by id;
+ id 
+----
+  1
+  2
+  4
+(3 rows)
+
+reset session authorization;
+drop table regress_dbms_tx_other_user_t;
+drop role regress_dbms_tx_other_user;
+drop table dbms_tx_t;

--- a/contrib/ivorysql_ora/expected/dbms_transaction_1.out
+++ b/contrib/ivorysql_ora/expected/dbms_transaction_1.out
@@ -3,7 +3,7 @@
 --
 -- tests for DBMS_TRANSACTION:
 --   COMMIT / ROLLBACK, SAVEPOINT / ROLLBACK_SAVEPOINT,
---   READ_ONLY / READ_WRITE, LOCAL_TRANSACTION_ID,
+--   READ_ONLY / READ_WRITE,
 --   legacy no-ops, and the documented-unsupported distributed
 --   transaction recovery subprograms.
 --
@@ -166,43 +166,6 @@ select * from dbms_tx_t where id = 15;
  id |           val           
 ----+-------------------------
  15 | allowed with read_write
-(1 row)
-
--- LOCAL_TRANSACTION_ID
-select dbms_transaction.local_transaction_id() is null as no_xid_without_create from dual;
- no_xid_without_create 
------------------------
- t
-(1 row)
-
-BEGIN;
-    select dbms_transaction.local_transaction_id(true) is not null as xid_created from dual;
- xid_created 
--------------
- t
-(1 row)
-
-    select dbms_transaction.local_transaction_id() is not null as xid_now_visible from dual;
- xid_now_visible 
------------------
- t
-(1 row)
-
-    -- calling again with create_transaction=true on an already-assigned
-    -- transaction just returns the existing id, it does not assign a new one
-    select dbms_transaction.local_transaction_id(true) = dbms_transaction.local_transaction_id() as xid_stable from dual;
- xid_stable 
-------------
- t
-(1 row)
-
-COMMIT;
--- the transaction (and its id) ends with the commit above -- a fresh
--- transaction has no id again until something assigns one
-select dbms_transaction.local_transaction_id() is null as no_xid_in_new_transaction from dual;
- no_xid_in_new_transaction 
----------------------------
- t
 (1 row)
 
 --
@@ -412,49 +375,6 @@ FROM pg_available_extensions WHERE name = 'dblink' \gset
             END IF;
     END;    
     $$;
-    -- LOCAL_TRANSACTION_ID: an autonomous transaction gets its own transaction
-    -- id, distinct from (and independent of) the calling transaction's id --
-    -- and the autonomous insert is visible immediately, before the outer
-    -- transaction commits.
-    create table dbms_tx_autonomous (which text, xid text);
-    create or replace procedure dbms_tx_autonomous_xid() as
-    pragma autonomous_transaction;
-    begin
-        insert into dbms_tx_autonomous values ('inner', dbms_transaction.local_transaction_id(true));
-    end;
-    /
-    begin;
-    insert into dbms_tx_autonomous values ('outer', dbms_transaction.local_transaction_id(true));
-    call dbms_tx_autonomous_xid();
-    select which, xid is not null as has_xid from dbms_tx_autonomous order by which;
- which | has_xid 
--------+---------
- inner | t
- outer | t
-(2 rows)
-
-    commit;
-    select count(distinct xid) = 2 as outer_and_inner_xids_differ from dbms_tx_autonomous;
- outer_and_inner_xids_differ 
------------------------------
- t
-(1 row)
-
-    -- the autonomous insert survives even though the calling transaction rolls
-    -- back -- COMMIT/ROLLBACK of the outer transaction have no effect on it.
-    truncate dbms_tx_autonomous;
-    begin;
-    insert into dbms_tx_autonomous values ('outer_rolled_back', dbms_transaction.local_transaction_id(true));
-    call dbms_tx_autonomous_xid();
-    rollback;
-    select which from dbms_tx_autonomous order by which;
- which 
--------
- inner
-(1 row)
-
-    drop procedure dbms_tx_autonomous_xid();
-    drop table dbms_tx_autonomous;
     --
     -- SAVEPOINT / ROLLBACK_SAVEPOINT / COMMIT / ROLLBACK inside an autonomous
     -- transaction: the dblink call that executes the autonomous procedure is a
@@ -620,19 +540,7 @@ select current_user;
 
 -- no explicit GRANT needed: EXECUTE on the package is granted to PUBLIC
 -- when dbms_transaction is installed
-select dbms_transaction.local_transaction_id() is null as no_xid_without_create;
- no_xid_without_create 
------------------------
- t
-(1 row)
-
 begin;
-select dbms_transaction.local_transaction_id(true) is not null as xid_created;
- xid_created 
--------------
- t
-(1 row)
-
 call dbms_transaction.savepoint('other_user_sp');
 call dbms_transaction.rollback_savepoint('other_user_sp');
 commit;

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -9,3 +9,4 @@ src/builtin_packages/dbms_lock/dbms_lock
 src/builtin_packages/utl_raw/utl_raw
 src/builtin_packages/utl_encode/utl_encode
 src/builtin_packages/dbms_session/dbms_session
+src/builtin_packages/dbms_transaction/dbms_transaction

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -32,7 +32,8 @@ ivorysql_ora_sources = files(
   'src/builtin_packages/dbms_lock/dbms_lock.c',
   'src/builtin_packages/utl_raw/utl_raw.c',
   'src/builtin_packages/utl_encode/utl_encode.c',
-  'src/builtin_packages/dbms_session/dbms_session.c'
+  'src/builtin_packages/dbms_session/dbms_session.c',
+  'src/builtin_packages/dbms_transaction/dbms_transaction.c'
 )
 
 if host_system == 'windows'

--- a/contrib/ivorysql_ora/sql/dbms_transaction.sql
+++ b/contrib/ivorysql_ora/sql/dbms_transaction.sql
@@ -3,7 +3,7 @@
 --
 -- tests for DBMS_TRANSACTION:
 --   COMMIT / ROLLBACK, SAVEPOINT / ROLLBACK_SAVEPOINT,
---   READ_ONLY / READ_WRITE, LOCAL_TRANSACTION_ID,
+--   READ_ONLY / READ_WRITE,
 --   legacy no-ops, and the documented-unsupported distributed
 --   transaction recovery subprograms.
 --
@@ -113,20 +113,6 @@ BEGIN;
     insert into dbms_tx_t values (15, 'allowed with read_write');
 COMMIT;
 select * from dbms_tx_t where id = 15;
-
--- LOCAL_TRANSACTION_ID
-select dbms_transaction.local_transaction_id() is null as no_xid_without_create from dual;
-BEGIN;
-    select dbms_transaction.local_transaction_id(true) is not null as xid_created from dual;
-    select dbms_transaction.local_transaction_id() is not null as xid_now_visible from dual;
-    -- calling again with create_transaction=true on an already-assigned
-    -- transaction just returns the existing id, it does not assign a new one
-    select dbms_transaction.local_transaction_id(true) = dbms_transaction.local_transaction_id() as xid_stable from dual;
-COMMIT;
-
--- the transaction (and its id) ends with the commit above -- a fresh
--- transaction has no id again until something assigns one
-select dbms_transaction.local_transaction_id() is null as no_xid_in_new_transaction from dual;
 
 --
 -- SAVEPOINT / ROLLBACK_SAVEPOINT: additional boundary conditions
@@ -304,38 +290,6 @@ FROM pg_available_extensions WHERE name = 'dblink' \gset
     END;    
     $$;
 
-    -- LOCAL_TRANSACTION_ID: an autonomous transaction gets its own transaction
-    -- id, distinct from (and independent of) the calling transaction's id --
-    -- and the autonomous insert is visible immediately, before the outer
-    -- transaction commits.
-    create table dbms_tx_autonomous (which text, xid text);
-
-    create or replace procedure dbms_tx_autonomous_xid() as
-    pragma autonomous_transaction;
-    begin
-        insert into dbms_tx_autonomous values ('inner', dbms_transaction.local_transaction_id(true));
-    end;
-    /
-
-    begin;
-    insert into dbms_tx_autonomous values ('outer', dbms_transaction.local_transaction_id(true));
-    call dbms_tx_autonomous_xid();
-    select which, xid is not null as has_xid from dbms_tx_autonomous order by which;
-    commit;
-    select count(distinct xid) = 2 as outer_and_inner_xids_differ from dbms_tx_autonomous;
-
-    -- the autonomous insert survives even though the calling transaction rolls
-    -- back -- COMMIT/ROLLBACK of the outer transaction have no effect on it.
-    truncate dbms_tx_autonomous;
-    begin;
-    insert into dbms_tx_autonomous values ('outer_rolled_back', dbms_transaction.local_transaction_id(true));
-    call dbms_tx_autonomous_xid();
-    rollback;
-    select which from dbms_tx_autonomous order by which;
-
-    drop procedure dbms_tx_autonomous_xid();
-    drop table dbms_tx_autonomous;
-
     --
     -- SAVEPOINT / ROLLBACK_SAVEPOINT / COMMIT / ROLLBACK inside an autonomous
     -- transaction: the dblink call that executes the autonomous procedure is a
@@ -453,10 +407,7 @@ select current_user;
 
 -- no explicit GRANT needed: EXECUTE on the package is granted to PUBLIC
 -- when dbms_transaction is installed
-select dbms_transaction.local_transaction_id() is null as no_xid_without_create;
-
 begin;
-select dbms_transaction.local_transaction_id(true) is not null as xid_created;
 call dbms_transaction.savepoint('other_user_sp');
 call dbms_transaction.rollback_savepoint('other_user_sp');
 commit;

--- a/contrib/ivorysql_ora/sql/dbms_transaction.sql
+++ b/contrib/ivorysql_ora/sql/dbms_transaction.sql
@@ -1,0 +1,487 @@
+--
+-- dbms_transaction.sql
+--
+-- tests for DBMS_TRANSACTION:
+--   COMMIT / ROLLBACK, SAVEPOINT / ROLLBACK_SAVEPOINT,
+--   READ_ONLY / READ_WRITE, LOCAL_TRANSACTION_ID,
+--   legacy no-ops, and the documented-unsupported distributed
+--   transaction recovery subprograms.
+--
+
+create table dbms_tx_t (id int, val varchar2(100));
+
+--
+-- COMMIT / ROLLBACK: valid only when the package procedure is invoked as a
+-- top-level CALL (non-atomic context) -- same restriction as a bare
+-- COMMIT/ROLLBACK statement inside a PL/iSQL procedure.
+
+-- AUTOCOMMIT is default ON in psql
+\set AUTOCOMMIT off
+insert into dbms_tx_t values (0, 'committed');
+call dbms_transaction.commit();
+\set AUTOCOMMIT on
+COMMIT;
+
+insert into dbms_tx_t values (1, 'committed');
+call dbms_transaction.commit();
+select * from dbms_tx_t order by id;
+
+insert into dbms_tx_t values (2, 'rolled back');
+call dbms_transaction.rollback();
+select * from dbms_tx_t order by id;
+
+BEGIN
+    insert into dbms_tx_t values (3, 'committed');
+    dbms_transaction.commit();
+    insert into dbms_tx_t values (4, 'rolled back');
+    dbms_transaction.rollback();
+END;
+/
+select * from dbms_tx_t order by id;
+
+--
+-- SAVEPOINT / ROLLBACK_SAVEPOINT: unlike COMMIT/ROLLBACK, these require an
+-- explicit transaction block, same as a bare SQL SAVEPOINT statement.
+--
+call dbms_transaction.savepoint('sp_outside');
+
+-- PG starts transactions explicitly while Oracle starts transactions implicityly
+BEGIN;
+    insert into dbms_tx_t values (5, 'before sp1');
+    call dbms_transaction.savepoint('sp1');
+    insert into dbms_tx_t values (6, 'after sp1, will be rolled back');
+    call dbms_transaction.rollback_savepoint('sp1');
+    insert into dbms_tx_t values (7, 'after rollback to sp1');
+COMMIT;
+select * from dbms_tx_t order by id;
+
+-- nested savepoints: rolling back to the outer one undoes both
+BEGIN;
+    call dbms_transaction.savepoint('a');
+    insert into dbms_tx_t values (8, 'a');
+    call dbms_transaction.savepoint('b');
+    insert into dbms_tx_t values (9, 'b');
+    call dbms_transaction.rollback_savepoint('a');
+    insert into dbms_tx_t values (10, 'after rollback to a');
+COMMIT;
+select * from dbms_tx_t order by id;
+
+-- rollback to a savepoint that does not exist
+
+BEGIN;
+    call dbms_transaction.savepoint('a');
+    insert into dbms_tx_t values (8, 'a');
+    call dbms_transaction.savepoint('b');
+    insert into dbms_tx_t values (9, 'b');
+    call dbms_transaction.rollback_savepoint('a');
+    insert into dbms_tx_t values (10, 'after rollback to a');
+    call dbms_transaction.rollback_savepoint('b');
+COMMIT;
+select * from dbms_tx_t order by id;
+
+BEGIN;
+    call dbms_transaction.rollback_savepoint('does_not_exist');
+ROLLBACK;
+
+-- SAVEPOINT/ROLLBACK_SAVEPOINT also accept Oracle's named-parameter call
+-- syntax now that the parameter is named "savept" (matching Oracle's
+-- documented signature) instead of the "sp" name used previously.
+begin;
+insert into dbms_tx_t values (11, 'before named-param savepoint');
+call dbms_transaction.savepoint(savept => 'sp_named');
+insert into dbms_tx_t values (12, 'after named-param savepoint, will be rolled back');
+call dbms_transaction.rollback_savepoint(savept => 'sp_named');
+insert into dbms_tx_t values (13, 'after named-param rollback_savepoint');
+commit;
+select * from dbms_tx_t where id between 11 and 13 order by id;
+
+--
+-- READ_ONLY / READ_WRITE
+--
+BEGIN;
+    call dbms_transaction.read_only();
+    insert into dbms_tx_t values (14, 'blocked by read only');
+ROLLBACK;
+
+-- READ_WRITE as the first statement of a transaction is a no-op that must
+-- not block subsequent writes.  (Switching a transaction back from read-only
+-- to read-write after another statement has already run is a PostgreSQL
+-- restriction -- "transaction read-write mode must be set before any
+-- query" -- so that sequence is intentionally not exercised here.)
+BEGIN;
+    call dbms_transaction.read_write();
+    insert into dbms_tx_t values (15, 'allowed with read_write');
+COMMIT;
+select * from dbms_tx_t where id = 15;
+
+-- LOCAL_TRANSACTION_ID
+select dbms_transaction.local_transaction_id() is null as no_xid_without_create from dual;
+BEGIN;
+    select dbms_transaction.local_transaction_id(true) is not null as xid_created from dual;
+    select dbms_transaction.local_transaction_id() is not null as xid_now_visible from dual;
+    -- calling again with create_transaction=true on an already-assigned
+    -- transaction just returns the existing id, it does not assign a new one
+    select dbms_transaction.local_transaction_id(true) = dbms_transaction.local_transaction_id() as xid_stable from dual;
+COMMIT;
+
+-- the transaction (and its id) ends with the commit above -- a fresh
+-- transaction has no id again until something assigns one
+select dbms_transaction.local_transaction_id() is null as no_xid_in_new_transaction from dual;
+
+--
+-- SAVEPOINT / ROLLBACK_SAVEPOINT: additional boundary conditions
+--
+
+-- NULL savepoint name is rejected explicitly by the C bridge, for both
+-- SAVEPOINT and ROLLBACK_SAVEPOINT.
+begin;
+call dbms_transaction.savepoint(NULL);
+rollback;
+begin;
+call dbms_transaction.rollback_savepoint(NULL);
+rollback;
+
+-- savepoint name length boundary: 255 bytes is accepted, 256 is rejected
+-- (DBMS_TRANSACTION_SAVEPOINT_NAME_LEN in dbms_transaction.c is 256, so the
+-- longest accepted name is 255 bytes).
+begin;
+call dbms_transaction.savepoint(repeat('x', 255));
+call dbms_transaction.rollback_savepoint(repeat('x', 255));
+rollback;
+begin;
+call dbms_transaction.savepoint(repeat('x', 256));
+rollback;
+
+-- an empty-string savepoint name hits the same "must not be NULL" error as
+-- an explicit NULL: VARCHAR2 treats '' as NULL, and savept is declared
+-- VARCHAR2, so the C bridge never sees a non-NULL empty string here.
+begin;
+call dbms_transaction.savepoint('');
+rollback;
+
+-- redefining the same savepoint name rolls back to the most recently
+-- defined one, matching plain SQL SAVEPOINT semantics -- the first
+-- definition's row is unaffected, only the row inserted after the second
+-- "a" is undone.
+begin;
+insert into dbms_tx_t values (20, 'before first a');
+call dbms_transaction.savepoint('a');
+insert into dbms_tx_t values (21, 'after first a');
+call dbms_transaction.savepoint('a');
+insert into dbms_tx_t values (22, 'after second a, will be rolled back');
+call dbms_transaction.rollback_savepoint('a');
+commit;
+select * from dbms_tx_t where id between 20 and 22 order by id;
+
+-- rolling back to the same savepoint repeatedly is allowed each time --
+-- ROLLBACK_SAVEPOINT does not release/consume the savepoint, so it can be
+-- targeted again.
+begin;
+call dbms_transaction.savepoint('rep');
+insert into dbms_tx_t values (23, 'first attempt, will be rolled back');
+call dbms_transaction.rollback_savepoint('rep');
+insert into dbms_tx_t values (23, 'second attempt, will also be rolled back');
+call dbms_transaction.rollback_savepoint('rep');
+commit;
+select * from dbms_tx_t where id = 23;
+
+-- ROLLBACK_SAVEPOINT called entirely outside a transaction block (no
+-- enclosing BEGIN at all, unlike the "does_not_exist" case above which was
+-- inside an explicit BEGIN) must raise the same kind of ordinary error as
+-- ROLLBACK TO SAVEPOINT would, not crash the backend.
+call dbms_transaction.rollback_savepoint('never_defined');
+
+-- savepoint names are opaque text, not SQL identifiers -- whitespace is
+-- accepted without quoting games.
+begin;
+call dbms_transaction.savepoint('sp with space');
+insert into dbms_tx_t values (24, 'will be rolled back');
+call dbms_transaction.rollback_savepoint('sp with space');
+commit;
+select * from dbms_tx_t where id = 24;
+
+--
+-- READ_ONLY / READ_WRITE: switching modes within one transaction
+--
+
+-- switching from read-only back to read-write in the same transaction hits
+-- PostgreSQL's "must be set before any query" restriction, because
+-- READ_ONLY's own SET TRANSACTION READ ONLY already counts as a query.
+begin;
+call dbms_transaction.read_only();
+call dbms_transaction.read_write();
+rollback;
+
+-- the reverse direction -- read-write down to read-only -- is always
+-- allowed, since it only narrows what the transaction can do.
+begin;
+call dbms_transaction.read_write();
+call dbms_transaction.read_only();
+select current_setting('transaction_read_only');
+rollback;
+
+--
+-- COMMIT/ROLLBACK: atomic context (nested inside another procedure's CALL)
+--
+
+-- COMMIT/ROLLBACK are only valid as the top-level CALL; invoking them from
+-- inside a procedure that is itself being CALLed (so the whole thing runs
+-- atomically) must raise an error instead of silently no-op'ing.
+create or replace procedure dbms_tx_wrapper_commit() as
+begin
+    dbms_transaction.commit();
+end;
+/
+begin;
+call dbms_tx_wrapper_commit();
+rollback;
+drop procedure dbms_tx_wrapper_commit();
+
+-- SAVEPOINT/ROLLBACK_SAVEPOINT: the nested-call guard must not be bypassable
+-- by setting plisql.inside_autonomous_transaction directly.  That GUC is
+-- PGC_USERSET (dblink's own connection has to be able to set it), so an
+-- ordinary session can set it to "on" without ever going through the
+-- autonomous-transaction machinery -- the guard must still reject a nested
+-- SAVEPOINT/ROLLBACK_SAVEPOINT call in that case, not fall through to
+-- DefineSavepoint()/RollbackToSavepoint().
+create or replace procedure dbms_tx_wrapper_savepoint() as
+begin
+    dbms_transaction.savepoint('should_not_be_reached');
+end;
+/
+set plisql.inside_autonomous_transaction = true;
+begin;
+call dbms_tx_wrapper_savepoint();
+rollback;
+reset plisql.inside_autonomous_transaction;
+drop procedure dbms_tx_wrapper_savepoint();
+
+--
+-- Skip the autonomous-transaction section entirely if dblink isn't even
+-- installable in this environment, instead of letting CREATE EXTENSION
+-- error out and cascade into a wall of unrelated failures below.
+--
+SELECT count(*) > 0 AS have_dblink
+FROM pg_available_extensions WHERE name = 'dblink' \gset
+
+\if :have_dblink
+    --
+    -- The autonomous-transaction tests below run PRAGMA AUTONOMOUS_TRANSACTION
+    -- procedures via dblink.  dblink's connection string (built in
+    -- pl_autonomous.c) has no explicit "user=", so libpq falls back to
+    -- whatever OS user the postgres server process itself is running as --
+    -- if no role of that name exists, every autonomous-transaction test below
+    -- would fail with an unrelated connection error instead of testing what
+    -- it's meant to.  Probe the same loopback connection here and create the
+    -- missing role up front if that's the problem.
+    --
+    CREATE EXTENSION IF NOT EXISTS dblink;
+
+    DO $$
+    DECLARE
+        missing_role text;
+        probe_connstr text;
+        err_detail    text;
+    BEGIN
+        -- mirror pl_autonomous.c's own connection string exactly: dbname + port,
+        -- no user=
+        probe_connstr := 'dbname=' || current_database()
+                        || ' port=' || current_setting('port');
+                        
+        PERFORM dblink_connect('dbms_tx_probe', probe_connstr);
+        PERFORM dblink_disconnect('dbms_tx_probe');
+    EXCEPTION
+        WHEN OTHERS THEN
+            GET STACKED DIAGNOSTICS err_detail = PG_EXCEPTION_DETAIL;
+            missing_role := substring(err_detail FROM 'role "([^"]+)" does not exist');
+            IF missing_role IS NOT NULL THEN
+                EXECUTE format('CREATE ROLE %I LOGIN SUPERUSER', missing_role);
+                -- record it so the cleanup block below knows to drop it again
+                PERFORM set_config('dbms_tx_test.created_role', missing_role, false);
+            ELSE
+                RAISE;  -- some other, unrelated connection problem -- don't hide it
+            END IF;
+    END;    
+    $$;
+
+    -- LOCAL_TRANSACTION_ID: an autonomous transaction gets its own transaction
+    -- id, distinct from (and independent of) the calling transaction's id --
+    -- and the autonomous insert is visible immediately, before the outer
+    -- transaction commits.
+    create table dbms_tx_autonomous (which text, xid text);
+
+    create or replace procedure dbms_tx_autonomous_xid() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_autonomous values ('inner', dbms_transaction.local_transaction_id(true));
+    end;
+    /
+
+    begin;
+    insert into dbms_tx_autonomous values ('outer', dbms_transaction.local_transaction_id(true));
+    call dbms_tx_autonomous_xid();
+    select which, xid is not null as has_xid from dbms_tx_autonomous order by which;
+    commit;
+    select count(distinct xid) = 2 as outer_and_inner_xids_differ from dbms_tx_autonomous;
+
+    -- the autonomous insert survives even though the calling transaction rolls
+    -- back -- COMMIT/ROLLBACK of the outer transaction have no effect on it.
+    truncate dbms_tx_autonomous;
+    begin;
+    insert into dbms_tx_autonomous values ('outer_rolled_back', dbms_transaction.local_transaction_id(true));
+    call dbms_tx_autonomous_xid();
+    rollback;
+    select which from dbms_tx_autonomous order by which;
+
+    drop procedure dbms_tx_autonomous_xid();
+    drop table dbms_tx_autonomous;
+
+    --
+    -- SAVEPOINT / ROLLBACK_SAVEPOINT / COMMIT / ROLLBACK inside an autonomous
+    -- transaction: the dblink call that executes the autonomous procedure is a
+    -- single bare "CALL proc();" with no surrounding BEGIN, so from that
+    -- session's point of view there is no explicit transaction block --
+    -- SAVEPOINT/ROLLBACK_SAVEPOINT there fail the same way a bare top-level
+    -- SAVEPOINT statement would (see "call dbms_transaction.savepoint('sp_outside')"
+    -- above).  COMMIT/ROLLBACK are still invoked from within the autonomous
+    -- procedure's own body (a nested CALL to dbms_transaction.commit()/rollback()),
+    -- so they hit the same "invalid transaction termination" restriction as any
+    -- other nested CALL -- PRAGMA AUTONOMOUS_TRANSACTION does not change either
+    -- restriction.
+    --
+    create or replace procedure dbms_tx_autonomous_savepoint() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.savepoint('autosp');
+    end;
+    /
+    call dbms_tx_autonomous_savepoint();
+    drop procedure dbms_tx_autonomous_savepoint();
+
+    create or replace procedure dbms_tx_autonomous_rbsp() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.rollback_savepoint('autosp');
+    end;
+    /
+    call dbms_tx_autonomous_rbsp();
+    drop procedure dbms_tx_autonomous_rbsp();
+
+    create or replace procedure dbms_tx_autonomous_commit() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_t values (900, 'should not be committed');
+        dbms_transaction.commit();
+    end;
+    /
+    call dbms_tx_autonomous_commit();
+    select * from dbms_tx_t where id = 900;
+    drop procedure dbms_tx_autonomous_commit();
+
+    create or replace procedure dbms_tx_autonomous_rollback() as
+    pragma autonomous_transaction;
+    begin
+        insert into dbms_tx_t values (901, 'should error before rollback runs');
+        dbms_transaction.rollback();
+    end;
+    /
+    call dbms_tx_autonomous_rollback();
+    select * from dbms_tx_t where id = 901;
+    drop procedure dbms_tx_autonomous_rollback();
+
+    --
+    -- READ_ONLY / READ_WRITE inside an autonomous transaction: these are plain
+    -- SET TRANSACTION statements and do not need an explicit transaction block,
+    -- so (unlike SAVEPOINT/COMMIT above) they work the same as at the top level.
+    --
+    create or replace procedure dbms_tx_autonomous_readonly() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.read_only();
+        insert into dbms_tx_t values (902, 'blocked by autonomous read_only');
+    end;
+    /
+    call dbms_tx_autonomous_readonly();
+    select * from dbms_tx_t where id = 902;
+    drop procedure dbms_tx_autonomous_readonly();
+
+    create or replace procedure dbms_tx_autonomous_readwrite() as
+    pragma autonomous_transaction;
+    begin
+        dbms_transaction.read_write();
+        insert into dbms_tx_t values (903, 'allowed by autonomous read_write, autocommitted');
+    end;
+    /
+    call dbms_tx_autonomous_readwrite();
+    select * from dbms_tx_t where id = 903;
+    drop procedure dbms_tx_autonomous_readwrite();
+
+
+    --
+    -- Clean up: drop the role again, but only if this script is the one that
+    -- created it -- never drop a role that already existed before we got here.
+    -- Note: no "<> ''" check alongside IS NOT NULL -- Oracle-compat mode's
+    -- empty-string-is-NULL semantics turns such a comparison into NULL, which
+    -- IF treats as not-satisfied, silently skipping the DROP.
+    --
+    DO $$
+    DECLARE
+        r text := current_setting('dbms_tx_test.created_role', true);
+    BEGIN 
+        IF r IS NOT NULL THEN
+            EXECUTE format('DROP ROLE %I', r);
+        END IF;
+    END;
+    $$;
+\else
+    \echo 'dblink is not available in this environment, skipping DBMS_TRANSACTION autonomous-transaction tests'
+\endif
+--
+-- Cross-user execution: the package must be callable by any role, not just
+-- the owner/superuser that ran CREATE EXTENSION, and it must run with the
+-- caller's own privileges (AUTHID CURRENT_USER) rather than the package
+-- owner's -- this is what Oracle's own documentation for DBMS_TRANSACTION
+-- promises ("all subprograms ... run with the privileges of the calling
+-- user, rather than the package owner SYS").
+--
+create role regress_dbms_tx_other_user login;
+create table regress_dbms_tx_other_user_t (id int);
+grant all on regress_dbms_tx_other_user_t to regress_dbms_tx_other_user;
+
+set session authorization regress_dbms_tx_other_user;
+select current_user;
+
+-- no explicit GRANT needed: EXECUTE on the package is granted to PUBLIC
+-- when dbms_transaction is installed
+select dbms_transaction.local_transaction_id() is null as no_xid_without_create;
+
+begin;
+select dbms_transaction.local_transaction_id(true) is not null as xid_created;
+call dbms_transaction.savepoint('other_user_sp');
+call dbms_transaction.rollback_savepoint('other_user_sp');
+commit;
+
+-- COMMIT/ROLLBACK also work for a non-owner role, same as for the owner
+insert into regress_dbms_tx_other_user_t values (1);
+call dbms_transaction.commit();
+insert into regress_dbms_tx_other_user_t values (2);
+call dbms_transaction.rollback();
+select * from regress_dbms_tx_other_user_t order by id;
+
+-- READ_ONLY/READ_WRITE also work for a non-owner role
+begin;
+call dbms_transaction.read_only();
+insert into regress_dbms_tx_other_user_t values (3);
+rollback;
+
+begin;
+call dbms_transaction.read_write();
+insert into regress_dbms_tx_other_user_t values (4);
+commit;
+select * from regress_dbms_tx_other_user_t order by id;
+
+reset session authorization;
+drop table regress_dbms_tx_other_user_t;
+drop role regress_dbms_tx_other_user;
+
+drop table dbms_tx_t;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction--1.0.sql
@@ -58,7 +58,6 @@ CREATE OR REPLACE PACKAGE dbms_transaction AUTHID CURRENT_USER IS
 
     PROCEDURE read_only;
     PROCEDURE read_write;
-    FUNCTION local_transaction_id(create_transaction IN BOOLEAN DEFAULT FALSE) RETURN VARCHAR2;
 
 END dbms_transaction;
 
@@ -92,17 +91,6 @@ CREATE OR REPLACE PACKAGE BODY dbms_transaction IS
     PROCEDURE read_write IS
     BEGIN
         EXECUTE 'SET TRANSACTION READ WRITE';
-    END;
-
-    FUNCTION local_transaction_id(create_transaction IN BOOLEAN DEFAULT FALSE) RETURN VARCHAR2 IS
-        xid_text VARCHAR2(32);
-    BEGIN
-        IF create_transaction THEN
-            SELECT pg_current_xact_id()::text INTO xid_text;
-        ELSE
-            SELECT pg_current_xact_id_if_assigned()::text INTO xid_text;
-        END IF;
-        RETURN xid_text;
     END;
 
 END dbms_transaction;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction--1.0.sql
@@ -1,0 +1,113 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * dbms_transaction--1.0.sql
+ *
+ * Oracle-compatible DBMS_TRANSACTION package.
+ *
+ * COMMIT/ROLLBACK reuse PL/iSQL's native COMMIT/ROLLBACK statements (only
+ * valid when the package procedure is invoked as a top-level CALL, exactly
+ * like a bare COMMIT/ROLLBACK would be).  SAVEPOINT/ROLLBACK_SAVEPOINT call
+ * into a small C bridge (dbms_transaction.c) that reaches directly into
+ * PostgreSQL's DefineSavepoint()/RollbackToSavepoint(), since PL/iSQL has no
+ * native savepoint statement.  READ_ONLY/READ_WRITE and the metadata readers
+ * are thin wrappers around existing SQL facilities.
+ *
+ * AUTHID CURRENT_USER: Oracle's own documentation for DBMS_TRANSACTION says
+ * "All subprograms in the DBMS_TRANSACTION package run with the privileges
+ * of the calling user, rather than the package owner SYS" -- i.e. invoker's
+ * rights, not the CREATE PACKAGE default of definer's rights.  EXECUTE is
+ * also granted to PUBLIC below, matching Oracle's catalog scripts granting
+ * SYS.DBMS_TRANSACTION to PUBLIC at database creation, so that ordinary
+ * users can call it without a DBA having to GRANT it per-role first.
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction--1.0.sql
+ *
+ *-------------------------------------------------------------------------
+ */
+
+-- Register C functions for the named-savepoint operations
+CREATE FUNCTION sys.ora_dbms_transaction_savepoint(name TEXT)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'ora_dbms_transaction_savepoint'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_transaction_rollback_savepoint(name TEXT)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'ora_dbms_transaction_rollback_savepoint'
+LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE PACKAGE dbms_transaction AUTHID CURRENT_USER IS
+
+    PROCEDURE commit;
+    PROCEDURE rollback;
+    PROCEDURE savepoint(savept IN VARCHAR2);
+    PROCEDURE rollback_savepoint(savept IN VARCHAR2);
+
+    PROCEDURE read_only;
+    PROCEDURE read_write;
+    FUNCTION local_transaction_id(create_transaction IN BOOLEAN DEFAULT FALSE) RETURN VARCHAR2;
+
+END dbms_transaction;
+
+CREATE OR REPLACE PACKAGE BODY dbms_transaction IS
+
+    PROCEDURE commit IS
+    BEGIN
+        COMMIT;
+    END;
+
+    PROCEDURE rollback IS
+    BEGIN
+        ROLLBACK;
+    END;
+
+    PROCEDURE savepoint(savept IN VARCHAR2) IS
+    BEGIN
+        PERFORM sys.ora_dbms_transaction_savepoint(savept);
+    END;
+
+    PROCEDURE rollback_savepoint(savept IN VARCHAR2) IS
+    BEGIN
+        PERFORM sys.ora_dbms_transaction_rollback_savepoint(savept);
+    END;
+
+    PROCEDURE read_only IS
+    BEGIN
+        EXECUTE 'SET TRANSACTION READ ONLY';
+    END;
+
+    PROCEDURE read_write IS
+    BEGIN
+        EXECUTE 'SET TRANSACTION READ WRITE';
+    END;
+
+    FUNCTION local_transaction_id(create_transaction IN BOOLEAN DEFAULT FALSE) RETURN VARCHAR2 IS
+        xid_text VARCHAR2(32);
+    BEGIN
+        IF create_transaction THEN
+            SELECT pg_current_xact_id()::text INTO xid_text;
+        ELSE
+            SELECT pg_current_xact_id_if_assigned()::text INTO xid_text;
+        END IF;
+        RETURN xid_text;
+    END;
+
+END dbms_transaction;
+
+-- Packages default to no PUBLIC privileges at all (unlike plain FUNCTION/
+-- PROCEDURE, which grant EXECUTE to PUBLIC by default) -- without this,
+-- only the role that ran CREATE EXTENSION could call any subprogram here.
+GRANT EXECUTE ON PACKAGE dbms_transaction TO PUBLIC;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction.c
@@ -1,0 +1,209 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Implementation of Oracle's DBMS_TRANSACTION package (savepoint subset).
+ * This module is part of ivorysql_ora extension.
+ *
+ * COMMIT, ROLLBACK, READ ONLY/READ WRITE and the metadata readers are plain
+ * PL/iSQL wrappers (see dbms_transaction--1.0.sql) around statements the
+ * language already supports natively.  Only the named-savepoint operations
+ * need a C-level bridge, because PL/iSQL has no SAVEPOINT/ROLLBACK TO
+ * SAVEPOINT statement of its own.
+ *
+ * These bridge functions call DefineSavepoint()/RollbackToSavepoint()
+ * (declared in access/xact.h) directly rather than going through SPI.
+ * Unlike SPI_commit()/SPI_rollback(), a savepoint operation never
+ * terminates the current top-level transaction -- it only marks the
+ * transaction state so a subtransaction is started/ended when control
+ * returns to CommitTransactionCommand() at the end of the current
+ * top-level command, exactly as happens for a plain SQL SAVEPOINT /
+ * ROLLBACK TO SAVEPOINT statement.  That means none of SPI's machinery
+ * (connection stack, atomic-context checks, the PG_TRY/
+ * StartTransactionCommand dance SPI_commit()/SPI_rollback() need) is
+ * relevant here, so there is nothing to gain from routing through SPI --
+ * standard_ProcessUtility() calls these same xact.c functions directly
+ * for a plain SQL SAVEPOINT statement, and this bridge does the same.
+ *
+ * "control returns to CommitTransactionCommand() at the end of the current
+ * top-level command" above is not just descriptive, it is load-bearing:
+ * DefineSavepoint()/RollbackToSavepoint() only push a placeholder
+ * transaction-state node (blockState TBLOCK_SUBBEGIN, or a pending restart
+ * for rollback) -- xact.c's own comment on StartSubTransaction() explains
+ * that finishing the job is deliberately deferred because "the SAVEPOINT
+ * utility command will be executed inside a Portal", so the real
+ * subtransaction setup has to wait for CommitTransactionCommand() to run
+ * once that Portal's top-level command has fully finished.  A bare SQL
+ * SAVEPOINT/ROLLBACK TO SAVEPOINT statement is always its own complete
+ * top-level command, so that handoff always happens before anything else
+ * can run.  When SAVEPOINT/ROLLBACK_SAVEPOINT is called from *inside*
+ * another already-executing PL/iSQL routine, though, the enclosing routine
+ * keeps running -- and can invoke more package/PL code -- before that
+ * top-level command ever finishes.  Any such call (even something with no
+ * relation to transactions at all, like DBMS_OUTPUT.PUT_LINE) needs a
+ * catalog/relcache lookup, and doing that while the pushed transaction
+ * state is still just a placeholder trips an Assert(IsTransactionState())
+ * in relcache.c and takes the whole backend down with SIGABRT.
+ *
+ * (A tempting-looking alternative -- calling CommitTransactionCommand()/
+ * StartTransactionCommand() ourselves right away, to finish that handoff
+ * immediately instead of refusing the nested call -- was tried and
+ * discarded: doing so from mid-command, underneath an already-open SPI
+ * connection, desyncs resource-owner bookkeeping ("snapshot reference ...
+ * is not owned by resource owner SubTransaction") instead of fixing
+ * anything. check_not_nested_in_pl_call() below just refuses the
+ * combination up front with an ordinary ERROR instead.)
+ *
+ * check_not_nested_in_pl_call() applies unconditionally, with no exemption
+ * for PRAGMA AUTONOMOUS_TRANSACTION.  An earlier version tried to carve one
+ * out by reading the plisql.inside_autonomous_transaction GUC (set by the
+ * autonomous-transaction machinery, see pl_autonomous.c/pl_handler.c) and
+ * skipping this check when it was "on" -- but that GUC is PGC_USERSET (it
+ * has to be, so dblink's own separate connection can set it via plain SQL;
+ * see the comment on its DefineCustomBoolVariable() call in pl_handler.c),
+ * meaning any ordinary session can just "SET plisql.inside_autonomous_
+ * transaction = true" before making a nested call and walk straight past
+ * this guard into the unsafe DefineSavepoint()/RollbackToSavepoint() path
+ * it exists to block.  There is no session-local state here that only the
+ * real dblink machinery can set, so no such exemption can be made safely.
+ *
+ * The exemption was also unnecessary for the case it targeted: a genuine
+ * autonomous-transaction call arrives over a fresh, single-use dblink
+ * connection (dblink_exec()/dblink() with no connection name always open-
+ * execute-close a brand new session) that never has an explicit transaction
+ * block open, so RequireTransactionBlock(true, ...) -- which runs *before*
+ * check_not_nested_in_pl_call() in both entry points below -- already
+ * rejects it with "SAVEPOINT can only be used in transaction blocks" every
+ * time, regardless of this check.  Removing the exemption changes nothing
+ * for that legitimate case and closes the bypass for every other one.
+ *
+ * Portions Copyright (c) 2025-2026, IvorySQL Global Development Team
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/dbms_transaction/dbms_transaction.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+#include "access/xact.h"
+#include "executor/spi.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+
+/*
+ * Oracle limits a savepoint identifier to 30 bytes; we are more generous but
+ * still reject absurdly long names up front rather than let them flow into
+ * TopTransactionContext-allocated savepoint bookkeeping.
+ */
+#define DBMS_TRANSACTION_SAVEPOINT_NAME_LEN	256
+
+PG_FUNCTION_INFO_V1(ora_dbms_transaction_savepoint);
+PG_FUNCTION_INFO_V1(ora_dbms_transaction_rollback_savepoint);
+
+static char *
+get_savepoint_name(FunctionCallInfo fcinfo)
+{
+	char	   *name;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("DBMS_TRANSACTION savepoint name must not be NULL")));
+
+	name = text_to_cstring(PG_GETARG_TEXT_PP(0));
+
+	if (strlen(name) >= DBMS_TRANSACTION_SAVEPOINT_NAME_LEN)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("DBMS_TRANSACTION savepoint name too long (max %d bytes)",
+						DBMS_TRANSACTION_SAVEPOINT_NAME_LEN - 1)));
+
+	return name;
+}
+
+/*
+ * check_not_nested_in_pl_call
+ *
+ * Reject SAVEPOINT/ROLLBACK_SAVEPOINT when this call is nested inside
+ * another already-executing PL/iSQL routine, rather than being the direct
+ * result of a top-level CALL to DBMS_TRANSACTION.SAVEPOINT/
+ * ROLLBACK_SAVEPOINT itself.  See the file header comment for why, and for
+ * why this has no exemption for PRAGMA AUTONOMOUS_TRANSACTION.
+ *
+ * plisql_call_handler() (and every other PL/iSQL entry point) calls
+ * SPI_connect_ext() once per invocation, so SPI_get_connected() reports 0
+ * only when the routine currently running -- here, DBMS_TRANSACTION's own
+ * SAVEPOINT/ROLLBACK_SAVEPOINT wrapper procedure -- is itself the outermost
+ * SPI-connected call, i.e. was reached directly from a top-level CALL.  Any
+ * higher value means one or more PL/iSQL routines are already running
+ * underneath us, and control will return to them (not to
+ * CommitTransactionCommand()) once we're done.
+ */
+static void
+check_not_nested_in_pl_call(const char *stmtType)
+{
+	if (SPI_get_connected() > 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TRANSACTION_STATE),
+				 errmsg("DBMS_TRANSACTION.%s cannot be called from within another PL/iSQL routine",
+						stmtType),
+				 errdetail("It must be the direct result of a top-level CALL, the same way a bare SQL "
+						   "SAVEPOINT/ROLLBACK TO SAVEPOINT statement must be its own complete statement."),
+				 errhint("Move the call to DBMS_TRANSACTION.%s out to its own top-level CALL statement.",
+						 stmtType)));
+}
+
+/*
+ * DBMS_TRANSACTION.SAVEPOINT(name)
+ *
+ * Establishes a named savepoint in the current transaction.  Requires an
+ * explicit transaction block to already be open, same as a bare SQL
+ * SAVEPOINT statement -- unlike COMMIT/ROLLBACK, this has nothing to do
+ * with atomic vs. non-atomic CALL context.
+ */
+Datum
+ora_dbms_transaction_savepoint(PG_FUNCTION_ARGS)
+{
+	char	   *name = get_savepoint_name(fcinfo);
+
+	RequireTransactionBlock(true, "SAVEPOINT");
+	check_not_nested_in_pl_call("SAVEPOINT");
+	DefineSavepoint(name);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * DBMS_TRANSACTION.ROLLBACK_SAVEPOINT(name)
+ *
+ * Rolls back to a previously established savepoint without ending the
+ * transaction.  Requires an explicit transaction block for the same reason
+ * SAVEPOINT does: RollbackToSavepoint() asserts the transaction state is
+ * already TBLOCK_INPROGRESS (or a subtransaction thereof), which is only
+ * true once a transaction block has been started.  Without this guard,
+ * calling ROLLBACK_SAVEPOINT as a standalone top-level statement hits that
+ * state-machine assertion and crashes the backend instead of raising a
+ * normal error -- standard_ProcessUtility() guards the equivalent plain SQL
+ * ROLLBACK TO SAVEPOINT statement the same way.
+ */
+Datum
+ora_dbms_transaction_rollback_savepoint(PG_FUNCTION_ARGS)
+{
+	char	   *name = get_savepoint_name(fcinfo);
+
+	RequireTransactionBlock(true, "ROLLBACK TO SAVEPOINT");
+	check_not_nested_in_pl_call("ROLLBACK_SAVEPOINT");
+	RollbackToSavepoint(name);
+
+	PG_RETURN_VOID();
+}


### PR DESCRIPTION
Close #1050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Oracle-compatible `DBMS_TRANSACTION` support.
- Added commit, rollback, named savepoint, transaction mode, and local transaction ID operations.
- Added legacy compatibility procedures and caller-privilege execution.
- Added autonomous transaction support, including independent transaction IDs and savepoint behavior.

## Bug Fixes
- Added validation for savepoint names, transaction context, and nested procedure usage.
- Unsupported distributed transaction recovery operations now report clear feature-not-supported errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->