### PR TITLE
fix(ivorysql_ora): return IEEE results from binary float arithmetic

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_binary_double.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_double.out
@@ -399,7 +399,16 @@ UPDATE BINARY_DOUBLE_TBL
    SET f1 = BINARY_DOUBLE_TBL.f1 * '-1'
    WHERE BINARY_DOUBLE_TBL.f1 > '0.0';
 SELECT '' AS bad, f.f1 * '1e200' from BINARY_DOUBLE_TBL f;
-ERROR:  value out of range: overflow
+ bad |     ?column?     
+-----+------------------
+     | 0
+     | -3.484e+201
+     | 
+     | -1.0043e+203
+     | -Inf
+     | -1.2345678901234
+(6 rows)
+
 SELECT '' AS bad, f.f1 ^ '1e200' from BINARY_DOUBLE_TBL f;
 ERROR:  value out of range: overflow
 SELECT 0 ^ 0 + 0 ^ 1 + 0 ^ 0.0 + 0 ^ 0.5;
@@ -415,7 +424,16 @@ ERROR:  cannot take logarithm of a negative number
 SELECT '' AS bad, exp(f.f1) from BINARY_DOUBLE_TBL f;
 ERROR:  value out of range: underflow
 SELECT '' AS bad, f.f1 / '0.0' from BINARY_DOUBLE_TBL f;
-ERROR:  division by zero
+ bad | ?column? 
+-----+----------
+     | Nan
+     | -Inf
+     | 
+     | -Inf
+     | -Inf
+     | -Inf
+(6 rows)
+
 SELECT '' AS five, * FROM BINARY_DOUBLE_TBL;
  five |          f1           
 ------+-----------------------
@@ -677,5 +695,89 @@ SELECT to_binary_double(42::sys.binary_float);
  to_binary_double 
 ------------------
  42
+(1 row)
+
+--
+-- IEEE 754 exception semantics
+--
+-- Oracle returns Infinity, zero or NaN where PostgreSQL raises. Expected
+-- values measured against Oracle Database 21c Express Edition.
+--
+-- overflow
+SELECT 1e308d * 10;
+ ?column? 
+----------
+ Inf
+(1 row)
+
+SELECT 1e308d + 1e308d;
+ ?column? 
+----------
+ Inf
+(1 row)
+
+-- underflow
+SELECT 1e-320d / 1e10;
+ ?column? 
+----------
+ 0
+(1 row)
+
+SELECT 1e308d * 0;
+ ?column? 
+----------
+ 0
+(1 row)
+
+-- Underflow of a negative value, and underflow via multiplication. The first
+-- would be -0 under pure IEEE; Oracle keeps a single zero, so both are 0.
+SELECT (0d - 1e-320d) / 1e10;
+ ?column? 
+----------
+ 0
+(1 row)
+
+SELECT 1e-200d * 1e-200d;
+ ?column? 
+----------
+ 0
+(1 row)
+
+-- division by zero
+SELECT 1d / 0d;
+ ?column? 
+----------
+ Inf
+(1 row)
+
+SELECT (0d - 1d) / 0d;
+ ?column? 
+----------
+ -Inf
+(1 row)
+
+SELECT 0d / 0d;
+ ?column? 
+----------
+ Nan
+(1 row)
+
+-- ordinary arithmetic, unaffected
+SELECT 2d * 3d;
+ ?column? 
+----------
+ 6
+(1 row)
+
+SELECT 7d / 2d;
+ ?column? 
+----------
+ 3.5
+(1 row)
+
+SELECT (0d - 1e308d) * 10;
+ ?column? 
+----------
+ -Inf
 (1 row)
 

--- a/contrib/ivorysql_ora/expected/ora_binary_float.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_float.out
@@ -234,7 +234,20 @@ SELECT '' AS three, f.f1, f.f1 - '-10' AS x FROM BINARY_FLOAT_TBL f
 
 -- test divide by zero
 SELECT '' AS bad, f.f1 / '0.0' from BINARY_FLOAT_TBL f;
