### PR TITLE
Compatible with Oracle LENGTHC

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2743,39 +2743,63 @@ select lengthc(' ') from dual;
        1
 (1 row)
 
--- (7) domains over text fold onto lengthc(text)
+-- (7) the LOB types are rejected, the way Oracle's LENGTHC rejects them.
+-- Its documented inputs are CHAR/VARCHAR2/NCHAR/NVARCHAR2 only, and an
+-- instance answers LENGTHC of TO_CLOB/TO_NCLOB/TO_BLOB with ORA-00932 while
+-- LENGTH(TO_CLOB('abc')) still returns 3.  sys.clob/nclob are domains over
+-- text and sys.blob over bytea, so plain resolution would fold them onto the
+-- text/oravarcharchar overloads; the rejection comes from the exact-match
+-- overloads bound to ora_lengthc_unsupported().  Those are not STRICT, so a
+-- NULL of a rejected type is a type error rather than a NULL result.
+--
+-- sys.long is deliberately still accepted: LONG is not a LOB, Oracle's LONG
+-- columns are barely usable in expressions at all, and sys.length(long)
+-- works here -- singling out lengthc would only diverge from length().
 select lengthc(cast('abc' as clob)) from dual;
- lengthc 
----------
-       3
-(1 row)
-
+ERROR:  inconsistent datatypes: lengthc() does not accept clob
+DETAIL:  Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.
 select lengthc(cast('abc' as nclob)) from dual;
- lengthc 
----------
-       3
-(1 row)
-
+ERROR:  inconsistent datatypes: lengthc() does not accept nclob
+DETAIL:  Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.
+select lengthc(cast('e'||chr(769) as clob)) from dual;
+ERROR:  inconsistent datatypes: lengthc() does not accept clob
+DETAIL:  Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.
+select lengthc(cast(null as clob)) from dual;
+ERROR:  inconsistent datatypes: lengthc() does not accept clob
+DETAIL:  Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.
 select lengthc(cast('abc' as long)) from dual;
  lengthc 
 ---------
        3
 (1 row)
 
-select lengthc(cast('e'||chr(769) as clob)) from dual;
+-- the supported route for LOB content, and the Oracle-portable spelling
+select lengthc(cast(cast('e'||chr(769) as clob) as text)) from dual;
  lengthc 
 ---------
        1
 (1 row)
 
-select lengthc(cast(repeat('e'||chr(769), 1000) as clob)) from dual;
- lengthc 
----------
-    1000
-(1 row)
-
 -- (8) numeric/date overloads; binary_float and timestamptz resolve via
--- the preferred types binary_double and oratimestamptz
+-- the preferred types binary_double and oratimestamptz.
+--
+-- Oracle does not list DATE/TIMESTAMP/NUMBER as LENGTHC inputs either, but
+-- unlike the LOB types in (7) it accepts them through the generic implicit
+-- argument conversion: an instance returns LENGTHC(SYSDATE) = 19,
+-- LENGTHC(SYSTIMESTAMP) = 35, LENGTHC(192) = 3, LENGTHC(192.922) = 7.  What
+-- is pinned down here is that conversion path, and the answer depends on the
+-- NLS format -- hence the alter session below.
+--
+-- Note the alter session is not what lets lengthc take a datetime at all --
+-- LENGTHC(SYSTIMESTAMP) answers 35 off the untouched NLS_TIMESTAMP_TZ_FORMAT
+-- -- it is what makes the answer reproducible.  It also decides whether the
+-- literals below parse: run these standalone and Oracle fails inside the
+-- CAST rather than in lengthc, because the default formats are DD-MON-RR and
+-- DD-MON-RR HH.MI.SSXFF AM.  '2019-12-12' as DATE then gets ORA-01861
+-- (literal does not match format string) and as TIMESTAMP it gets ORA-01843
+-- (invalid month, from reading "19" where MON is expected).  With the
+-- formats set Oracle accepts them, as lenient as we are about a literal
+-- shorter than the format string.
 alter session set nls_date_format = 'YYYY-MM-DD HH24:MI:SS';
 alter session set nls_timestamp_format = 'YYYY-MM-DD HH24:MI:SS';
 select length(192), lengthc(192) from dual;
@@ -2862,11 +2886,18 @@ from (values ('abc'), (''), (' '), ('今天'),
  t
 (1 row)
 
--- (10) binary input.  Oracle raises ORA-00932 here; IvorySQL instead counts
--- the hex text, because pg_cast has an implicit bytea -> sys.oravarcharchar
--- entry that every sys function with an oravarcharchar overload inherits
--- (compare sys.ltrim('abc'::bytea), which likewise yields \x616263).
--- length()/lengthb() differ only because they have exact bytea matches.
+-- (10) binary input.  Oracle accepts RAW here: it goes through the same
+-- implicit conversion as (8) and counts the hex text, so
+-- LENGTHC(HEXTORAW('616263')) is 6.  IvorySQL accepts it too, via the
+-- implicit bytea -> sys.oravarcharchar cast that every sys function with an
+-- oravarcharchar overload inherits (compare sys.ltrim('abc'::bytea), which
+-- likewise yields \x616263).  We agree on the mechanism but not on the
+-- number: PG's bytea output carries the "\x" prefix, so each answer below is
+-- Oracle's plus two.  That is the cast's semantics, not lengthc's.
+-- length()/lengthb() sit this out because they have exact bytea matches.
+--
+-- BLOB is a different matter: it is a LOB, so Oracle rejects it and so do
+-- we -- see (7).
 select length(cast('ab' as raw(2))), lengthb(cast('ab' as raw(2))),
        lengthc(cast('ab' as raw(2))) from dual;
  length | lengthb | lengthc 
@@ -2880,6 +2911,9 @@ select length('abc'::bytea), lengthb('abc'::bytea), lengthc('abc'::bytea) from d
       3 |       3 |       8
 (1 row)
 
+select lengthc(cast('abc'::bytea as blob)) from dual;
+ERROR:  inconsistent datatypes: lengthc() does not accept blob
+DETAIL:  Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.
 -- (11) attribute guardrails: IMMUTABLE is required for expression indexes
 CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50));
 CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
@@ -2892,18 +2926,24 @@ SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args,
            args           | provolatile | proisstrict | proparallel 
 --------------------------+-------------+-------------+-------------
  binary_double            | i           | t           | s
+ blob                     | i           | f           | s
+ bytea                    | i           | t           | s
  char                     | i           | t           | s
  char                     | i           | t           | s
+ clob                     | i           | f           | s
  date                     | i           | t           | s
