### PR TITLE
Reject overlength time zone abbreviations in to_char (CVE-2026-14669)

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -84,6 +84,14 @@ ERROR:  syntax error at or near "default"
 LINE 1: ... s1.f_alter(arg1 number, arg2 number, arg3 number default 10...
                                                              ^
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number) compile;
+-- to_char must reject overlength time zone abbreviations instead of
+-- overflowing its output buffer (upstream CVE-2026-14669)
+set timezone = '<AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>-07:30';
+select to_char(cast(now() as sys.oratimestamptz), 'TZ') from dual;
+ERROR:  time zone format value too long
+select to_char(cast(now() as sys.oratimestamptz), 'tz') from dual;
+ERROR:  time zone format value too long
+reset timezone;
 -- clean
 drop table dtos_tb1tidid004134318;
 drop table char_tb2;

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -71,6 +71,14 @@ alter function s1.f_alter(arg1 OUT int) compile;
 alter function s1.f_alter(arg1 text) compile;
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number default 10) compile;
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number) compile;
+
+-- to_char must reject overlength time zone abbreviations instead of
+-- overflowing its output buffer (upstream CVE-2026-14669)
+set timezone = '<AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>-07:30';
+select to_char(cast(now() as sys.oratimestamptz), 'TZ') from dual;
+select to_char(cast(now() as sys.oratimestamptz), 'tz') from dual;
+reset timezone;
+
 -- clean
 drop table dtos_tb1tidid004134318;
 drop table char_tb2;

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -2717,10 +2717,18 @@ DCH_to_char(FormatNode *node, bool is_interval, TmToChar *in, char *out, Oid col
 				INVALID_FOR_INTERVAL;
 				if (tmtcTzn(in))
 				{
-					/* We assume here that timezone names aren't localized */
+					/*
+					 * We assume here that timezone abbreviations aren't
+					 * localized, so ASCII-only downcasing is sufficient.
+					 */
 					char	   *p = asc_tolower_z(tmtcTzn(in));
 
-					strcpy(s, p);
+					if (strlen(p) <= n->key->len * DCH_MAX_ITEM_SIZ)
+						strcpy(s, p);
+					else
+						ereport(ERROR,
+								(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+								 errmsg("time zone format value too long")));
 					pfree(p);
 					s += strlen(s);
 				}
@@ -2729,7 +2737,14 @@ DCH_to_char(FormatNode *node, bool is_interval, TmToChar *in, char *out, Oid col
 				INVALID_FOR_INTERVAL;
 				if (tmtcTzn(in))
 				{
-					strcpy(s, tmtcTzn(in));
+					const char *p = tmtcTzn(in);
+
+					if (strlen(p) <= n->key->len * DCH_MAX_ITEM_SIZ)
+						strcpy(s, p);
+					else
+						ereport(ERROR,
+								(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+								 errmsg("time zone format value too long")));
 					s += strlen(s);
 				}
 				break;


### PR DESCRIPTION
## Issue

Fixes #1767

## Summary

Ports the upstream fix for **CVE-2026-14669** (commit `3d724bf4fde67a2931733a5143b7d6c12b23990c`, PostgreSQL 18.6) to IvorySQL: `DCH_to_char()` now rejects time zone abbreviations longer than the reserved `12 * fmt_len` output space instead of `strcpy()`-ing past the end of the palloc'd buffer.

Any session can reach this with its own `timezone` setting:

```sql
SET timezone = '<AAA...80 chars...>-07:30';
SELECT to_char(now(), 'TZ');
```

Before (assert build): `WARNING: detected write past chunk end in ExprContext ...` (silent heap corruption on production builds).
After: `ERROR:  time zone format value too long`.

## Details

The change is a verbatim port of the upstream guard for both `DCH_tz` and `DCH_TZ` spellings: `strlen(p) <= n->key->len * DCH_MAX_ITEM_SIZ` or `ereport(ERROR, (ERRCODE_DATETIME_VALUE_OUT_OF_RANGE, errmsg("time zone format value too long")))`. IvorySQL's `formatting.c` carries Oracle-compatible modifications in other areas, but this hunk applies cleanly and unchanged.

## Testing

Regression cases added to `datatype_and_func_bugs` (an 80-character POSIX abbreviation with both `'TZ'` and `'tz'`). Full `make oracle-check` for `ivorysql_ora`: **all 26 tests pass**. The PoC that previously tripped the allocator's chunk-end check now produces the clean error and the server stays healthy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved time zone formatting to safely handle overlong abbreviations and names.
  - Displays a clear error instead of allowing oversized values to overflow output.
  - Preserves expected uppercase and lowercase formatting behavior.

- **Tests**
  - Added regression coverage for overlength time zone abbreviations using both uppercase and lowercase formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->