### PR TITLE
Reject SQL calls to functions taking or returning type internal (CVE-2026-14680)

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -84,6 +84,22 @@ ERROR:  syntax error at or near "default"
 LINE 1: ... s1.f_alter(arg1 number, arg2 number, arg3 number default 10...
                                                              ^
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number) compile;
+-- calls to functions taking type "internal" are rejected from SQL
+-- (upstream CVE-2026-14680); every route must fail cleanly
+select xid8recv(NULL) from dual;
+ERROR:  function xid8recv(unknown) does not exist
+LINE 1: select xid8recv(NULL) from dual;
+               ^
+DETAIL:  No function of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
+select pg_ddl_command_recv(NULL::internal) from dual;
+ERROR:  cannot cast type unknown to internal
+LINE 1: select pg_ddl_command_recv(NULL::internal) from dual;
+                                       ^
+select cast(NULL as internal) is null from dual;
+ERROR:  cannot cast type unknown to internal
+LINE 1: select cast(NULL as internal) is null from dual;
+               ^
 -- clean
 drop table dtos_tb1tidid004134318;
 drop table char_tb2;

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -71,6 +71,12 @@ alter function s1.f_alter(arg1 OUT int) compile;
 alter function s1.f_alter(arg1 text) compile;
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number default 10) compile;
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number) compile;
+-- calls to functions taking type "internal" are rejected from SQL
+-- (upstream CVE-2026-14680); every route must fail cleanly
+select xid8recv(NULL) from dual;
+select pg_ddl_command_recv(NULL::internal) from dual;
+select cast(NULL as internal) is null from dual;
+
 -- clean
 drop table dtos_tb1tidid004134318;
 drop table char_tb2;

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -836,6 +836,10 @@ can_coerce_type(int nargs, const Oid *input_typeids, const Oid *target_typeids,
 		if (inputTypeId == targetTypeId)
 			continue;
 
+		/* reject all cases of casting something else to/from "internal" */
+		if (inputTypeId == INTERNALOID || targetTypeId == INTERNALOID)
+			return false;
+
 		/* accept if target is ANY */
 		if (targetTypeId == ANYOID)
 			continue;
@@ -3510,6 +3514,10 @@ find_coercion_pathway(Oid targetTypeId, Oid sourceTypeId,
 	/* Domains are always coercible to and from their base type */
 	if (sourceTypeId == targetTypeId)
 		return COERCION_PATH_RELABELTYPE;
+
+	/* Reject all cases of casting something else to/from "internal" */
+	if (sourceTypeId == INTERNALOID || targetTypeId == INTERNALOID)
+		return COERCION_PATH_NONE;
 
 	/* Look in pg_cast */
 	tuple = SearchSysCache2(CASTSOURCETARGET,

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -948,6 +948,32 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 											   rettype,
 											   false);
 
+	/*
+	 * Reject any attempt to call a function that takes or returns type
+	 * internal from SQL.  (The FUNCDETAIL_COERCION case does not reach this
+	 * check because of the early return above, but that's okay because we
+	 * disallow coercions to or from type internal.)  Note that we are
+	 * checking the resolved argument and result types, so this will reject
+	 * calls to polymorphic functions that pass internal-type arguments.  The
+	 * casting rules should prevent that anyway, since we won't cast internal
+	 * to any polymorphic type, but no harm in being doubly sure.
+	 */
+	for (int i = 0; i < nargsplusdefs; i++)
+	{
+		if (declared_arg_types[i] == INTERNALOID)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("functions accepting type \"%s\" cannot be called explicitly",
+							"internal"),
+					 parser_errposition(pstate, location)));
+	}
+	if (rettype == INTERNALOID)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("functions returning type \"%s\" cannot be called explicitly",
+						"internal"),
+				 parser_errposition(pstate, location)));
+
 	/* perform the necessary typecasting of arguments */
 	make_fn_arguments(pstate, fargs, actual_arg_types, declared_arg_types);
 

--- a/src/backend/parser/parse_oper.c
+++ b/src/backend/parser/parse_oper.c
@@ -811,6 +811,28 @@ make_op(ParseState *pstate, List *opname, Node *ltree, Node *rtree,
 											   opform->oprresult,
 											   false);
 
+	/*
+	 * Reject any attempt to call a function that takes or returns type
+	 * internal from SQL.  This is just like the check in ParseFuncOrColumn,
+	 * but for operator syntax.  (Despite that, we say "function" in the error
+	 * messages; doesn't seem worth having two sets of translatable strings.)
+	 */
+	for (int i = 0; i < nargs; i++)
+	{
+		if (declared_arg_types[i] == INTERNALOID)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("functions accepting type \"%s\" cannot be called explicitly",
+							"internal"),
+					 parser_errposition(pstate, location)));
+	}
+	if (rettype == INTERNALOID)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("functions returning type \"%s\" cannot be called explicitly",
+						"internal"),
+				 parser_errposition(pstate, location)));
+
 	/* perform the necessary typecasting of arguments */
 	make_fn_arguments(pstate, args, actual_arg_types, declared_arg_types);
 

