### PR TITLE
Add Oracle-compatible UTL_URL.UNESCAPE

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -33,6 +33,7 @@ OBJS = \
 	src/builtin_packages/dbms_utility/dbms_utility.o \
 	src/builtin_packages/dbms_lock/dbms_lock.o \
 	src/builtin_packages/utl_encode/utl_encode.o \
+	src/builtin_packages/utl_url/utl_url.o \
 	src/builtin_packages/dbms_session/dbms_session.o
 
 EXTENSION = ivorysql_ora
@@ -84,6 +85,7 @@ ORA_REGRESS = \
 	utl_file \
 	utl_raw \
 	utl_encode \
+	utl_url \
 	dbms_session
 
 # Include path for plisql.h (needed by dbms_utility)

--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -61,6 +61,11 @@ cleansql:
 
 # REGRESS_OPTS mainly used for installcheck or debug.
 #REGRESS_OPTS = --port=1521
+# The utl_url regression tests exercise multibyte input and charset
+# conversions, so pin the test database to UTF8 instead of relying on
+# whatever encoding initdb derives from the invoking environment's locale.
+ENCODING = UTF8
+
 ORA_REGRESS = \
 	ora_character \
 	ora_datetime \

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -187,6 +187,21 @@ SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
  a%20b     | a%20b
 (1 row)
 
+-- The url_charset contract: omitting the argument and passing an explicit
+-- NULL are the same thing here -- both mean "the database encoding, do not
+-- convert".  Oracle makes them different: an omitted url_charset defaults
+-- to utl_http.body_charset (ISO-8859-1) while an explicit NULL selects the
+-- database character set.  Defaulting to the database encoding instead of
+-- ISO-8859-1 is the declared deviation of this port (ISO-8859-1 cannot
+-- represent non-Latin text; see the package documentation), and this case
+-- pins the contract so the difference stays visible.
+SELECT utl_url.escape('é') AS default_charset,
+       utl_url.escape('é', FALSE, NULL) AS explicit_null_charset;
+ default_charset | explicit_null_charset 
+-----------------+-----------------------
+ %C3%A9          | %C3%A9
+(1 row)
+
 -- An unrecognized character set is rejected
 SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
 ERROR:  UTL_URL: unrecognized URL character set "NO_SUCH_CHARSET"

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -1,11 +1,13 @@
 --
 -- utl_url.sql
 --
--- Tests for the UTL_URL package (ESCAPE function)
+-- Tests for the UTL_URL package (ESCAPE and UNESCAPE functions)
 --
 -- The escaped form of a multibyte character depends on the character set the
 -- character is converted to, so the multibyte cases below pass 'UTF8'
--- explicitly rather than relying on the database encoding.
+-- explicitly rather than relying on the database encoding.  The round-trip
+-- cases that omit url_charset work in any database encoding that can hold the
+-- literal.
 --
 -- ============================================================
 -- Tests for UTL_URL.ESCAPE
@@ -196,6 +198,156 @@ SELECT utl_url.escape('中文', FALSE, 'LATIN1');
 ERROR:  character with byte sequence 0xe4 0xb8 0xad in encoding "UTF8" has no equivalent in encoding "LATIN1"
 CONTEXT:  PL/iSQL function sys.utl_url.escape line 5 at RETURN
 -- ============================================================
+-- Tests for UTL_URL.UNESCAPE
+-- ============================================================
+-- NULL input returns NULL
+SELECT utl_url.unescape(NULL) IS NULL AS unescape_null;
+ unescape_null 
+---------------
+ t
+(1 row)
+
+-- Basic decoding
+SELECT utl_url.unescape('a%20b%2Fc') AS basic;
+ basic 
+-------
+ a b/c
+(1 row)
+
+-- Lower case hex digits are accepted on input
+SELECT utl_url.unescape('a%2fb%2Fc') AS lower_hex;
+ lower_hex 
+-----------
+ a/b/c
+(1 row)
+
+-- The empty string round-trips to the empty string
+SELECT utl_url.unescape('') AS unescape_empty;
+ unescape_empty 
+----------------
+ 
+(1 row)
+
+-- A '%' produced by ESCAPE decodes back to a literal '%': double-escaped
+-- input collapses one level, as on Oracle
+SELECT utl_url.unescape('a%25b') AS pct_literal;
+ pct_literal 
+-------------
+ a%b
+(1 row)
+
+SELECT utl_url.unescape('a%2520b') AS double_escaped;
+ double_escaped 
+----------------
+ a%20b
+(1 row)
+
+-- Unescaped characters are passed through untouched
+SELECT utl_url.unescape('http://oracle-base.com/my%20page.html') AS doc_unescape;
+            doc_unescape             
+-------------------------------------
+ http://oracle-base.com/my page.html
+(1 row)
+
+SELECT utl_url.unescape('http%3A%2F%2Foracle-base.com%2Fmy%20page.html') AS doc_unescape_reserved;
+        doc_unescape_reserved        
+-------------------------------------
+ http://oracle-base.com/my page.html
+(1 row)
+
+-- Multibyte: consecutive %XX groups are reassembled into one character
+SELECT utl_url.unescape('%E4%B8%AD%E6%96%87', 'UTF8') AS cjk_utf8;
+ cjk_utf8 
+----------
+ 中文
+(1 row)
+
+-- GBK bytes are converted from the named charset (the IANA/PostgreSQL
+-- spelling; Oracle writes ZHS16GBK)
+SELECT utl_url.unescape('%D6%D0%CE%C4', 'GBK') AS cjk_gbk;
+ cjk_gbk 
+---------
+ 中文
+(1 row)
+
+-- An unrecognized character set is rejected (Oracle reports ORA-01482)
+SELECT utl_url.unescape('a%20b', 'NO_SUCH_CHARSET');
+ERROR:  UTL_URL: unrecognized URL character set "NO_SUCH_CHARSET"
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+-- ============================================================
+-- Round-trip identity: UNESCAPE(ESCAPE(x)) = x
+-- ============================================================
+SELECT utl_url.unescape(utl_url.escape('a b/中文')) = 'a b/中文' AS roundtrip_default;
+ roundtrip_default 
+-------------------
+ t
+(1 row)
+
+SELECT utl_url.unescape(utl_url.escape('a b/中文', TRUE)) = 'a b/中文' AS roundtrip_reserved;
+ roundtrip_reserved 
+--------------------
+ t
+(1 row)
+
+SELECT utl_url.unescape(utl_url.escape('中文测试', FALSE, 'UTF8'), 'UTF8') = '中文测试' AS roundtrip_charset;
+ roundtrip_charset 
+-------------------
+ t
+(1 row)
+
+SELECT utl_url.unescape(utl_url.escape('中文', FALSE, 'GB18030'), 'GB18030') = '中文' AS roundtrip_gb18030;
+ roundtrip_gb18030 
+-------------------
+ t
+(1 row)
+
+-- '%' and '#' are always escaped (including the default mode), so every
+-- literal round-trips in either mode
+SELECT utl_url.unescape(utl_url.escape(';/?:@&=+$%,# <>"')) = ';/?:@&=+$%,# <>"' AS roundtrip_all_default;
+ roundtrip_all_default 
+-----------------------
+ t
+(1 row)
+
+SELECT utl_url.unescape(utl_url.escape(';/?:@&=+$%,# <>"', TRUE)) = ';/?:@&=+$%,# <>"' AS roundtrip_all_reserved;
+ roundtrip_all_reserved 
+------------------------
+ t
+(1 row)
+
+-- ============================================================
+-- Error cases: badly formed escape code sequences
+-- Oracle raises UTL_URL.BAD_URL (ORA-29262) for these
+-- ============================================================
+-- '%' at the end of the string
+SELECT utl_url.unescape('bad%');
+ERROR:  UTL_URL.UNESCAPE: truncated escape code sequence in URL
+DETAIL:  A "%" at position 4 is not followed by two hexadecimal digits.
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+-- '%' followed by non-hexadecimal characters
+SELECT utl_url.unescape('%ZZ');
+ERROR:  UTL_URL.UNESCAPE: badly formed escape code sequence in URL
+DETAIL:  The escape code sequence at position 1 is not "%" followed by two hexadecimal digits.
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+-- '%' followed by only one hexadecimal digit
+SELECT utl_url.unescape('a%2');
+ERROR:  UTL_URL.UNESCAPE: truncated escape code sequence in URL
+DETAIL:  A "%" at position 2 is not followed by two hexadecimal digits.
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+-- A literal '%' in the middle of an otherwise valid URL
+SELECT utl_url.unescape('100%20%pure');
+ERROR:  UTL_URL.UNESCAPE: badly formed escape code sequence in URL
+DETAIL:  The escape code sequence at position 7 is not "%" followed by two hexadecimal digits.
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+-- %00 cannot be represented in a text value
+SELECT utl_url.unescape('a%00b');
+ERROR:  UTL_URL.UNESCAPE: escaped NUL character (%00) is not supported
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+-- A %XX group that does not form a valid character in the source charset
+SELECT utl_url.unescape('%E4%B8', 'UTF8');
+ERROR:  invalid byte sequence for encoding "UTF8": 0xe4 0xb8
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+-- ============================================================
 -- PL/iSQL package interface
 -- ============================================================
 DECLARE
