### PR TITLE
Fix UTL_FILE.FSEEK invalid offset handling

### DIFF
--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -128,7 +128,7 @@ begin
     raise notice '>>%<<', line;
     utl_file.fflush(f);
     -- data reading after fflush
-    utl_file.fseek(f1); -- reset off_set to 0
+    utl_file.fseek(f1, 0, NULL); -- reset offset to 0
     raise notice 'data read after fflush';
     utl_file.get_line(f1, line);
     line2_pos := utl_file.fgetpos(f1); -- after reading line 1, get position
@@ -169,6 +169,51 @@ NOTICE:  lets print line#2 again
 NOTICE:  >>line 2<<
 NOTICE:  lets print line#2 again via relative seek
 NOTICE:  >>line 2<<
+-- invalid FSEEK offsets must not move the file position
+declare
+    f sys.ora_utl_file_file_type;
+    fexists boolean;
+    file_length number;
+    block_size integer;
+begin
+    utl_file.fgetattr('data_directory', 'regressflush.txt',
+                      fexists, file_length, block_size);
+    f := utl_file.fopen('data_directory', 'regressflush.txt', 'r');
+    begin
+        utl_file.fseek(f);
+    exception
+        when others then
+            raise notice 'null offsets: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+    begin
+        utl_file.fseek(f, -1, NULL);
+    exception
+        when others then
+            raise notice 'negative absolute offset: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+    begin
+        utl_file.fseek(f, file_length + 1, NULL);
+    exception
+        when others then
+            raise notice 'absolute offset past EOF: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+    begin
+        utl_file.fseek(f, NULL, file_length + 1);
+    exception
+        when others then
+            raise notice 'relative offset past EOF: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+    utl_file.fclose(f);
+end;
+/
+NOTICE:  null offsets: INVALID_OFFSET, position: 0
+NOTICE:  negative absolute offset: INVALID_OFFSET, position: 0
+NOTICE:  absolute offset past EOF: INVALID_OFFSET, position: 0
+NOTICE:  relative offset past EOF: INVALID_OFFSET, position: 0
 -- test cases for automatic file closing on session terminated/rollback etc
 declare
     f sys.ora_utl_file_file_type;

--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -207,6 +207,16 @@ begin
             raise notice 'relative offset past EOF: %, position: %', sqlerrm,
                          utl_file.fgetpos(f);
     end;
+    begin
+        utl_file.fseek(f, NULL, -1);
+    exception
+        when others then
+            raise notice 'relative offset before start: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+    utl_file.fseek(f, file_length, NULL);
+    raise notice 'offset at EOF accepted: %',
+                 utl_file.fgetpos(f) = file_length;
     utl_file.fclose(f);
 end;
 /
@@ -214,6 +224,8 @@ NOTICE:  null offsets: INVALID_OFFSET, position: 0
 NOTICE:  negative absolute offset: INVALID_OFFSET, position: 0
 NOTICE:  absolute offset past EOF: INVALID_OFFSET, position: 0
 NOTICE:  relative offset past EOF: INVALID_OFFSET, position: 0
+NOTICE:  relative offset before start: INVALID_OFFSET, position: 0
+NOTICE:  offset at EOF accepted: t
 -- test cases for automatic file closing on session terminated/rollback etc
 declare
     f sys.ora_utl_file_file_type;

--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -174,10 +174,12 @@ declare
     f sys.ora_utl_file_file_type;
     fexists boolean;
     file_length number;
+    seek_offset integer;
     block_size integer;
 begin
     utl_file.fgetattr('data_directory', 'regressflush.txt',
                       fexists, file_length, block_size);
+    seek_offset := file_length;
     f := utl_file.fopen('data_directory', 'regressflush.txt', 'r');
     begin
         utl_file.fseek(f);
@@ -194,29 +196,30 @@ begin
                          utl_file.fgetpos(f);
     end;
     begin
-        utl_file.fseek(f, file_length + 1, NULL);
+        utl_file.fseek(f, seek_offset + 1, NULL);
     exception
         when others then
             raise notice 'absolute offset past EOF: %, position: %', sqlerrm,
                          utl_file.fgetpos(f);
     end;
     begin
-        utl_file.fseek(f, NULL, file_length + 1);
+        utl_file.fseek(f, NULL, seek_offset + 1);
     exception
         when others then
             raise notice 'relative offset past EOF: %, position: %', sqlerrm,
                          utl_file.fgetpos(f);
     end;
+    utl_file.fseek(f, 1, NULL);
     begin
-        utl_file.fseek(f, NULL, -1);
+        utl_file.fseek(f, NULL, -2);
     exception
         when others then
             raise notice 'relative offset before start: %, position: %', sqlerrm,
                          utl_file.fgetpos(f);
     end;