--- a/src/pl/plisql/src/pl_exec.c
+++ b/src/pl/plisql/src/pl_exec.c
@@ -9065,12 +9065,20 @@ get_cast_hashentry(PLiSQL_execstate * estate,
 		 * If there's no cast path according to the parser, fall back to using
 		 * an I/O coercion; this is semantically dubious but matches plisql's
 		 * historical behavior.  We would need something of the sort for
-		 * UNKNOWN literals in any case.  (This is probably now only reachable
-		 * in the case where srctype is UNKNOWN/RECORD.)
+		 * UNKNOWN literals in any case.  The only case we reject is casting
+		 * to/from INTERNAL.  (Other than that case, this is probably now only
+		 * reachable in the case where srctype is UNKNOWN/RECORD.)
 		 */
 		if (cast_expr == NULL)
 		{
 			CoerceViaIO *iocoerce = makeNode(CoerceViaIO);
+
+			if (srctype == INTERNALOID || dsttype == INTERNALOID)
+				ereport(ERROR,
+						(errcode(ERRCODE_CANNOT_COERCE),
+						 errmsg("cannot cast type %s to %s",
+								format_type_be(srctype),
+								format_type_be(dsttype))));
 
 			iocoerce->arg = (Expr *) placeholder;
 			iocoerce->resulttype = dsttype;

--- a/src/pl/plpgsql/src/pl_exec.c
+++ b/src/pl/plpgsql/src/pl_exec.c
@@ -8145,12 +8145,20 @@ get_cast_hashentry(PLpgSQL_execstate *estate,
 		 * If there's no cast path according to the parser, fall back to using
 		 * an I/O coercion; this is semantically dubious but matches plpgsql's
 		 * historical behavior.  We would need something of the sort for
-		 * UNKNOWN literals in any case.  (This is probably now only reachable
-		 * in the case where srctype is UNKNOWN/RECORD.)
+		 * UNKNOWN literals in any case.  The only case we reject is casting
+		 * to/from INTERNAL.  (Other than that case, this is probably now only
+		 * reachable in the case where srctype is UNKNOWN/RECORD.)
 		 */
 		if (cast_expr == NULL)
 		{
 			CoerceViaIO *iocoerce = makeNode(CoerceViaIO);
+
+			if (srctype == INTERNALOID || dsttype == INTERNALOID)
+				ereport(ERROR,
+						(errcode(ERRCODE_CANNOT_COERCE),
+						 errmsg("cannot cast type %s to %s",
+								format_type_be(srctype),
+								format_type_be(dsttype))));
 
 			iocoerce->arg = (Expr *) placeholder;
 			iocoerce->resulttype = dsttype;


### PR DESCRIPTION
## Issue

Fixes #1769 (part of the upstream security-sync gap tracked in #1767)

## Summary

Ports upstream commit `8f7e35b08a` (PostgreSQL 18.6, 2026-08-13, CVE-2026-14680, CVSS 8.8): SQL can no longer resolve calls to functions whose declared argument or result types include `internal`, because each such function defines that layout differently and a resolved call is a type-confusion primitive.

| File | Change |
|---|---|
| `parse_coerce.c` | `can_coerce_type()` and `find_coercion_pathway()` reject any cast to/from `internal` |
| `parse_func.c` | `ParseFuncOrColumn()` rejects resolved calls whose declared argument types or return type are `internal` |
| `parse_oper.c` | same check for operator syntax in `make_op()` |
| `src/pl/plpgsql/src/pl_exec.c` | `get_cast_hashentry()` rejects the I/O-coercion fallback for `internal` |
| `src/pl/plisql/src/pl_exec.c` | **IvorySQL-specific:** the identical guard added to their own PL/iSQL fork, which upstream's plpgsql fix does not cover |

The first four hunks are a verbatim port of the upstream commit (it applies cleanly with `git apply`). The fifth is the same guard added to IvorySQL's PL/iSQL copy of the fallback, which the upstream patch could not reach.

## Testing

Full `make oracle-check` for `ivorysql_ora`: **all 26 tests pass** - the Oracle compatibility layer (varchar2/number overloads, packages, PL/iSQL routines) does not rely on SQL-resolvable `internal` calls, matching the fact that upstream applied the same restriction to every supported branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented SQL functions and operators from directly accepting or returning the internal system type.
  * Blocked implicit and explicit casts to or from the internal type.
  * Improved error reporting for unsupported internal-type conversions in procedural code.
  * Preserved supported fallback conversions for other special types.
  * Added regression coverage to verify these invalid calls and casts fail cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up (commit 2): behavior-level tests added

The upstream commit shipped no test, so three deterministic SQL routes are now covered in `datatype_and_func_bugs`:

| Call | Result |
|---|---|
| `SELECT xid8recv(NULL)` (untyped NULL into an `internal`-argument function) | `ERROR: function xid8recv(unknown) does not exist` (resolution no longer reaches the function) |
| `SELECT pg_ddl_command_recv(NULL::internal)` | `ERROR: cannot cast type unknown to internal` |
| `SELECT cast(NULL as internal) IS NULL` | same coercion error |

Full `ivorysql_ora` suite: **26/26** including the new cases.
