### PR TITLE
add BIT_AND_AGG, BIT_OR_AGG, BIT_XOR_AGG

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -85,7 +85,8 @@ ORA_REGRESS = \
 	utl_file \
 	utl_raw \
 	utl_encode \
-	dbms_session
+	dbms_session \
+	ora_bit_agg
 
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src

--- a/contrib/ivorysql_ora/expected/ora_bit_agg.out
+++ b/contrib/ivorysql_ora/expected/ora_bit_agg.out
@@ -1,0 +1,450 @@
+--
+-- ora_bit_agg.sql: test Oracle-compatible BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG
+-- aggregate functions
+--
+CREATE TABLE bit_agg_test (grp VARCHAR2(10), val NUMBER);
+INSERT INTO bit_agg_test VALUES ('A', 12);
+INSERT INTO bit_agg_test VALUES ('A', 10);
+INSERT INTO bit_agg_test VALUES ('A', 9);
+INSERT INTO bit_agg_test VALUES ('B', 5);
+-- Basic usage: 12 & 10 & 9 = 8, 12 | 10 | 9 = 15, 12 # 10 # 9 = 15
+-- (bare NUMBER values need no cast -- they coerce implicitly, same as
+-- passing a plain integer to LENGTH()/LENGTHB() needs none)
+SELECT bit_and_agg(val) FROM bit_agg_test WHERE grp = 'A';
+ bit_and_agg 
+-------------
+ 8
+(1 row)
+
+SELECT bit_or_agg(val) FROM bit_agg_test WHERE grp = 'A';
+ bit_or_agg 
+------------
+ 15
+(1 row)
+
+SELECT bit_xor_agg(val) FROM bit_agg_test WHERE grp = 'A';
+ bit_xor_agg 
+-------------
+ 15
+(1 row)
+
+-- GROUP BY usage
+SELECT grp, bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test GROUP BY grp ORDER BY grp;
+ grp | bit_and_agg | bit_or_agg | bit_xor_agg 
+-----+-------------+------------+-------------
+ A   | 8           | 15         | 15
+ B   | 5           | 5          | 5
+(2 rows)
+
+-- Single value: identity
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test WHERE grp = 'B';
+ bit_and_agg | bit_or_agg | bit_xor_agg 
+-------------+------------+-------------
+ 5           | 5          | 5
+(1 row)
+
+-- NULL handling: NULLs are ignored
+INSERT INTO bit_agg_test VALUES ('A', NULL);
+SELECT bit_and_agg(val) FROM bit_agg_test WHERE grp = 'A';
+ bit_and_agg 
+-------------
+ 8
+(1 row)
+
+SELECT bit_or_agg(val) FROM bit_agg_test WHERE grp = 'A';
+ bit_or_agg 
+------------
+ 15
+(1 row)
+
+SELECT bit_xor_agg(val) FROM bit_agg_test WHERE grp = 'A';
+ bit_xor_agg 
+-------------
+ 15
+(1 row)
+
+-- All-NULL input returns 0, not NULL (confirmed against a real Oracle
+-- instance; some published docs suggest NULL, but that is not what Oracle
+-- actually does).
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test WHERE val IS NULL;
+ bit_and_agg | bit_or_agg | bit_xor_agg 
+-------------+------------+-------------
+ 0           | 0          | 0
+(1 row)
+
+-- Empty set likewise returns 0, not NULL.
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test WHERE grp = 'NONE';
+ bit_and_agg | bit_or_agg | bit_xor_agg 
+-------------+------------+-------------
+ 0           | 0          | 0
+(1 row)
+
+-- Result type is NUMBER
+SELECT pg_typeof(bit_and_agg(val)), pg_typeof(bit_xor_agg(val))
+  FROM bit_agg_test WHERE grp = 'A';
+ pg_typeof | pg_typeof 
+-----------+-----------
+ number    | number
+(1 row)
+
+-- Negative numbers (two's complement semantics via int8)
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM (SELECT -1 AS val FROM dual UNION ALL SELECT -2 FROM dual) v;
+ bit_and_agg | bit_or_agg | bit_xor_agg 
+-------------+------------+-------------
+ -2          | -1         | 1
+(1 row)
+
+-- Oracle truncates fractional NUMBER values toward zero before the bitwise
+-- op (it does not round): trunc(2.7)=2, trunc(3.2)=3, so 2&3=2, 2|3=3, 2#3=1.
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM (SELECT 2.7 AS val FROM dual UNION ALL SELECT 3.2 FROM dual) v;
+ bit_and_agg | bit_or_agg | bit_xor_agg 
+-------------+------------+-------------
+ 2           | 3          | 1
+(1 row)
+
+-- Truncation toward zero also applies to negative fractions: trunc(-2.7)=-2.
+SELECT bit_and_agg(val) FROM (SELECT -2.7 AS val FROM dual) v;
+ bit_and_agg 
+-------------
+ -2
+(1 row)
+
+DROP TABLE bit_agg_test;
+--
+-- Boundary values
+--
+-- Zero is a valid operand: it's the OR/XOR identity element and forces AND to 0.
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM (SELECT 0 AS val FROM dual UNION ALL SELECT 5 FROM dual) v;
+ bit_and_agg | bit_or_agg | bit_xor_agg 
+-------------+------------+-------------
+ 0           | 5          | 5
+(1 row)
+
+-- Exact int8 boundary (2^63-1 and -2^63) must work without overflowing,
+-- and without silently losing precision through an unintended cast to
+-- double precision along the way (trunc(NUMBER) is ambiguous between
+-- trunc(numeric) and trunc(double precision); this implementation forces
+-- the numeric overload).
+CREATE TABLE bit_agg_bounds (val NUMBER);
+INSERT INTO bit_agg_bounds VALUES (9223372036854775807);
+INSERT INTO bit_agg_bounds VALUES (-9223372036854775808);
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val) FROM bit_agg_bounds;
+ bit_and_agg | bit_or_agg | bit_xor_agg 
+-------------+------------+-------------
+ 0           | -1         | -1
+(1 row)
+
+DROP TABLE bit_agg_bounds;
+--
+-- Out-of-range / non-finite input: this implementation supports the int8
+-- range (-2^63 to 2^63-1). Real Oracle's BIT_AND_AGG/BIT_OR_AGG/BIT_XOR_AGG
+-- support a wider 128-bit signed range (-2^127 to 2^127-1) and would only
+-- error beyond that; a NUMBER outside int8 range but within 128 bits is a
+-- known, accepted gap here. NUMBER never holds NaN/Infinity in real Oracle,
+-- so there is no Oracle behavior to match for those inputs -- as long as
+-- they fail clearly (rather than silently miscompute), that is acceptable.
+-- CAST(... AS NUMBER), not the PostgreSQL-only "::" operator, is used here
+-- since these values need an explicit, portable typed literal.
+--
+-- One beyond the positive int8 boundary
+SELECT bit_and_agg(val) FROM (SELECT CAST(9223372036854775808 AS number) AS val FROM dual) v;
+ERROR:  bigint out of range
+CONTEXT:  PL/pgSQL function number_int8and_transfn(pg_catalog.int8,number) line 13 at RETURN
+-- One beyond the negative int8 boundary
+SELECT bit_and_agg(val) FROM (SELECT CAST(-9223372036854775809 AS number) AS val FROM dual) v;
+ERROR:  bigint out of range
+CONTEXT:  PL/pgSQL function number_int8and_transfn(pg_catalog.int8,number) line 13 at RETURN
+-- NaN and Infinity: NUMBER is built on PostgreSQL's numeric type, which can
+-- represent these even though Oracle NUMBER cannot; they must fail cleanly
+-- rather than misbehave.
+SELECT bit_and_agg(val) FROM (SELECT CAST('NaN' AS number) AS val FROM dual) v;
+ERROR:  cannot convert NaN to bigint
+CONTEXT:  PL/pgSQL function number_int8and_transfn(pg_catalog.int8,number) line 13 at RETURN
+SELECT bit_or_agg(val) FROM (SELECT CAST('Infinity' AS number) AS val FROM dual) v;
+ERROR:  cannot convert infinity to bigint
+CONTEXT:  PL/pgSQL function number_int8or_transfn(pg_catalog.int8,number) line 13 at RETURN
+SELECT bit_xor_agg(val) FROM (SELECT CAST('-Infinity' AS number) AS val FROM dual) v;
+ERROR:  cannot convert infinity to bigint
+CONTEXT:  PL/pgSQL function number_int8xor_transfn(pg_catalog.int8,number) line 13 at RETURN
+-- A value that cannot be parsed as a NUMBER at all fails at cast time,
+-- before ever reaching the aggregate.
+SELECT bit_and_agg(val) FROM (SELECT CAST('abc' AS number) AS val FROM dual) v;
+ERROR:  invalid input syntax for type numeric: "abc"
+LINE 1: SELECT bit_and_agg(val) FROM (SELECT CAST('abc' AS number) A...
+                                                  ^
+--
+-- DISTINCT: XOR is sensitive to repeated values (a value XORed with itself
+-- cancels out), so DISTINCT changes the result -- unlike AND/OR, which are
+-- idempotent and unaffected by duplicates.
+--
+SELECT bit_xor_agg(val), bit_xor_agg(DISTINCT val)
+  FROM (SELECT 3 AS val FROM dual UNION ALL SELECT 3 FROM dual UNION ALL SELECT 5 FROM dual) v;
+ bit_xor_agg | bit_xor_agg 
+-------------+-------------
+ 5           | 6
+(1 row)
+
+--
+-- FILTER clause (standard SQL, works generically for any aggregate)
+--
+SELECT bit_and_agg(val) FILTER (WHERE val > 0)
+  FROM (SELECT -1 AS val FROM dual UNION ALL SELECT 6 FROM dual UNION ALL SELECT 4 FROM dual) v;
+ bit_and_agg 
+-------------
+ 4
+(1 row)
+
+--
+-- Analytic/window usage: Oracle documents these as usable both as
+-- aggregate and analytic functions.
+--
+CREATE TABLE bit_agg_window (grp VARCHAR2(10), val NUMBER);
+INSERT INTO bit_agg_window VALUES ('A', 12);
+INSERT INTO bit_agg_window VALUES ('A', 10);
+INSERT INTO bit_agg_window VALUES ('A', 9);
+INSERT INTO bit_agg_window VALUES ('B', 5);
+INSERT INTO bit_agg_window VALUES ('B', 1);
+SELECT grp, val, bit_and_agg(val) OVER (PARTITION BY grp)
+  FROM bit_agg_window ORDER BY grp, val;
+ grp | val | bit_and_agg 
+-----+-----+-------------
+ A   | 9   | 8
+ A   | 10  | 8
+ A   | 12  | 8
+ B   | 1   | 1
+ B   | 5   | 1
+(5 rows)
+
+DROP TABLE bit_agg_window;
+--
+-- Parallel aggregation: cross-check against PostgreSQL's native
+-- bit_and/bit_or/bit_xor over the same underlying int8 values, with
+-- settings that make a parallel plan (Partial Aggregate + Gather +
+-- Finalize Aggregate, exercising COMBINEFUNC) likely on machines with
+-- spare worker slots. The comparison is against core's own result rather
+-- than a hardcoded constant, so the expected output is stable regardless
+-- of whether this particular environment actually goes parallel.
+-- generate_series()/bit_and()/bit_or()/bit_xor() are plain PostgreSQL,
+-- used here only as bulk test-data plumbing and as an independent oracle
+-- to check against -- not part of the Oracle compatibility surface under
+-- test, so they are not rewritten into Oracle idiom.
+--
+CREATE TABLE bit_agg_xcheck AS
+SELECT CAST(g % 4096 AS number) AS val, CAST(g % 4096 AS int8) AS val8
+  FROM generate_series(1, 50000) g;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET max_parallel_workers_per_gather = 4;
+SELECT bit_and_agg(val) = bit_and(val8) AS and_matches,
+       bit_or_agg(val) = bit_or(val8) AS or_matches,
+       bit_xor_agg(val) = bit_xor(val8) AS xor_matches
+  FROM bit_agg_xcheck;
+ and_matches | or_matches | xor_matches 
+-------------+------------+-------------
+ t           | t          | t
+(1 row)
+
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET min_parallel_table_scan_size;
+RESET max_parallel_workers_per_gather;
+DROP TABLE bit_agg_xcheck;
+------------------------------------------------------------------------
+-- Oracle-Compatible tests
+-- Following sqls are alse tested against Oracle 26ai
+------------------------------------------------------------------------
+CREATE TABLE bit_agg_check_user_perms (
+  user_id   NUMBER,
+  dept_id   NUMBER,
+  perm_mask NUMBER,
+  flag_raw  RAW(4)
+);
+INSERT INTO bit_agg_check_user_perms VALUES (1, 10, 12,   HEXTORAW('0000000C'));  -- 1100
+INSERT INTO bit_agg_check_user_perms VALUES (2, 10, 14,   HEXTORAW('0000000E'));  -- 1110
+INSERT INTO bit_agg_check_user_perms VALUES (3, 10, 10,   HEXTORAW('0000000A'));  -- 1010
+INSERT INTO bit_agg_check_user_perms VALUES (4, 20,  7,   HEXTORAW('00000007'));  -- 0111
+INSERT INTO bit_agg_check_user_perms VALUES (5, 20,  3,   HEXTORAW('00000003'));  -- 0011
+INSERT INTO bit_agg_check_user_perms VALUES (6, 20, NULL, NULL);
+COMMIT;
+WARNING:  there is no transaction in progress
+-- basical table agg
+SELECT BIT_AND_AGG(perm_mask) AS common_bits
+FROM   bit_agg_check_user_perms;
+ common_bits 
+-------------
+ 0
+(1 row)
+
+-- with GROUP BY
+SELECT dept_id,
+       BIT_AND_AGG(perm_mask) AS dept_common_bits
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;
+ dept_id | dept_common_bits 
+---------+------------------
+ 10      | 8
+ 20      | 3
+(2 rows)
+
+-- with HAVING
+SELECT dept_id, BIT_AND_AGG(perm_mask) AS m
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id
+HAVING BIT_AND_AGG(perm_mask) > 0;
+ dept_id | m 
+---------+---
+ 10      | 8
+ 20      | 3
+(2 rows)
+
+-- mixed
+SELECT dept_id,
+       BIT_AND_AGG(perm_mask) AS all_have,
+       BIT_OR_AGG (perm_mask) AS any_have,
+       BIT_XOR_AGG(perm_mask) AS parity
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;
+ dept_id | all_have | any_have | parity 
+---------+----------+----------+--------
+ 10      | 8        | 14       | 8
+ 20      | 3        | 7        | 4
+(2 rows)
+
+-- empty OVER
+SELECT user_id, dept_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER () AS global_and
+FROM   bit_agg_check_user_perms;
+ user_id | dept_id | perm_mask | global_and 
+---------+---------+-----------+------------
+ 1       | 10      | 12        | 0
+ 2       | 10      | 14        | 0
+ 3       | 10      | 10        | 0
+ 4       | 20      | 7         | 0
+ 5       | 20      | 3         | 0
+ 6       | 20      |           | 0
+(6 rows)
+
+-- with PARTITION BY
+SELECT user_id, dept_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER (PARTITION BY dept_id) AS dept_and
+FROM   bit_agg_check_user_perms;
+ user_id | dept_id | perm_mask | dept_and 
+---------+---------+-----------+----------
+ 1       | 10      | 12        | 8
+ 2       | 10      | 14        | 8
+ 3       | 10      | 10        | 8
+ 4       | 20      | 7         | 3
+ 5       | 20      | 3         | 3
+ 6       | 20      |           | 3
+(6 rows)
+
+-- windowed
+SELECT user_id, dept_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER (
+         PARTITION BY dept_id
+         ORDER BY user_id
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS running_and
+FROM   bit_agg_check_user_perms;
+ user_id | dept_id | perm_mask | running_and 
+---------+---------+-----------+-------------
+ 1       | 10      | 12        | 12
+ 2       | 10      | 14        | 12
+ 3       | 10      | 10        | 8
+ 4       | 20      | 7         | 7
+ 5       | 20      | 3         | 3
+ 6       | 20      |           | 3
+(6 rows)
+
+-- sliding window
+SELECT user_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER (
+         ORDER BY user_id
+         ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+       ) AS win3_and
+FROM   bit_agg_check_user_perms;
+ user_id | perm_mask | win3_and 
+---------+-----------+----------
+ 1       | 12        | 12
+ 2       | 14        | 8
+ 3       | 10        | 2
+ 4       | 7         | 2
+ 5       | 3         | 3
+ 6       |           | 3
+(6 rows)
+
+-- ROLLUP / GROUPING SETS
+SELECT dept_id,
+       BIT_AND_AGG(perm_mask) AS m,
+       GROUPING(dept_id)      AS is_total
+FROM   bit_agg_check_user_perms
+GROUP  BY ROLLUP(dept_id);
+ dept_id | m | is_total 
+---------+---+----------
+ 10      | 8 |        0
+ 20      | 3 |        0
+         | 0 |        1
+(3 rows)
+
+-- RAW type
+SELECT dept_id,
+       BIT_AND_AGG(flag_raw) AS raw_and
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;
+ERROR:  function bit_and_agg(raw) does not exist
+LINE 2:        BIT_AND_AGG(flag_raw) AS raw_and
+               ^
+DETAIL:  No function of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
+-- CASE
+SELECT BIT_AND_AGG(CASE WHEN perm_mask IS NULL THEN 4294967295
+                        ELSE perm_mask END) AS and_with_null_as_allones
+FROM   bit_agg_check_user_perms;
+ and_with_null_as_allones 
+--------------------------
+ 0
+(1 row)
+
+SELECT BIT_AND_AGG(TRUNC(perm_mask / 2)) FROM bit_agg_check_user_perms;
+ bit_and_agg 
+-------------
+ 0
+(1 row)
+
+-- compare with BITAND
+SELECT BITAND(12, 14)      AS two_args,
+       BITAND(BITAND(12,14), 10) AS three_vals
+FROM dual;
+ two_args | three_vals 
+----------+------------
+ 12       | 8
+(1 row)
+
+SELECT BIT_AND_AGG(m) FROM (SELECT 12 m FROM dual UNION ALL
+                            SELECT 14 FROM dual UNION ALL
+                            SELECT 10 FROM dual);
+ bit_and_agg 
+-------------
+ 8
+(1 row)
+
+-- real case: check if all has specific flag
+SELECT dept_id,
+       CASE WHEN BITAND(BIT_AND_AGG(perm_mask), 8) = 8
+            THEN 'Y' ELSE 'N' END AS all_have_bit3
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;
+ dept_id | all_have_bit3 
+---------+---------------
+ 10      | Y
+ 20      | N
+(2 rows)
+

--- a/contrib/ivorysql_ora/sql/ora_bit_agg.sql
+++ b/contrib/ivorysql_ora/sql/ora_bit_agg.sql
@@ -1,0 +1,269 @@
+--
+-- ora_bit_agg.sql: test Oracle-compatible BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG
+-- aggregate functions
+--
+CREATE TABLE bit_agg_test (grp VARCHAR2(10), val NUMBER);
+INSERT INTO bit_agg_test VALUES ('A', 12);
+INSERT INTO bit_agg_test VALUES ('A', 10);
+INSERT INTO bit_agg_test VALUES ('A', 9);
+INSERT INTO bit_agg_test VALUES ('B', 5);
+
+-- Basic usage: 12 & 10 & 9 = 8, 12 | 10 | 9 = 15, 12 # 10 # 9 = 15
+-- (bare NUMBER values need no cast -- they coerce implicitly, same as
+-- passing a plain integer to LENGTH()/LENGTHB() needs none)
+SELECT bit_and_agg(val) FROM bit_agg_test WHERE grp = 'A';
+SELECT bit_or_agg(val) FROM bit_agg_test WHERE grp = 'A';
+SELECT bit_xor_agg(val) FROM bit_agg_test WHERE grp = 'A';
+
+-- GROUP BY usage
+SELECT grp, bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test GROUP BY grp ORDER BY grp;
+
+-- Single value: identity
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test WHERE grp = 'B';
+
+-- NULL handling: NULLs are ignored
+INSERT INTO bit_agg_test VALUES ('A', NULL);
+SELECT bit_and_agg(val) FROM bit_agg_test WHERE grp = 'A';
+SELECT bit_or_agg(val) FROM bit_agg_test WHERE grp = 'A';
+SELECT bit_xor_agg(val) FROM bit_agg_test WHERE grp = 'A';
+
+-- All-NULL input returns 0, not NULL (confirmed against a real Oracle
+-- instance; some published docs suggest NULL, but that is not what Oracle
+-- actually does).
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test WHERE val IS NULL;
+
+-- Empty set likewise returns 0, not NULL.
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM bit_agg_test WHERE grp = 'NONE';
+
+-- Result type is NUMBER
+SELECT pg_typeof(bit_and_agg(val)), pg_typeof(bit_xor_agg(val))
+  FROM bit_agg_test WHERE grp = 'A';
+
+-- Negative numbers (two's complement semantics via int8)
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM (SELECT -1 AS val FROM dual UNION ALL SELECT -2 FROM dual) v;
+
+-- Oracle truncates fractional NUMBER values toward zero before the bitwise
+-- op (it does not round): trunc(2.7)=2, trunc(3.2)=3, so 2&3=2, 2|3=3, 2#3=1.
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM (SELECT 2.7 AS val FROM dual UNION ALL SELECT 3.2 FROM dual) v;
+
+-- Truncation toward zero also applies to negative fractions: trunc(-2.7)=-2.
+SELECT bit_and_agg(val) FROM (SELECT -2.7 AS val FROM dual) v;
+
+DROP TABLE bit_agg_test;
+
+--
+-- Boundary values
+--
+
+-- Zero is a valid operand: it's the OR/XOR identity element and forces AND to 0.
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val)
+  FROM (SELECT 0 AS val FROM dual UNION ALL SELECT 5 FROM dual) v;
+
+-- Exact int8 boundary (2^63-1 and -2^63) must work without overflowing,
+-- and without silently losing precision through an unintended cast to
+-- double precision along the way (trunc(NUMBER) is ambiguous between
+-- trunc(numeric) and trunc(double precision); this implementation forces
+-- the numeric overload).
+CREATE TABLE bit_agg_bounds (val NUMBER);
+INSERT INTO bit_agg_bounds VALUES (9223372036854775807);
+INSERT INTO bit_agg_bounds VALUES (-9223372036854775808);
+SELECT bit_and_agg(val), bit_or_agg(val), bit_xor_agg(val) FROM bit_agg_bounds;
+DROP TABLE bit_agg_bounds;
+
+--
+-- Out-of-range / non-finite input: this implementation supports the int8
+-- range (-2^63 to 2^63-1). Real Oracle's BIT_AND_AGG/BIT_OR_AGG/BIT_XOR_AGG
+-- support a wider 128-bit signed range (-2^127 to 2^127-1) and would only
+-- error beyond that; a NUMBER outside int8 range but within 128 bits is a
+-- known, accepted gap here. NUMBER never holds NaN/Infinity in real Oracle,
+-- so there is no Oracle behavior to match for those inputs -- as long as
+-- they fail clearly (rather than silently miscompute), that is acceptable.
+-- CAST(... AS NUMBER), not the PostgreSQL-only "::" operator, is used here
+-- since these values need an explicit, portable typed literal.
+--
+
+-- One beyond the positive int8 boundary
+SELECT bit_and_agg(val) FROM (SELECT CAST(9223372036854775808 AS number) AS val FROM dual) v;
+
+-- One beyond the negative int8 boundary
+SELECT bit_and_agg(val) FROM (SELECT CAST(-9223372036854775809 AS number) AS val FROM dual) v;
+
+-- NaN and Infinity: NUMBER is built on PostgreSQL's numeric type, which can
+-- represent these even though Oracle NUMBER cannot; they must fail cleanly
+-- rather than misbehave.
+SELECT bit_and_agg(val) FROM (SELECT CAST('NaN' AS number) AS val FROM dual) v;
+SELECT bit_or_agg(val) FROM (SELECT CAST('Infinity' AS number) AS val FROM dual) v;
+SELECT bit_xor_agg(val) FROM (SELECT CAST('-Infinity' AS number) AS val FROM dual) v;
+
+-- A value that cannot be parsed as a NUMBER at all fails at cast time,
+-- before ever reaching the aggregate.
+SELECT bit_and_agg(val) FROM (SELECT CAST('abc' AS number) AS val FROM dual) v;
+
+--
+-- DISTINCT: XOR is sensitive to repeated values (a value XORed with itself
+-- cancels out), so DISTINCT changes the result -- unlike AND/OR, which are
+-- idempotent and unaffected by duplicates.
+--
+SELECT bit_xor_agg(val), bit_xor_agg(DISTINCT val)
+  FROM (SELECT 3 AS val FROM dual UNION ALL SELECT 3 FROM dual UNION ALL SELECT 5 FROM dual) v;
+
+--
+-- FILTER clause (standard SQL, works generically for any aggregate)
+--
+SELECT bit_and_agg(val) FILTER (WHERE val > 0)
+  FROM (SELECT -1 AS val FROM dual UNION ALL SELECT 6 FROM dual UNION ALL SELECT 4 FROM dual) v;
+
+--
+-- Analytic/window usage: Oracle documents these as usable both as
+-- aggregate and analytic functions.
+--
+CREATE TABLE bit_agg_window (grp VARCHAR2(10), val NUMBER);
+INSERT INTO bit_agg_window VALUES ('A', 12);
+INSERT INTO bit_agg_window VALUES ('A', 10);
+INSERT INTO bit_agg_window VALUES ('A', 9);
+INSERT INTO bit_agg_window VALUES ('B', 5);
+INSERT INTO bit_agg_window VALUES ('B', 1);
+SELECT grp, val, bit_and_agg(val) OVER (PARTITION BY grp)
+  FROM bit_agg_window ORDER BY grp, val;
+DROP TABLE bit_agg_window;
+
+--
+-- Parallel aggregation: cross-check against PostgreSQL's native
+-- bit_and/bit_or/bit_xor over the same underlying int8 values, with
+-- settings that make a parallel plan (Partial Aggregate + Gather +
+-- Finalize Aggregate, exercising COMBINEFUNC) likely on machines with
+-- spare worker slots. The comparison is against core's own result rather
+-- than a hardcoded constant, so the expected output is stable regardless
+-- of whether this particular environment actually goes parallel.
+-- generate_series()/bit_and()/bit_or()/bit_xor() are plain PostgreSQL,
+-- used here only as bulk test-data plumbing and as an independent oracle
+-- to check against -- not part of the Oracle compatibility surface under
+-- test, so they are not rewritten into Oracle idiom.
+--
+CREATE TABLE bit_agg_xcheck AS
+SELECT CAST(g % 4096 AS number) AS val, CAST(g % 4096 AS int8) AS val8
+  FROM generate_series(1, 50000) g;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET max_parallel_workers_per_gather = 4;
+SELECT bit_and_agg(val) = bit_and(val8) AS and_matches,
+       bit_or_agg(val) = bit_or(val8) AS or_matches,
+       bit_xor_agg(val) = bit_xor(val8) AS xor_matches
+  FROM bit_agg_xcheck;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET min_parallel_table_scan_size;
+RESET max_parallel_workers_per_gather;
+DROP TABLE bit_agg_xcheck;
+
+------------------------------------------------------------------------
+-- Oracle-Compatible tests
+-- Following sqls are alse tested against Oracle 26ai
+------------------------------------------------------------------------
+
+CREATE TABLE bit_agg_check_user_perms (
+  user_id   NUMBER,
+  dept_id   NUMBER,
+  perm_mask NUMBER,
+  flag_raw  RAW(4)
+);
+
+INSERT INTO bit_agg_check_user_perms VALUES (1, 10, 12,   HEXTORAW('0000000C'));  -- 1100
+INSERT INTO bit_agg_check_user_perms VALUES (2, 10, 14,   HEXTORAW('0000000E'));  -- 1110
+INSERT INTO bit_agg_check_user_perms VALUES (3, 10, 10,   HEXTORAW('0000000A'));  -- 1010
+INSERT INTO bit_agg_check_user_perms VALUES (4, 20,  7,   HEXTORAW('00000007'));  -- 0111
+INSERT INTO bit_agg_check_user_perms VALUES (5, 20,  3,   HEXTORAW('00000003'));  -- 0011
+INSERT INTO bit_agg_check_user_perms VALUES (6, 20, NULL, NULL);
+COMMIT;
+
+-- basical table agg
+SELECT BIT_AND_AGG(perm_mask) AS common_bits
+FROM   bit_agg_check_user_perms;
+
+-- with GROUP BY
+SELECT dept_id,
+       BIT_AND_AGG(perm_mask) AS dept_common_bits
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;
+
+-- with HAVING
+SELECT dept_id, BIT_AND_AGG(perm_mask) AS m
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id
+HAVING BIT_AND_AGG(perm_mask) > 0;
+
+-- mixed
+SELECT dept_id,
+       BIT_AND_AGG(perm_mask) AS all_have,
+       BIT_OR_AGG (perm_mask) AS any_have,
+       BIT_XOR_AGG(perm_mask) AS parity
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;
+
+-- empty OVER
+SELECT user_id, dept_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER () AS global_and
+FROM   bit_agg_check_user_perms;
+
+-- with PARTITION BY
+SELECT user_id, dept_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER (PARTITION BY dept_id) AS dept_and
+FROM   bit_agg_check_user_perms;
+
+-- windowed
+SELECT user_id, dept_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER (
+         PARTITION BY dept_id
+         ORDER BY user_id
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS running_and
+FROM   bit_agg_check_user_perms;
+
+-- sliding window
+SELECT user_id, perm_mask,
+       BIT_AND_AGG(perm_mask) OVER (
+         ORDER BY user_id
+         ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+       ) AS win3_and
+FROM   bit_agg_check_user_perms;
+
+-- ROLLUP / GROUPING SETS
+SELECT dept_id,
+       BIT_AND_AGG(perm_mask) AS m,
+       GROUPING(dept_id)      AS is_total
+FROM   bit_agg_check_user_perms
+GROUP  BY ROLLUP(dept_id);
+
+-- RAW type
+SELECT dept_id,
+       BIT_AND_AGG(flag_raw) AS raw_and
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;
+
+-- CASE
+SELECT BIT_AND_AGG(CASE WHEN perm_mask IS NULL THEN 4294967295
+                        ELSE perm_mask END) AS and_with_null_as_allones
+FROM   bit_agg_check_user_perms;
+SELECT BIT_AND_AGG(TRUNC(perm_mask / 2)) FROM bit_agg_check_user_perms;
+
+-- compare with BITAND
+SELECT BITAND(12, 14)      AS two_args,
+       BITAND(BITAND(12,14), 10) AS three_vals
+FROM dual;
+SELECT BIT_AND_AGG(m) FROM (SELECT 12 m FROM dual UNION ALL
+                            SELECT 14 FROM dual UNION ALL
+                            SELECT 10 FROM dual);
+
+-- real case: check if all has specific flag
+SELECT dept_id,
+       CASE WHEN BITAND(BIT_AND_AGG(perm_mask), 8) = 8
+            THEN 'Y' ELSE 'N' END AS all_have_bit3
+FROM   bit_agg_check_user_perms
+GROUP  BY dept_id;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1696,3 +1696,139 @@ LANGUAGE C
 STRICT
 IMMUTABLE;
 /* End - VSIZE */
+
+/* BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG */
+/*
+ * Oracle 21c+ bitwise aggregate functions over NUMBER.
+ *
+ * sys.number's transtype can't be int8 directly: its argument type
+ * (sys.number) is not binary-coercible to int8, and CREATE AGGREGATE's
+ * strict/no-INITCOND bootstrap (see advance_transition_function() in
+ * nodeAgg.c) requires that coercibility whenever the transfn is STRICT.
+ * An INITCOND of 0 would sidestep that type mismatch too, but 0 is only
+ * the correct identity element for OR/XOR, not for AND (whose identity is
+ * all-ones) -- so a single shared INITCOND across all three would make
+ * AND wrong on real input. Instead the transfn is NOT STRICT and does its
+ * own NULL bookkeeping (ignore NULL inputs; let a NULL running state pass
+ * through untouched), and the finalfn maps a running state that never saw
+ * a non-NULL input to NUMBER 0 -- confirmed against a real Oracle instance
+ * that BIT_AND_AGG/BIT_OR_AGG/BIT_XOR_AGG over an empty or all-NULL group
+ * all return 0, not NULL (despite some published docs suggesting NULL).
+ */
+CREATE FUNCTION sys.number_int8and_transfn(int8, sys.number)
+RETURNS int8
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    /* Oracle truncates expr to an integer before applying the bitwise op
+     * (it does not round), so trunc() first rather than casting directly.
+     * Cast to numeric explicitly: trunc(sys.number) alone is ambiguous
+     * between trunc(numeric) and trunc(double precision), and PostgreSQL's
+     * numeric-category tie-break prefers float8, silently losing precision
+     * (and even spuriously overflowing int8 right at its boundary, since
+     * 9223372036854775807 rounds up to 2^63 as a double). */
+    IF $2 IS NULL THEN
+        RETURN $1;
+    ELSIF $1 IS NULL THEN
+        RETURN trunc($2::numeric)::int8;
+    ELSE
+        RETURN pg_catalog.int8and($1, trunc($2::numeric)::int8);
+    END IF;
+END;
+$$;
+
+CREATE FUNCTION sys.number_int8or_transfn(int8, sys.number)
+RETURNS int8
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    /* Oracle truncates expr to an integer before applying the bitwise op
+     * (it does not round), so trunc() first rather than casting directly.
+     * Cast to numeric explicitly: trunc(sys.number) alone is ambiguous
+     * between trunc(numeric) and trunc(double precision), and PostgreSQL's
+     * numeric-category tie-break prefers float8, silently losing precision
+     * (and even spuriously overflowing int8 right at its boundary, since
+     * 9223372036854775807 rounds up to 2^63 as a double). */
+    IF $2 IS NULL THEN
+        RETURN $1;
+    ELSIF $1 IS NULL THEN
+        RETURN trunc($2::numeric)::int8;
+    ELSE
+        RETURN pg_catalog.int8or($1, trunc($2::numeric)::int8);
+    END IF;
+END;
+$$;
+
+CREATE FUNCTION sys.number_bitagg_finalfn(int8)
+RETURNS sys.number
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    /* A NULL running state means no non-NULL input was ever seen (empty
+     * group, or every value was NULL). Real Oracle returns 0 for that
+     * case for all three functions, not NULL. */
+    IF $1 IS NULL THEN
+        RETURN 0;
+    ELSE
+        RETURN sys.int8_number($1);
+    END IF;
+END;
+$$;
+
+CREATE AGGREGATE sys.bit_and_agg(sys.number) (
+    SFUNC       = sys.number_int8and_transfn,
+    STYPE       = int8,
+    FINALFUNC   = sys.number_bitagg_finalfn,
+    COMBINEFUNC = pg_catalog.int8and,
+    PARALLEL    = SAFE
+);
+COMMENT ON AGGREGATE sys.bit_and_agg(sys.number) IS 'Oracle-compatible bitwise AND aggregate over NUMBER values';
+
+CREATE AGGREGATE sys.bit_or_agg(sys.number) (
+    SFUNC       = sys.number_int8or_transfn,
+    STYPE       = int8,
+    FINALFUNC   = sys.number_bitagg_finalfn,
+    COMBINEFUNC = pg_catalog.int8or,
+    PARALLEL    = SAFE
+);
+COMMENT ON AGGREGATE sys.bit_or_agg(sys.number) IS 'Oracle-compatible bitwise OR aggregate over NUMBER values';
+
+CREATE FUNCTION sys.number_int8xor_transfn(int8, sys.number)
+RETURNS int8
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    /* Oracle truncates expr to an integer before applying the bitwise op
+     * (it does not round), so trunc() first rather than casting directly.
+     * Cast to numeric explicitly: trunc(sys.number) alone is ambiguous
+     * between trunc(numeric) and trunc(double precision), and PostgreSQL's
+     * numeric-category tie-break prefers float8, silently losing precision
+     * (and even spuriously overflowing int8 right at its boundary, since
+     * 9223372036854775807 rounds up to 2^63 as a double). */
+    IF $2 IS NULL THEN
+        RETURN $1;
+    ELSIF $1 IS NULL THEN
+        RETURN trunc($2::numeric)::int8;
+    ELSE
+        RETURN pg_catalog.int8xor($1, trunc($2::numeric)::int8);
+    END IF;
+END;
+$$;
+
+CREATE AGGREGATE sys.bit_xor_agg(sys.number) (
+    SFUNC       = sys.number_int8xor_transfn,
+    STYPE       = int8,
+    FINALFUNC   = sys.number_bitagg_finalfn,
+    COMBINEFUNC = pg_catalog.int8xor,
+    PARALLEL    = SAFE
+);
+COMMENT ON AGGREGATE sys.bit_xor_agg(sys.number) IS 'Oracle-compatible bitwise XOR aggregate over NUMBER values';
+/* End - BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG */


### PR DESCRIPTION
Close #1734
Close #1735
Close #1736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added Oracle-compatible `BIT_AND_AGG`, `BIT_OR_AGG`, and `BIT_XOR_AGG` aggregate functions for numeric values.
- Supports grouped, filtered, distinct, analytic/window, and parallel aggregation.
- Handles NULL and empty inputs, fractional values, boundary values, and invalid inputs with consistent Oracle-compatible behavior.

## Tests

- Added comprehensive regression coverage for aggregation, windowing, grouping sets, error handling, and Oracle compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->