-    utl_file.fseek(f, file_length, NULL);
+    utl_file.fseek(f, seek_offset, NULL);
     raise notice 'offset at EOF accepted: %',
-                 utl_file.fgetpos(f) = file_length;
+                 utl_file.fgetpos(f) = seek_offset;
     utl_file.fclose(f);
 end;
 /
@@ -224,7 +227,7 @@ NOTICE:  null offsets: INVALID_OFFSET, position: 0
 NOTICE:  negative absolute offset: INVALID_OFFSET, position: 0
 NOTICE:  absolute offset past EOF: INVALID_OFFSET, position: 0
 NOTICE:  relative offset past EOF: INVALID_OFFSET, position: 0
-NOTICE:  relative offset before start: INVALID_OFFSET, position: 0
+NOTICE:  relative offset before start: INVALID_OFFSET, position: 1
 NOTICE:  offset at EOF accepted: t
 -- test cases for automatic file closing on session terminated/rollback etc
 declare

--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -229,6 +229,18 @@ NOTICE:  absolute offset past EOF: INVALID_OFFSET, position: 0
 NOTICE:  relative offset past EOF: INVALID_OFFSET, position: 0
 NOTICE:  relative offset before start: INVALID_OFFSET, position: 1
 NOTICE:  offset at EOF accepted: t
+-- FSEEK on a write handle must see data that is still buffered
+declare
+    f sys.ora_utl_file_file_type;
+begin
+    f := utl_file.fopen('data_directory', 'regressseek.txt', 'w');
+    utl_file.put_line(f, 'abc');   -- 4 bytes, still in the stdio buffer
+    utl_file.fseek(f, 2, NULL);
+    raise notice 'buffered write seek position: %', utl_file.fgetpos(f);
+    utl_file.fclose(f);
+end;
+/
+NOTICE:  buffered write seek position: 2
 -- test cases for automatic file closing on session terminated/rollback etc
 declare
     f sys.ora_utl_file_file_type;

--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -235,11 +235,14 @@ declare
 begin
     f := utl_file.fopen('data_directory', 'regressseek.txt', 'w');
     utl_file.put_line(f, 'abc');   -- 4 bytes, still in the stdio buffer
+    utl_file.fseek(f, NULL, -2);
+    raise notice 'buffered relative seek position: %', utl_file.fgetpos(f);
     utl_file.fseek(f, 2, NULL);
     raise notice 'buffered write seek position: %', utl_file.fgetpos(f);
     utl_file.fclose(f);
 end;
 /
+NOTICE:  buffered relative seek position: 2
 NOTICE:  buffered write seek position: 2
 -- test cases for automatic file closing on session terminated/rollback etc
 declare

--- a/contrib/ivorysql_ora/sql/utl_file.sql
+++ b/contrib/ivorysql_ora/sql/utl_file.sql
@@ -119,7 +119,7 @@ begin
     utl_file.fflush(f);
 
     -- data reading after fflush
-    utl_file.fseek(f1); -- reset off_set to 0
+    utl_file.fseek(f1, 0, NULL); -- reset offset to 0
     raise notice 'data read after fflush';
     utl_file.get_line(f1, line);
     line2_pos := utl_file.fgetpos(f1); -- after reading line 1, get position
@@ -147,6 +147,53 @@ begin
             utl_file.fclose_all();
             raise notice 'is_open(f) = %', utl_file.is_open(f);
             raise notice 'is_open(f1) = %', utl_file.is_open(f1);
+end;
+/
+
+-- invalid FSEEK offsets must not move the file position
+declare
+    f sys.ora_utl_file_file_type;
+    fexists boolean;
+    file_length number;
+    block_size integer;
+begin
+    utl_file.fgetattr('data_directory', 'regressflush.txt',
+                      fexists, file_length, block_size);
+    f := utl_file.fopen('data_directory', 'regressflush.txt', 'r');
+
+    begin
+        utl_file.fseek(f);
+    exception
+        when others then
+            raise notice 'null offsets: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+
+    begin
+        utl_file.fseek(f, -1, NULL);
+    exception
+        when others then
+            raise notice 'negative absolute offset: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+
+    begin
+        utl_file.fseek(f, file_length + 1, NULL);
+    exception
+        when others then
+            raise notice 'absolute offset past EOF: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+
+    begin
+        utl_file.fseek(f, NULL, file_length + 1);
+    exception
+        when others then
+            raise notice 'relative offset past EOF: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+
+    utl_file.fclose(f);
 end;
 /
 

--- a/contrib/ivorysql_ora/sql/utl_file.sql
+++ b/contrib/ivorysql_ora/sql/utl_file.sql
@@ -193,6 +193,18 @@ begin
                          utl_file.fgetpos(f);
     end;
 
