### PR TITLE
plisql: keep package body-private members hidden after body compile

### DIFF
--- a/src/oracle_test/regress/expected/ora_package.out
+++ b/src/oracle_test/regress/expected/ora_package.out
@@ -920,23 +920,13 @@ begin
   fetch pkg.c1 into r;
   raise info '%',r.name;
   call pkg.test_close();
-  --raise syntax error
+  -- typo aside, c2 is body-private to pkg and must be rejected before
+  -- this is even parseable as a FETCH
   fetchs pkg.c2 INTO r;
 end;
 /
-ERROR:  syntax error at or near "fetchs"
-LINE 9:   fetchs pkg.c2 INTO r;
-          ^
-QUERY:  declare
- r mds%rowtype;
- ret integer;
-begin
-  fetch pkg.c1 into r;
-  raise info '%',r.name;
-  call pkg.test_close();
-  --raise syntax error
-  fetchs pkg.c2 INTO r;
-end
+ERROR:  "c2" doesn't exist in package "pkg"
+CONTEXT:  compilation of PL/iSQL function "inline_code_block" near line 7
 drop package pkg;
 --test replace src doesn't change
 --test ok
@@ -4670,6 +4660,59 @@ end;
 /
 INFO:  2
 drop package pkg1;
+-- body-only declarations (no top-level BEGIN block in the body) must stay
+-- private to the package even after the body has been compiled/cached by
+-- an earlier call (github issue #1725)
+CREATE OR REPLACE PACKAGE pkg_priv_novisibility AS
+    FUNCTION pub_fn RETURN integer;
+END pkg_priv_novisibility;
+/
+CREATE OR REPLACE PACKAGE BODY pkg_priv_novisibility AS
+    priv_var integer := 1;
+    FUNCTION priv_fn RETURN integer IS
+    BEGIN
+        RETURN priv_var;
+    END;
+    FUNCTION pub_fn RETURN integer IS
+    BEGIN
+        RETURN priv_fn();
+    END;
+END pkg_priv_novisibility;
+/
+-- before the body is compiled: correctly rejected
+SELECT pkg_priv_novisibility.priv_fn();
+ERROR:  "priv_fn" doesn't exist in package "pkg_priv_novisibility"
+LINE 1: SELECT pkg_priv_novisibility.priv_fn();
+               ^
+-- force body compile
+SELECT pkg_priv_novisibility.pub_fn();
+ pub_fn 
+--------
+      1
+(1 row)
+
+-- after body compile: must still be rejected
+SELECT pkg_priv_novisibility.priv_fn();
+ERROR:  "priv_fn" doesn't exist in package "pkg_priv_novisibility"
+LINE 1: SELECT pkg_priv_novisibility.priv_fn();
+               ^
+begin
+  raise info '%', pkg_priv_novisibility.priv_var;
+end;
+/
+ERROR:  "priv_var" doesn't exist in package "pkg_priv_novisibility"
+CONTEXT:  compilation of PL/iSQL function "inline_code_block" near line 2
+-- %TYPE against a body-private var (PACKAGE_PARSE_TYPE, not just
+-- PACKAGE_PARSE_VAR/ENTRY above) must also stay rejected
+declare
+  v pkg_priv_novisibility.priv_var%TYPE;
+begin
+  raise info '%', v;
+end;
+/
+ERROR:  "priv_var" doesn't exist in package "pkg_priv_novisibility"
+CONTEXT:  compilation of PL/iSQL function "inline_code_block" near line 2
+drop package pkg_priv_novisibility;
 --test pg array and object  type
 create type complex1 as (r float8, i float8);
 create type quadarray as (c1 complex1[], c2 complex1);

--- a/src/oracle_test/regress/sql/ora_package.sql
+++ b/src/oracle_test/regress/sql/ora_package.sql
@@ -852,7 +852,8 @@ begin
   fetch pkg.c1 into r;
   raise info '%',r.name;
   call pkg.test_close();
-  --raise syntax error
+  -- typo aside, c2 is body-private to pkg and must be rejected before
+  -- this is even parseable as a FETCH
   fetchs pkg.c2 INTO r;
 end;
 /
@@ -4605,6 +4606,53 @@ end;
 /
 
 drop package pkg1;
+
+-- body-only declarations (no top-level BEGIN block in the body) must stay
+-- private to the package even after the body has been compiled/cached by
+-- an earlier call (github issue #1725)
+CREATE OR REPLACE PACKAGE pkg_priv_novisibility AS
+    FUNCTION pub_fn RETURN integer;
+END pkg_priv_novisibility;
+/
+
+CREATE OR REPLACE PACKAGE BODY pkg_priv_novisibility AS
+    priv_var integer := 1;
+
+    FUNCTION priv_fn RETURN integer IS
+    BEGIN
+        RETURN priv_var;
+    END;
+
+    FUNCTION pub_fn RETURN integer IS
+    BEGIN
+        RETURN priv_fn();
+    END;
+END pkg_priv_novisibility;
+/
+
+-- before the body is compiled: correctly rejected
+SELECT pkg_priv_novisibility.priv_fn();
+
+-- force body compile
+SELECT pkg_priv_novisibility.pub_fn();
+
+-- after body compile: must still be rejected
+SELECT pkg_priv_novisibility.priv_fn();
+begin
+  raise info '%', pkg_priv_novisibility.priv_var;
+end;
+/
+
+-- %TYPE against a body-private var (PACKAGE_PARSE_TYPE, not just
+-- PACKAGE_PARSE_VAR/ENTRY above) must also stay rejected
+declare
+  v pkg_priv_novisibility.priv_var%TYPE;
+begin
+  raise info '%', v;
+end;
+/
+
+drop package pkg_priv_novisibility;
 
 --test pg array and object  type
 create type complex1 as (r float8, i float8);

--- a/src/pl/plisql/src/pl_gram.y
+++ b/src/pl/plisql/src/pl_gram.y
@@ -549,7 +549,20 @@ ora_pl_package: ora_decl_sect K_END opt_label
 				new->n_initvars = $1.n_initvars;
 				new->initvarnos = $1.initvarnos;
 
-				plisql_compile_packageitem->special_cur = plisql_ns_top();
+				/*
+				 * This production (a package spec/body with no top-level
+				 * BEGIN block) runs for the spec compile AND for any body
+				 * compile that lacks an init block. special_cur must only
+				 * ever capture the spec's own namespace boundary (see its
+				 * declaration in pl_package.h): it is what qualified
+				 * external lookups in plisql_package_parse() search, so
+				 * body-only declarations must never end up in it. Guard
+				 * this the same way the status update below it already
+				 * is, or a body-only member becomes externally visible
+				 * the moment its package body is first compiled.
+				 */
+				if (!plisql_compile_packageitem->finish_compile_special)
+					plisql_compile_packageitem->special_cur = plisql_ns_top();
 				plisql_IdentifierLookup = IDENTIFIER_LOOKUP_NORMAL;
 				/* Remember variables declared in decl_stmts */
 				check_labels($1.label, $3, @3, yyscanner);


### PR DESCRIPTION
special_cur (the namespace boundary plisql_package_parse() uses for qualified external lookups, per its declaration in pl_package.h) was meant to capture only the package spec's own namespace. But ora_pl_package's grammar action -- shared by the spec compile and by any body compile that lacks a top-level BEGIN block -- unconditionally overwrote it with the current namespace top.

Guard the assignment the same way the compile-status update right below it already is: only take the snapshot during the spec compile.

Fixes #1725.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package visibility handling so body-only variables, functions, and type references remain private.
  * Prevented private package declarations from being accessed before or after package-body compilation.
  * Improved error reporting for invalid private cursor access.
  * Preserved access to public functions, including their ability to call private package functions.

* **Tests**
  * Added regression coverage for package-private declaration visibility, compiled package caching, and `%TYPE` references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->