@@ -209,9 +361,14 @@ BEGIN
     dbms_output.put_line('escaped=' || v_escaped);
     dbms_output.get_line(line, status);
     RAISE NOTICE '%', line;
+    dbms_output.put_line('roundtrip=' ||
+        CASE WHEN utl_url.unescape(v_escaped) = v_url THEN 't' ELSE 'f' END);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
 END;
 /
 NOTICE:  escaped=http://example.com/a%20b/%E4%B8%AD%E6%96%87?x=1&y=2
+NOTICE:  roundtrip=t
 -- All three arguments through the package
 DECLARE
     v_escaped VARCHAR2(400);
@@ -223,6 +380,22 @@ BEGIN
     dbms_output.put_line('escaped=' || v_escaped);
     dbms_output.get_line(line, status);
     RAISE NOTICE '%', line;
+    dbms_output.put_line('unescaped=' || utl_url.unescape(v_escaped, 'UTF8'));
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
 END;
 /
 NOTICE:  escaped=a%20b%24c
+NOTICE:  unescaped=a b$c
+-- BAD_URL surfaces as an error inside PL/iSQL too
+DECLARE
+    v_out VARCHAR2(400);
+BEGIN
+    v_out := utl_url.unescape('bad%');
+    RAISE NOTICE 'should not get here: %', v_out;
+END;
+/
+ERROR:  UTL_URL.UNESCAPE: truncated escape code sequence in URL
+DETAIL:  A "%" at position 4 is not followed by two hexadecimal digits.
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
+PL/iSQL function inline_code_block line 4 at assignment

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -1,0 +1,154 @@
+--
+-- utl_url.sql
+--
+-- Tests for the UTL_URL package (ESCAPE function)
+--
+-- The escaped form of a multibyte character depends on the character set the
+-- character is converted to, so the multibyte cases below pass 'UTF8'
+-- explicitly rather than relying on the database encoding.
+--
+-- ============================================================
+-- Tests for UTL_URL.ESCAPE
+-- ============================================================
+-- NULL input returns NULL
+SELECT utl_url.escape(NULL) IS NULL AS escape_null;
+ escape_null 
+-------------
+ t
+(1 row)
+
+-- Empty input
+SELECT utl_url.escape('') AS escape_empty, utl_url.escape('') IS NULL AS empty_is_null;
+ escape_empty | empty_is_null 
+--------------+---------------
+              | t
+(1 row)
+
+-- Unreserved characters are never escaped
+SELECT utl_url.escape('AZaz09-_.!~*''()') AS unreserved;
+   unreserved    
+-----------------
+ AZaz09-_.!~*'()
+(1 row)
+
+-- Space and the other illegal characters are escaped, reserved ones are not
+SELECT utl_url.escape('a b/c?d=e&f') AS default_mode;
+ default_mode  
+---------------
+ a%20b/c?d=e&f
+(1 row)
+
+-- With escape_reserved_chars = TRUE the delimiters are escaped as well
+SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
+     reserved_mode     
+-----------------------
+ a%20b%2Fc%3Fd%3De%26f
+(1 row)
+
+-- Full reserved set: passed through by default, escaped on request
+SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
+ reserved_default 
+------------------
+ ;/?:@&=+$%,#
+(1 row)
+
+SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
+           reserved_escaped           
+--------------------------------------
+ %3B%2F%3F%3A%40%26%3D%2B%24%25%2C%23
+(1 row)
+
+-- Illegal ASCII characters are always escaped
+SELECT utl_url.escape('<>"{}|\\^[]`') AS illegal_ascii;
+            illegal_ascii             
+--------------------------------------
+ %3C%3E%22%7B%7D%7C%5C%5C%5E%5B%5D%60
+(1 row)
+
+-- Control characters are escaped
+SELECT utl_url.escape('a' || chr(9) || 'b' || chr(10) || 'c') AS control_chars;
+ control_chars 
+---------------
+ a%09b%0Ac
+(1 row)
+
+-- Examples from the Oracle documentation
+SELECT utl_url.escape('http://www.acme.com/a url with space.html') AS doc_escape;
+                   doc_escape                    
+-------------------------------------------------
+ http://www.acme.com/a%20url%20with%20space.html
+(1 row)
+
+SELECT utl_url.escape('http://oracle-base.com/my page.html', TRUE) AS doc_escape_reserved;
+              doc_escape_reserved              
+-----------------------------------------------
+ http%3A%2F%2Foracle-base.com%2Fmy%20page.html
+(1 row)
+
+SELECT utl_url.escape('Is the use of the "$" sign okay?', TRUE) AS doc_escape_value;
+                    doc_escape_value                    
+--------------------------------------------------------
+ Is%20the%20use%20of%20the%20%22%24%22%20sign%20okay%3F
+(1 row)
+
+-- Multibyte characters: each byte of the converted character gets its own %XX
+SELECT utl_url.escape('中文测试', FALSE, 'UTF8') AS cjk_utf8;
+               cjk_utf8               
+--------------------------------------
+ %E4%B8%AD%E6%96%87%E6%B5%8B%E8%AF%95
+(1 row)
+
+-- Explicit character set conversion: the same characters in GB18030
+SELECT utl_url.escape('中文', FALSE, 'GB18030') AS cjk_gb18030;
+ cjk_gb18030  
+--------------
+ %D6%D0%CE%C4
+(1 row)
+
+-- The charset name may be spelled the IANA way or the PostgreSQL way
+SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
+       utl_url.escape('a b', FALSE, 'LATIN1') AS pg_name;
+ iana_name | pg_name 
+-----------+---------
+ a%20b     | a%20b
+(1 row)
+
+-- An unrecognized character set is rejected
+SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
+ERROR:  UTL_URL: unrecognized URL character set "NO_SUCH_CHARSET"
+CONTEXT:  PL/iSQL function sys.utl_url.escape line 5 at RETURN
+-- A character with no representation in the target character set is rejected
+SELECT utl_url.escape('中文', FALSE, 'LATIN1');
+ERROR:  character with byte sequence 0xe4 0xb8 0xad in encoding "UTF8" has no equivalent in encoding "LATIN1"
+CONTEXT:  PL/iSQL function sys.utl_url.escape line 5 at RETURN
+-- ============================================================
+-- PL/iSQL package interface
+-- ============================================================
+DECLARE
+    v_url     VARCHAR2(200) := 'http://example.com/a b/中文?x=1&y=2';
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape(v_url);
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+NOTICE:  escaped=http://example.com/a%20b/%E4%B8%AD%E6%96%87?x=1&y=2
+-- All three arguments through the package
+DECLARE
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape('a b$c', TRUE, 'UTF8');
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+NOTICE:  escaped=a%20b%24c

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -45,17 +45,91 @@ SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
  a%20b%2Fc%3Fd%3De%26f
 (1 row)
 
--- Full reserved set: passed through by default, escaped on request
+-- The reserved delimiters: passed through by default, escaped on request.
+-- '%' and '#' are not passthrough delimiters and are escaped even in the
+-- default mode.
 SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
  reserved_default 
 ------------------