+ long_raw                 | i           | t           | s
+ nclob                    | i           | f           | s
  number                   | i           | t           | s
  pg_catalog.int4          | i           | t           | s
  pg_catalog.numeric       | i           | t           | s
+ raw                      | i           | t           | s
  text                     | i           | t           | s
  timestamp                | i           | t           | s
  timestamp with time zone | i           | t           | s
  varchar2                 | i           | t           | s
  varchar2                 | i           | t           | s
-(12 rows)
+(18 rows)
 
 /*
  * round

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2581,6 +2581,331 @@ select lengthb(cast('2020-06-18 14:40:20' as timestamp)) from dual;
 (1 row)
 
 /*
+ * lengthc
+ *
+ * LENGTHC counts complete Unicode characters, i.e. code points after NFC
+ * normalization.  NB: the cases below assume a UTF8 database, as does the
+ * rest of this file (see length('今天') above).  On a non-UTF8 cluster
+ * lengthc() deliberately degrades to length() instead of erroring the way
+ * pg_catalog.normalize() does; that path is verified manually.
+ */
+-- (1) ASCII equivalence and three-way comparison
+select length('Highgo DB!'), lengthb('Highgo DB!'), lengthc('Highgo DB!') from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+     10 |      10 |      10
+(1 row)
+
+select length('今天'), lengthb('今天'), lengthc('今天') from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+      2 |       6 |       2
+(1 row)
+
+select sys.lengthc('明天') from dual;
+ lengthc 
+---------
+       2
+(1 row)
+
+-- (2) CHAR blank padding is counted, not trimmed
+select lengthc(cast('ab' as char(5))) from dual;
+ lengthc 
+---------
+       5
+(1 row)
+
+select lengthc(cast('abc' as char(5 byte))) from dual;
+ lengthc 
+---------
+       5
+(1 row)
+
+select lengthc(cast('abc' as char(5 char))) from dual;
+ lengthc 
+---------
+       5
+(1 row)
+
+select lengthc(cast('Highgo DB!' as char(20))) from dual;
+ lengthc 
+---------
+      20
+(1 row)
+
+select lengthc(cast('今天是Monday' as char(20))) from dual;
+ lengthc 
+---------
+      14
+(1 row)
+
+select lengthc(cast('Highgo DB!' as varchar2(20))) from dual;
+ lengthc 
+---------
+      10
+(1 row)
+
+-- padding kept + NFC composition + three different answers, all in one row
+select length(cast('e'||chr(769) as char(10 char))),
+       lengthb(cast('e'||chr(769) as char(10 char))),
+       lengthc(cast('e'||chr(769) as char(10 char))) from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+     10 |      11 |       9
+(1 row)
+
+CREATE TABLE TEST_LENGTHC_CHAR(a char(5 byte), b char(5 char));
+INSERT INTO TEST_LENGTHC_CHAR VALUES('aaa', 'bbb');
+INSERT INTO TEST_LENGTHC_CHAR VALUES('e'||chr(769), 'e'||chr(769));
+SELECT length(a), lengthc(a), length(b), lengthc(b) FROM TEST_LENGTHC_CHAR;
+ length | lengthc | length | lengthc 
+--------+---------+--------+---------
+      5 |       5 |      5 |       5
+      4 |       3 |      5 |       4
+(2 rows)
+
+DROP TABLE TEST_LENGTHC_CHAR;
+-- (3) actual normalization
+select length('e'||chr(769)), lengthb('e'||chr(769)), lengthc('e'||chr(769)) from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+      2 |       3 |       1
+(1 row)
+
+select length(chr(233)), lengthc(chr(233)) from dual;
+ length | lengthc 
+--------+---------
+      1 |       1
+(1 row)
+
+select length(decompose('áéíóú')), lengthc(decompose('áéíóú')) from dual;
+ length | lengthc 
+--------+---------
+     10 |       5
+(1 row)
+
+-- QC_NO plus canonical reordering: U+0301 (ccc 230) before U+0328 (ccc 202)
+select length('a'||chr(769)||chr(808)), lengthc('a'||chr(769)||chr(808)) from dual;
+ length | lengthc 
+--------+---------
+      3 |       2
+(1 row)
+
+-- conjoining jamo L+V+T compose algorithmically into one syllable
+select length(chr(4370)||chr(4449)||chr(4523)), lengthc(chr(4370)||chr(4449)||chr(4523)) from dual;
+ length | lengthc 
+--------+---------
+      3 |       1
+(1 row)
+
+-- (4) NFC can also lengthen: U+0958 is a composition exclusion
+select length(chr(2392)), lengthb(chr(2392)), lengthc(chr(2392)) from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+      1 |       3 |       2
+(1 row)
+
+select asciistr(compose(chr(2392))) from dual;
+  asciistr  
+------------
+ \0915\093C
+(1 row)
+
+-- (5) supplementary plane / no UCS-2 confusion
+select length(chr(119070)), lengthb(chr(119070)), lengthc(chr(119070)) from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+      1 |       4 |       1
+(1 row)
+
+select lengthc(chr(119070)||chr(119070)) from dual;
+ lengthc 
+---------
+       2
+(1 row)
+
+-- (6) NULL and empty string
+select lengthc(null) from dual;
+ lengthc 
+---------
+        
+(1 row)
+
+select lengthc('') from dual;
+ lengthc 
+---------
+        
+(1 row)
+
+select lengthc(' ') from dual;
+ lengthc 
+---------
+       1
+(1 row)
+
+-- (7) domains over text fold onto lengthc(text)
+select lengthc(cast('abc' as clob)) from dual;
+ lengthc 
+---------
+       3
+(1 row)
+
+select lengthc(cast('abc' as nclob)) from dual;
+ lengthc 
+---------
+       3
+(1 row)
+
+select lengthc(cast('abc' as long)) from dual;
+ lengthc 
+---------
+       3
+(1 row)
+
+select lengthc(cast('e'||chr(769) as clob)) from dual;
+ lengthc 
+---------
+       1
+(1 row)
+
+select lengthc(cast(repeat('e'||chr(769), 1000) as clob)) from dual;
+ lengthc 
+---------
+    1000
+(1 row)
+
+-- (8) numeric/date overloads; binary_float and timestamptz resolve via
+-- the preferred types binary_double and oratimestamptz
+alter session set nls_date_format = 'YYYY-MM-DD HH24:MI:SS';
+alter session set nls_timestamp_format = 'YYYY-MM-DD HH24:MI:SS';
+select length(192), lengthc(192) from dual;
+ length | lengthc 
+--------+---------
+      3 |       3
+(1 row)
+
+select length(192.922), lengthc(192.922) from dual;
+ length | lengthc 
+--------+---------
+      7 |       7
+(1 row)
+
+select length(cast(192 as int2)), lengthc(cast(192 as int2)) from dual;
+ length | lengthc 
+--------+---------
+      3 |       3
+(1 row)
+
+select length(cast(192 as int4)), lengthc(cast(192 as int4)) from dual;
+ length | lengthc 
+--------+---------
+      3 |       3
+(1 row)
+
+select length(cast(192 as int8)), lengthc(cast(192 as int8)) from dual;
+ length | lengthc 
+--------+---------
+      3 |       3
+(1 row)
+
+select length(cast(192.922 as numeric)), lengthc(cast(192.922 as numeric)) from dual;
+ length | lengthc 
+--------+---------
+      7 |       7
+(1 row)
+
+select length(cast(192.922 as number)), lengthc(cast(192.922 as number)) from dual;
+ length | lengthc 
+--------+---------
+      7 |       7
+(1 row)
+
+select lengthc(cast(1.5 as binary_double)) from dual;
+ lengthc 
+---------
+       3
+(1 row)
+
+select lengthc(cast(1.5 as binary_float)) from dual;
+ lengthc 
+---------
+       3
+(1 row)
+
+select length(cast('2019-12-12' as date)), lengthc(cast('2019-12-12' as date)) from dual;
+ length | lengthc 
+--------+---------
+     19 |      19
+(1 row)
+
+select length(cast('2019-12-12' as timestamp)), lengthc(cast('2019-12-12' as timestamp)) from dual;
+ length | lengthc 
+--------+---------
+     19 |      19
+(1 row)
+
+-- (9) differential invariant against pg_catalog.normalize(); this pins down
+-- both the ASCII fast path and the NFC quick-check fast path at once.
+-- CHAR values must not go in here: cast(char as text) rtrims.
+select bool_and(sys.lengthc(s) = pg_catalog.length(pg_catalog.normalize(s, 'NFC'))) as lengthc_matches_nfc
+from (values ('abc'), (''), (' '), ('今天'),
+             ('e'||chr(769)), (chr(233)), (chr(2392)),
+             ('a'||chr(769)||chr(808)),
+             (chr(4370)||chr(4449)||chr(4523)),
+             (chr(119070)),
+             (repeat('a',5000)||'e'||chr(769)),
+             (repeat('今',5000)||'e'||chr(769)),
+             (repeat('e'||chr(769), 5000))
+      ) t(s);
+ lengthc_matches_nfc 
+---------------------
+ t
+(1 row)
+
+-- (10) binary input.  Oracle raises ORA-00932 here; IvorySQL instead counts
+-- the hex text, because pg_cast has an implicit bytea -> sys.oravarcharchar
+-- entry that every sys function with an oravarcharchar overload inherits
+-- (compare sys.ltrim('abc'::bytea), which likewise yields \x616263).
+-- length()/lengthb() differ only because they have exact bytea matches.
+select length(cast('ab' as raw(2))), lengthb(cast('ab' as raw(2))),
+       lengthc(cast('ab' as raw(2))) from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+      2 |       2 |       6
+(1 row)
+
+select length('abc'::bytea), lengthb('abc'::bytea), lengthc('abc'::bytea) from dual;
+ length | lengthb | lengthc 
+--------+---------+---------
+      3 |       3 |       8
+(1 row)
+
+-- (11) attribute guardrails: IMMUTABLE is required for expression indexes
+CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50));
+CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
+DROP TABLE TEST_LENGTHC_IDX;
+SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args,
+       p.provolatile, p.proisstrict, p.proparallel
+  FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys' AND p.proname = 'lengthc'
+ ORDER BY 1;
+           args           | provolatile | proisstrict | proparallel 
+--------------------------+-------------+-------------+-------------
+ binary_double            | i           | t           | s
+ char                     | i           | t           | s
+ char                     | i           | t           | s
+ date                     | i           | t           | s
+ number                   | i           | t           | s
+ pg_catalog.int4          | i           | t           | s
+ pg_catalog.numeric       | i           | t           | s
+ text                     | i           | t           | s
+ timestamp                | i           | t           | s
+ timestamp with time zone | i           | t           | s
+ varchar2                 | i           | t           | s
+ varchar2                 | i           | t           | s
+(12 rows)
+
+/*
  * round
  */
 select round(cast(1.234 as double precision), 2), trunc(cast(1.234 as double precision), 2) from dual;

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2914,37 +2914,27 @@ select length('abc'::bytea), lengthb('abc'::bytea), lengthc('abc'::bytea) from d
 select lengthc(cast('abc'::bytea as blob)) from dual;
 ERROR:  inconsistent datatypes: lengthc() does not accept blob
 DETAIL:  Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.
