### PR TITLE
Fix volatility of session-dependent functions

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -94,3 +94,15 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+-- Functions that inspect session or wall-clock state must not be immutable.
+select proname, provolatile
+from pg_catalog.pg_proc
+where oid in ('sys.tz_offset(text)'::regprocedure,
+              'sys.uid()'::regprocedure)
+order by proname;
+  proname  | provolatile 
+-----------+-------------
+ tz_offset | s
+ uid       | s
+(2 rows)
+

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -81,3 +81,10 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+
+-- Functions that inspect session or wall-clock state must not be immutable.
+select proname, provolatile
+from pg_catalog.pg_proc
+where oid in ('sys.tz_offset(text)'::regprocedure,
+              'sys.uid()'::regprocedure)
+order by proname;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -677,7 +677,7 @@ AS 'MODULE_PATHNAME', 'ora_tz_offset'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 CREATE FUNCTION sys.months_between(sys.oradate, sys.oradate)
 RETURNS double precision
@@ -1132,7 +1132,7 @@ AS 'MODULE_PATHNAME','uid'
 LANGUAGE C
 STRICT
 PARALLEL SAFE
-IMMUTABLE;
+STABLE;
 
 /*
  * Oracle USERENV support

--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -656,7 +656,7 @@ ora_tz_offset(PG_FUNCTION_ARGS)
 	text	   *txtimezone1 = PG_GETARG_TEXT_PP(0);
 
 	char	   *strtimezone1 = text_to_cstring(txtimezone1);
-	TimestampTz timestamp = GetCurrentTimestamp();
+	TimestampTz timestamp = GetCurrentStatementStartTimestamp();
 
 	/* to get pg_tz struct data of char */
 	if ((timezonedat = ora_make_timezone(&strtimezone1)) == NULL)


### PR DESCRIPTION
## Summary

- mark `sys.uid()` as `STABLE` because it reads the current effective user
- mark `sys.tz_offset(text)` as `STABLE` because its result depends on the statement execution date and time-zone rules
- use the statement start timestamp so `sys.tz_offset(text)` remains stable throughout one statement
- add regression coverage for the functions' `pg_proc.provolatile` metadata

## Testing

- follow-up: `git diff --check`
- follow-up: verified `GetCurrentStatementStartTimestamp()` is declared by the existing `access/xact.h` include
- initial revision: built `src/backend/postgres`, `contrib/ivorysql_ora/ivorysql_ora.dylib`, `initdb`, `pg_ctl`, `psql`, and `pg_regress` with Meson/Ninja
- initial revision: verified the generated `ivorysql_ora--1.0.sql` declares both functions as `STABLE`

The follow-up C change was not rebuilt in the current Windows workspace because its Perl/build harness is unavailable; CI should compile and run the regression suite. The initial full default-target build reached an existing macOS `libpq_check.pl` failure for the `_exit` symbol, while the affected extension target itself built successfully.

## Upgrade note

`ivorysql_ora` currently publishes only extension version `1.0` and has no versioned update path. The SQL volatility correction therefore applies to fresh extension installations; existing installations retain their current catalog metadata until the project introduces an extension upgrade script or the functions are recreated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the volatility classification of `sys.tz_offset(text)` and `sys.uid()` from immutable to stable.
  * Time zone offsets are now calculated using the start time of the current statement for consistent results.

* **Tests**
  * Added regression coverage verifying the functions’ stable classifications and expected catalog metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1754