- ;/?:@&=+$%,#
+ ;/?:@&=+$%25,%23
 (1 row)
 
 SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
            reserved_escaped           
 --------------------------------------
  %3B%2F%3F%3A%40%26%3D%2B%24%25%2C%23
+(1 row)
+
+-- A literal '%' is always escaped, even in default mode, so that
+-- already-escaped input is double-escaped (matching Oracle)
+SELECT utl_url.escape('a%b') AS pct_default;
+ pct_default 
+-------------
+ a%25b
+(1 row)
+
+SELECT utl_url.escape('a%b', TRUE) AS pct_reserved;
+ pct_reserved 
+--------------
+ a%25b
+(1 row)
+
+SELECT utl_url.escape('a%20b') AS preescaped_default;
+ preescaped_default 
+--------------------
+ a%2520b
+(1 row)
+
+SELECT utl_url.escape('a%20b', TRUE) AS preescaped_reserved;
+ preescaped_reserved 
+---------------------
+ a%2520b
+(1 row)
+
+-- '#' is always escaped, including default mode, matching Oracle.
+SELECT utl_url.escape('a#b') AS hash_default;
+ hash_default 
+--------------
+ a%23b
+(1 row)
+
+SELECT utl_url.escape('a#b', TRUE) AS hash_reserved;
+ hash_reserved 
+---------------
+ a%23b
+(1 row)
+
+-- A real-world URL with a pre-escaped component and a fragment
+SELECT utl_url.escape('http://h/p?q=a%20b#frag') AS url_default;
+         url_default         
+-----------------------------
+ http://h/p?q=a%2520b%23frag
+(1 row)
+
+-- '#' alone
+SELECT utl_url.escape('#') AS hash_only_default;
+ hash_only_default 
+-------------------
+ %23
+(1 row)
+
+SELECT utl_url.escape('#', TRUE) AS hash_only_reserved;
+ hash_only_reserved 
+--------------------
+ %23
+(1 row)
+
+-- a fragment/query-like string in both modes
+SELECT utl_url.escape('a#b?c=d', FALSE) AS hash_query_default;
+ hash_query_default 
+--------------------
+ a%23b?c=d
+(1 row)
+
+SELECT utl_url.escape('a#b?c=d', TRUE) AS hash_query_reserved;
+ hash_query_reserved 
+---------------------
+ a%23b%3Fc%3Dd
 (1 row)
 
 -- Illegal ASCII characters are always escaped

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -270,6 +270,16 @@ SELECT utl_url.unescape('%D6%D0%CE%C4', 'GBK') AS cjk_gbk;
  中文
 (1 row)
 
+-- Mixed literal (database encoding) and %XX (url_charset): literal
+-- characters are preserved as-is; only the %XX bytes are converted from
+-- url_charset (a UTF-8 literal must not be re-interpreted through the
+-- url_charset)
+SELECT utl_url.unescape('café%21', 'LATIN1') AS mixed_literal_pct;
+ mixed_literal_pct 
+-------------------
+ café!
+(1 row)
+
 -- An unrecognized character set is rejected (Oracle reports ORA-01482)
 SELECT utl_url.unescape('a%20b', 'NO_SUCH_CHARSET');
 ERROR:  UTL_URL: unrecognized URL character set "NO_SUCH_CHARSET"

--- a/contrib/ivorysql_ora/expected/utl_url.out
+++ b/contrib/ivorysql_ora/expected/utl_url.out
@@ -295,6 +295,29 @@ SELECT utl_url.unescape('café%21', 'LATIN1') AS mixed_literal_pct;
  café!
 (1 row)
 
+-- The same contract on the decode side: an omitted and an explicit NULL
+-- url_charset both mean "the bytes are already in the database encoding"
+SELECT utl_url.unescape('%C3%A9') AS default_charset,
+       utl_url.unescape('%C3%A9', NULL) AS explicit_null_charset;
+ default_charset | explicit_null_charset 
+-----------------+-----------------------
+ é               | é
+(1 row)
+
+-- A lone LATIN1 %E9 group decodes to é through the explicit charset
+SELECT utl_url.unescape('%E9', 'LATIN1') AS latin1_decode;
+ latin1_decode 
+---------------
+ é
+(1 row)
+
+-- With the database-encoding default, a lone %E9 is not valid UTF8 text,
+-- so the call reports an encoding error -- where Oracle's omitted-
+-- url_charset default (utl_http.body_charset, ISO-8859-1) would return é.
+-- Declared deviation, pinned here so the difference stays visible.
+SELECT utl_url.unescape('%E9');
+ERROR:  invalid byte sequence for encoding "UTF8": 0xe9
+CONTEXT:  PL/iSQL function sys.utl_url.unescape line 11 at RETURN
 -- An unrecognized character set is rejected (Oracle reports ORA-01482)
 SELECT utl_url.unescape('a%20b', 'NO_SUCH_CHARSET');
 ERROR:  UTL_URL: unrecognized URL character set "NO_SUCH_CHARSET"

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -8,4 +8,5 @@ src/builtin_packages/dbms_utility/dbms_utility
 src/builtin_packages/dbms_lock/dbms_lock
 src/builtin_packages/utl_raw/utl_raw
 src/builtin_packages/utl_encode/utl_encode
+src/builtin_packages/utl_url/utl_url
 src/builtin_packages/dbms_session/dbms_session

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -32,6 +32,7 @@ ivorysql_ora_sources = files(
   'src/builtin_packages/dbms_lock/dbms_lock.c',
   'src/builtin_packages/utl_raw/utl_raw.c',
   'src/builtin_packages/utl_encode/utl_encode.c',
+  'src/builtin_packages/utl_url/utl_url.c',
   'src/builtin_packages/dbms_session/dbms_session.c'
 )
 

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -1,0 +1,91 @@
+--
+-- utl_url.sql
+--
+-- Tests for the UTL_URL package (ESCAPE function)
+--
+-- The escaped form of a multibyte character depends on the character set the
+-- character is converted to, so the multibyte cases below pass 'UTF8'
+-- explicitly rather than relying on the database encoding.
+--
+
+-- ============================================================
+-- Tests for UTL_URL.ESCAPE
+-- ============================================================
+
+-- NULL input returns NULL
+SELECT utl_url.escape(NULL) IS NULL AS escape_null;
+
+-- Empty input
+SELECT utl_url.escape('') AS escape_empty, utl_url.escape('') IS NULL AS empty_is_null;
+
+-- Unreserved characters are never escaped
+SELECT utl_url.escape('AZaz09-_.!~*''()') AS unreserved;
+
+-- Space and the other illegal characters are escaped, reserved ones are not
+SELECT utl_url.escape('a b/c?d=e&f') AS default_mode;
+
+-- With escape_reserved_chars = TRUE the delimiters are escaped as well
+SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
+
+-- Full reserved set: passed through by default, escaped on request
+SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
+SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
+
+-- Illegal ASCII characters are always escaped
+SELECT utl_url.escape('<>"{}|\\^[]`') AS illegal_ascii;
+
+-- Control characters are escaped
+SELECT utl_url.escape('a' || chr(9) || 'b' || chr(10) || 'c') AS control_chars;
+
+-- Examples from the Oracle documentation
+SELECT utl_url.escape('http://www.acme.com/a url with space.html') AS doc_escape;
+SELECT utl_url.escape('http://oracle-base.com/my page.html', TRUE) AS doc_escape_reserved;
+SELECT utl_url.escape('Is the use of the "$" sign okay?', TRUE) AS doc_escape_value;
+
+-- Multibyte characters: each byte of the converted character gets its own %XX
+SELECT utl_url.escape('中文测试', FALSE, 'UTF8') AS cjk_utf8;
+
+-- Explicit character set conversion: the same characters in GB18030
+SELECT utl_url.escape('中文', FALSE, 'GB18030') AS cjk_gb18030;
+
+-- The charset name may be spelled the IANA way or the PostgreSQL way
+SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
+       utl_url.escape('a b', FALSE, 'LATIN1') AS pg_name;
+
+-- An unrecognized character set is rejected
+SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
+
+-- A character with no representation in the target character set is rejected
+SELECT utl_url.escape('中文', FALSE, 'LATIN1');
+
+-- ============================================================
+-- PL/iSQL package interface
+-- ============================================================
+
+DECLARE
+    v_url     VARCHAR2(200) := 'http://example.com/a b/中文?x=1&y=2';
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape(v_url);
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+
+-- All three arguments through the package
+DECLARE
+    v_escaped VARCHAR2(400);
+    line      TEXT;
+    status    INTEGER;
+BEGIN
+    dbms_output.enable();
+    v_escaped := utl_url.escape('a b$c', TRUE, 'UTF8');
+    dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -1,11 +1,13 @@
 --
 -- utl_url.sql
 --