--- (11) attribute guardrails: IMMUTABLE is required for expression indexes
-CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50));
+-- (11) lengthc() must stay IMMUTABLE on the character types, or it cannot
+-- carry an expression index.  The datetime overloads are STABLE on purpose:
+-- their answer is whatever nls_date_format says, so an index over them would
+-- go stale on the next alter session, and CREATE INDEX has to refuse it.
+--
+-- length(d) is shown alongside to record that it does NOT refuse it yet.
+-- sys.length/sys.lengthb declare their own datetime wrappers IMMUTABLE
+-- (builtin_functions--1.0.sql:1429-1448, 1470-1485) even though the cast
+-- inside them reaches the STABLE sys.oradate_out(); the wrapper hides that
+-- from contain_mutable_functions(), which never looks inside a SQL function
+-- body.  Fixing those is a separate change -- they are three whole function
+-- families' worth of user-visible behaviour -- so the asymmetry is pinned
+-- down here rather than left to be discovered.
+CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50), d date);
 CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
+CREATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d));
+ERROR:  functions in index expression must be marked IMMUTABLE
+LINE 1: ...ATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d)...
+                                                             ^
+CREATE INDEX TEST_LENGTHC_IDX_L ON TEST_LENGTHC_IDX (length(d));
 DROP TABLE TEST_LENGTHC_IDX;
-SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args,
-       p.provolatile, p.proisstrict, p.proparallel
-  FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
- WHERE n.nspname = 'sys' AND p.proname = 'lengthc'
- ORDER BY 1;
-           args           | provolatile | proisstrict | proparallel 
---------------------------+-------------+-------------+-------------
- binary_double            | i           | t           | s
- blob                     | i           | f           | s
- bytea                    | i           | t           | s
- char                     | i           | t           | s
- char                     | i           | t           | s
- clob                     | i           | f           | s
- date                     | i           | t           | s
- long_raw                 | i           | t           | s
- nclob                    | i           | f           | s
- number                   | i           | t           | s
- pg_catalog.int4          | i           | t           | s
- pg_catalog.numeric       | i           | t           | s
- raw                      | i           | t           | s
- text                     | i           | t           | s
- timestamp                | i           | t           | s
- timestamp with time zone | i           | t           | s
- varchar2                 | i           | t           | s
- varchar2                 | i           | t           | s
-(18 rows)
-
 /*
  * round
  */

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1132,6 +1132,117 @@ select lengthb(cast('2020-06-18 14:40:20' as date)) from dual;
 select lengthb(cast('2020-06-18 14:40:20' as timestamp)) from dual;
 
 /*
+ * lengthc
+ *
+ * LENGTHC counts complete Unicode characters, i.e. code points after NFC
+ * normalization.  NB: the cases below assume a UTF8 database, as does the
+ * rest of this file (see length('今天') above).  On a non-UTF8 cluster
+ * lengthc() deliberately degrades to length() instead of erroring the way
+ * pg_catalog.normalize() does; that path is verified manually.
+ */
+-- (1) ASCII equivalence and three-way comparison
+select length('Highgo DB!'), lengthb('Highgo DB!'), lengthc('Highgo DB!') from dual;
+select length('今天'), lengthb('今天'), lengthc('今天') from dual;
+select sys.lengthc('明天') from dual;
+
+-- (2) CHAR blank padding is counted, not trimmed
+select lengthc(cast('ab' as char(5))) from dual;
+select lengthc(cast('abc' as char(5 byte))) from dual;
+select lengthc(cast('abc' as char(5 char))) from dual;
+select lengthc(cast('Highgo DB!' as char(20))) from dual;
+select lengthc(cast('今天是Monday' as char(20))) from dual;
+select lengthc(cast('Highgo DB!' as varchar2(20))) from dual;
+-- padding kept + NFC composition + three different answers, all in one row
+select length(cast('e'||chr(769) as char(10 char))),
+       lengthb(cast('e'||chr(769) as char(10 char))),
+       lengthc(cast('e'||chr(769) as char(10 char))) from dual;
+
+CREATE TABLE TEST_LENGTHC_CHAR(a char(5 byte), b char(5 char));
+INSERT INTO TEST_LENGTHC_CHAR VALUES('aaa', 'bbb');
+INSERT INTO TEST_LENGTHC_CHAR VALUES('e'||chr(769), 'e'||chr(769));
+SELECT length(a), lengthc(a), length(b), lengthc(b) FROM TEST_LENGTHC_CHAR;
+DROP TABLE TEST_LENGTHC_CHAR;
+
+-- (3) actual normalization
+select length('e'||chr(769)), lengthb('e'||chr(769)), lengthc('e'||chr(769)) from dual;
+select length(chr(233)), lengthc(chr(233)) from dual;
+select length(decompose('áéíóú')), lengthc(decompose('áéíóú')) from dual;
+-- QC_NO plus canonical reordering: U+0301 (ccc 230) before U+0328 (ccc 202)
+select length('a'||chr(769)||chr(808)), lengthc('a'||chr(769)||chr(808)) from dual;
+-- conjoining jamo L+V+T compose algorithmically into one syllable
+select length(chr(4370)||chr(4449)||chr(4523)), lengthc(chr(4370)||chr(4449)||chr(4523)) from dual;
+
+-- (4) NFC can also lengthen: U+0958 is a composition exclusion
+select length(chr(2392)), lengthb(chr(2392)), lengthc(chr(2392)) from dual;
+select asciistr(compose(chr(2392))) from dual;
+
+-- (5) supplementary plane / no UCS-2 confusion
+select length(chr(119070)), lengthb(chr(119070)), lengthc(chr(119070)) from dual;
+select lengthc(chr(119070)||chr(119070)) from dual;
+
+-- (6) NULL and empty string
+select lengthc(null) from dual;
+select lengthc('') from dual;
+select lengthc(' ') from dual;
+
+-- (7) domains over text fold onto lengthc(text)
+select lengthc(cast('abc' as clob)) from dual;
+select lengthc(cast('abc' as nclob)) from dual;
+select lengthc(cast('abc' as long)) from dual;
+select lengthc(cast('e'||chr(769) as clob)) from dual;
+select lengthc(cast(repeat('e'||chr(769), 1000) as clob)) from dual;
+
+-- (8) numeric/date overloads; binary_float and timestamptz resolve via
+-- the preferred types binary_double and oratimestamptz
+alter session set nls_date_format = 'YYYY-MM-DD HH24:MI:SS';
+alter session set nls_timestamp_format = 'YYYY-MM-DD HH24:MI:SS';
+select length(192), lengthc(192) from dual;
+select length(192.922), lengthc(192.922) from dual;
+select length(cast(192 as int2)), lengthc(cast(192 as int2)) from dual;
+select length(cast(192 as int4)), lengthc(cast(192 as int4)) from dual;
+select length(cast(192 as int8)), lengthc(cast(192 as int8)) from dual;
+select length(cast(192.922 as numeric)), lengthc(cast(192.922 as numeric)) from dual;
+select length(cast(192.922 as number)), lengthc(cast(192.922 as number)) from dual;
+select lengthc(cast(1.5 as binary_double)) from dual;
+select lengthc(cast(1.5 as binary_float)) from dual;
+select length(cast('2019-12-12' as date)), lengthc(cast('2019-12-12' as date)) from dual;
+select length(cast('2019-12-12' as timestamp)), lengthc(cast('2019-12-12' as timestamp)) from dual;
+
+-- (9) differential invariant against pg_catalog.normalize(); this pins down
+-- both the ASCII fast path and the NFC quick-check fast path at once.
+-- CHAR values must not go in here: cast(char as text) rtrims.
+select bool_and(sys.lengthc(s) = pg_catalog.length(pg_catalog.normalize(s, 'NFC'))) as lengthc_matches_nfc
+from (values ('abc'), (''), (' '), ('今天'),
+             ('e'||chr(769)), (chr(233)), (chr(2392)),
+             ('a'||chr(769)||chr(808)),
+             (chr(4370)||chr(4449)||chr(4523)),
+             (chr(119070)),
+             (repeat('a',5000)||'e'||chr(769)),
+             (repeat('今',5000)||'e'||chr(769)),
+             (repeat('e'||chr(769), 5000))
+      ) t(s);
+
+-- (10) binary input.  Oracle raises ORA-00932 here; IvorySQL instead counts
+-- the hex text, because pg_cast has an implicit bytea -> sys.oravarcharchar
+-- entry that every sys function with an oravarcharchar overload inherits
+-- (compare sys.ltrim('abc'::bytea), which likewise yields \x616263).
+-- length()/lengthb() differ only because they have exact bytea matches.
+select length(cast('ab' as raw(2))), lengthb(cast('ab' as raw(2))),
+       lengthc(cast('ab' as raw(2))) from dual;
+select length('abc'::bytea), lengthb('abc'::bytea), lengthc('abc'::bytea) from dual;
+
+-- (11) attribute guardrails: IMMUTABLE is required for expression indexes
+CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50));
+CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
+DROP TABLE TEST_LENGTHC_IDX;
+
+SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args,
+       p.provolatile, p.proisstrict, p.proparallel
+  FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys' AND p.proname = 'lengthc'
+ ORDER BY 1;
+
+/*
  * round
  */
 select round(cast(1.234 as double precision), 2), trunc(cast(1.234 as double precision), 2) from dual;

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1270,16 +1270,24 @@ select length(cast('ab' as raw(2))), lengthb(cast('ab' as raw(2))),
 select length('abc'::bytea), lengthb('abc'::bytea), lengthc('abc'::bytea) from dual;
 select lengthc(cast('abc'::bytea as blob)) from dual;
 
