### PR TITLE
Fix ascii() out-of-bound reads for invalid multibyte characters (CVE-2026-18024)

### DIFF
--- a/src/backend/utils/adt/oracle_compat.c
+++ b/src/backend/utils/adt/oracle_compat.c
@@ -952,8 +952,10 @@ ascii(PG_FUNCTION_ARGS)
 	text	   *string = PG_GETARG_TEXT_PP(0);
 	int			encoding = GetDatabaseEncoding();
 	unsigned char *data;
+	int			len;
 
-	if (VARSIZE_ANY_EXHDR(string) <= 0)
+	len = VARSIZE_ANY_EXHDR(string);
+	if (len <= 0)
 		PG_RETURN_INT32(0);
 
 	data = (unsigned char *) VARDATA_ANY(string);
@@ -976,18 +978,31 @@ ascii(PG_FUNCTION_ARGS)
 			result = *data & 0x0F;
 			tbytes = 2;
 		}
-		else
+		else if (*data > 0xC0)
 		{
-			Assert(*data > 0xC0);
 			result = *data & 0x1f;
 			tbytes = 1;
 		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+					 errmsg("invalid byte sequence for encoding \"%s\"",
+							GetDatabaseEncodingName())));
 
-		Assert(tbytes > 0);
+		/* All continuation bytes are present in the input */
+		if (tbytes >= len)
+			ereport(ERROR,
+					(errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+					 errmsg("invalid byte sequence for encoding \"%s\"",
+							GetDatabaseEncodingName())));
 
 		for (i = 1; i <= tbytes; i++)
 		{
-			Assert((data[i] & 0xC0) == 0x80);
+			if (unlikely((data[i] & 0xC0) != 0x80))
+				ereport(ERROR,
+						(errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+						 errmsg("invalid byte sequence for encoding \"%s\"",
+								GetDatabaseEncodingName())));
 			result = (result << 6) + (data[i] & 0x3f);
 		}
 

--- a/src/oracle_test/regress/expected/encoding.out
+++ b/src/oracle_test/regress/expected/encoding.out
@@ -408,6 +408,25 @@ SELECT SUBSTRING(c FROM 3000 FOR 1) FROM toast_4b_utf8;
  🚀
 (1 row)
 
+-- ascii() and multibyte characters
+SELECT ascii(test_bytea_to_text('\xc3'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xe2'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xe282'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf0'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf09f'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf09f98'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+-- invalid continuation byte
+SELECT ascii(test_bytea_to_text('\xc3ff'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+-- invalid leading byte
+SELECT ascii(test_bytea_to_text('\x80'));
+ERROR:  invalid byte sequence for encoding "UTF8"
 DROP TABLE encoding_tests;
 DROP TABLE toast_4b_utf8;
 DROP FUNCTION test_encoding;

--- a/src/oracle_test/regress/sql/encoding.sql
+++ b/src/oracle_test/regress/sql/encoding.sql
@@ -226,6 +226,18 @@ ALTER TABLE toast_3b_utf8 RENAME TO toast_4b_utf8;
 UPDATE toast_4b_utf8 SET c = repeat(U&'\+01F680', 3000);
 SELECT SUBSTRING(c FROM 3000 FOR 1) FROM toast_4b_utf8;
 
+-- ascii() and multibyte characters
+SELECT ascii(test_bytea_to_text('\xc3'));
+SELECT ascii(test_bytea_to_text('\xe2'));
+SELECT ascii(test_bytea_to_text('\xe282'));
+SELECT ascii(test_bytea_to_text('\xf0'));
+SELECT ascii(test_bytea_to_text('\xf09f'));
+SELECT ascii(test_bytea_to_text('\xf09f98'));
+-- invalid continuation byte
+SELECT ascii(test_bytea_to_text('\xc3ff'));
+-- invalid leading byte
+SELECT ascii(test_bytea_to_text('\x80'));
+
 DROP TABLE encoding_tests;
 DROP TABLE toast_4b_utf8;
 DROP FUNCTION test_encoding;

--- a/src/test/regress/expected/encoding.out
+++ b/src/test/regress/expected/encoding.out
@@ -401,6 +401,25 @@ SELECT SUBSTRING(c FROM 3000 FOR 1) FROM toast_4b_utf8;
  🚀
 (1 row)
 
+-- ascii() and multibyte characters
+SELECT ascii(test_bytea_to_text('\xc3'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xe2'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xe282'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf0'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf09f'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf09f98'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+-- invalid continuation byte
+SELECT ascii(test_bytea_to_text('\xc3ff'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+-- invalid leading byte
+SELECT ascii(test_bytea_to_text('\x80'));
+ERROR:  invalid byte sequence for encoding "UTF8"
 DROP TABLE encoding_tests;
 DROP TABLE toast_4b_utf8;
 DROP FUNCTION test_encoding;

--- a/src/test/regress/sql/encoding.sql
+++ b/src/test/regress/sql/encoding.sql
@@ -219,6 +219,18 @@ ALTER TABLE toast_3b_utf8 RENAME TO toast_4b_utf8;
 UPDATE toast_4b_utf8 SET c = repeat(U&'\+01F680', 3000);
 SELECT SUBSTRING(c FROM 3000 FOR 1) FROM toast_4b_utf8;
 
+-- ascii() and multibyte characters
+SELECT ascii(test_bytea_to_text('\xc3'));
+SELECT ascii(test_bytea_to_text('\xe2'));
+SELECT ascii(test_bytea_to_text('\xe282'));
+SELECT ascii(test_bytea_to_text('\xf0'));
+SELECT ascii(test_bytea_to_text('\xf09f'));
+SELECT ascii(test_bytea_to_text('\xf09f98'));
+-- invalid continuation byte
+SELECT ascii(test_bytea_to_text('\xc3ff'));
+-- invalid leading byte
+SELECT ascii(test_bytea_to_text('\x80'));
+
 DROP TABLE encoding_tests;
 DROP TABLE toast_4b_utf8;
 DROP FUNCTION test_encoding;


### PR DESCRIPTION
## Issue

Fixes #1773 (part of the upstream security-sync gap tracked in #1767)

## Summary

Ports upstream commit `a16c31d39c` (PostgreSQL 18.6, 2026-08-13, **CVE-2026-18024**): `ascii()` now rejects truncated or malformed UTF-8 sequences instead of reading past the end of the datum. For every invalid case it reports:

```
ERROR:  invalid byte sequence for encoding "UTF8"
```

The `oracle_compat.c` hunk applies verbatim to this snapshot.

## Testing

* The upstream regression cases (eight `ascii(test_bytea_to_text(...))` calls covering truncated 2/3/4-byte sequences, an invalid continuation byte, and an invalid leading byte) were added to the **oracle_test** copy of the encoding test, which is the suite this tree actually runs - upstream's own additions only touched `src/test/regress`, which this fork does not execute in CI.
* Full core oracle regression suite: **259/259**, including the new encoding cases.
* Full `ivorysql_ora` oracle suite: **26/26** (IvorySQL's own `ora_ascii()` only reads the first byte and is unaffected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `ascii()` handling of malformed UTF-8 input.
  - Invalid leading bytes, continuation bytes, and incomplete multibyte sequences now return clear encoding errors instead of potentially triggering assertions.

- **Tests**
  - Added coverage for truncated UTF-8 sequences and invalid byte combinations across supported regression test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->