### PR TITLE
meson: install IvorySQL libpq public headers

### DIFF
--- a/src/interfaces/libpq/meson.build
+++ b/src/interfaces/libpq/meson.build
@@ -150,7 +150,9 @@ pkgconfig.generate(
 
 install_headers(
   'libpq-fe.h',
+  'libpq-ivy.h',
   'libpq-events.h',
+  'ivy_sema.h',
 )
 
 install_headers(


### PR DESCRIPTION
## Summary

Meson installations currently omit the IvorySQL-specific public libpq headers even though the Makefile installation provides them. Add `libpq-ivy.h` and `ivy_sema.h` to the public Meson header install list so applications receive the same client API from either build system.

Fixes #1756

## Validation

- `git diff --check`
- verified the Meson public header list now contains `libpq-fe.h`, `libpq-events.h`, `libpq-ivy.h`, and `ivy_sema.h`

A local Meson install was not run because Meson is unavailable in this environment; the project CI will validate the build definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two additional public headers to the libpq installation, expanding the available client development interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->