--- (11) attribute guardrails: IMMUTABLE is required for expression indexes
-CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50));
+-- (11) lengthc() must stay IMMUTABLE on the character types, or it cannot
+-- carry an expression index.  The datetime overloads are STABLE on purpose:
+-- their answer is whatever nls_date_format says, so an index over them would
+-- go stale on the next alter session, and CREATE INDEX has to refuse it.
+--
+-- length(d) is shown alongside to record that it does NOT refuse it yet.
+-- sys.length/sys.lengthb declare their own datetime wrappers IMMUTABLE
+-- (builtin_functions--1.0.sql:1429-1448, 1470-1485) even though the cast
+-- inside them reaches the STABLE sys.oradate_out(); the wrapper hides that
+-- from contain_mutable_functions(), which never looks inside a SQL function
+-- body.  Fixing those is a separate change -- they are three whole function
+-- families' worth of user-visible behaviour -- so the asymmetry is pinned
+-- down here rather than left to be discovered.
+CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50), d date);
 CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
+CREATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d));
+CREATE INDEX TEST_LENGTHC_IDX_L ON TEST_LENGTHC_IDX (length(d));
 DROP TABLE TEST_LENGTHC_IDX;
-
-SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args,
-       p.provolatile, p.proisstrict, p.proparallel
-  FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
- WHERE n.nspname = 'sys' AND p.proname = 'lengthc'
- ORDER BY 1;
 
 /*
  * round

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1185,15 +1185,46 @@ select lengthc(null) from dual;
 select lengthc('') from dual;
 select lengthc(' ') from dual;
 
--- (7) domains over text fold onto lengthc(text)
+-- (7) the LOB types are rejected, the way Oracle's LENGTHC rejects them.
+-- Its documented inputs are CHAR/VARCHAR2/NCHAR/NVARCHAR2 only, and an
+-- instance answers LENGTHC of TO_CLOB/TO_NCLOB/TO_BLOB with ORA-00932 while
+-- LENGTH(TO_CLOB('abc')) still returns 3.  sys.clob/nclob are domains over
+-- text and sys.blob over bytea, so plain resolution would fold them onto the
+-- text/oravarcharchar overloads; the rejection comes from the exact-match
+-- overloads bound to ora_lengthc_unsupported().  Those are not STRICT, so a
+-- NULL of a rejected type is a type error rather than a NULL result.
+--
+-- sys.long is deliberately still accepted: LONG is not a LOB, Oracle's LONG
+-- columns are barely usable in expressions at all, and sys.length(long)
+-- works here -- singling out lengthc would only diverge from length().
 select lengthc(cast('abc' as clob)) from dual;
 select lengthc(cast('abc' as nclob)) from dual;
-select lengthc(cast('abc' as long)) from dual;
 select lengthc(cast('e'||chr(769) as clob)) from dual;
-select lengthc(cast(repeat('e'||chr(769), 1000) as clob)) from dual;
+select lengthc(cast(null as clob)) from dual;
+select lengthc(cast('abc' as long)) from dual;
+-- the supported route for LOB content, and the Oracle-portable spelling
+select lengthc(cast(cast('e'||chr(769) as clob) as text)) from dual;
 
 -- (8) numeric/date overloads; binary_float and timestamptz resolve via
--- the preferred types binary_double and oratimestamptz
+-- the preferred types binary_double and oratimestamptz.
+--
+-- Oracle does not list DATE/TIMESTAMP/NUMBER as LENGTHC inputs either, but
+-- unlike the LOB types in (7) it accepts them through the generic implicit
+-- argument conversion: an instance returns LENGTHC(SYSDATE) = 19,
+-- LENGTHC(SYSTIMESTAMP) = 35, LENGTHC(192) = 3, LENGTHC(192.922) = 7.  What
+-- is pinned down here is that conversion path, and the answer depends on the
+-- NLS format -- hence the alter session below.
+--
+-- Note the alter session is not what lets lengthc take a datetime at all --
+-- LENGTHC(SYSTIMESTAMP) answers 35 off the untouched NLS_TIMESTAMP_TZ_FORMAT
+-- -- it is what makes the answer reproducible.  It also decides whether the
+-- literals below parse: run these standalone and Oracle fails inside the
+-- CAST rather than in lengthc, because the default formats are DD-MON-RR and
+-- DD-MON-RR HH.MI.SSXFF AM.  '2019-12-12' as DATE then gets ORA-01861
+-- (literal does not match format string) and as TIMESTAMP it gets ORA-01843
+-- (invalid month, from reading "19" where MON is expected).  With the
+-- formats set Oracle accepts them, as lenient as we are about a literal
+-- shorter than the format string.
 alter session set nls_date_format = 'YYYY-MM-DD HH24:MI:SS';
 alter session set nls_timestamp_format = 'YYYY-MM-DD HH24:MI:SS';
 select length(192), lengthc(192) from dual;
@@ -1222,14 +1253,22 @@ from (values ('abc'), (''), (' '), ('今天'),
              (repeat('e'||chr(769), 5000))
       ) t(s);
 
--- (10) binary input.  Oracle raises ORA-00932 here; IvorySQL instead counts
--- the hex text, because pg_cast has an implicit bytea -> sys.oravarcharchar
--- entry that every sys function with an oravarcharchar overload inherits
--- (compare sys.ltrim('abc'::bytea), which likewise yields \x616263).
--- length()/lengthb() differ only because they have exact bytea matches.
+-- (10) binary input.  Oracle accepts RAW here: it goes through the same
+-- implicit conversion as (8) and counts the hex text, so
+-- LENGTHC(HEXTORAW('616263')) is 6.  IvorySQL accepts it too, via the
+-- implicit bytea -> sys.oravarcharchar cast that every sys function with an
+-- oravarcharchar overload inherits (compare sys.ltrim('abc'::bytea), which
+-- likewise yields \x616263).  We agree on the mechanism but not on the
+-- number: PG's bytea output carries the "\x" prefix, so each answer below is
+-- Oracle's plus two.  That is the cast's semantics, not lengthc's.
+-- length()/lengthb() sit this out because they have exact bytea matches.
+--
+-- BLOB is a different matter: it is a LOB, so Oracle rejects it and so do
+-- we -- see (7).
 select length(cast('ab' as raw(2))), lengthb(cast('ab' as raw(2))),
        lengthc(cast('ab' as raw(2))) from dual;
 select length('abc'::bytea), lengthb('abc'::bytea), lengthc('abc'::bytea) from dual;
+select lengthc(cast('abc'::bytea as blob)) from dual;
 
 -- (11) attribute guardrails: IMMUTABLE is required for expression indexes
 CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50));

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -130,6 +130,117 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE;
 
+/*
+ * lengthc --- Oracle's LENGTHC: the number of complete Unicode characters,
+ * that is, the number of code points left after NFC normalization.
+ *
+ * All five character types bind the C symbol directly and none of them go
+ * through a cast: sys.oracharchar -> text and sys.oracharchar ->
+ * sys.oravarcharchar are both implemented by rtrim(), so routing CHAR through
+ * either of them would silently drop the blank padding that Oracle counts.
+ *
+ * The overload set deliberately mirrors sys.length(): with more than one
+ * candidate in the same namespace, func_select_candidate() cannot break the
+ * tie by search path position and fails with "function ... is not unique".
+ * Dropping the text overload would therefore break lengthc('abc'), and
+ * dropping the numeric/date wrappers would break lengthc(192).  Conversely
+ * sys.binary_float and sys.oratimestampltz are intentionally absent: they
+ * resolve via the preferred types sys.binary_double and sys.oratimestamptz.
+ * sys.clob/nclob/long are domains over text and fold onto lengthc(text).
+ *
+ * Oracle rejects binary arguments with ORA-00932, but we cannot: pg_cast has
+ * an implicit bytea -> sys.oravarcharchar entry, so bytea/raw/blob reach the
+ * oravarcharchar overload and are counted as their hex text, exactly as they
+ * already are by sys.ltrim() and the rest of this extension.  Removing the
+ * oravarcharchar overload is not an option -- it is what keeps CHAR blank
+ * padding out of rtrim().  Note length()/lengthb() escape this only because
+ * pg_catalog.length(bytea) and sys.lengthb(bytea) are exact matches.
+ */
+
+CREATE FUNCTION sys.lengthc(text)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.lengthc(sys.oracharchar)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.lengthc(sys.oracharbyte)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.lengthc(sys.oravarcharchar)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.lengthc(sys.oravarcharbyte)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+COMMENT ON FUNCTION sys.lengthc(text) IS 'Return the number of complete Unicode characters (code points after NFC normalization)';
+
+CREATE FUNCTION sys.lengthc(integer)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(numeric)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(sys.number)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(sys.binary_double)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(sys.oradate)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(sys.oratimestamp)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(sys.oratimestamptz)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
 CREATE FUNCTION sys.length(integer)
 RETURNS integer
 AS $$SELECT sys.length(cast($1 as sys.oravarcharchar));$$

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -235,23 +235,33 @@ AS 'select sys.lengthc($1::sys.oravarcharchar)'
 LANGUAGE SQL
 IMMUTABLE PARALLEL SAFE STRICT;
 