--- Tests for the UTL_URL package (ESCAPE function)
+-- Tests for the UTL_URL package (ESCAPE and UNESCAPE functions)
 --
 -- The escaped form of a multibyte character depends on the character set the
 -- character is converted to, so the multibyte cases below pass 'UTF8'
--- explicitly rather than relying on the database encoding.
+-- explicitly rather than relying on the database encoding.  The round-trip
+-- cases that omit url_charset work in any database encoding that can hold the
+-- literal.
 --
 
 -- ============================================================
@@ -83,6 +85,78 @@ SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
 SELECT utl_url.escape('中文', FALSE, 'LATIN1');
 
 -- ============================================================
+-- Tests for UTL_URL.UNESCAPE
+-- ============================================================
+
+-- NULL input returns NULL
+SELECT utl_url.unescape(NULL) IS NULL AS unescape_null;
+
+-- Basic decoding
+SELECT utl_url.unescape('a%20b%2Fc') AS basic;
+
+-- Lower case hex digits are accepted on input
+SELECT utl_url.unescape('a%2fb%2Fc') AS lower_hex;
+
+-- The empty string round-trips to the empty string
+SELECT utl_url.unescape('') AS unescape_empty;
+
+-- A '%' produced by ESCAPE decodes back to a literal '%': double-escaped
+-- input collapses one level, as on Oracle
+SELECT utl_url.unescape('a%25b') AS pct_literal;
+SELECT utl_url.unescape('a%2520b') AS double_escaped;
+
+-- Unescaped characters are passed through untouched
+SELECT utl_url.unescape('http://oracle-base.com/my%20page.html') AS doc_unescape;
+SELECT utl_url.unescape('http%3A%2F%2Foracle-base.com%2Fmy%20page.html') AS doc_unescape_reserved;
+
+-- Multibyte: consecutive %XX groups are reassembled into one character
+SELECT utl_url.unescape('%E4%B8%AD%E6%96%87', 'UTF8') AS cjk_utf8;
+
+-- GBK bytes are converted from the named charset (the IANA/PostgreSQL
+-- spelling; Oracle writes ZHS16GBK)
+SELECT utl_url.unescape('%D6%D0%CE%C4', 'GBK') AS cjk_gbk;
+
+-- An unrecognized character set is rejected (Oracle reports ORA-01482)
+SELECT utl_url.unescape('a%20b', 'NO_SUCH_CHARSET');
+
+-- ============================================================
+-- Round-trip identity: UNESCAPE(ESCAPE(x)) = x
+-- ============================================================
+
+SELECT utl_url.unescape(utl_url.escape('a b/中文')) = 'a b/中文' AS roundtrip_default;
+SELECT utl_url.unescape(utl_url.escape('a b/中文', TRUE)) = 'a b/中文' AS roundtrip_reserved;
+SELECT utl_url.unescape(utl_url.escape('中文测试', FALSE, 'UTF8'), 'UTF8') = '中文测试' AS roundtrip_charset;
+SELECT utl_url.unescape(utl_url.escape('中文', FALSE, 'GB18030'), 'GB18030') = '中文' AS roundtrip_gb18030;
+
+-- '%' and '#' are always escaped (including the default mode), so every
+-- literal round-trips in either mode
+SELECT utl_url.unescape(utl_url.escape(';/?:@&=+$%,# <>"')) = ';/?:@&=+$%,# <>"' AS roundtrip_all_default;
+SELECT utl_url.unescape(utl_url.escape(';/?:@&=+$%,# <>"', TRUE)) = ';/?:@&=+$%,# <>"' AS roundtrip_all_reserved;
+
+-- ============================================================
+-- Error cases: badly formed escape code sequences
+-- Oracle raises UTL_URL.BAD_URL (ORA-29262) for these
+-- ============================================================
+
+-- '%' at the end of the string
+SELECT utl_url.unescape('bad%');
+
+-- '%' followed by non-hexadecimal characters
+SELECT utl_url.unescape('%ZZ');
+
+-- '%' followed by only one hexadecimal digit
+SELECT utl_url.unescape('a%2');
+
+-- A literal '%' in the middle of an otherwise valid URL
+SELECT utl_url.unescape('100%20%pure');
+
+-- %00 cannot be represented in a text value
+SELECT utl_url.unescape('a%00b');
+
+-- A %XX group that does not form a valid character in the source charset
+SELECT utl_url.unescape('%E4%B8', 'UTF8');
+
+-- ============================================================
 -- PL/iSQL package interface
 -- ============================================================
 
@@ -95,6 +169,10 @@ BEGIN
     dbms_output.enable();
     v_escaped := utl_url.escape(v_url);
     dbms_output.put_line('escaped=' || v_escaped);
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+    dbms_output.put_line('roundtrip=' ||
+        CASE WHEN utl_url.unescape(v_escaped) = v_url THEN 't' ELSE 'f' END);
     dbms_output.get_line(line, status);
     RAISE NOTICE '%', line;
 END;
@@ -111,5 +189,17 @@ BEGIN
     dbms_output.put_line('escaped=' || v_escaped);
     dbms_output.get_line(line, status);
     RAISE NOTICE '%', line;
+    dbms_output.put_line('unescaped=' || utl_url.unescape(v_escaped, 'UTF8'));
+    dbms_output.get_line(line, status);
+    RAISE NOTICE '%', line;
+END;
+/
+
+-- BAD_URL surfaces as an error inside PL/iSQL too
+DECLARE
+    v_out VARCHAR2(400);
+BEGIN
+    v_out := utl_url.unescape('bad%');
+    RAISE NOTICE 'should not get here: %', v_out;
 END;
 /

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -27,9 +27,33 @@ SELECT utl_url.escape('a b/c?d=e&f') AS default_mode;
 -- With escape_reserved_chars = TRUE the delimiters are escaped as well
 SELECT utl_url.escape('a b/c?d=e&f', TRUE) AS reserved_mode;
 
--- Full reserved set: passed through by default, escaped on request
+-- The reserved delimiters: passed through by default, escaped on request.
+-- '%' and '#' are not passthrough delimiters and are escaped even in the
+-- default mode.
 SELECT utl_url.escape(';/?:@&=+$%,#') AS reserved_default;
 SELECT utl_url.escape(';/?:@&=+$%,#', TRUE) AS reserved_escaped;
+
+-- A literal '%' is always escaped, even in default mode, so that
+-- already-escaped input is double-escaped (matching Oracle)
+SELECT utl_url.escape('a%b') AS pct_default;
+SELECT utl_url.escape('a%b', TRUE) AS pct_reserved;
+SELECT utl_url.escape('a%20b') AS preescaped_default;
+SELECT utl_url.escape('a%20b', TRUE) AS preescaped_reserved;
+
+-- '#' is always escaped, including default mode, matching Oracle.
+SELECT utl_url.escape('a#b') AS hash_default;
+SELECT utl_url.escape('a#b', TRUE) AS hash_reserved;
+
+-- A real-world URL with a pre-escaped component and a fragment
+SELECT utl_url.escape('http://h/p?q=a%20b#frag') AS url_default;
+
+-- '#' alone
+SELECT utl_url.escape('#') AS hash_only_default;
+SELECT utl_url.escape('#', TRUE) AS hash_only_reserved;
+
+-- a fragment/query-like string in both modes
+SELECT utl_url.escape('a#b?c=d', FALSE) AS hash_query_default;
+SELECT utl_url.escape('a#b?c=d', TRUE) AS hash_query_reserved;
 
 -- Illegal ASCII characters are always escaped
 SELECT utl_url.escape('<>"{}|\\^[]`') AS illegal_ascii;

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -133,6 +133,20 @@ SELECT utl_url.unescape('%D6%D0%CE%C4', 'GBK') AS cjk_gbk;
 -- url_charset)
 SELECT utl_url.unescape('café%21', 'LATIN1') AS mixed_literal_pct;
 