-ERROR:  division by zero
+ bad | ?column? 
+-----+----------
+     | Nan
+     | Inf
+     | -Inf
+     | Inf
+     | Inf
+     | Inf
+     | -Inf
+     | Nan
+     | Nan
+     | 
+(10 rows)
+
 SELECT '' AS five, * FROM BINARY_FLOAT_TBL;
  five |     f1      
 ------+-------------
@@ -557,5 +570,136 @@ SELECT to_binary_float(42::sys.binary_double);
  to_binary_float 
 -----------------
  42
+(1 row)
+
+--
+-- IEEE 754 exception semantics
+--
+-- See ora_binary_double.sql. Expected values measured against Oracle
+-- Database 21c Express Edition.
+--
+-- overflow and underflow
+SELECT 3.4e38f * 10;
+ ?column? 
+----------
+ Inf
+(1 row)
+
+SELECT 1e-45f / 1e10;
+ ?column? 
+----------
+ 0
+(1 row)
+
+-- Underflow of a negative value, and underflow via multiplication. The first
+-- would be -0 under pure IEEE; Oracle keeps a single zero, so both are 0
+-- (measured: dividing one by each result yields Inf, never -Inf).
+SELECT (0f - 1e-45f) / 1e10;
+ ?column? 
+----------
+ 0
+(1 row)
+
+SELECT 1e-20f * 1e-30f;
+ ?column? 
+----------
+ 0
+(1 row)
+
+-- division by zero
+SELECT 1f / 0f;
+ ?column? 
+----------
+ Inf
+(1 row)
+
+SELECT 0f / 0f;
+ ?column? 
+----------
+ Nan
+(1 row)
+
+-- Signed results. The sign of an operand has to survive into the exception
+-- value: a rule that returned +Inf for these would still pass every case
+-- above. Written as a subtraction from zero rather than as unary minus,
+-- which resolves to float8 on these types and would take the expression out
+-- of binary_float arithmetic altogether.
+SELECT (0f - 3.4e38f) * 10;
+ ?column? 
+----------
+ -Inf
+(1 row)
+
+SELECT (0f - 3.4e38f) - 3.4e38f;
+ ?column? 
+----------
+ -Inf
+(1 row)
+
+SELECT (0f - 1f) / 0f;
+ ?column? 
+----------
+ -Inf
+(1 row)
+
+-- ordinary arithmetic, and mixed precision promoting to binary_double
+SELECT 1.5f + 2.5f;
+ ?column? 
+----------
+ 4
+(1 row)
+
+SELECT 1f + 1d;
+ ?column? 
+----------
+ 2
+(1 row)
+
+-- Mixed precision in both operand orders. BINARY_DOUBLE outranks BINARY_FLOAT,
+-- so every combination yields binary_double; the operand order matters because
+-- each direction is a separate operator.
+SELECT pg_typeof(1f + 1d), pg_typeof(1d + 1f);
+   pg_typeof   |   pg_typeof   
+---------------+---------------
+ binary_double | binary_double
+(1 row)
+
+SELECT pg_typeof(1f - 1d), pg_typeof(1d - 1f);
+   pg_typeof   |   pg_typeof   
+---------------+---------------
+ binary_double | binary_double
+(1 row)
+
+SELECT pg_typeof(1f * 1d), pg_typeof(1d * 1f);
+   pg_typeof   |   pg_typeof   
+---------------+---------------
+ binary_double | binary_double
+(1 row)
+
+SELECT pg_typeof(1f / 1d), pg_typeof(1d / 1f);
+   pg_typeof   |   pg_typeof   
+---------------+---------------
+ binary_double | binary_double
+(1 row)
+
+-- The result must also keep binary_double range and precision, not merely be
+-- labelled with the type. A binary_float result would overflow the first two,
+-- and would round the third to exactly 1.
+SELECT 3.4e38f * 10d;
+       ?column?       
+----------------------
+ 3.39999995214436e+39
+(1 row)
+
+SELECT 10d * 3.4e38f;
+       ?column?       
+----------------------
+ 3.39999995214436e+39
+(1 row)
+
+SELECT 1f + 1e-10d;
+   ?column?   
+--------------
+ 1.0000000001
 (1 row)
 