+/*
+ * The datetime overloads are STABLE, not IMMUTABLE: the cast to
+ * oravarcharchar goes through sys.oradate_out() and friends, which are
+ * themselves STABLE because they read nls_date_format / nls_timestamp_format
+ * -- the same reason pg_catalog.date_out() and timestamp_out() are STABLE.
+ * Declaring these IMMUTABLE would launder that dependency past
+ * contain_mutable_functions(), which does not look inside a SQL function
+ * body, and let CREATE INDEX ... (lengthc(date_col)) store lengths that go
+ * stale the moment the format changes.
+ */
 CREATE FUNCTION sys.lengthc(sys.oradate)
 RETURNS integer
 AS 'select sys.lengthc($1::sys.oravarcharchar)'
 LANGUAGE SQL
-IMMUTABLE PARALLEL SAFE STRICT;
+STABLE PARALLEL SAFE STRICT;
 
 CREATE FUNCTION sys.lengthc(sys.oratimestamp)
 RETURNS integer
 AS 'select sys.lengthc($1::sys.oravarcharchar)'
 LANGUAGE SQL
-IMMUTABLE PARALLEL SAFE STRICT;
+STABLE PARALLEL SAFE STRICT;
 
 CREATE FUNCTION sys.lengthc(sys.oratimestamptz)
 RETURNS integer
 AS 'select sys.lengthc($1::sys.oravarcharchar)'
 LANGUAGE SQL