+-- The same contract on the decode side: an omitted and an explicit NULL
+-- url_charset both mean "the bytes are already in the database encoding"
+SELECT utl_url.unescape('%C3%A9') AS default_charset,
+       utl_url.unescape('%C3%A9', NULL) AS explicit_null_charset;
+
+-- A lone LATIN1 %E9 group decodes to é through the explicit charset
+SELECT utl_url.unescape('%E9', 'LATIN1') AS latin1_decode;
+
+-- With the database-encoding default, a lone %E9 is not valid UTF8 text,
+-- so the call reports an encoding error -- where Oracle's omitted-
+-- url_charset default (utl_http.body_charset, ISO-8859-1) would return é.
+-- Declared deviation, pinned here so the difference stays visible.
+SELECT utl_url.unescape('%E9');
+
 -- An unrecognized character set is rejected (Oracle reports ORA-01482)
 SELECT utl_url.unescape('a%20b', 'NO_SUCH_CHARSET');
 

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -116,6 +116,12 @@ SELECT utl_url.unescape('%E4%B8%AD%E6%96%87', 'UTF8') AS cjk_utf8;
 -- spelling; Oracle writes ZHS16GBK)
 SELECT utl_url.unescape('%D6%D0%CE%C4', 'GBK') AS cjk_gbk;
 
+-- Mixed literal (database encoding) and %XX (url_charset): literal
+-- characters are preserved as-is; only the %XX bytes are converted from
+-- url_charset (a UTF-8 literal must not be re-interpreted through the
+-- url_charset)
+SELECT utl_url.unescape('café%21', 'LATIN1') AS mixed_literal_pct;
+
 -- An unrecognized character set is rejected (Oracle reports ORA-01482)
 SELECT utl_url.unescape('a%20b', 'NO_SUCH_CHARSET');
 

--- a/contrib/ivorysql_ora/sql/utl_url.sql
+++ b/contrib/ivorysql_ora/sql/utl_url.sql
@@ -76,6 +76,17 @@ SELECT utl_url.escape('中文', FALSE, 'GB18030') AS cjk_gb18030;
 SELECT utl_url.escape('a b', FALSE, 'ISO-8859-1') AS iana_name,
        utl_url.escape('a b', FALSE, 'LATIN1') AS pg_name;
 
+-- The url_charset contract: omitting the argument and passing an explicit
+-- NULL are the same thing here -- both mean "the database encoding, do not
+-- convert".  Oracle makes them different: an omitted url_charset defaults
+-- to utl_http.body_charset (ISO-8859-1) while an explicit NULL selects the
+-- database character set.  Defaulting to the database encoding instead of
+-- ISO-8859-1 is the declared deviation of this port (ISO-8859-1 cannot
+-- represent non-Latin text; see the package documentation), and this case
+-- pins the contract so the difference stays visible.
+SELECT utl_url.escape('é') AS default_charset,
+       utl_url.escape('é', FALSE, NULL) AS explicit_null_charset;
+
 -- An unrecognized character set is rejected
 SELECT utl_url.escape('a b', FALSE, 'NO_SUCH_CHARSET');
 

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -2,7 +2,7 @@
  *
  * UTL_URL Package
  *
- * Oracle-compatible URL escape utilities (RFC 2396).
+ * Oracle-compatible URL escape/unescape utilities (RFC 2396).
  *
  * contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
  *