+    begin
+        utl_file.fseek(f, NULL, -1);
+    exception
+        when others then
+            raise notice 'relative offset before start: %, position: %', sqlerrm,
+                         utl_file.fgetpos(f);
+    end;
+
+    utl_file.fseek(f, file_length, NULL);
+    raise notice 'offset at EOF accepted: %',
+                 utl_file.fgetpos(f) = file_length;
+
     utl_file.fclose(f);
 end;
 /

--- a/contrib/ivorysql_ora/sql/utl_file.sql
+++ b/contrib/ivorysql_ora/sql/utl_file.sql
@@ -155,10 +155,12 @@ declare
     f sys.ora_utl_file_file_type;
     fexists boolean;
     file_length number;
+    seek_offset integer;
     block_size integer;
 begin
     utl_file.fgetattr('data_directory', 'regressflush.txt',
                       fexists, file_length, block_size);
+    seek_offset := file_length;
     f := utl_file.fopen('data_directory', 'regressflush.txt', 'r');
 
     begin
@@ -178,7 +180,7 @@ begin
     end;
 
     begin
-        utl_file.fseek(f, file_length + 1, NULL);
+        utl_file.fseek(f, seek_offset + 1, NULL);
     exception
         when others then
             raise notice 'absolute offset past EOF: %, position: %', sqlerrm,
@@ -186,24 +188,25 @@ begin
     end;
 
     begin
-        utl_file.fseek(f, NULL, file_length + 1);
+        utl_file.fseek(f, NULL, seek_offset + 1);
     exception
         when others then
             raise notice 'relative offset past EOF: %, position: %', sqlerrm,
                          utl_file.fgetpos(f);
     end;
 
+    utl_file.fseek(f, 1, NULL);
     begin
-        utl_file.fseek(f, NULL, -1);
+        utl_file.fseek(f, NULL, -2);
     exception
         when others then
             raise notice 'relative offset before start: %, position: %', sqlerrm,
                          utl_file.fgetpos(f);
     end;
 
-    utl_file.fseek(f, file_length, NULL);
+    utl_file.fseek(f, seek_offset, NULL);
     raise notice 'offset at EOF accepted: %',
-                 utl_file.fgetpos(f) = file_length;
+                 utl_file.fgetpos(f) = seek_offset;
 
     utl_file.fclose(f);
 end;

--- a/contrib/ivorysql_ora/sql/utl_file.sql
+++ b/contrib/ivorysql_ora/sql/utl_file.sql
@@ -212,6 +212,18 @@ begin
 end;
 /
 
+-- FSEEK on a write handle must see data that is still buffered
+declare
+    f sys.ora_utl_file_file_type;
+begin
+    f := utl_file.fopen('data_directory', 'regressseek.txt', 'w');
+    utl_file.put_line(f, 'abc');   -- 4 bytes, still in the stdio buffer
+    utl_file.fseek(f, 2, NULL);
+    raise notice 'buffered write seek position: %', utl_file.fgetpos(f);
+    utl_file.fclose(f);
+end;
+/
+
 -- test cases for automatic file closing on session terminated/rollback etc
 declare
     f sys.ora_utl_file_file_type;

--- a/contrib/ivorysql_ora/sql/utl_file.sql
+++ b/contrib/ivorysql_ora/sql/utl_file.sql
@@ -218,6 +218,8 @@ declare
 begin
     f := utl_file.fopen('data_directory', 'regressseek.txt', 'w');
     utl_file.put_line(f, 'abc');   -- 4 bytes, still in the stdio buffer
