### PR TITLE
Apply Oracle match-parameter semantics to regexp_like and regexp_count

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -1574,6 +1574,43 @@ select * from t_regexp_like where regexp_like(null, null, null);
 ----+-------
 (0 rows)
 
+-- Oracle newline semantics: '.' does not match a newline unless 'n' is given
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, 'b.cd'::varchar2) from dual;
+ regexp_like 
+-------------
+ f
+(1 row)
+
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, 'b.cd'::varchar2, 'n'::varchar2) from dual;
+ regexp_like 
+-------------
+ t
+(1 row)
+
+-- 'm' is a valid Oracle match parameter: ^/$ also match at newlines
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, '^cd'::varchar2, 'm'::varchar2) from dual;
+ regexp_like 
+-------------
+ t
+(1 row)
+
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, '^cd'::varchar2) from dual;
+ regexp_like 
+-------------
+ f
+(1 row)
+
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, 'ab$'::varchar2, 'm'::varchar2) from dual;
+ regexp_like 
+-------------
+ t
+(1 row)
+
+-- PostgreSQL-only match parameters are still rejected
+select regexp_like('abc'::varchar2, 'abc'::varchar2, 'p'::varchar2) from dual;
+ERROR:  invalid option of regexp_like: p
+select regexp_like('abc'::varchar2, 'abc'::varchar2, 'q'::varchar2) from dual;
+ERROR:  invalid option of regexp_like: q
 DROP table t_regexp_like;
 /*
  * regexp_count
@@ -1752,7 +1789,7 @@ SELECT REGEXP_COUNT(1231, 123::int2, 1::int2, 'c'::char) REGEXP_COUNT FROM DUAL;
 (1 row)
 
 SELECT REGEXP_COUNT(123123::int4, 2312::int4, 1::int4, 'cd') REGEXP_COUNT FROM DUAL;
-ERROR:  invalid regular expression option: "d"
+ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
 SELECT REGEXP_COUNT(12312312312, 231, 1, 'c') REGEXP_COUNT FROM DUAL;
  regexp_count 
 --------------
@@ -1775,6 +1812,21 @@ SELECT REGEXP_COUNT(123123123::int, 123::int, 4.9, 'c') REGEXP_COUNT FROM DUAL;
  regexp_count 
 --------------
             2
+(1 row)
+
+-- every character of the match parameter is validated, not just the first
+SELECT REGEXP_COUNT('ABCabcabcABCABC', 'abc', 1, 'is') COUNT FROM DUAL;	-- error: 's' is not an Oracle parameter
+ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
+SELECT REGEXP_COUNT('ABCabcabcABCABC', 'abc', 1, 'ci') COUNT FROM DUAL;
+ count 
+-------
+     5
+(1 row)
+
+SELECT REGEXP_COUNT('ABCabcabcABCABC', 'abc', 1, 'in') COUNT FROM DUAL;
+ count 
+-------
+     5
 (1 row)
 
 SELECT REGEXP_COUNT('ABCabcabcABCABC'::text, 'abc'::text, 3::int, 'c') COUNT FROM DUAL;
@@ -1979,11 +2031,7 @@ ERROR:  the 4th argument is illegal parameter for function. the parameter can be
 SELECT REGEXP_COUNT('', '', 1, 'dc') COUNT FROM DUAL;
 ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
 SELECT REGEXP_COUNT('', '', 1, 'ie') COUNT FROM DUAL;
- count 
--------
-      
-(1 row)
-
+ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
 SELECT REGEXP_COUNT('', '', 1, '-100') COUNT FROM DUAL;
 ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
 SELECT REGEXP_COUNT('', '', 1, '100') COUNT FROM DUAL;
@@ -2029,11 +2077,7 @@ ERROR:  the 4th argument is illegal parameter for function. the parameter can be
 SELECT REGEXP_COUNT(' ', ' ', 1, 'dc') COUNT FROM DUAL;
 ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
 SELECT REGEXP_COUNT(' ', ' ', 1, 'ie') COUNT FROM DUAL;
- count 
--------
-     1
-(1 row)
-
+ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
 SELECT REGEXP_COUNT(' ', ' ', 1, '-100') COUNT FROM DUAL;
 ERROR:  the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.
 SELECT REGEXP_COUNT(' ', ' ', 1, '100') COUNT FROM DUAL;

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -796,6 +796,17 @@ select * from t_regexp_like where regexp_like('', null);
 select * from t_regexp_like where regexp_like(null, null);
 select * from t_regexp_like where regexp_like(null, null, null);
 
+-- Oracle newline semantics: '.' does not match a newline unless 'n' is given
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, 'b.cd'::varchar2) from dual;
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, 'b.cd'::varchar2, 'n'::varchar2) from dual;
+-- 'm' is a valid Oracle match parameter: ^/$ also match at newlines
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, '^cd'::varchar2, 'm'::varchar2) from dual;
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, '^cd'::varchar2) from dual;
+select regexp_like(('ab'||chr(10)||'cd')::varchar2, 'ab$'::varchar2, 'm'::varchar2) from dual;
+-- PostgreSQL-only match parameters are still rejected
+select regexp_like('abc'::varchar2, 'abc'::varchar2, 'p'::varchar2) from dual;
+select regexp_like('abc'::varchar2, 'abc'::varchar2, 'q'::varchar2) from dual;
+
 DROP table t_regexp_like;
 
 /*
@@ -858,6 +869,11 @@ SELECT REGEXP_COUNT(12312312312, 231, 1, 'c') REGEXP_COUNT FROM DUAL;
 SELECT REGEXP_COUNT(1231.2312312312355, 1.23, 4.9, 'c') REGEXP_COUNT FROM DUAL;
 SELECT REGEXP_COUNT('12312312312312355', '123', 4.9, 'c') REGEXP_COUNT FROM DUAL;
 SELECT REGEXP_COUNT(123123123::int, 123::int, 4.9, 'c') REGEXP_COUNT FROM DUAL;
+
+-- every character of the match parameter is validated, not just the first
+SELECT REGEXP_COUNT('ABCabcabcABCABC', 'abc', 1, 'is') COUNT FROM DUAL;	-- error: 's' is not an Oracle parameter
+SELECT REGEXP_COUNT('ABCabcabcABCABC', 'abc', 1, 'ci') COUNT FROM DUAL;
+SELECT REGEXP_COUNT('ABCabcabcABCABC', 'abc', 1, 'in') COUNT FROM DUAL;
 
 SELECT REGEXP_COUNT('ABCabcabcABCABC'::text, 'abc'::text, 3::int, 'c') COUNT FROM DUAL;
 SELECT REGEXP_COUNT('ABCabcabcABCABC'::text, 'abc'::text, 3::int, 'i') COUNT FROM DUAL;

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -602,6 +602,7 @@ ora_regexp_like(PG_FUNCTION_ARGS)
 	char		*in_flag_p = NULL;
 	int			in_flag_len, i, out_flag;
 	bool		match;
+	pg_re_flags	flags;
 	regmatch_t	pmatch[2];
 
 	if ((NULL == s) || (NULL == p))
@@ -612,32 +613,26 @@ ora_regexp_like(PG_FUNCTION_ARGS)
 	in_flag_p = VARDATA(in_flag);
 	in_flag_len = (VARSIZE(in_flag) - VARHDRSZ);
 
-	/* parse flag options */
-	out_flag = REG_ADVANCED;
-	for (i = 0; i <in_flag_len; i++)
+	/*
+	 * Oracle's match parameters are i, c, n, m and x.  Reject anything else
+	 * with regexp_like's own message first, because the shared flag parser
+	 * would silently accept PostgreSQL-only options such as 'p'.  Then parse
+	 * with the Oracle semantics: '.' does not match a newline by default,
+	 * 'n' lets it match, and 'm' makes ^/$ anchors match at newlines.
+	 */
+	for (i = 0; i < in_flag_len; i++)
 	{
-		switch (in_flag_p[i])
-		{
-			case 'i':
-				out_flag  |=  REG_ICASE;
-				break;
-			case 'n':
-				out_flag |= REG_NEWLINE;
-				break;
-			case 'c':
-				out_flag  &=  ~REG_ICASE;
-				break;
-			case 'x':
-				out_flag |= REG_EXPANDED;
-				break;
-			default:
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("invalid option of regexp_like: %c",
-						 in_flag_p[i])));
-				break;
-		}
+		if (in_flag_p[i] != 'i' && in_flag_p[i] != 'c' &&
+			in_flag_p[i] != 'n' && in_flag_p[i] != 'm' &&
+			in_flag_p[i] != 'x')
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid option of regexp_like: %c",
+					 in_flag_p[i])));
 	}
