### PR TITLE
Fix the Oracle prompt service-name escape

### DIFF
--- a/src/bin/psql/ora_prompt.c
+++ b/src/bin/psql/ora_prompt.c
@@ -192,7 +192,7 @@ ora_get_prompt(Ora_promptStatus_t status, ConditionalStack cstack)
 						if (service_name)
 							strlcpy(buf, service_name, sizeof(buf));
 					}
-					pg_fallthrough;
+					break;
 					/* backend pid */
 				case 'p':
 					if (pset.db)

--- a/src/bin/psql/t/040_prompt.pl
+++ b/src/bin/psql/t/040_prompt.pl
@@ -110,6 +110,21 @@ like(
 	qr/BEFORE\[ORA\]AFTER/,
 	"%o expands to [ORA] when compatible_mode is oracle");
 
+# The Oracle prompt renderer must not let the service-name escape fall
+# through to the backend-PID escape when a connection is active.
+$h->query_until(
+	qr/^ok3\r?$/m,
+	"\\set SERVICE oracle_service\n"
+	  . "\\set PROMPT1 'BEFORE%sAFTER'\n"
+	  . "select 'p6' as p;\nselect 'ok3' as r;\n");
+$out = $h->query_until(
+	qr/^res4\r?$/m,
+	"select 'p7' as p;\nselect 'res4' as r;\n");
+like(
+	$out,
+	qr/BEFOREoracle_serviceAFTER/,
+	"%s expands to the service name in an oracle-mode session");
+
 # Confirm the value %o keys off of.
 my $mode = $h->query_until(qr/^oracle\r?$/m, "show ivorysql.compatible_mode;\n");
 like($mode, qr/^oracle\r?$/m,


### PR DESCRIPTION
## Summary

- stop the Oracle prompt `%s` service-name escape from falling through to `%p`
- preserve the configured `SERVICE` value while connected
- extend the interactive Oracle-mode prompt TAP test

## Problem

`ora_get_prompt()` copied the service name into the prompt buffer and then continued into the backend-PID branch. With an active connection, `%s` consequently rendered the PID instead of the `SERVICE` psql variable. The PostgreSQL prompt implementation terminates the `%s` branch normally.

## Validation

- `git diff --check`
- verified the service branch terminates before the backend-PID branch
- the interactive TAP test requires the Linux PostgreSQL test harness and `IO::Pty`, which are unavailable in this Windows checkout; CI should execute it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Oracle-mode prompt so the `%s` escape displays the configured service name correctly.
  * Prevented the service-name prompt escape from incorrectly showing backend process information.

* **Tests**
  * Added coverage verifying the corrected prompt behavior while connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1743