-IMMUTABLE PARALLEL SAFE STRICT;
+STABLE PARALLEL SAFE STRICT;
 
 /*
  * bytea and the two non-LOB domains over it.  These only restate the

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -146,15 +146,27 @@ IMMUTABLE;
  * dropping the numeric/date wrappers would break lengthc(192).  Conversely
  * sys.binary_float and sys.oratimestampltz are intentionally absent: they
  * resolve via the preferred types sys.binary_double and sys.oratimestamptz.
- * sys.clob/nclob/long are domains over text and fold onto lengthc(text).
+ * sys.long is a domain over text and folds onto lengthc(text).
  *
- * Oracle rejects binary arguments with ORA-00932, but we cannot: pg_cast has
- * an implicit bytea -> sys.oravarcharchar entry, so bytea/raw/blob reach the
- * oravarcharchar overload and are counted as their hex text, exactly as they
- * already are by sys.ltrim() and the rest of this extension.  Removing the
- * oravarcharchar overload is not an option -- it is what keeps CHAR blank
- * padding out of rtrim().  Note length()/lengthb() escape this only because
- * pg_catalog.length(bytea) and sys.lengthb(bytea) are exact matches.
+ * The numeric and datetime wrappers are not a liberty we take: Oracle does
+ * not list DATE/TIMESTAMP/NUMBER as LENGTHC inputs either, but it reaches
+ * them through the generic implicit argument conversion and answers
+ * normally -- LENGTHC(SYSDATE) is 19, LENGTHC(SYSTIMESTAMP) 35,
+ * LENGTHC(192.922) 7 -- exactly as sys.length() already does here.
+ *
+ * The LOB types are the real exception.  Oracle's LENGTH entry says
+ * LENGTHC/LENGTH2/LENGTH4 "do not allow char to be a CLOB or NCLOB", and an
+ * instance rejects BLOB the same way, so sys.clob, sys.nclob and sys.blob
+ * get exact-match overloads bound to ora_lengthc_unsupported() below.
+ * Without them nothing would be rejected: the first two are domains over
+ * text and the third one over bytea, which has an implicit cast to
+ * sys.oravarcharchar.
+ *
+ * RAW stays accepted, because Oracle accepts it -- LENGTHC(HEXTORAW(
+ * '616263')) is 6, the length of the hex text.  We agree on the mechanism
+ * but not on the number: PG's bytea output carries a "\x" prefix, so our
+ * answers are Oracle's plus two.  That belongs to the extension-wide
+ * bytea -> sys.oravarcharchar cast, not to lengthc.
  */
 
 CREATE FUNCTION sys.lengthc(text)
@@ -240,6 +252,59 @@ RETURNS integer
 AS 'select sys.lengthc($1::sys.oravarcharchar)'
 LANGUAGE SQL
 IMMUTABLE PARALLEL SAFE STRICT;
+
+/*
+ * bytea and the two non-LOB domains over it.  These only restate the
+ * coercion that used to happen on its own, and they have to be spelled out
+ * because sys.lengthc(sys.blob) below made bytea ambiguous: a bytea reaches
+ * both the blob overload (domain relabel) and the oravarcharchar one
+ * (implicit cast), and category U has no preferred type to break the tie.
+ * The text side needs no such help -- sys.clob/nclob/long all lose to
+ * lengthc(text), text being the preferred type of category S.
+ */
+CREATE FUNCTION sys.lengthc(pg_catalog.bytea)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(sys.raw)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.lengthc(sys.long_raw)
+RETURNS integer
+AS 'select sys.lengthc($1::sys.oravarcharchar)'
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+/*
+ * The three LOB types Oracle's LENGTHC refuses; see
+ * ora_lengthc_unsupported().  NOT STRICT on purpose -- Oracle rejects the
+ * type while parsing, so a NULL CLOB has to be a type error here too.
+ */
+CREATE FUNCTION sys.lengthc(sys.clob)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc_unsupported'
+LANGUAGE C
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.lengthc(sys.nclob)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc_unsupported'
+LANGUAGE C
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.lengthc(sys.blob)
+RETURNS integer
+AS 'MODULE_PATHNAME','ora_lengthc_unsupported'
+LANGUAGE C
+PARALLEL SAFE
+IMMUTABLE;
 
 CREATE FUNCTION sys.length(integer)
 RETURNS integer

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -32,11 +32,13 @@
 #include "varatt.h"
 
 #include "access/detoast.h"
+#include "common/unicode_norm.h"
 #include "lib/stringinfo.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "regex/regex.h"
 #include "utils/builtins.h"
+#include "utils/memutils.h"
 #include "utils/numeric.h"
 
 
@@ -52,6 +54,7 @@ PG_FUNCTION_INFO_V1(oracharlen);
 PG_FUNCTION_INFO_V1(oracharoctetlen);
 PG_FUNCTION_INFO_V1(oravarcharlen);
 PG_FUNCTION_INFO_V1(oravarcharoctetlen);
+PG_FUNCTION_INFO_V1(ora_lengthc);
 PG_FUNCTION_INFO_V1(rtrim1);
 PG_FUNCTION_INFO_V1(rtrim2);
 PG_FUNCTION_INFO_V1(ltrim1);
@@ -157,6 +160,137 @@ oravarcharoctetlen(PG_FUNCTION_ARGS)
 
 	/* We need not detoast the input at all */
 	PG_RETURN_INT32(toast_raw_datum_size(str) - VARHDRSZ);
