### PR TITLE
Fix sys.instr edge cases: position=0, occurrence<=0, and INT32_MIN position crash

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3370,6 +3370,37 @@ SELECT INSTR('Information for the information age requires information.', 'infor
      0
 (1 row)
 
+-- position = 0 returns 0 (Oracle documents this); position/occurrence edge cases
+SELECT INSTR('abcabc', 'abc', 0) FROM DUAL;
+ instr 
+-------
+     0
+(1 row)
+
+SELECT INSTR('abcabc', 'b', 0, 2) FROM DUAL;
+ instr 
+-------
+     0
+(1 row)
+
+SELECT INSTR('abcabc', 'b', 3, 0) FROM DUAL;	-- error: occurrence must be positive
+ERROR:  The parameter of occurrence must be positive
+SELECT INSTR('abcabc', 'b', 3, -1) FROM DUAL;	-- error: occurrence must be positive
+ERROR:  The parameter of occurrence must be positive
+SELECT INSTR('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
+ instr 
+-------
+     0
+(1 row)
+
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 0, 2) FROM DUAL;
+ instrb 
+--------
+      0
+(1 row)
+
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, 0) FROM DUAL;	-- error: occurrence must be positive
+ERROR:  The parameter of occurrence must be positive
 /*
  * asciistr
  */

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3401,6 +3401,14 @@ SELECT INSTRB('CORPORATE FLOOR', 'OR', 0, 2) FROM DUAL;
 
 SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, 0) FROM DUAL;	-- error: occurrence must be positive
 ERROR:  The parameter of occurrence must be positive
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, -1) FROM DUAL;	-- error: occurrence must be positive
+ERROR:  The parameter of occurrence must be positive
+SELECT INSTRB('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
+ instrb 
+--------
+      0
+(1 row)
+
 /*
  * asciistr
  */
@@ -3411,24 +3419,6 @@ ERROR:  The parameter of occurrence must be positive
 ---------------
  Hello, World!
 (1 row)
-
-SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, -1) FROM DUAL;	-- error: occurrence must be positive
-ERROR:  The parameter of occurrence must be positive
-SELECT INSTRB('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
- instrb 
---------
-      0
-(1 row)
-
-
-SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, -1) FROM DUAL;	-- error: occurrence must be positive
-ERROR:  The parameter of occurrence must be positive
-SELECT INSTRB('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
- instrb 
---------
-      0
-(1 row)
-
 
  select asciistr('Hello\nWorld') from dual;
      asciistr     

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -3412,6 +3412,24 @@ ERROR:  The parameter of occurrence must be positive
  Hello, World!
 (1 row)
 
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, -1) FROM DUAL;	-- error: occurrence must be positive
+ERROR:  The parameter of occurrence must be positive
+SELECT INSTRB('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
+ instrb 
+--------
+      0
+(1 row)
+
+
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, -1) FROM DUAL;	-- error: occurrence must be positive
+ERROR:  The parameter of occurrence must be positive
+SELECT INSTRB('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
+ instrb 
+--------
+      0
+(1 row)
+
+
  select asciistr('Hello\nWorld') from dual;
      asciistr     
 ------------------

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1320,6 +1320,15 @@ SELECT INSTR('Information for the information age requires information.', 'infor
 SELECT INSTR('Information for the information age requires information.', 'information', 2);
 SELECT INSTR('Information for the information age requires information.', 'information', 1, 4);
 
+-- position = 0 returns 0 (Oracle documents this); position/occurrence edge cases
+SELECT INSTR('abcabc', 'abc', 0) FROM DUAL;
+SELECT INSTR('abcabc', 'b', 0, 2) FROM DUAL;
+SELECT INSTR('abcabc', 'b', 3, 0) FROM DUAL;	-- error: occurrence must be positive
+SELECT INSTR('abcabc', 'b', 3, -1) FROM DUAL;	-- error: occurrence must be positive
+SELECT INSTR('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 0, 2) FROM DUAL;
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, 0) FROM DUAL;	-- error: occurrence must be positive
+
 /*
  * asciistr
  */

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1328,6 +1328,8 @@ SELECT INSTR('abcabc', 'b', 3, -1) FROM DUAL;	-- error: occurrence must be posit
 SELECT INSTR('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
 SELECT INSTRB('CORPORATE FLOOR', 'OR', 0, 2) FROM DUAL;
 SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, 0) FROM DUAL;	-- error: occurrence must be positive
+SELECT INSTRB('CORPORATE FLOOR', 'OR', 5, -1) FROM DUAL;	-- error: occurrence must be positive
+SELECT INSTRB('abc', 'a', -2147483648) FROM DUAL;	-- out-of-range position, must not crash
 
 /*
  * asciistr

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -1009,14 +1009,6 @@ ora_instrb(PG_FUNCTION_ARGS)
 	int32	position = DatumGetInt32(DirectFunctionCall1(numeric_int4, DirectFunctionCall2(numeric_trunc, PG_GETARG_DATUM(2),Int32GetDatum(0))));
 	int32	occurrence = DatumGetInt32(DirectFunctionCall1(numeric_int4, DirectFunctionCall2(numeric_trunc, PG_GETARG_DATUM(3),Int32GetDatum(0))));
 
-	if (position == 0)
-		PG_RETURN_INT32(0);
-	
-	if (occurrence <= 0)
-		ereport(ERROR,
-					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-					 errmsg("The parameter of occurrence must be positive")));
-
 	str = PG_GETARG_TEXT_PP(0);
 	search_str = PG_GETARG_TEXT_PP(1);
 
@@ -1515,12 +1507,37 @@ text_instring(text *str, text *search_str, int32 position, int32 occurrence, boo
 	int32	result;
 	TextPositionState	state;
 
+	/*
+	 * Oracle documents that if position is 0, the result is 0, regardless
+	 * of the other arguments.  Handle that here so that every entry point
+	 * (instr and instrb alike) agrees.
+	 */
+	if (position == 0)
+		return 0;
+
+	/* occurrence must be a positive integer (Oracle ORA-01428) */
+	if (occurrence <= 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("The parameter of occurrence must be positive")));
+
 	text_position_setup(str, search_str, &state, isByte);
 
 	src_text_len = state.len1;
 	sub_text_len = state.len2;
 
 	if (src_text_len <= 0 || sub_text_len <= 0)
+	{
+		text_position_cleanup(&state);
+		return 0;
+	}
+
+	/*
+	 * Bound-check position before it is negated in the maxTimes computation
+	 * below; -INT_MIN would overflow, and a position outside the string can
+	 * never match anyway.
+	 */
+	if (position > src_text_len || position < -src_text_len)
 	{
 		text_position_cleanup(&state);
 		return 0;
@@ -1545,17 +1562,17 @@ text_instring(text *str, text *search_str, int32 position, int32 occurrence, boo
 	else
 		maxTimes = src_text_len - Max(sub_text_len, -position) + 1;
 
-	if (abs(position) > src_text_len || src_text_len < sub_text_len || occurrence > maxTimes)
+	if (src_text_len < sub_text_len || occurrence > maxTimes)
 	{
 		text_position_cleanup(&state);
 		return 0;
 	}
-	
+
 	if (position > 0)
 	{
 		/*searching from begin with the specific times */
 		result = position - 1;
-		
+
 		for (i = 0; i < occurrence; i++)
 		{
 			result = text_position_next(result + 1, &state);
@@ -1567,7 +1584,7 @@ text_instring(text *str, text *search_str, int32 position, int32 occurrence, boo
 	{
 		/*searching from back with the specific times */
 		result = src_text_len + position + 2;
-		
+
 		for (i = 0; i < occurrence; i++)
 		{
 			result = text_position_prev(result - 1, &state);


### PR DESCRIPTION
## Issue

Fixes #1763

## Summary

Hardens the `sys.instr` / `sys.instrb` family against three parameter edge cases, one of which crashes the backend under `--enable-cassert`:

| Call | Before | After |
|---|---|---|
| `SELECT instr('abcabc', 'abc', 0)` | `4` (wrong match) | `0` (Oracle-documented) |
| `SELECT instr('abcabc', 'b', 3, 0)` | `2` (bogus) | `ERROR: The parameter of occurrence must be positive` |
| `SELECT instr('abc', 'a', -2147483648)` | backend crash (Assert/UB) | `0` |
| `SELECT instrb('CORPORATE FLOOR', 'OR', 5, 0)` | wrong SQLSTATE (XX540) | same error, `ERRCODE_INVALID_PARAMETER_VALUE` (22023) |

## Details

1. **`position = 0`**: handled up front in `text_instring()` so `instr` and `instrb` agree (previously only `instrb()`'s wrapper special-cased it, while the character variant fell into the negative-position path).
2. **`occurrence <= 0`**: validated in `text_instring()` (Oracle ORA-01428), replacing `instrb()`'s wrapper check that used `ERRCODE_PROGRAM_LIMIT_EXCEEDED`.
3. **`position = INT32_MIN`**: `abs(INT_MIN)` overflows and the old guard never fired; the backend then hit `Assert(start_pos > 0)` in `text_position_prev()` under cassert builds. The range check now compares `position` against `+-src_text_len` *before* `position` is negated for the `maxTimes` computation, so no negation of `INT_MIN` ever happens.

## Testing

Nine regression cases added to `ora_character_datatype_functions` covering `position = 0` for both variants, `occurrence = 0` / negative, the `INT32_MIN` position (used to crash cassert builds), and the fixed SQLSTATE. Full `make oracle-check` for `ivorysql_ora`: **all 26 tests pass**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `INSTR` and `INSTRB` handling for zero, negative, and out-of-range positions.
  * Added consistent validation for zero or negative occurrence values, returning the documented error.
  * Prevented crashes when searches use the minimum supported 32-bit position.
  * Standardized behavior across character- and byte-based searches.

* **Tests**
  * Added regression coverage for position and occurrence edge cases in both functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up (commit 2)

Per the automated review, two additional INSTRB cases were added: `occurrence = -1` (same positivity error) and `position = -2147483648` (range-rejected without crashing).
