### PR TITLE
Fix add_months for BC dates (negative month totals) and int32 month truncation

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -29,6 +29,37 @@ select add_months('2022-08-23',3) from dual;
  2022-11-23 00:00:00
 (1 row)
 
+-- add_months across BC years; SYYYY makes the era visible
+select to_char(add_months(to_date('0002-06-15 BC', 'yyyy-mm-dd ad'), 3), 'syyyy-mm-dd') as add_months_bc;
+ add_months_bc 
+---------------
+ -0002-09-15
+(1 row)
+
+select to_char(add_months(to_date('4712-01-01 BC', 'yyyy-mm-dd ad'), 12), 'syyyy-mm-dd') as add_months_bc_min;
+ add_months_bc_min 
+-------------------
+ -4711-01-01
+(1 row)
+
+select to_char(add_months(to_date('0005-01-31 BC', 'yyyy-mm-dd ad'), 1), 'syyyy-mm-dd') as add_months_bc_leap;
+ add_months_bc_leap 
+--------------------
+ -0005-02-29
+(1 row)
+
+select to_char(add_months('0001-01-01', -25), 'syyyy-mm-dd') as add_months_ad_to_bc;
+ add_months_ad_to_bc 
+---------------------
+ -0003-12-01
+(1 row)
+
+select to_char(add_months('9999-12-31', -120002), 'syyyy-mm-dd') as add_months_back_to_bc;
+ add_months_back_to_bc 
+-----------------------
+ -0002-10-31
+(1 row)
+
 alter session set NLS_LENGTH_SEMANTICS='BYTE';
 create table char_tb(char_clo char(3));
 insert into char_tb values('测试');

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -17,6 +17,12 @@ END;
 
 alter session set NLS_DATE_FORMAT='yyyy-mm-dd hh24:mi:ss';
 select add_months('2022-08-23',3) from dual;
+-- add_months across BC years; SYYYY makes the era visible
+select to_char(add_months(to_date('0002-06-15 BC', 'yyyy-mm-dd ad'), 3), 'syyyy-mm-dd') as add_months_bc;
+select to_char(add_months(to_date('4712-01-01 BC', 'yyyy-mm-dd ad'), 12), 'syyyy-mm-dd') as add_months_bc_min;
+select to_char(add_months(to_date('0005-01-31 BC', 'yyyy-mm-dd ad'), 1), 'syyyy-mm-dd') as add_months_bc_leap;
+select to_char(add_months('0001-01-01', -25), 'syyyy-mm-dd') as add_months_ad_to_bc;
+select to_char(add_months('9999-12-31', -120002), 'syyyy-mm-dd') as add_months_back_to_bc;
 alter session set NLS_LENGTH_SEMANTICS='BYTE';
 create table char_tb(char_clo char(3));
 insert into char_tb values('测试');

--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -399,12 +399,12 @@ add_months(PG_FUNCTION_ARGS)
 				d = 0;
 	int			days;
 	Timestamp	result;
-	div_t		v;
+	lldiv_t		v;
 	bool		last_day;
 	int64		n;
 	Numeric		num = PG_GETARG_NUMERIC(1);
 
-	n = DatumGetInt32(DirectFunctionCall1(numeric_int8, NumericGetDatum(num)));
+	n = DatumGetInt64(DirectFunctionCall1(numeric_int8, NumericGetDatum(num)));
 
 	TMODULO(time, date, USECS_PER_DAY);
 	if (time < INT64CONST(0))
@@ -417,11 +417,21 @@ add_months(PG_FUNCTION_ARGS)
 	j2date((int) date, &y, &m, &d);
 	last_day = (d == days_of_month(y, m));
 
-	v = div(y * 12 + m - 1 + n, 12);
-	y = v.quot;
-	if (y < 0)
-		y += 1;
-	m = v.rem + 1;
+	/*
+	 * Split the total month count into year and month.  lldiv() truncates
+	 * toward zero, so for a negative total the remainder is non-positive;
+	 * borrow one year to bring the month back into 1..12.  This keeps
+	 * results that land in BC years (year <= 0) valid, instead of producing
+	 * month 0 or a negative month and a bogus date.
+	 */
+	v = lldiv((int64) y * 12 + m - 1 + n, 12);
+	y = (int) v.quot;
+	m = (int) v.rem + 1;
+	if (m <= 0)
+	{
+		y -= 1;
+		m += 12;
+	}
 
 	days = days_of_month(y, m);
 	if (last_day || d > days)


### PR DESCRIPTION
## Issue

Fixes #1761

## Summary

`add_months()` produced wrong results (or `ERROR: date out of range`) whenever the total month count went negative, i.e. whenever the result crossed into the BC era:

| Call (master) | Before | After |
|---|---|---|
| `add_months(to_date('0002-06-15 BC','yyyy-mm-dd ad'), 3)` | `ERROR: date out of range` | `-0002-09-15` |
| `to_char(add_months(to_date('4712-01-01 BC','yyyy-mm-dd ad'), 12), 'syyyy-mm-dd')` | `-4710-01-01` (a year off) | `-4711-01-01` |
| `to_char(add_months('0001-01-01', -25), 'syyyy-mm-dd')` | `ERROR: date out of range` | `-0003-12-01` |

## Root cause and fix

`div()` truncates toward zero, so for a negative total the remainder is non-positive; the old code compensated with `if (y < 0) y += 1`, which leaves `m = v.rem + 1` at `0` or negative and shifts the year by a full 12 months. The fix normalizes the `lldiv()` result so the month always lands in 1..12:

```c
v = lldiv((int64) y * 12 + m - 1 + n, 12);
y = (int) v.quot;
m = (int) v.rem + 1;
if (m <= 0)
{
    y -= 1;
    m += 12;
}
```

This also widens the month argument to `int64` (`DatumGetInt64`), so large `NUMBER` inputs no longer silently truncate through `DatumGetInt32` (the `add_months` item of #1621).

## Testing

Five regression cases added to `datatype_and_func_bugs` (BC forward step, the 4712 BC lower bound, last-day rule across a BC leap February, an AD-to-BC crossing, and a 6-digit negative month count). Full `make oracle-check` for `ivorysql_ora`: **all 26 tests pass**, including the untouched `ora_datetime*` suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `add_months` handling for dates crossing between AD and BC years.
  - Corrected calculations for BC dates, including leap days, the earliest supported BC year, and large month offsets.
  - Prevented invalid month values when date arithmetic crosses year boundaries.

- **Tests**
  - Added regression coverage for BC-era date arithmetic, year transitions, leap-year behavior, and extreme date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->