@@ -18,6 +18,11 @@
 CREATE FUNCTION sys.utl_url_escape(url text, escape_reserved_chars boolean, url_charset text)
 RETURNS text
 AS 'MODULE_PATHNAME', 'ivorysql_utl_url_escape'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION sys.utl_url_unescape(url text, url_charset text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ivorysql_utl_url_unescape'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 -- PL/iSQL package declaration
@@ -61,6 +66,30 @@ CREATE OR REPLACE PACKAGE utl_url AS
                     escape_reserved_chars IN BOOLEAN DEFAULT FALSE,
                     url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2;
 
+    /*
+     * UNESCAPE
+     * Converts the %XX escape code sequences of a URL back to the original
+     * characters.  Multibyte characters are reassembled from consecutive %XX
+     * groups, so UNESCAPE(ESCAPE(x)) returns x.
+     *
+     * Parameters:
+     *   url          IN VARCHAR2 - the URL to unescape
+     *   url_charset  IN VARCHAR2 - character set the unescaped bytes are
+     *                              assumed to be in; they are converted from
+     *                              it to the database encoding.  NULL (the
+     *                              default) means the bytes are already in the
+     *                              database encoding.
+     * Returns:
+     *   VARCHAR2 - the unescaped URL, or NULL when url IS NULL
+     *
+     * A "%" that is not followed by two hexadecimal digits raises an error
+     * (Oracle raises UTL_URL.BAD_URL, ORA-29262).  A %00 escape is likewise
+     * rejected, because a text value cannot contain a NUL byte (Oracle
+     * instead returns a string containing a NUL byte).
+     */
+    FUNCTION unescape(url IN VARCHAR2,
+                      url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2;
+
 END utl_url;
 
 CREATE OR REPLACE PACKAGE BODY utl_url AS
@@ -70,6 +99,12 @@ CREATE OR REPLACE PACKAGE BODY utl_url AS
                     url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2 IS
     BEGIN
         RETURN sys.utl_url_escape(url, escape_reserved_chars, url_charset);
+    END;
+
+    FUNCTION unescape(url IN VARCHAR2,
+                      url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2 IS
+    BEGIN
+        RETURN sys.utl_url_unescape(url, url_charset);
     END;
 
 END utl_url;

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -82,9 +82,14 @@ CREATE OR REPLACE PACKAGE utl_url AS
      *   url          IN VARCHAR2 - the URL to unescape
      *   url_charset  IN VARCHAR2 - character set the unescaped bytes are
      *                              assumed to be in; they are converted from
-     *                              it to the database encoding.  NULL (the
-     *                              default) means the bytes are already in the
-     *                              database encoding.
+     *                              it to the database encoding.  An omitted
+     *                              url_charset and an explicit NULL are
+     *                              equivalent here and both mean the bytes
+     *                              are already in the database encoding;
+     *                              Oracle's omitted form defaults to
+     *                              utl_http.body_charset (ISO-8859-1)
+     *                              instead (declared deviation, see the
+     *                              ESCAPE documentation above).
      * Returns:
      *   VARCHAR2 - the unescaped URL, or NULL when url IS NULL
      *

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -31,10 +31,11 @@ CREATE OR REPLACE PACKAGE utl_url AS
      * Unreserved characters, never escaped:
      *     A-Z  a-z  0-9  -  _  .  !  ~  *  '  (  )
      * Reserved characters, escaped only when escape_reserved_chars is TRUE:
-     *     ;  /  ?  :  @  &  =  +  $  %  ,  #
+     *     ;  /  ?  :  @  &  =  +  $  ,
      * Everything else, always escaped:
-     *     space, control characters, " < > { } | \ ^ [ ] ` and every
-     *     non-ASCII byte.
+     *     #, space, control characters, " < > { } | \ ^ [ ] ` , every
+     *     non-ASCII byte, and a literal "%" (already-escaped input is
+     *     double-escaped, matching Oracle).
      *
      * Parameters:
      *   url                    IN VARCHAR2 - the original URL
@@ -44,7 +45,15 @@ CREATE OR REPLACE PACKAGE utl_url AS
      *                                         converted to before being
      *                                         escaped.  NULL (the default)
      *                                         means the database encoding,
-     *                                         with no conversion.
+     *                                         with no conversion.  Note:
+     *                                         Oracle's documented default is
+     *                                         utl_http.body_charset
+     *                                         (ISO-8859-1); using the database
+     *                                         encoding instead is a deliberate
+     *                                         deviation, since ISO-8859-1
+     *                                         cannot represent non-Latin text
+     *                                         and UTL_HTTP is not available
+     *                                         here.
      * Returns:
      *   VARCHAR2 - the escaped URL, or NULL when url IS NULL
      */

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -1,0 +1,66 @@
+/***************************************************************
+ *
+ * UTL_URL Package
+ *
+ * Oracle-compatible URL escape utilities (RFC 2396).
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+ *
+ ***************************************************************/
+
+/*
+ * Register the C implementation in the sys schema.
+ *
+ * NOT declared STRICT on purpose: url_charset is legitimately NULL whenever
+ * the caller relies on the default, and a STRICT function would then return
+ * NULL for every call.  NULL propagation for the url argument is handled in C.
+ */
+CREATE FUNCTION sys.utl_url_escape(url text, escape_reserved_chars boolean, url_charset text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ivorysql_utl_url_escape'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- PL/iSQL package declaration
+CREATE OR REPLACE PACKAGE utl_url AS
+
+    /*
+     * ESCAPE
+     * Returns a URL with the illegal characters (and optionally the reserved
+     * characters) escaped using the %2-digit-hex-code format.
+     *
+     * Unreserved characters, never escaped:
+     *     A-Z  a-z  0-9  -  _  .  !  ~  *  '  (  )
+     * Reserved characters, escaped only when escape_reserved_chars is TRUE:
+     *     ;  /  ?  :  @  &  =  +  $  %  ,  #
+     * Everything else, always escaped:
+     *     space, control characters, " < > { } | \ ^ [ ] ` and every
+     *     non-ASCII byte.
+     *
+     * Parameters:
+     *   url                    IN VARCHAR2 - the original URL
+     *   escape_reserved_chars  IN BOOLEAN   - also escape the reserved
+     *                                         delimiters (default FALSE)
+     *   url_charset            IN VARCHAR2  - character set the characters are
+     *                                         converted to before being
+     *                                         escaped.  NULL (the default)
+     *                                         means the database encoding,
+     *                                         with no conversion.
+     * Returns:
+     *   VARCHAR2 - the escaped URL, or NULL when url IS NULL
+     */
+    FUNCTION escape(url IN VARCHAR2,
+                    escape_reserved_chars IN BOOLEAN DEFAULT FALSE,
+                    url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2;
+
+END utl_url;
+
+CREATE OR REPLACE PACKAGE BODY utl_url AS
+
+    FUNCTION escape(url IN VARCHAR2,
+                    escape_reserved_chars IN BOOLEAN DEFAULT FALSE,
+                    url_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2 IS
+    BEGIN
+        RETURN sys.utl_url_escape(url, escape_reserved_chars, url_charset);
+    END;
+
+END utl_url;

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url--1.0.sql
@@ -43,17 +43,23 @@ CREATE OR REPLACE PACKAGE utl_url AS
      *                                         delimiters (default FALSE)
      *   url_charset            IN VARCHAR2  - character set the characters are
      *                                         converted to before being
-     *                                         escaped.  NULL (the default)
-     *                                         means the database encoding,
-     *                                         with no conversion.  Note:
-     *                                         Oracle's documented default is
+     *                                         escaped.  An omitted
+     *                                         url_charset and an explicit
+     *                                         NULL are equivalent here and
+     *                                         both mean the database
+     *                                         encoding, with no conversion.
+     *                                         Oracle distinguishes the two
+     *                                         forms: an omitted argument
+     *                                         defaults to
      *                                         utl_http.body_charset
-     *                                         (ISO-8859-1); using the database
-     *                                         encoding instead is a deliberate
-     *                                         deviation, since ISO-8859-1
-     *                                         cannot represent non-Latin text
-     *                                         and UTL_HTTP is not available
-     *                                         here.
+     *                                         (ISO-8859-1) while an explicit
+     *                                         NULL selects the database
+     *                                         character set.  Using the
+     *                                         database encoding for both is
+     *                                         a deliberate deviation:
+     *                                         ISO-8859-1 cannot represent
+     *                                         non-Latin text and UTL_HTTP
+     *                                         is not available here.
      * Returns:
      *   VARCHAR2 - the escaped URL, or NULL when url IS NULL
      */

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
@@ -209,9 +209,10 @@ ivorysql_utl_url_escape(PG_FUNCTION_ARGS)
  * Oracle-compatible UNESCAPE implementation:
  *   - Converts every %XX sequence back to the byte it encodes; all other
  *     characters are copied verbatim
- *   - The reassembled byte string is assumed to be in url_charset and is
- *     converted to the database encoding, so a %E4%B8%AD group becomes one
- *     UTF-8 character
+ *   - Literal characters are already in the database encoding and are kept
+ *     as they are; only the %XX-decoded bytes are interpreted in
+ *     url_charset and converted to the database encoding, so a %E4%B8%AD
+ *     group becomes one UTF-8 character
  *   - A NULL url returns NULL
  *   - A NULL url_charset means "the bytes are already in the database
  *     encoding, do not convert"
@@ -233,10 +234,11 @@ ivorysql_utl_url_unescape(PG_FUNCTION_ARGS)
 	int			source_encoding;
 	char	   *src;
 	int			src_len;
-	char	   *raw;
-	int			raw_len;
+	StringInfoData out;		/* output, in database encoding */
+	char	   *pending;	/* accumulated %XX bytes, in url_charset */
+	int			pending_len;
+	int			pending_alloc;
 	int			i;
-	char	   *converted;
 
 	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL();
@@ -249,9 +251,21 @@ ivorysql_utl_url_unescape(PG_FUNCTION_ARGS)
 	src = text_to_cstring(url);
 	src_len = strlen(src);
 
-	/* Decoding never grows the string, so src_len bytes always suffice */
-	raw = palloc(src_len + 1);
-	raw_len = 0;
+	/*
+	 * Walk the URL byte by byte.  Literal characters are already in the
+	 * database encoding and are appended to the output directly; %XX
+	 * decoded bytes are accumulated in a separate buffer and flushed
+	 * (converted from url_charset to the database encoding) whenever a
+	 * literal character or the end of the string is encountered.  Keeping
+	 * the two encoding domains separate matters when url_charset differs
+	 * from the database encoding: mixing them into one buffer would
+	 * misinterpret database-encoded literal bytes as url_charset bytes
+	 * (a UTF-8 literal in a LATIN1 url_charset would come back mangled).
+	 */
+	initStringInfo(&out);
+	pending_alloc = 64;
+	pending = palloc(pending_alloc + 1);
+	pending_len = 0;
 	i = 0;
 
 	while (i < src_len)
@@ -283,20 +297,62 @@ ivorysql_utl_url_unescape(PG_FUNCTION_ARGS)
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("UTL_URL.UNESCAPE: escaped NUL character (%%00) is not supported")));
 
-			raw[raw_len++] = (char) ((hi << 4) | lo);
+			if (pending_len >= pending_alloc)
+			{
+				pending_alloc *= 2;
+				pending = repalloc(pending, pending_alloc + 1);
+			}
+			pending[pending_len++] = (char) ((hi << 4) | lo);
 			i += 3;
 		}
 		else
-			raw[raw_len++] = src[i++];
+		{
+			/*
+			 * Literal character: flush any accumulated %XX bytes (which
+			 * are in url_charset) through the charset conversion before
+			 * appending this byte, which is already in the database
+			 * encoding.
+			 */
+			if (pending_len > 0)
+			{
+				char	   *converted;
+				int			converted_len;
+
+				/*
+				 * pg_any_to_server() may return the input pointer
+				 * unchanged, so terminate the buffer for strlen().
+				 */
+				pending[pending_len] = '\0';
+
+				/*
+				 * pg_any_to_server() validates the byte string even when
+				 * no conversion is required, so a %XX group that does not
+				 * form a valid character in url_charset is reported rather
+				 * than silently stored.
+				 */
+				converted = pg_any_to_server(pending, pending_len,
+											 source_encoding);
+				converted_len = strlen(converted);
+				appendBinaryStringInfo(&out, converted, converted_len);
+				pending_len = 0;
+			}
+			appendStringInfoChar(&out, src[i]);
+			i++;
+		}
 	}
-	raw[raw_len] = '\0';
 
-	/*
-	 * pg_any_to_server() validates the byte string even when no conversion is
-	 * required, so a %XX group that does not form a valid character in the
-	 * source encoding is reported rather than silently stored.
-	 */
-	converted = pg_any_to_server(raw, raw_len, source_encoding);
+	/* Flush any trailing %XX bytes */
+	if (pending_len > 0)
+	{
+		char	   *converted;
+		int			converted_len;
 
-	PG_RETURN_TEXT_P(cstring_to_text_with_len(converted, strlen(converted)));
+		pending[pending_len] = '\0';
+		converted = pg_any_to_server(pending, pending_len,
+									 source_encoding);
+		converted_len = strlen(converted);
+		appendBinaryStringInfo(&out, converted, converted_len);
+	}
+
+	PG_RETURN_TEXT_P(cstring_to_text_with_len(out.data, out.len));
 }

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
@@ -16,7 +16,7 @@
  * Implementation of Oracle's UTL_URL package.
  * This module is part of ivorysql_ora extension.
  *
- * Provides the URL escape mechanism described by RFC 2396 (which is
+ * Provides the URL escape/unescape mechanism described by RFC 2396 (which is
  * what Oracle's UTL_URL implements).  Note that this is NOT the
  * x-www-form-urlencoded scheme: a space becomes "%20", never "+".
  *
@@ -55,6 +55,7 @@
 
 static bool utl_url_is_unreserved(unsigned char c);
 static bool utl_url_is_reserved(unsigned char c);
+static int	utl_url_hexval(unsigned char c);
 static int	utl_url_charset_to_encoding(text *charset);
 
 /*
@@ -84,6 +85,24 @@ utl_url_is_reserved(unsigned char c)
 }
 
 /*
+ * utl_url_hexval - value of a single hex digit, or -1 if c is not one.
+ *
+ * Both upper and lower case digits are accepted on input; ESCAPE always
+ * produces upper case, matching Oracle.
+ */
+static int
+utl_url_hexval(unsigned char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	return -1;
+}
+
+/*
  * utl_url_charset_to_encoding - resolve a url_charset argument.
  *
  * Accepts both IANA names ("ISO-8859-1", "UTF-8") and PostgreSQL names
@@ -93,7 +112,8 @@ utl_url_is_reserved(unsigned char c)
  * Oracle raises BAD_FIXED_WIDTH_CHARSET (ORA-29274) for fixed-width multibyte
  * character sets.  PostgreSQL has no such encoding in its catalog at all
  * (UTF-16/UTF-32 are not supported), so that condition is unreachable here and
- * every rejected name lands in the "unrecognized" branch below.
+ * every rejected name lands in the "unrecognized" branch below; Oracle
+ * reports those as ORA-01482 (unsupported character set).
  */
 static int
 utl_url_charset_to_encoding(text *charset)
@@ -181,4 +201,102 @@ ivorysql_utl_url_escape(PG_FUNCTION_ARGS)
 
 	/* The result is pure ASCII, hence valid in every server encoding */
 	PG_RETURN_TEXT_P(cstring_to_text_with_len(buf.data, buf.len));
+}
+
+/*
+ * ivorysql_utl_url_unescape
+ *
+ * Oracle-compatible UNESCAPE implementation:
+ *   - Converts every %XX sequence back to the byte it encodes; all other
+ *     characters are copied verbatim
+ *   - The reassembled byte string is assumed to be in url_charset and is
+ *     converted to the database encoding, so a %E4%B8%AD group becomes one
+ *     UTF-8 character
+ *   - A NULL url returns NULL
+ *   - A NULL url_charset means "the bytes are already in the database
+ *     encoding, do not convert"
+ *   - A "%" that is not followed by two hexadecimal digits raises an error.
+ *     Oracle raises UTL_URL.BAD_URL (ORA-29262) here
+ *   - %00 is rejected: PostgreSQL text values cannot contain a NUL byte
+ *
+ * Oracle signature:
+ *   UTL_URL.UNESCAPE(url IN VARCHAR2,
+ *                    url_charset IN VARCHAR2 DEFAULT utl_http.body_charset)
+ *   RETURN VARCHAR2
+ * Maps to: (text, text) -> text
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_url_unescape);
+Datum
+ivorysql_utl_url_unescape(PG_FUNCTION_ARGS)
+{
+	text	   *url;
+	int			source_encoding;
+	char	   *src;
+	int			src_len;
+	char	   *raw;
+	int			raw_len;
+	int			i;
+	char	   *converted;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	url = PG_GETARG_TEXT_PP(0);
+
+	source_encoding = PG_ARGISNULL(1) ? GetDatabaseEncoding() :
+		utl_url_charset_to_encoding(PG_GETARG_TEXT_PP(1));
+
+	src = text_to_cstring(url);
+	src_len = strlen(src);
+
+	/* Decoding never grows the string, so src_len bytes always suffice */
+	raw = palloc(src_len + 1);
+	raw_len = 0;
+	i = 0;
+
+	while (i < src_len)
+	{
+		if (src[i] == '%')
+		{
+			int			hi;
+			int			lo;
+
+			if (i + 2 >= src_len)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("UTL_URL.UNESCAPE: truncated escape code sequence in URL"),
+						 errdetail("A \"%%\" at position %d is not followed by two hexadecimal digits.",
+								   i + 1)));
+
+			hi = utl_url_hexval((unsigned char) src[i + 1]);
+			lo = utl_url_hexval((unsigned char) src[i + 2]);
+
+			if (hi < 0 || lo < 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("UTL_URL.UNESCAPE: badly formed escape code sequence in URL"),
+						 errdetail("The escape code sequence at position %d is not \"%%\" followed by two hexadecimal digits.",
+								   i + 1)));
+
+			if (hi == 0 && lo == 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("UTL_URL.UNESCAPE: escaped NUL character (%%00) is not supported")));
+
+			raw[raw_len++] = (char) ((hi << 4) | lo);
+			i += 3;
+		}
+		else
+			raw[raw_len++] = src[i++];
+	}
+	raw[raw_len] = '\0';
+
+	/*
+	 * pg_any_to_server() validates the byte string even when no conversion is
+	 * required, so a %XX group that does not form a valid character in the
+	 * source encoding is reported rather than silently stored.
+	 */
+	converted = pg_any_to_server(raw, raw_len, source_encoding);
+
+	PG_RETURN_TEXT_P(cstring_to_text_with_len(converted, strlen(converted)));
 }

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
@@ -1,0 +1,182 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Implementation of Oracle's UTL_URL package.
+ * This module is part of ivorysql_ora extension.
+ *
+ * Provides the URL escape mechanism described by RFC 2396 (which is
+ * what Oracle's UTL_URL implements).  Note that this is NOT the
+ * x-www-form-urlencoded scheme: a space becomes "%20", never "+".
+ *
+ * Portions Copyright (c) 2025-2026, IvorySQL Global Development Team
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "lib/stringinfo.h"
+#include "mb/pg_wchar.h"
+#include "utils/builtins.h"
+
+/*
+ * RFC 2396 / Oracle UTL_URL character classes.
+ *
+ * "Unreserved" characters are always passed through unescaped:
+ *		A-Z  a-z  0-9  -  _  .  !  ~  *  '  (  )
+ *
+ * "Reserved" characters are URL delimiters.  They are passed through when
+ * escape_reserved_chars is FALSE (the Oracle default) and escaped when it is
+ * TRUE:
+ *		;  /  ?  :  @  &  =  +  $  %  ,  #
+ *
+ * Everything else (space, control characters, "<", ">", quotes, braces,
+ * brackets, backslash, and every non-ASCII byte) is an "illegal" URL
+ * character and is always escaped.
+ */
+#define UTL_URL_UNRESERVED_CHARS	"-_.!~*'()"
+#define UTL_URL_RESERVED_CHARS		";/?:@&=+$%,#"
+
+static bool utl_url_is_unreserved(unsigned char c);
+static bool utl_url_is_reserved(unsigned char c);
+static int	utl_url_charset_to_encoding(text *charset);
+
+/*
+ * utl_url_is_unreserved - is c an RFC 2396 unreserved character?
+ *
+ * Only plain ASCII alphanumerics qualify, so we deliberately avoid the
+ * locale-dependent isalnum() here.
+ */
+static bool
+utl_url_is_unreserved(unsigned char c)
+{
+	if ((c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9'))
+		return true;
+
+	return (c != '\0' && strchr(UTL_URL_UNRESERVED_CHARS, c) != NULL);
+}
+
+/*
+ * utl_url_is_reserved - is c an RFC 2396 reserved (delimiter) character?
+ */
+static bool
+utl_url_is_reserved(unsigned char c)
+{
+	return (c != '\0' && strchr(UTL_URL_RESERVED_CHARS, c) != NULL);
+}
+
+/*
+ * utl_url_charset_to_encoding - resolve a url_charset argument.
+ *
+ * Accepts both IANA names ("ISO-8859-1", "UTF-8") and PostgreSQL names
+ * ("LATIN1", "UTF8"); pg_char_to_encoding() normalises case, dashes and
+ * underscores for us.
+ *
+ * Oracle raises BAD_FIXED_WIDTH_CHARSET (ORA-29274) for fixed-width multibyte
+ * character sets.  PostgreSQL has no such encoding in its catalog at all
+ * (UTF-16/UTF-32 are not supported), so that condition is unreachable here and
+ * every rejected name lands in the "unrecognized" branch below.
+ */
+static int
+utl_url_charset_to_encoding(text *charset)
+{
+	char	   *name = text_to_cstring(charset);
+	int			encoding = pg_char_to_encoding(name);
+
+	if (encoding < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("UTL_URL: unrecognized URL character set \"%s\"", name)));
+
+	pfree(name);
+
+	return encoding;
+}
+
+/*
+ * ivorysql_utl_url_escape
+ *
+ * Oracle-compatible ESCAPE implementation:
+ *   - Escapes illegal URL characters as %XX (upper-case hex)
+ *   - Escapes the reserved delimiters as well when escape_reserved_chars is
+ *     TRUE; passes them through when it is FALSE (Oracle's default)
+ *   - Multibyte characters are first converted to url_charset and then each
+ *     resulting byte is escaped separately, so a UTF-8 CJK character yields
+ *     three %XX groups
+ *   - A NULL url returns NULL
+ *   - A NULL url_charset means "use the database encoding, do not convert",
+ *     which is Oracle's documented behaviour for a NULL url_charset
+ *
+ * Oracle signature:
+ *   UTL_URL.ESCAPE(url IN VARCHAR2,
+ *                  escape_reserved_chars IN BOOLEAN DEFAULT FALSE,
+ *                  url_charset IN VARCHAR2 DEFAULT utl_http.body_charset)
+ *   RETURN VARCHAR2
+ * Maps to: (text, bool, text) -> text
+ *
+ * Not declared STRICT: url_charset is legitimately NULL in the default case,
+ * and a STRICT function would then wrongly return NULL for every call.
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_url_escape);
+Datum
+ivorysql_utl_url_escape(PG_FUNCTION_ARGS)
+{
+	text	   *url;
+	bool		escape_reserved;
+	int			target_encoding;
+	char	   *src;
+	char	   *converted;
+	int			len;
+	int			i;
+	StringInfoData buf;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	url = PG_GETARG_TEXT_PP(0);
+
+	/* A NULL boolean is treated like the default, FALSE */
+	escape_reserved = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
+
+	target_encoding = PG_ARGISNULL(2) ? GetDatabaseEncoding() :
+		utl_url_charset_to_encoding(PG_GETARG_TEXT_PP(2));
+
+	/*
+	 * Work on a NUL-terminated copy: pg_server_to_any() may hand the input
+	 * pointer straight back, and the conversion helpers expect C strings.
+	 */
+	src = text_to_cstring(url);
+	converted = pg_server_to_any(src, strlen(src), target_encoding);
+	len = strlen(converted);
+
+	initStringInfo(&buf);
+	for (i = 0; i < len; i++)
+	{
+		unsigned char c = (unsigned char) converted[i];
+
+		if (utl_url_is_unreserved(c) ||
+			(!escape_reserved && utl_url_is_reserved(c)))
+			appendStringInfoChar(&buf, (char) c);
+		else
+			appendStringInfo(&buf, "%%%02X", c);
+	}
+
+	/* The result is pure ASCII, hence valid in every server encoding */
+	PG_RETURN_TEXT_P(cstring_to_text_with_len(buf.data, buf.len));
+}

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_url/utl_url.c
@@ -42,14 +42,16 @@
  * "Reserved" characters are URL delimiters.  They are passed through when
  * escape_reserved_chars is FALSE (the Oracle default) and escaped when it is
  * TRUE:
- *		;  /  ?  :  @  &  =  +  $  %  ,  #
+ *		;  /  ?  :  @  &  =  +  $  ,
  *
  * Everything else (space, control characters, "<", ">", quotes, braces,
- * brackets, backslash, and every non-ASCII byte) is an "illegal" URL
- * character and is always escaped.
+ * brackets, backslash, every non-ASCII byte, and literal "%" and "#"
+ * characters) is an "illegal" URL character and is always escaped.  Escaping
+ * "%" unconditionally means already-escaped input is double-escaped
+ * ("a%20b" becomes "a%2520b"), matching Oracle's observed behaviour.
  */
 #define UTL_URL_UNRESERVED_CHARS	"-_.!~*'()"