--- a/contrib/ivorysql_ora/sql/ora_binary_double.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_double.sql
@@ -122,7 +122,6 @@ SELECT ||/ binary_double '27' AS three;
 
 SELECT '' AS five, f.f1, ||/f.f1 AS cbrt_f1 FROM BINARY_DOUBLE_TBL f;
 
-
 SELECT '' AS five, * FROM BINARY_DOUBLE_TBL;
 
 UPDATE BINARY_DOUBLE_TBL
@@ -250,4 +249,33 @@ SELECT to_binary_double('-inf');
 SELECT to_binary_double(42::numeric);
 SELECT to_binary_double(42::sys.binary_double);
 SELECT to_binary_double(42::sys.binary_float);
+--
+-- IEEE 754 exception semantics
+--
+-- Oracle returns Infinity, zero or NaN where PostgreSQL raises. Expected
+-- values measured against Oracle Database 21c Express Edition.
+--
+
+-- overflow
+SELECT 1e308d * 10;
+SELECT 1e308d + 1e308d;
+
+-- underflow
+SELECT 1e-320d / 1e10;
+SELECT 1e308d * 0;
+
+-- Underflow of a negative value, and underflow via multiplication. The first
+-- would be -0 under pure IEEE; Oracle keeps a single zero, so both are 0.
+SELECT (0d - 1e-320d) / 1e10;
+SELECT 1e-200d * 1e-200d;
+
+-- division by zero
+SELECT 1d / 0d;
+SELECT (0d - 1d) / 0d;
+SELECT 0d / 0d;
+
+-- ordinary arithmetic, unaffected
+SELECT 2d * 3d;
+SELECT 7d / 2d;
+SELECT (0d - 1e308d) * 10;
 

--- a/contrib/ivorysql_ora/sql/ora_binary_float.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_float.sql
@@ -89,7 +89,6 @@ SELECT '' AS five, * FROM BINARY_FLOAT_TBL;
 -- drop table
 DROP TABLE BINARY_FLOAT_TBL;
 
-
 --SIMPLE_FLOAT
 CREATE TABLE SIMPLE_FLOAT_TBL (f1 binary_float);
 
@@ -192,3 +191,52 @@ SELECT to_binary_float('-inf');
 SELECT to_binary_float(42::numeric);
 SELECT to_binary_float(42::sys.binary_float);
 SELECT to_binary_float(42::sys.binary_double);
+--
+-- IEEE 754 exception semantics
+--
+-- See ora_binary_double.sql. Expected values measured against Oracle
+-- Database 21c Express Edition.
+--
+
+-- overflow and underflow
+SELECT 3.4e38f * 10;
+SELECT 1e-45f / 1e10;
+
+-- Underflow of a negative value, and underflow via multiplication. The first
+-- would be -0 under pure IEEE; Oracle keeps a single zero, so both are 0
+-- (measured: dividing one by each result yields Inf, never -Inf).
+SELECT (0f - 1e-45f) / 1e10;
+SELECT 1e-20f * 1e-30f;
+
+-- division by zero
+SELECT 1f / 0f;
+SELECT 0f / 0f;
+
+-- Signed results. The sign of an operand has to survive into the exception
+-- value: a rule that returned +Inf for these would still pass every case
+-- above. Written as a subtraction from zero rather than as unary minus,
+-- which resolves to float8 on these types and would take the expression out
+-- of binary_float arithmetic altogether.
+SELECT (0f - 3.4e38f) * 10;
+SELECT (0f - 3.4e38f) - 3.4e38f;
+SELECT (0f - 1f) / 0f;
+
+-- ordinary arithmetic, and mixed precision promoting to binary_double
+SELECT 1.5f + 2.5f;
+SELECT 1f + 1d;
+
+-- Mixed precision in both operand orders. BINARY_DOUBLE outranks BINARY_FLOAT,
+-- so every combination yields binary_double; the operand order matters because
+-- each direction is a separate operator.
+SELECT pg_typeof(1f + 1d), pg_typeof(1d + 1f);
+SELECT pg_typeof(1f - 1d), pg_typeof(1d - 1f);
+SELECT pg_typeof(1f * 1d), pg_typeof(1d * 1f);
+SELECT pg_typeof(1f / 1d), pg_typeof(1d / 1f);
+
+-- The result must also keep binary_double range and precision, not merely be
+-- labelled with the type. A binary_float result would overflow the first two,
+-- and would round the third to exactly 1.
+SELECT 3.4e38f * 10d;
+SELECT 10d * 3.4e38f;
+SELECT 1f + 1e-10d;
+