+
+	ora_parse_re_flags(&flags, in_flag);
+	out_flag = flags.cflags;
 
 	/*
 	 * We pass two regmatch_t structs to get info about the overall match and
@@ -677,8 +672,11 @@ ora_regexp_like_no_flags(PG_FUNCTION_ARGS)
 	{
 		PG_RETURN_BOOL(false);
 	}
-	/* parse flag options */
-	out_flag = REG_ADVANCED;
+	/*
+	 * Oracle's default: '.' does not match a newline (REG_NLDOT), the same
+	 * semantics the shared flag parser applies to the 3-argument variant.
+	 */
+	out_flag = REG_ADVANCED | REG_NLDOT;
 
 	/*
 	 * We pass two regmatch_t structs to get info about the overall match and
@@ -749,11 +747,19 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 		paramstr = text_to_cstring(match_param);
 		if (paramstr && paramstr[0] != '\0')
 		{
-			if (paramstr[0] != 'x' && paramstr[0] != 'm' && paramstr[0] != 'i' && 
-				paramstr[0] != 'c' && paramstr[0] != 'n' && paramstr[0] != 'g')
-					ereport(ERROR,
-							 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-								 errmsg("the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.")));
+			/*
+			 * Validate every character, not just the first one; otherwise
+			 * strings like 'is' or 'cs' silently apply PostgreSQL-only
+			 * flag semantics that Oracle rejects (ORA-01428).
+			 */
+			for (int j = 0; paramstr[j] != '\0'; j++)
+			{
+				if (paramstr[j] != 'x' && paramstr[j] != 'm' && paramstr[j] != 'i' &&
+					paramstr[j] != 'c' && paramstr[j] != 'n' && paramstr[j] != 'g')
+						ereport(ERROR,
+								 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+									 errmsg("the 4th argument is illegal parameter for function. the parameter can be one of x, m, i, c, n.")));
+			}
 		}
 	}
 