-#define UTL_URL_RESERVED_CHARS		";/?:@&=+$%,#"
+#define UTL_URL_RESERVED_CHARS		";/?:@&=+$,"
 
 static bool utl_url_is_unreserved(unsigned char c);
 static bool utl_url_is_reserved(unsigned char c);


### PR DESCRIPTION
## Summary

- add UTL_URL.UNESCAPE to the ivorysql_ora extension, the decoding half
  of the UTL_URL package: every %XX group becomes the byte it encodes,
  other characters pass through, and the reassembled byte string is
  converted from url_charset to the database encoding, so consecutive
  %XX groups of a multibyte character reassemble into that character
- stacked on top of the UTL_URL.ESCAPE change (#1728); the package is
  only complete with both halves
- note: until #1728 is merged, the diff below also shows the ESCAPE
  commits; it collapses to the UNESCAPE-only change once #1728 lands
- the regression test gains the unescape cases, the double-escape
  decode ("a%2520b" -> "a%20b"), every malformed-sequence error, and
  the round-trip identity UNESCAPE(ESCAPE(x)) = x in both modes

Behaviour verified against real Oracle XE 11.2 and 21 with the same
probe script shared in #1728; the behaviour matches, with deviations
carried over from the ESCAPE change and documented there:

- a NULL url_charset means "database encoding, no conversion" (Oracle
  defaults to utl_http.body_charset / ISO-8859-1)
- %00 is rejected because text cannot contain a NUL byte, where Oracle
  returns a string containing a NUL byte
- a %XX group that does not form a valid character in url_charset
  surfaces as a PostgreSQL encoding error ("invalid byte sequence"),
  not as Oracle's internal UTL_URL error
- charset names use the IANA/PostgreSQL spellings (GBK, LATIN1, ...);
  Oracle-specific spellings such as ZHS16GBK are not recognized, but
  the IANA names are valid on Oracle too

A "%" that is not followed by two hexadecimal digits raises an error,
matching Oracle's UTL_URL.BAD_URL (ORA-29262); an unrecognized charset
is rejected (Oracle reports ORA-01482).

## Testing

- oracle regression suite passes: 25/25 in both a UTF8 and a C locale
- make check: 249/249
- meson build of the full tree: 2728/2728

## Reference

- Oracle UTL_URL documentation:
  https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/UTL_URL.html
- RFC 2396: https://datatracker.ietf.org/doc/html/rfc2396

Fixes #1061


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oracle-compatible `UTL_URL` support.
  * Added URL escaping and unescaping, including reserved-character handling and character-set conversion.
  * Added validation for malformed escape sequences and invalid URL data.
  * Added `DBMS_TRANSACTION` support and `ORA_VSIZE` coverage.

* **Tests**
  * Added comprehensive coverage for null, empty, multibyte, character-set, round-trip, and error scenarios.
  * Added regression coverage using UTF8 databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->