--- a/contrib/ivorysql_ora/src/datatype/binary_double.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_double.c
@@ -329,3 +329,125 @@ binary_double_send(PG_FUNCTION_ARGS)
 	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
 }
 
+
+/* ---------------------------------------------------------------------------
+ * Oracle BINARY_DOUBLE arithmetic
+ *
+ * See the corresponding comment in binary_float.c.  BINARY_DOUBLE is IEEE 754
+ * binary64 and honours IEEE exception semantics, where PostgreSQL's core
+ * float8 operators deliberately raise instead.
+ *
+ * Measured against Oracle Database 21c Express Edition:
+ *
+ *		1e308d * 10		-> inf		PostgreSQL: ERROR 22003 overflow
+ *		1e-320d / 1e10	-> 0		PostgreSQL: ERROR 22003 underflow
+ *		1d / 0d			-> inf		PostgreSQL: ERROR 22012 division by zero
+ *		-1d / 0d		-> -inf
+ *		0d / 0d			-> nan
+ *		(0d - 1e-320d) / 1e10	-> 0	a positive zero: Oracle keeps no -0
+ *		1e-200d * 1e-200d	-> 0
+ *
+ * The mixed-precision variants promote to binary64 before operating, matching
+ * Oracle's numeric conversion precedence: BINARY_DOUBLE outranks BINARY_FLOAT.
+ * ------------------------------------------------------------------------- */
+
+/*
+ * Zero-sign normalisation, as in binary_float.c: Oracle keeps a single zero,
+ * so an arithmetic result of -0 becomes +0.
+ */
+static inline float8
+ora_binary_double_result(float8 result)
+{
+	if (result == 0.0)
+		result = 0.0;
+	return result;
+}
+
+PG_FUNCTION_INFO_V1(ora_binary_double_pl);
+PG_FUNCTION_INFO_V1(ora_binary_double_mi);
+PG_FUNCTION_INFO_V1(ora_binary_double_mul);
+PG_FUNCTION_INFO_V1(ora_binary_double_div);
+PG_FUNCTION_INFO_V1(ora_binary_float_double_pl);
+PG_FUNCTION_INFO_V1(ora_binary_float_double_mi);
+PG_FUNCTION_INFO_V1(ora_binary_float_double_mul);
+PG_FUNCTION_INFO_V1(ora_binary_float_double_div);
+PG_FUNCTION_INFO_V1(ora_binary_double_float_pl);
+PG_FUNCTION_INFO_V1(ora_binary_double_float_mi);
+PG_FUNCTION_INFO_V1(ora_binary_double_float_mul);
+PG_FUNCTION_INFO_V1(ora_binary_double_float_div);
+
+Datum
+ora_binary_double_pl(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) + PG_GETARG_FLOAT8(1)));
+}
+
+Datum
+ora_binary_double_mi(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) - PG_GETARG_FLOAT8(1)));
+}
+
+Datum
+ora_binary_double_mul(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) * PG_GETARG_FLOAT8(1)));
+}
+
+Datum
+ora_binary_double_div(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) / PG_GETARG_FLOAT8(1)));
+}
+
+/* binary_float OP binary_double -> binary_double */
+
+Datum
+ora_binary_float_double_pl(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result((float8) PG_GETARG_FLOAT4(0) + PG_GETARG_FLOAT8(1)));
+}
+
+Datum
+ora_binary_float_double_mi(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result((float8) PG_GETARG_FLOAT4(0) - PG_GETARG_FLOAT8(1)));
+}
+
+Datum
+ora_binary_float_double_mul(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result((float8) PG_GETARG_FLOAT4(0) * PG_GETARG_FLOAT8(1)));
+}
+
+Datum
+ora_binary_float_double_div(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result((float8) PG_GETARG_FLOAT4(0) / PG_GETARG_FLOAT8(1)));
+}
+
+/* binary_double OP binary_float -> binary_double */
+
+Datum
+ora_binary_double_float_pl(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) + (float8) PG_GETARG_FLOAT4(1)));
+}
+
+Datum
+ora_binary_double_float_mi(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) - (float8) PG_GETARG_FLOAT4(1)));
+}
+
+Datum
+ora_binary_double_float_mul(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) * (float8) PG_GETARG_FLOAT4(1)));
+}
+
+Datum
+ora_binary_double_float_div(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT8(ora_binary_double_result(PG_GETARG_FLOAT8(0) / (float8) PG_GETARG_FLOAT4(1)));
+}