### PR DESCRIPTION
## Issue

Fixes #1765

## Summary

Brings `sys.regexp_like` (and `sys.regexp_count`'s parameter validation) in line with the Oracle regex semantics the engine was already patched for:

| Call | Before | After (Oracle) |
|---|---|---|
| `regexp_like('ab\n', '^cd', 'm')` | `ERROR: invalid option of regexp_like: m` | `t` |
| `regexp_like('ab\ncd', 'b.cd')` | `t` (`.` matched `\n`) | `f` |
| `regexp_like('ab\ncd', 'b.cd', 'n')` | `f` | `t` |
| `regexp_like(..., 'q')` | `t` (PG REG_QUOTE silently applied) | `ERROR: invalid option of regexp_like: q` |
| `regexp_count(..., 'is')` | `t`-style silent PG flags | `ERROR: the 4th argument is illegal parameter...` |

## Details

* `ora_regexp_like()` validated flags with its own switch (i/n/c/x) and built PostgreSQL compile flags directly. It now (1) rejects any character outside Oracle's set `{i,c,n,m,x}` up front - keeping the historical `invalid option of regexp_like: %c` message - and (2) delegates to `ora_parse_re_flags()`, which implements the Oracle newline semantics (default `REG_NLDOT`, `'n'` lets `.` match `\n`, `'m'` makes `^`/`$` line anchors).
* `ora_regexp_like_no_flags()` now uses `REG_ADVANCED | REG_NLDOT`, so the default flavor matches Oracle (`.` does not match a newline).
* `ora_regexp_count()` checked only `paramstr[0]`, letting PostgreSQL-only letters (`s`, `p`, `w`, `e`, `q`, ...) flow into the shared parser silently; every character is now validated against the same set, raising the existing `illegal parameter` error for the whole string.
* Two pre-existing expected results that depended on the leak (`'cd'` falling through to the PG regex parser's message, `'ie'` silently using PG's `'e'` flag) now report the regexp_count validation error, matching Oracle's ORA-01428.

## Testing

Regression cases added for `.`-vs-newline with and without `'n'`, `'m'` anchors on multi-line strings, rejection of `'p'`/`'q'`, and multi-character match parameters for `regexp_count`. Full `make oracle-check` for `ivorysql_ora`: **all 26 tests pass**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle-compatible regular expression behavior for newline matching and multiline anchors.
  * Match parameters are now fully validated, with consistent errors for unsupported options.
  * Correctly rejects PostgreSQL-only and other invalid options in regular expression functions.
  * `REGEXP_COUNT` now handles valid and invalid parameter combinations consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->