### PR TITLE
Fix pg_trgm picksplit out-of-bounds read (CVE-2026-14678)

### DIFF
--- a/contrib/pg_trgm/trgm_gist.c
+++ b/contrib/pg_trgm/trgm_gist.c
@@ -902,7 +902,7 @@ gtrgm_picksplit(PG_FUNCTION_ARGS)
 			else
 				size_alpha = SIGLENBIT(siglen) -
 					sizebitvec((cache[j].allistrue) ? GETSIGN(datum_l) :
-							   GETSIGN(cache[j].sign),
+							   cache[j].sign,
 							   siglen);
 		}
 		else
@@ -915,7 +915,7 @@ gtrgm_picksplit(PG_FUNCTION_ARGS)
 			else
 				size_beta = SIGLENBIT(siglen) -
 					sizebitvec((cache[j].allistrue) ? GETSIGN(datum_r) :
-							   GETSIGN(cache[j].sign),
+							   cache[j].sign,
 							   siglen);
 		}
 		else


### PR DESCRIPTION
## Issue

Fixes #1775 (part of the upstream security-sync gap tracked in #1767)

## Summary

Ports upstream commit `66c2dbb204` (PostgreSQL 18.6, 2026-08-13, **CVE-2026-14678**): `gtrgm_picksplit()` must not wrap the `CACHESIGN` union's `sign` field in `GETSIGN()` - the union member is already a `BITVECP`, and the cast inside `GETSIGN()` turned the type error into a silent out-of-bounds read inside `sizebitvec()`. The fix passes `cache[j].sign` directly (+2/-2, verbatim).

## Testing

* `contrib/pg_trgm` regression suite: **4/4**;
* full core oracle regression suite: **259/259**;
* full `ivorysql_ora` oracle suite: **26/26**.

Upstream shipped the commit in all supported branches with no test changes, consistent with these results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trigram index signature processing to ensure searches and index operations use the correct signature data.
  * Improved reliability of operations involving trigram-based indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->