### PR TITLE
using pg_switch_wal() to clear WAL before tests

### DIFF
--- a/src/bin/pg_waldump/t/002_save_fullpage.pl
+++ b/src/bin/pg_waldump/t/002_save_fullpage.pl
@@ -42,6 +42,12 @@ $node->start;
 $node->safe_psql(
 	'postgres',
 	"SELECT 'init' FROM pg_create_physical_replication_slot('regress_pg_waldump_slot', true, false);
+-- Start a fresh WAL segment so that the records below don't have to
+-- share a segment with whatever WAL bootstrap already produced (this
+-- can vary a lot, e.g. much more with an Oracle-compatible initdb
+-- template that preloads plisql/ivorysql_ora, leaving little headroom
+-- in the first segment).
+SELECT pg_switch_wal();
 CREATE TABLE test_table AS SELECT generate_series(1,100) a;
 -- Force FPWs on the next writes.
 CHECKPOINT;


### PR DESCRIPTION
Close #1744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved WAL dump test reliability by starting table WAL generation in a fresh WAL segment.
  * Added explanatory comments documenting the segment separation requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->