--- a/contrib/ivorysql_ora/src/datatype/binary_float.c
+++ b/contrib/ivorysql_ora/src/datatype/binary_float.c
@@ -670,3 +670,69 @@ number_binary_double(PG_FUNCTION_ARGS)
 
 	PG_RETURN_DATUM(result);
 }
+
+/* ---------------------------------------------------------------------------
+ * Oracle BINARY_FLOAT arithmetic
+ *
+ * Oracle's BINARY_FLOAT is IEEE 754 binary32 and honours IEEE exception
+ * semantics.  PostgreSQL's float4_pl() and friends deliberately diverge from
+ * IEEE -- they raise rather than produce Infinity or zero -- so the core
+ * float4pl/mi/mul/div functions cannot be reused for this type.
+ *
+ * Measured against Oracle Database 21c Express Edition:
+ *
+ *		3.4e38f * 10	-> inf		PostgreSQL: ERROR 22003 overflow
+ *		1e-45f / 1e10	-> 0		PostgreSQL: ERROR 22003 underflow
+ *		1f / 0f			-> inf		PostgreSQL: ERROR 22012 division by zero
+ *		0f / 0f			-> nan		PostgreSQL: ERROR 22012 division by zero
+ *
+ * These wrappers return the IEEE result directly, except that a zero result
+ * always carries a positive sign, because Oracle keeps a single zero (see
+ * ora_binary_float_result below).  The functions are declared STRICT in SQL,
+ * so NULL operands never reach here.
+ * ------------------------------------------------------------------------- */
+
+/*
+ * Oracle keeps a single zero.  IEEE 754 produces -0 from the underflow of a
+ * negative value and from multiplying zero by a negative, but Oracle returns
+ * +0 for every such case -- measured on 21c by dividing one by the result,
+ * which yields Inf, never -Inf.  Normalise the sign so the exception values
+ * match Oracle exactly.  This is the one place these wrappers depart from
+ * IEEE, and they depart to follow Oracle.
+ */
+static inline float4
+ora_binary_float_result(float4 result)
+{
+	if (result == 0.0f)
+		result = 0.0f;
+	return result;
+}
+
+PG_FUNCTION_INFO_V1(ora_binary_float_pl);
+PG_FUNCTION_INFO_V1(ora_binary_float_mi);
+PG_FUNCTION_INFO_V1(ora_binary_float_mul);
+PG_FUNCTION_INFO_V1(ora_binary_float_div);
+
+Datum
+ora_binary_float_pl(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT4(ora_binary_float_result(PG_GETARG_FLOAT4(0) + PG_GETARG_FLOAT4(1)));
+}
+
+Datum
+ora_binary_float_mi(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT4(ora_binary_float_result(PG_GETARG_FLOAT4(0) - PG_GETARG_FLOAT4(1)));
+}
+
+Datum
+ora_binary_float_mul(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT4(ora_binary_float_result(PG_GETARG_FLOAT4(0) * PG_GETARG_FLOAT4(1)));
+}
+
+Datum
+ora_binary_float_div(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_FLOAT4(ora_binary_float_result(PG_GETARG_FLOAT4(0) / PG_GETARG_FLOAT4(1)));
+}

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -9326,8 +9326,8 @@ CREATE OPERATOR <= (
 
 CREATE FUNCTION sys.binary_float_pl(sys.binary_float, sys.binary_float)
 RETURNS sys.binary_float
-AS 'float4pl'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_pl'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9341,8 +9341,8 @@ CREATE OPERATOR + (
 
 CREATE FUNCTION sys.binary_float_mi(sys.binary_float, sys.binary_float)
 RETURNS sys.binary_float
-AS 'float4mi'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_mi'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9355,8 +9355,8 @@ CREATE OPERATOR - (
 
 CREATE FUNCTION sys.binary_float_mul(sys.binary_float, sys.binary_float)
 RETURNS sys.binary_float
-AS 'float4mul'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_mul'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9370,8 +9370,8 @@ CREATE OPERATOR * (
 
 CREATE FUNCTION sys.binary_float_div(sys.binary_float, sys.binary_float)
 RETURNS sys.binary_float
-AS 'float4div'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_div'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9742,8 +9742,8 @@ CREATE OPERATOR <= (
 
 CREATE FUNCTION sys.binary_double_pl(sys.binary_double, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float8pl'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_pl'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9757,8 +9757,8 @@ CREATE OPERATOR + (
 
 CREATE FUNCTION sys.binary_double_mi(sys.binary_double, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float8mi'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_mi'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9771,8 +9771,8 @@ CREATE OPERATOR - (
 
 CREATE FUNCTION sys.binary_double_mul(sys.binary_double, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float8mul'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_mul'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9786,8 +9786,8 @@ CREATE OPERATOR * (
 
 CREATE FUNCTION sys.binary_double_div(sys.binary_double, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float8div'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_div'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9927,8 +9927,8 @@ CREATE OPERATOR <= (
 
 CREATE FUNCTION sys.binary_float_pl_binary_double(sys.binary_float, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float48pl'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_double_pl'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9942,8 +9942,8 @@ CREATE OPERATOR + (
 
 CREATE FUNCTION sys.binary_float_mi_binary_double(sys.binary_float, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float48mi'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_double_mi'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9956,8 +9956,8 @@ CREATE OPERATOR - (
 
 CREATE FUNCTION sys.binary_float_mul_binary_double(sys.binary_float, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float48mul'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_double_mul'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -9971,8 +9971,8 @@ CREATE OPERATOR * (
 
 CREATE FUNCTION sys.binary_float_div_binary_double(sys.binary_float, sys.binary_double)
 RETURNS sys.binary_double
-AS 'float48div'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_float_double_div'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -10099,8 +10099,8 @@ CREATE OPERATOR <= (
 
 CREATE FUNCTION sys.binary_double_pl_binary_float(sys.binary_double, sys.binary_float)
 RETURNS sys.binary_double
-AS 'float84pl'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_float_pl'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -10114,8 +10114,8 @@ CREATE OPERATOR + (
 
 CREATE FUNCTION sys.binary_double_mi_binary_float(sys.binary_double, sys.binary_float)
 RETURNS sys.binary_double
-AS 'float84mi'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_float_mi'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -10128,8 +10128,8 @@ CREATE OPERATOR - (
 
 CREATE FUNCTION sys.binary_double_mul_binary_float(sys.binary_double, sys.binary_float)
 RETURNS sys.binary_double
-AS 'float84mul'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_float_mul'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;
@@ -10143,8 +10143,8 @@ CREATE OPERATOR * (
 
 CREATE FUNCTION sys.binary_double_div_binary_float(sys.binary_double, sys.binary_float)
 RETURNS sys.binary_double
-AS 'float84div'
-LANGUAGE internal
+AS 'MODULE_PATHNAME', 'ora_binary_double_float_div'
+LANGUAGE C
 PARALLEL SAFE
 STRICT
 IMMUTABLE;


### PR DESCRIPTION
## Summary

Arithmetic on `BINARY_FLOAT` and `BINARY_DOUBLE` raises on overflow, underflow and division by zero. Oracle returns `Inf`, `0` and `NaN` for those cases — both types are documented as IEEE 754 binary32 and binary64.

This adds arithmetic functions to the extension that return the IEEE result, and rebinds the sixteen operators to them.

Fixes #1737

## Root cause

The operators were bound to PostgreSQL's internal float functions — `float4mul`, `float8pl` and the rest. Those call the inline helpers in `src/include/utils/float.h`, which compute the IEEE result and then throw it away:

```c
result = val1 * val2;
if (unlikely(isinf(result)) && !isinf(val1) && !isinf(val2))
    float_overflow_error();
```

That is the right choice for `float4` and `float8`, which never promised IEEE exception semantics. It is the wrong one for two types that exist to model Oracle's.

Patching `float.h` behind a GUC was the obvious alternative, and I did not take it. `float.h` is PostgreSQL's: changing it moves `float4`/`float8` behaviour for every PostgreSQL user of this fork, in a direction PostgreSQL chose deliberately. It would also put a GUC check in the hottest arithmetic path in the backend, and leave a conflict to resolve in a core header on every PostgreSQL merge. `ivorysql_ora` already owns both types, so the operators are rebound there instead.

Comparison operators are left alone. Equality and ordering have no exception semantics to get wrong.

## Reproduction

Oracle Database 21c Express Edition, against IvorySQL master with `ivorysql.compatible_mode = oracle`:

```sql
SELECT 3.4e38f * 10f;   -- Oracle: Inf   IvorySQL: ERROR 22003 value out of range
SELECT 1e-45f / 1e10;   -- Oracle: 0     IvorySQL: ERROR 22003 value out of range
SELECT 1f / 0f;         -- Oracle: Inf   IvorySQL: ERROR 22012 division by zero
SELECT 0f / 0f;         -- Oracle: NaN   IvorySQL: ERROR 22012 division by zero
```

The underflow case is easy to miss. The guard in `float.h` is skipped when either operand is zero, so `1e-320d * 0.0` returns `0` correctly while `1e-320d / 1e10` raises.

## Testing

`contrib/ivorysql_ora` regression on master, same tree, patch applied and reverted between runs:

```
stock master      1 of 26 failed (ora_xml_functions)
with this patch   1 of 26 failed (ora_xml_functions)

ok 5   - ora_binary_float
ok 6   - ora_binary_double
```

Expected output is updated for the cases this changes. `ora_xml_functions` fails on stock master and is unrelated.

Rocky Linux 9, gcc 11.5, `--enable-depend --with-uuid=e2fs`.

---

Assisted-by: Claude:Opus-5
Percentage of AI-generated code: 95%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Oracle-compatible IEEE 754 arithmetic for `BINARY_FLOAT` and `BINARY_DOUBLE`.
  - Overflow and underflow now produce Infinity or zero as appropriate.
  - Division by zero returns `Infinity`, `-Infinity`, or `NaN` instead of an error.
  - Mixed-precision arithmetic promotes values consistently to `BINARY_DOUBLE`.
  - Ordinary arithmetic behavior remains unchanged.

- **Tests**
  - Added coverage for overflow, underflow, division by zero, ordinary arithmetic, signed results, and precision promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->