+    utl_file.fseek(f, NULL, -2);
+    raise notice 'buffered relative seek position: %', utl_file.fgetpos(f);
     utl_file.fseek(f, 2, NULL);
     raise notice 'buffered write seek position: %', utl_file.fgetpos(f);
     utl_file.fclose(f);

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_file/utl_file.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_file/utl_file.c
@@ -677,32 +677,44 @@ ora_utl_file_frename(PG_FUNCTION_ARGS)
 Datum
 ora_utl_file_fseek(PG_FUNCTION_ARGS)
 {
-	FILE   *fd;
+	FILE	   *fd;
+	bool		absolute_specified;
+	bool		relative_specified;
+	long		current_offset;
+	int64		target_offset;
+	struct stat statbuf;
+
 	CHECK_FILE_HANDLE();
 	fd = get_file_handle_from_slot(PG_GETARG_UINT32(0), NULL, NULL);
-	if(fd == NULL)
+	if (fd == NULL)
 		INVALID_FILEHANDLE_EXCEPTION();
-	if (PG_NARGS() > 1 && !PG_ARGISNULL(1))
+
+	absolute_specified = PG_NARGS() > 1 && !PG_ARGISNULL(1);
+	relative_specified = PG_NARGS() > 2 && !PG_ARGISNULL(2);
+	if (!absolute_specified && !relative_specified)
+		CUSTOM_EXCEPTION(INVALID_OFFSET,
+						 "Absolute and relative offsets cannot both be NULL.");
+
+	current_offset = ftell(fd);
+	if (current_offset < 0 || fstat(fileno(fd), &statbuf) != 0)
+		IO_EXCEPTION();
+
+	if (absolute_specified)
 	{
-		/* absolute_offset: seek from beginning */
-		long abs_offset = (long) PG_GETARG_INT32(1);
-		rewind(fd); /* first, reset pos to beginning */
-		if (fseek(fd, abs_offset, SEEK_SET) != 0)
-			CUSTOM_EXCEPTION(INVALID_OFFSET, "Provided absolute offsets are invalid.");
-	}
-	else if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
-	{
-		/* relative_offset: seek from current position */
-		long rel_offset = (long) PG_GETARG_INT32(2);
-		if (fseek(fd, rel_offset, SEEK_CUR) != 0)
-			CUSTOM_EXCEPTION(INVALID_OFFSET, "Provided relative offsets are invalid.");
+		target_offset = PG_GETARG_INT32(1);
 	}
 	else
 	{
-		/* no offset provided: no-op or reset to beginning */
-		if (fseek(fd, 0, SEEK_SET) != 0)
-			CUSTOM_EXCEPTION(INVALID_OFFSET, "Provided offsets are invalid.");
+		target_offset = (int64) current_offset + PG_GETARG_INT32(2);
 	}
+
+	if (target_offset < 0 || target_offset > statbuf.st_size ||
+		target_offset > LONG_MAX)
+		CUSTOM_EXCEPTION(INVALID_OFFSET, "Provided offset is outside the file.");
+
+	if (fseek(fd, (long) target_offset, SEEK_SET) != 0)
+		CUSTOM_EXCEPTION(INVALID_OFFSET, "Provided offset is invalid.");
+
 	PG_RETURN_VOID();
 }
 

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_file/utl_file.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_file/utl_file.c
@@ -682,7 +682,7 @@ ora_utl_file_fseek(PG_FUNCTION_ARGS)
 	bool		relative_specified;
 	long		current_offset;
 	int64		target_offset;
-	struct stat statbuf;
+	long		file_size;
 
 	CHECK_FILE_HANDLE();
 	fd = get_file_handle_from_slot(PG_GETARG_UINT32(0), NULL, NULL);
@@ -696,7 +696,21 @@ ora_utl_file_fseek(PG_FUNCTION_ARGS)
 						 "Absolute and relative offsets cannot both be NULL.");
 
 	current_offset = ftell(fd);
-	if (current_offset < 0 || fstat(fileno(fd), &statbuf) != 0)
+	if (current_offset < 0)
+		IO_EXCEPTION();
+
+	/*
+	 * fstat() reports only the size already on disk; buffered writes are
+	 * not included.  Flush the stream and measure the logical end of the
+	 * file, then restore the original position before validating the seek.
+	 */
+	do_flush(fd);
+	if (fseek(fd, 0, SEEK_END) != 0)
+		IO_EXCEPTION();
+	file_size = ftell(fd);
+	if (file_size < 0)
+		IO_EXCEPTION();
+	if (fseek(fd, current_offset, SEEK_SET) != 0)
 		IO_EXCEPTION();
 
 	if (absolute_specified)
@@ -708,7 +722,7 @@ ora_utl_file_fseek(PG_FUNCTION_ARGS)
 		target_offset = (int64) current_offset + PG_GETARG_INT32(2);
 	}
 
-	if (target_offset < 0 || target_offset > statbuf.st_size ||
+	if (target_offset < 0 || target_offset > file_size ||
 		target_offset > LONG_MAX)
 		CUSTOM_EXCEPTION(INVALID_OFFSET, "Provided offset is outside the file.");
 


### PR DESCRIPTION
## Summary

- reject calls where both FSEEK offsets are null
- reject negative and past-EOF target positions before moving the stream
- preserve valid absolute and relative seeks and cover invalid cases in the UTL_FILE regression test

The existing no-argument regression call now uses an explicit absolute offset of zero, matching Oracle's documented FSEEK contract.

Fixes #1755

## Validation

- `git diff --check`
- regression expectations added for null, negative, absolute past-EOF, and relative past-EOF offsets

The full IvorySQL regression suite was not run locally because the required Linux build environment is unavailable; the submitted CI workflows provide that coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file seeking with explicit absolute and relative offsets.
  * Invalid offsets now raise an appropriate error without changing the current file position.
  * Seeking exactly to the end of a file is now supported.
  * Prevented unintended resets to the beginning when no valid offset is provided.
  * Seeking on a write handle now accounts for buffered data.

* **Tests**
  * Expanded coverage for invalid and buffered-data seeking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->