### PR TITLE
Fix trailing semicolons in Oracle psql slash commands

### DIFF
--- a/src/bin/psql/ora_psqlscanslash.l
+++ b/src/bin/psql/ora_psqlscanslash.l
@@ -22,6 +22,8 @@
  */
 #include "postgres_fe.h"
 
+#include <ctype.h>
+
 #include "common.h"
 #include "ora_psqlscanslash.h"
 #include "common/logging.h"
@@ -620,7 +622,7 @@ ora_psql_scan_slash_option(PsqlScanState state,
 			/* empty arg */
 			break;
 		case xslasharg:
-			/* Strip any unquoted trailing semi-colons if requested */
+			/* Strip any unquoted trailing semicolons if requested */
 			if (semicolon)
 			{
 				while (unquoted_option_chars-- > 0 &&
@@ -652,7 +654,21 @@ ora_psql_scan_slash_option(PsqlScanState state,
 			termPQExpBuffer(&mybuf);
 			return NULL;
 		case xslashwholeline:
-			/* always okay */
+			/*
+			 * In whole-line mode, interpret semicolon = true as stripping
+			 * trailing whitespace as well as semicolons.  There is no concept
+			 * of quoting in this mode.
+			 */
+			if (semicolon)
+			{
+				while (mybuf.len > 0 &&
+					   (mybuf.data[mybuf.len - 1] == ';' ||
+						(isascii((unsigned char) mybuf.data[mybuf.len - 1]) &&
+						 isspace((unsigned char) mybuf.data[mybuf.len - 1]))))
+				{
+					mybuf.data[--mybuf.len] = '\0';
+				}
+			}
 			break;
 		default:
 			/* can't get here */

--- a/src/bin/psql/t/001_basic.pl
+++ b/src/bin/psql/t/001_basic.pl
@@ -540,4 +540,25 @@ psql_fails_like(
 	qr/backslash commands are restricted; only \\unrestrict is allowed/,
 	'meta-command in restrict mode fails');
 
+# Whole-line slash options use a separate scanner in Oracle mode.  Confirm
+# that it honors the request to strip trailing whitespace and semicolons.
+{
+	local $ENV{PG_TEST_INITDB_EXTRA_OPTS} = '-m oracle';
+	my $oracle_node = PostgreSQL::Test::Cluster->new('oracle_slash');
+
+	$oracle_node->init;
+	$oracle_node->start;
+	$oracle_node->safe_psql(
+		'postgres',
+		'CREATE FUNCTION slash_semicolon_test() RETURNS integer '
+		  . q{LANGUAGE SQL AS 'SELECT 1'});
+
+	local $ENV{PGOPTIONS} = '-c ivorysql.compatible_mode=oracle';
+	psql_like(
+		$oracle_node,
+		'\\sf public.slash_semicolon_test ;',
+		qr/CREATE OR REPLACE FUNCTION public\.slash_semicolon_test\(\)/,
+		'Oracle \\sf strips a trailing semicolon');
+}
+
 done_testing();


### PR DESCRIPTION
## Summary

- make the Oracle slash-command scanner honor the `semicolon` flag for whole-line arguments
- strip trailing whitespace and semicolons for commands such as `\sf`, `\ef`, `\sv`, and `\ev`
- add an Oracle-mode psql TAP regression for `\sf function_name ;`

## Problem

The PostgreSQL slash scanner handles the flag in `OT_WHOLE_LINE` mode, but the parallel Oracle scanner still treated the whole argument as-is. A harmless trailing semicolon therefore became part of the function or view name and caused lookup failures only in Oracle mode.

## Validation

- `git diff --check`
- verified the Oracle scanner now matches the established PostgreSQL scanner behavior
- the Linux-only psql TAP test cannot run in this Windows checkout and is included for CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Oracle-compatible `\sf` command parsing to correctly handle trailing whitespace and semicolons.
  - Function definitions now display as expected when `\sf` commands include a trailing semicolon.

- **Tests**
  - Added regression coverage for Oracle-mode `\sf` commands with trailing whitespace and semicolons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1742