+}
+
+/*
+ * lengthc() --- Oracle's LENGTHC.
+ *
+ * Returns the number of complete Unicode characters, that is, the number of
+ * code points the string has *after* NFC normalization.  A base character
+ * followed by a combining mark counts as one, so LENGTHC('e' || chr(769)) is
+ * 1 where LENGTH() is 2 and LENGTHB() is 3.  Conversely NFC can also lengthen
+ * a string -- composition exclusions such as U+0958, whose NFC form is the
+ * two code points U+0915 U+093C -- so the result is neither an upper nor a
+ * lower bound of LENGTH().
+ *
+ * One C symbol serves text, sys.oracharchar, sys.oracharbyte,
+ * sys.oravarcharchar and sys.oravarcharbyte: all of them are plain varlena
+ * strings, and PG_GETARG_TEXT_PP copes with any of them, TOASTed and
+ * short-header values included.
+ *
+ * NB: we deliberately do NOT strip trailing blanks.  Oracle's CHAR is
+ * blank-padded and LENGTHC(CAST('ab' AS CHAR(5))) is 5; this matches
+ * oracharlen() above, which likewise skips bcTruelen().  Do not "simplify"
+ * the CHAR variants into a SQL wrapper casting to text or oravarcharchar --
+ * both of those casts are implemented by rtrim() and would silently destroy
+ * the padding semantics.
+ *
+ * NB: like pg_catalog.normalize(), the result depends on the Unicode tables
+ * compiled into the server (PG_UNICODE_VERSION), so a major upgrade that
+ * brings in new tables could in principle invalidate an expression index on
+ * lengthc().  That is an accepted, pre-existing exposure -- do not downgrade
+ * this function to STABLE on account of it, or lengthc() would become less
+ * usable than length().
+ */
+Datum
+ora_lengthc(PG_FUNCTION_ARGS)
+{
+	text	   *arg = PG_GETARG_TEXT_PP(0);
+	const unsigned char *str = (const unsigned char *) VARDATA_ANY(arg);
+	int			nbytes = VARSIZE_ANY_EXHDR(arg);
+	int			nchars;
+	int			result;
+	char32_t   *input_chars;
+	char32_t   *output_chars;
+	const unsigned char *p;
+	int			i;
+
+	/*
+	 * Single-byte server encodings: one byte is one character, and a
+	 * decomposed sequence is not even representable, so every string is
+	 * already in NFC and LENGTHC == LENGTH == LENGTHB.
+	 */
+	if (pg_database_encoding_max_length() == 1)
+		PG_RETURN_INT32(nbytes);
+
+	/*
+	 * Canonical composition is only defined for Unicode.  The legacy
+	 * multibyte server encodings (EUC_*, MULE_INTERNAL) have no standalone
+	 * combining marks in their repertoire, so again every string is already
+	 * in NFC and the plain character count is the right answer.
+	 *
+	 * Note we intentionally do not raise an error the way
+	 * pg_catalog.normalize() does: Oracle's LENGTHC is perfectly usable in a
+	 * non-Unicode database character set, where it simply behaves like
+	 * LENGTH, and failing here would make the function unusable on such
+	 * clusters -- including the SQL_ASCII cluster that "make oracle-check"
+	 * produces under LANG=C.
+	 */
+	if (GetDatabaseEncoding() != PG_UTF8)
+		PG_RETURN_INT32(pg_mbstrlen_with_len((const char *) str, nbytes));
+
+	/*
+	 * Fast path: a pure ASCII string needs no work at all.  Every ASCII code
+	 * point is a starter whose NFC_QuickCheck value is Yes, and no canonical
+	 * composition has an ASCII character as its second element, so such a
+	 * string is NFC-invariant and contributes one character per byte.  This
+	 * also covers the empty string.
+	 */
+	for (i = 0; i < nbytes; i++)
+	{
+		if (str[i] >= 0x80)
+			break;
+	}
+	if (i == nbytes)
+		PG_RETURN_INT32(nbytes);
+
+	nchars = pg_mbstrlen_with_len((const char *) str, nbytes);
+
+	/*
+	 * Guard the 4x expansion of the code point array so that huge values get
+	 * a comprehensible error instead of palloc's "invalid memory alloc
+	 * request size".  Only reachable for inputs of a few hundred MB.
+	 */
+	if ((Size) nchars + 1 > MaxAllocSize / sizeof(char32_t))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("string is too long for lengthc()"),
+				 errdetail("lengthc() can normalize at most %zu characters.",
+						   MaxAllocSize / sizeof(char32_t) - 1)));
+
+	/* convert to char32_t, same as unicode_normalize_func() does */
+	input_chars = (char32_t *) palloc((nchars + 1) * sizeof(char32_t));
+	p = str;
+	for (i = 0; i < nchars; i++)
+	{
+		input_chars[i] = utf8_to_unicode(p);
+		p += pg_utf_mblen(p);
+	}
+	input_chars[i] = (char32_t) '\0';
+	Assert((const char *) p == (const char *) str + nbytes);
+
+	/*
+	 * The UAX #15 quick check: text that is already in NFC -- all precomposed
+	 * Latin, all CJK, all precomposed Hangul syllables -- needs no
+	 * normalization, and then the code point count is the answer.  This skips
+	 * the two further arrays unicode_normalize() would allocate.
+	 */
+	if (unicode_is_normalized_quickcheck(UNICODE_NFC, input_chars) == UNICODE_NORM_QC_YES)
+	{
+		pfree(input_chars);
+		PG_RETURN_INT32(nchars);
+	}
+
+	output_chars = unicode_normalize(UNICODE_NFC, input_chars);
+	pfree(input_chars);
+
+	result = 0;
+	for (char32_t *wp = output_chars; *wp; wp++)
+		result++;
+
+	pfree(output_chars);
+
+	PG_RETURN_INT32(result);
 }
 
 Datum

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -55,6 +55,7 @@ PG_FUNCTION_INFO_V1(oracharoctetlen);
 PG_FUNCTION_INFO_V1(oravarcharlen);
 PG_FUNCTION_INFO_V1(oravarcharoctetlen);
 PG_FUNCTION_INFO_V1(ora_lengthc);
+PG_FUNCTION_INFO_V1(ora_lengthc_unsupported);
 PG_FUNCTION_INFO_V1(rtrim1);
 PG_FUNCTION_INFO_V1(rtrim2);
 PG_FUNCTION_INFO_V1(ltrim1);
@@ -291,6 +292,47 @@ ora_lengthc(PG_FUNCTION_ARGS)
 	pfree(output_chars);
 
 	PG_RETURN_INT32(result);
+}
+
+/*
+ * ora_lengthc_unsupported --- reject the LOB types Oracle's LENGTHC rejects.
+ *
+ * Oracle documents LENGTHC as accepting only CHAR, VARCHAR2, NCHAR and
+ * NVARCHAR2, and names CLOB and NCLOB as excluded; a real instance answers
+ * LENGTHC(TO_CLOB('abc')), LENGTHC(TO_NCLOB('abc')) and
+ * LENGTHC(TO_BLOB(...)) with ORA-00932.  Non-LOB types are a different
+ * story: DATE, TIMESTAMP, NUMBER and RAW all reach LENGTHC through the
+ * generic implicit argument conversion there and are answered normally, so
+ * they keep their working overloads.
+ *
+ * Simply not declaring an overload would reject nothing.  sys.clob and
+ * sys.nclob are domains over text and sys.blob is a domain over bytea, so
+ * plain resolution folds them onto lengthc(text) and
+ * lengthc(sys.oravarcharchar).  An exact-match overload is what stops them,
+ * because func_get_detail() prefers an exact match over both domain folding
+ * and implicit coercion.
+ *
+ * Deliberately not STRICT: Oracle rejects the type while parsing, so a NULL
+ * of a rejected type has to error out too rather than quietly return NULL.
+ */
+Datum
+ora_lengthc_unsupported(PG_FUNCTION_ARGS)
+{
+	Oid			argtype = get_fn_expr_argtype(fcinfo->flinfo, 0);
+
+	if (OidIsValid(argtype))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("inconsistent datatypes: lengthc() does not accept %s",
+						format_type_be(argtype)),
+				 errdetail("Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.")));
+	else
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("inconsistent datatypes: lengthc() does not accept this data type"),
+				 errdetail("Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.")));
+
+	PG_RETURN_NULL();			/* keep the compiler quiet */
 }
 
 Datum


### PR DESCRIPTION
close #1747 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oracle-compatible `LENGTHC` support for character, numeric, date, timestamp, and binary values.
  * Counts complete Unicode characters after NFC normalization, including supplementary characters and combining marks.
  * Supports Oracle character types, NULL and empty values, and text-based domains.
  * Rejects unsupported CLOB, NCLOB, and BLOB inputs with clear datatype errors.

* **Tests**
  * Expanded coverage for normalization, padding, overloads, binary inputs, LOB handling, and expression-index compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->