### PR TITLE
Add Oracle-compatible DBMS_RANDOM package

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -34,7 +34,8 @@ OBJS = \
 	src/builtin_packages/dbms_lock/dbms_lock.o \
 	src/builtin_packages/utl_encode/utl_encode.o \
 	src/builtin_packages/dbms_session/dbms_session.o \
-	src/builtin_packages/dbms_transaction/dbms_transaction.o
+	src/builtin_packages/dbms_transaction/dbms_transaction.o \
+	src/builtin_packages/dbms_random/dbms_random.o
 
 EXTENSION = ivorysql_ora
 
@@ -87,7 +88,8 @@ ORA_REGRESS = \
 	utl_raw \
 	utl_encode \
 	dbms_session \
-	dbms_transaction
+	dbms_transaction \
+	dbms_random
 
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src

--- a/contrib/ivorysql_ora/expected/dbms_random.out
+++ b/contrib/ivorysql_ora/expected/dbms_random.out
@@ -54,10 +54,19 @@ from (select dbms_random.value(10, 20) as v
  t
 (1 row)
 
--- equal VALUE bounds are rejected; reverse ranges are supported
-select dbms_random.value(10, 10) from dual;
-ERROR:  the two bounds must not be equal
-CONTEXT:  PL/iSQL function sys.dbms_random.value line 43 at RETURN
+-- equal VALUE bounds return the shared bound; reverse ranges are supported
+select dbms_random.value(-1, -1) as negative_equal_bound from dual;
+ negative_equal_bound 
+----------------------
+ -1
+(1 row)
+
+select dbms_random.value(10, 10) as positive_equal_bound from dual;
+ positive_equal_bound 
+----------------------
+ 10
+(1 row)
+
 call dbms_random.seed(cast(99 as number));
 select min(v) > 0 and max(v) <= 11 as reverse_range_ok
 from (select dbms_random.value(11, 0) as v

--- a/contrib/ivorysql_ora/expected/dbms_random.out
+++ b/contrib/ivorysql_ora/expected/dbms_random.out
@@ -1,0 +1,148 @@
+--
+-- dbms_random.sql
+--
+-- tests for the DBMS_RANDOM package:
+--   INITIALIZE / SEED / TERMINATE / NORMAL / RANDOM / STRING / VALUE
+-- Seeded sequences are deterministic, so exact values can be asserted.
+--
+--
+-- Deterministic sequence after INITIALIZE
+--
+call dbms_random.initialize(42);
+select dbms_random.random() as r1,
+       dbms_random.random() as r2,
+       dbms_random.random() as r3;
+     r1     |     r2     |     r3     
+------------+------------+------------
+ 1776835382 | 1002646612 | 1043717732
+(1 row)
+
+-- reseeding with the same value replays the same sequence
+call dbms_random.seed(cast(42 as number));
+select dbms_random.random() as r1_replayed,
+       dbms_random.random() as r2_replayed;
+ r1_replayed | r2_replayed 
+-------------+-------------
+ 1776835382  | 1002646612
+(1 row)
+
+-- text seeds are hashed
+call dbms_random.seed('hello world');
+select dbms_random.random() as from_text_seed;
+ from_text_seed 
+----------------
+ -1232974089
+(1 row)
+
+--
+-- VALUE: [0, 1)
+--
+call dbms_random.seed(cast(7 as number));
+select dbms_random.value() >= 0 and dbms_random.value() < 1 as value_in_unit_range;
+ value_in_unit_range 
+---------------------
+ t
+(1 row)
+
+-- VALUE(low, high) stays within the requested bounds
+call dbms_random.seed(cast(99 as number));
+select min(v) >= 10 and max(v) < 20 as range_ok
+from (select dbms_random.value(10, 20) as v
+      from generate_series(1, 200) t) s;
+ range_ok 
+----------
+ t
+(1 row)
+
+-- low > high is rejected
+select dbms_random.value(20, 10) from dual;
+ERROR:  the lower bound must not be greater than the upper bound
+CONTEXT:  PL/iSQL function sys.dbms_random.value line 43 at RETURN
+--
+-- STRING: deterministic with a seed, honors the character class
+--
+call dbms_random.seed(cast(1234 as number));
+select dbms_random.string('U', 8) as upper_only;
+ upper_only 
+------------
+ QREBJFGB
+(1 row)
+
+select dbms_random.string('L', 8) as lower_only;
+ lower_only 
+------------
+ ygpxpgvk
+(1 row)
+
+select dbms_random.string('A', 8) as alpha_mixed;
+ alpha_mixed 
+-------------
+ eXpJRSKu
+(1 row)
+
+select dbms_random.string('X', 8) as upper_alnum;
+ upper_alnum 
+-------------
+ WKRQI633
+(1 row)
+
+select dbms_random.string('P', 8) as printable;
+ printable 
+-----------
+ C^IQlh%;
+(1 row)
+
+-- string of length 0 is empty
+select length(dbms_random.string('U', 0)) as empty_len;
+ empty_len 
+-----------
+         0
+(1 row)
+
+-- invalid character class and negative length are rejected
+select dbms_random.string('Z', 4) from dual;
+ERROR:  invalid character class "Z"
+HINT:  Valid classes are u, l, a, x and p.
+CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
+select dbms_random.string('UU', 4) from dual;
+ERROR:  the character class must be a single character: u, l, a, x or p
+CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
+select dbms_random.string('U', -1) from dual;
+ERROR:  the length must not be negative
+CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
+--
+-- RANDOM stays in BINARY_INTEGER range; NORMAL is a plain number
+--
+call dbms_random.seed(cast(-5 as number));
+select dbms_random.random() between -2147483648 and 2147483647 as random_in_range;
+ random_in_range 
+-----------------
+ t
+(1 row)
+
+select dbms_random.normal() is not null as normal_is_number;
+ normal_is_number 
+------------------
+ t
+(1 row)
+
+-- TERMINATE is a no-op that keeps working afterwards
+call dbms_random.terminate();
+select dbms_random.value() >= 0 as works_after_terminate;
+ works_after_terminate 
+-----------------------
+ t
+(1 row)
+
+--
+-- The generator state is reset by DISCARD ALL, so the next value comes
+-- from a fresh entropy-seeded state (cannot be asserted exactly).
+--
+call dbms_random.seed(cast(1 as number));
+discard all;
+select dbms_random.value() >= 0 as works_after_discard;
+ works_after_discard 
+---------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/dbms_random.out
+++ b/contrib/ivorysql_ora/expected/dbms_random.out
@@ -54,10 +54,23 @@ from (select dbms_random.value(10, 20) as v
  t
 (1 row)
 
--- low > high is rejected
+-- empty or inverted VALUE ranges are rejected
 select dbms_random.value(20, 10) from dual;
 ERROR:  the lower bound must not be greater than the upper bound
 CONTEXT:  PL/iSQL function sys.dbms_random.value line 43 at RETURN
+select dbms_random.value(10, 10) from dual;
+ERROR:  the lower bound must not be greater than the upper bound
+CONTEXT:  PL/iSQL function sys.dbms_random.value line 43 at RETURN
+-- VALUE retains NUMBER bounds that cannot be represented exactly as float8
+call dbms_random.seed(cast(99 as number));
+select min(v) >= 10000000000000001 and max(v) < 10000000000000002 as large_range_ok
+from (select dbms_random.value(10000000000000001, 10000000000000002) as v
+      from generate_series(1, 200) t) s;
+ large_range_ok 
+----------------
+ t
+(1 row)
+
 --
 -- STRING: deterministic with a seed, honors the character class
 --
@@ -99,17 +112,34 @@ select length(dbms_random.string('U', 0)) as empty_len;
          0
 (1 row)
 
--- invalid character class and negative length are rejected
-select dbms_random.string('Z', 4) from dual;
-ERROR:  invalid character class "Z"
-HINT:  Valid classes are u, l, a, x and p.
-CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
+-- unknown character classes default to uppercase; malformed input is rejected
+select dbms_random.string('Z', 4) ~ '^[A-Z]{4}$' as unknown_class_is_upper from dual;
+ unknown_class_is_upper 
+------------------------
+ t
+(1 row)
+
 select dbms_random.string('UU', 4) from dual;
 ERROR:  the character class must be a single character: u, l, a, x or p
 CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
 select dbms_random.string('U', -1) from dual;
 ERROR:  the length must not be negative
 CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
+-- NULL numeric seeds do not enter the C numeric conversion path
+call dbms_random.initialize(cast(NULL as number));
+select dbms_random.random() is not null as works_after_null_initialize;
+ works_after_null_initialize 
+-----------------------------
+ t
+(1 row)
+
+call dbms_random.seed(cast(NULL as number));
+select dbms_random.random() is not null as works_after_null_seed;
+ works_after_null_seed 
+-----------------------
+ t
+(1 row)
+
 --
 -- RANDOM stays in BINARY_INTEGER range; NORMAL is a plain number
 --

--- a/contrib/ivorysql_ora/expected/dbms_random.out
+++ b/contrib/ivorysql_ora/expected/dbms_random.out
@@ -56,10 +56,10 @@ from (select dbms_random.value(10, 20) as v
 
 -- equal VALUE bounds are rejected; reverse ranges are supported
 select dbms_random.value(10, 10) from dual;
-ERROR:  the lower bound must not be greater than the upper bound
+ERROR:  the two bounds must not be equal
 CONTEXT:  PL/iSQL function sys.dbms_random.value line 43 at RETURN
 call dbms_random.seed(cast(99 as number));
-select min(v) >= 0 and max(v) <= 11 as reverse_range_ok
+select min(v) > 0 and max(v) <= 11 as reverse_range_ok
 from (select dbms_random.value(11, 0) as v
       from generate_series(1, 200) t) s;
  reverse_range_ok 

--- a/contrib/ivorysql_ora/expected/dbms_random.out
+++ b/contrib/ivorysql_ora/expected/dbms_random.out
@@ -105,11 +105,68 @@ select dbms_random.string('P', 8) as printable;
  C^IQlh%;
 (1 row)
 
--- string of length 0 is empty
-select length(dbms_random.string('U', 0)) as empty_len;
- empty_len 
------------
-         0
+-- Oracle-compatible STRING NULL, length, and option behavior
+select dbms_random.string(null, null) from dual;
+ERROR:  an argument is NULL
+CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
+select dbms_random.string(null, -1) is null as null_opt_negative_len_is_null from dual;
+ null_opt_negative_len_is_null 
+-------------------------------
+ t
+(1 row)
+
+select dbms_random.string('U', 0) is null as zero_len_is_null from dual;
+ zero_len_is_null 
+------------------
+ t
+(1 row)
+
+select dbms_random.string(null, 5) ~ '^[A-Z]{5}$' as null_opt_is_upper from dual;
+ null_opt_is_upper 
+-------------------
+ t
+(1 row)
+
+select dbms_random.string('', 5) ~ '^[A-Z]{5}$' as empty_opt_is_upper from dual;
+ empty_opt_is_upper 
+--------------------
+ t
+(1 row)
+
+select length(dbms_random.string('U', '12')) as text_len;
+ text_len 
+----------
+       12
+(1 row)
+
+select length(dbms_random.string('U', 1e2)) as exponent_len;
+ exponent_len 
+--------------
+          100
+(1 row)
+
+select length(dbms_random.string('U', '1e2')) as text_exponent_len;
+ text_exponent_len 
+-------------------
+               100
+(1 row)
+
+select length(dbms_random.string('U', 11.22)) as fractional_len;
+ fractional_len 
+----------------
+             11
+(1 row)
+
+select length(dbms_random.string('U', '32767')) as capped_text_len;
+ capped_text_len 
+-----------------
+            4000
+(1 row)
+
+select length(dbms_random.string('U', '32768')) as capped_text_len_over;
+ capped_text_len_over 
+----------------------
+                 4000
 (1 row)
 
 -- unknown character classes default to uppercase; malformed input is rejected
@@ -121,9 +178,6 @@ select dbms_random.string('Z', 4) ~ '^[A-Z]{4}$' as unknown_class_is_upper from 
 
 select dbms_random.string('UU', 4) from dual;
 ERROR:  the character class must be a single character: u, l, a, x or p
-CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
-select dbms_random.string('U', -1) from dual;
-ERROR:  the length must not be negative
 CONTEXT:  PL/iSQL function sys.dbms_random.string line 33 at RETURN
 -- NULL numeric seeds do not enter the C numeric conversion path
 call dbms_random.initialize(cast(NULL as number));

--- a/contrib/ivorysql_ora/expected/dbms_random.out
+++ b/contrib/ivorysql_ora/expected/dbms_random.out
@@ -54,13 +54,19 @@ from (select dbms_random.value(10, 20) as v
  t
 (1 row)
 
--- empty or inverted VALUE ranges are rejected
-select dbms_random.value(20, 10) from dual;
-ERROR:  the lower bound must not be greater than the upper bound
-CONTEXT:  PL/iSQL function sys.dbms_random.value line 43 at RETURN
+-- equal VALUE bounds are rejected; reverse ranges are supported
 select dbms_random.value(10, 10) from dual;
 ERROR:  the lower bound must not be greater than the upper bound
 CONTEXT:  PL/iSQL function sys.dbms_random.value line 43 at RETURN
+call dbms_random.seed(cast(99 as number));
+select min(v) >= 0 and max(v) <= 11 as reverse_range_ok
+from (select dbms_random.value(11, 0) as v
+      from generate_series(1, 200) t) s;
+ reverse_range_ok 
+------------------
+ t
+(1 row)
+
 -- VALUE retains NUMBER bounds that cannot be represented exactly as float8
 call dbms_random.seed(cast(99 as number));
 select min(v) >= 10000000000000001 and max(v) < 10000000000000002 as large_range_ok

--- a/contrib/ivorysql_ora/expected/dbms_random.out
+++ b/contrib/ivorysql_ora/expected/dbms_random.out
@@ -44,6 +44,18 @@ select dbms_random.value() >= 0 and dbms_random.value() < 1 as value_in_unit_ran
  t
 (1 row)
 
+-- VALUE can be used without parentheses as an ORDER BY expression
+call dbms_random.seed(cast(42 as number));
+select n from generate_series(1, 5) as t(n) order by dbms_random.value;
+ n 
+---
+ 5
+ 4
+ 2
+ 3
+ 1
+(5 rows)
+
 -- VALUE(low, high) stays within the requested bounds
 call dbms_random.seed(cast(99 as number));
 select min(v) >= 10 and max(v) < 20 as range_ok

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -10,3 +10,4 @@ src/builtin_packages/utl_raw/utl_raw
 src/builtin_packages/utl_encode/utl_encode
 src/builtin_packages/dbms_session/dbms_session
 src/builtin_packages/dbms_transaction/dbms_transaction
+src/builtin_packages/dbms_random/dbms_random

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -33,7 +33,8 @@ ivorysql_ora_sources = files(
   'src/builtin_packages/utl_raw/utl_raw.c',
   'src/builtin_packages/utl_encode/utl_encode.c',
   'src/builtin_packages/dbms_session/dbms_session.c',
-  'src/builtin_packages/dbms_transaction/dbms_transaction.c'
+  'src/builtin_packages/dbms_transaction/dbms_transaction.c',
+  'src/builtin_packages/dbms_random/dbms_random.c'
 )
 
 if host_system == 'windows'

--- a/contrib/ivorysql_ora/sql/dbms_random.sql
+++ b/contrib/ivorysql_ora/sql/dbms_random.sql
@@ -55,13 +55,22 @@ select dbms_random.string('A', 8) as alpha_mixed;
 select dbms_random.string('X', 8) as upper_alnum;
 select dbms_random.string('P', 8) as printable;
 
--- string of length 0 is empty
-select length(dbms_random.string('U', 0)) as empty_len;
+-- Oracle-compatible STRING NULL, length, and option behavior
+select dbms_random.string(null, null) from dual;
+select dbms_random.string(null, -1) is null as null_opt_negative_len_is_null from dual;
+select dbms_random.string('U', 0) is null as zero_len_is_null from dual;
+select dbms_random.string(null, 5) ~ '^[A-Z]{5}$' as null_opt_is_upper from dual;
+select dbms_random.string('', 5) ~ '^[A-Z]{5}$' as empty_opt_is_upper from dual;
+select length(dbms_random.string('U', '12')) as text_len;
+select length(dbms_random.string('U', 1e2)) as exponent_len;
+select length(dbms_random.string('U', '1e2')) as text_exponent_len;
+select length(dbms_random.string('U', 11.22)) as fractional_len;
+select length(dbms_random.string('U', '32767')) as capped_text_len;
+select length(dbms_random.string('U', '32768')) as capped_text_len_over;
 
 -- unknown character classes default to uppercase; malformed input is rejected
 select dbms_random.string('Z', 4) ~ '^[A-Z]{4}$' as unknown_class_is_upper from dual;
 select dbms_random.string('UU', 4) from dual;
-select dbms_random.string('U', -1) from dual;
 
 -- NULL numeric seeds do not enter the C numeric conversion path
 call dbms_random.initialize(cast(NULL as number));

--- a/contrib/ivorysql_ora/sql/dbms_random.sql
+++ b/contrib/ivorysql_ora/sql/dbms_random.sql
@@ -35,8 +35,9 @@ select min(v) >= 10 and max(v) < 20 as range_ok
 from (select dbms_random.value(10, 20) as v
       from generate_series(1, 200) t) s;
 
--- equal VALUE bounds are rejected; reverse ranges are supported
-select dbms_random.value(10, 10) from dual;
+-- equal VALUE bounds return the shared bound; reverse ranges are supported
+select dbms_random.value(-1, -1) as negative_equal_bound from dual;
+select dbms_random.value(10, 10) as positive_equal_bound from dual;
 call dbms_random.seed(cast(99 as number));
 select min(v) > 0 and max(v) <= 11 as reverse_range_ok
 from (select dbms_random.value(11, 0) as v

--- a/contrib/ivorysql_ora/sql/dbms_random.sql
+++ b/contrib/ivorysql_ora/sql/dbms_random.sql
@@ -1,0 +1,76 @@
+--
+-- dbms_random.sql
+--
+-- tests for the DBMS_RANDOM package:
+--   INITIALIZE / SEED / TERMINATE / NORMAL / RANDOM / STRING / VALUE
+-- Seeded sequences are deterministic, so exact values can be asserted.
+--
+
+--
+-- Deterministic sequence after INITIALIZE
+--
+call dbms_random.initialize(42);
+select dbms_random.random() as r1,
+       dbms_random.random() as r2,
+       dbms_random.random() as r3;
+
+-- reseeding with the same value replays the same sequence
+call dbms_random.seed(cast(42 as number));
+select dbms_random.random() as r1_replayed,
+       dbms_random.random() as r2_replayed;
+
+-- text seeds are hashed
+call dbms_random.seed('hello world');
+select dbms_random.random() as from_text_seed;
+
+--
+-- VALUE: [0, 1)
+--
+call dbms_random.seed(cast(7 as number));
+select dbms_random.value() >= 0 and dbms_random.value() < 1 as value_in_unit_range;
+
+-- VALUE(low, high) stays within the requested bounds
+call dbms_random.seed(cast(99 as number));
+select min(v) >= 10 and max(v) < 20 as range_ok
+from (select dbms_random.value(10, 20) as v
+      from generate_series(1, 200) t) s;
+
+-- low > high is rejected
+select dbms_random.value(20, 10) from dual;
+
+--
+-- STRING: deterministic with a seed, honors the character class
+--
+call dbms_random.seed(cast(1234 as number));
+select dbms_random.string('U', 8) as upper_only;
+select dbms_random.string('L', 8) as lower_only;
+select dbms_random.string('A', 8) as alpha_mixed;
+select dbms_random.string('X', 8) as upper_alnum;
+select dbms_random.string('P', 8) as printable;
+
+-- string of length 0 is empty
+select length(dbms_random.string('U', 0)) as empty_len;
+
+-- invalid character class and negative length are rejected
+select dbms_random.string('Z', 4) from dual;
+select dbms_random.string('UU', 4) from dual;
+select dbms_random.string('U', -1) from dual;
+
+--
+-- RANDOM stays in BINARY_INTEGER range; NORMAL is a plain number
+--
+call dbms_random.seed(cast(-5 as number));
+select dbms_random.random() between -2147483648 and 2147483647 as random_in_range;
+select dbms_random.normal() is not null as normal_is_number;
+
+-- TERMINATE is a no-op that keeps working afterwards
+call dbms_random.terminate();
+select dbms_random.value() >= 0 as works_after_terminate;
+
+--
+-- The generator state is reset by DISCARD ALL, so the next value comes
+-- from a fresh entropy-seeded state (cannot be asserted exactly).
+--
+call dbms_random.seed(cast(1 as number));
+discard all;
+select dbms_random.value() >= 0 as works_after_discard;

--- a/contrib/ivorysql_ora/sql/dbms_random.sql
+++ b/contrib/ivorysql_ora/sql/dbms_random.sql
@@ -38,7 +38,7 @@ from (select dbms_random.value(10, 20) as v
 -- equal VALUE bounds are rejected; reverse ranges are supported
 select dbms_random.value(10, 10) from dual;
 call dbms_random.seed(cast(99 as number));
-select min(v) >= 0 and max(v) <= 11 as reverse_range_ok
+select min(v) > 0 and max(v) <= 11 as reverse_range_ok
 from (select dbms_random.value(11, 0) as v
       from generate_series(1, 200) t) s;
 

--- a/contrib/ivorysql_ora/sql/dbms_random.sql
+++ b/contrib/ivorysql_ora/sql/dbms_random.sql
@@ -35,9 +35,12 @@ select min(v) >= 10 and max(v) < 20 as range_ok
 from (select dbms_random.value(10, 20) as v
       from generate_series(1, 200) t) s;
 
--- empty or inverted VALUE ranges are rejected
-select dbms_random.value(20, 10) from dual;
+-- equal VALUE bounds are rejected; reverse ranges are supported
 select dbms_random.value(10, 10) from dual;
+call dbms_random.seed(cast(99 as number));
+select min(v) >= 0 and max(v) <= 11 as reverse_range_ok
+from (select dbms_random.value(11, 0) as v
+      from generate_series(1, 200) t) s;
 
 -- VALUE retains NUMBER bounds that cannot be represented exactly as float8
 call dbms_random.seed(cast(99 as number));

--- a/contrib/ivorysql_ora/sql/dbms_random.sql
+++ b/contrib/ivorysql_ora/sql/dbms_random.sql
@@ -35,8 +35,15 @@ select min(v) >= 10 and max(v) < 20 as range_ok
 from (select dbms_random.value(10, 20) as v
       from generate_series(1, 200) t) s;
 
--- low > high is rejected
+-- empty or inverted VALUE ranges are rejected
 select dbms_random.value(20, 10) from dual;
+select dbms_random.value(10, 10) from dual;
+
+-- VALUE retains NUMBER bounds that cannot be represented exactly as float8
+call dbms_random.seed(cast(99 as number));
+select min(v) >= 10000000000000001 and max(v) < 10000000000000002 as large_range_ok
+from (select dbms_random.value(10000000000000001, 10000000000000002) as v
+      from generate_series(1, 200) t) s;
 
 --
 -- STRING: deterministic with a seed, honors the character class
@@ -51,10 +58,16 @@ select dbms_random.string('P', 8) as printable;
 -- string of length 0 is empty
 select length(dbms_random.string('U', 0)) as empty_len;
 
--- invalid character class and negative length are rejected
-select dbms_random.string('Z', 4) from dual;
+-- unknown character classes default to uppercase; malformed input is rejected
+select dbms_random.string('Z', 4) ~ '^[A-Z]{4}$' as unknown_class_is_upper from dual;
 select dbms_random.string('UU', 4) from dual;
 select dbms_random.string('U', -1) from dual;
+
+-- NULL numeric seeds do not enter the C numeric conversion path
+call dbms_random.initialize(cast(NULL as number));
+select dbms_random.random() is not null as works_after_null_initialize;
+call dbms_random.seed(cast(NULL as number));
+select dbms_random.random() is not null as works_after_null_seed;
 
 --
 -- RANDOM stays in BINARY_INTEGER range; NORMAL is a plain number

--- a/contrib/ivorysql_ora/sql/dbms_random.sql
+++ b/contrib/ivorysql_ora/sql/dbms_random.sql
@@ -29,6 +29,10 @@ select dbms_random.random() as from_text_seed;
 call dbms_random.seed(cast(7 as number));
 select dbms_random.value() >= 0 and dbms_random.value() < 1 as value_in_unit_range;
 
+-- VALUE can be used without parentheses as an ORDER BY expression
+call dbms_random.seed(cast(42 as number));
+select n from generate_series(1, 5) as t(n) order by dbms_random.value;
+
 -- VALUE(low, high) stays within the requested bounds
 call dbms_random.seed(cast(99 as number));
 select min(v) >= 10 and max(v) < 20 as range_ok

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random--1.0.sql
@@ -1,0 +1,144 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * dbms_random--1.0.sql
+ *
+ * Oracle-compatible DBMS_RANDOM package.
+ *
+ * The generator state is per-backend; INITIALIZE/SEED make the sequence
+ * deterministic for a given seed, which is what migrated applications use
+ * it for.  Sequences are not bit-for-bit identical to Oracle's proprietary
+ * generator (nor are orafce's).
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random--1.0.sql
+ *
+ *-------------------------------------------------------------------------
+ */
+
+-- Register C functions for DBMS_RANDOM
+CREATE FUNCTION sys.ora_dbms_random_initialize(seed NUMBER)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'ora_dbms_random_initialize'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_random_seed_number(seed NUMBER)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'ora_dbms_random_seed_number'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_random_seed_text(seed VARCHAR2)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'ora_dbms_random_seed_text'
+LANGUAGE C VOLATILE STRICT;
+
+CREATE FUNCTION sys.ora_dbms_random_terminate()
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'ora_dbms_random_terminate'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_random_normal()
+RETURNS NUMBER
+AS 'MODULE_PATHNAME', 'ora_dbms_random_normal'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_random_random()
+RETURNS NUMBER
+AS 'MODULE_PATHNAME', 'ora_dbms_random_random'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_random_string(opt VARCHAR2, len NUMBER)
+RETURNS VARCHAR2
+AS 'MODULE_PATHNAME', 'ora_dbms_random_string'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_random_value()
+RETURNS NUMBER
+AS 'MODULE_PATHNAME', 'ora_dbms_random_value'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_dbms_random_value_range(low NUMBER, high NUMBER)
+RETURNS NUMBER
+AS 'MODULE_PATHNAME', 'ora_dbms_random_value_range'
+LANGUAGE C VOLATILE;
+
+-- DBMS_RANDOM Package Definition
+CREATE OR REPLACE PACKAGE dbms_random IS
+
+  PROCEDURE initialize(val IN NUMBER);
+  PROCEDURE seed(val IN NUMBER);
+  PROCEDURE seed(val IN VARCHAR2);
+  PROCEDURE terminate;
+
+  FUNCTION normal RETURN NUMBER;
+  FUNCTION random RETURN NUMBER;
+  FUNCTION string(opt IN CHAR, len IN NUMBER) RETURN VARCHAR2;
+  FUNCTION value RETURN NUMBER;
+  FUNCTION value(low IN NUMBER, high IN NUMBER) RETURN NUMBER;
+
+END dbms_random;
+
+CREATE OR REPLACE PACKAGE BODY dbms_random IS
+
+  PROCEDURE initialize(val IN NUMBER) IS
+  BEGIN
+    PERFORM sys.ora_dbms_random_initialize(val);
+  END;
+
+  PROCEDURE seed(val IN NUMBER) IS
+  BEGIN
+    PERFORM sys.ora_dbms_random_seed_number(val);
+  END;
+
+  PROCEDURE seed(val IN VARCHAR2) IS
+  BEGIN
+    PERFORM sys.ora_dbms_random_seed_text(val);
+  END;
+
+  PROCEDURE terminate IS
+  BEGIN
+    PERFORM sys.ora_dbms_random_terminate();
+  END;
+
+  FUNCTION normal RETURN NUMBER IS
+  BEGIN
+    RETURN sys.ora_dbms_random_normal();
+  END;
+
+  FUNCTION random RETURN NUMBER IS
+  BEGIN
+    RETURN sys.ora_dbms_random_random();
+  END;
+
+  FUNCTION string(opt IN CHAR, len IN NUMBER) RETURN VARCHAR2 IS
+  BEGIN
+    RETURN sys.ora_dbms_random_string(opt, len);
+  END;
+
+  FUNCTION value RETURN NUMBER IS
+  BEGIN
+    RETURN sys.ora_dbms_random_value();
+  END;
+
+  FUNCTION value(low IN NUMBER, high IN NUMBER) RETURN NUMBER IS
+  BEGIN
+    RETURN sys.ora_dbms_random_value_range(low, high);
+  END;
+
+END dbms_random;
+
+-- Packages default to no PUBLIC privileges at all (unlike plain FUNCTION/
+-- PROCEDURE, which grant EXECUTE to PUBLIC by default) -- without this,
+-- only the role that ran CREATE EXTENSION could call any subprogram here.
+GRANT EXECUTE ON PACKAGE dbms_random TO PUBLIC;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random--1.0.sql
@@ -74,7 +74,7 @@ AS 'MODULE_PATHNAME', 'ora_dbms_random_value_range'
 LANGUAGE C VOLATILE;
 
 -- DBMS_RANDOM Package Definition
-CREATE OR REPLACE PACKAGE dbms_random IS
+CREATE OR REPLACE PACKAGE dbms_random AUTHID CURRENT_USER IS
 
   PROCEDURE initialize(val IN NUMBER);
   PROCEDURE seed(val IN NUMBER);

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random--1.0.sql
@@ -31,12 +31,12 @@
 CREATE FUNCTION sys.ora_dbms_random_initialize(seed NUMBER)
 RETURNS VOID
 AS 'MODULE_PATHNAME', 'ora_dbms_random_initialize'
-LANGUAGE C VOLATILE;
+LANGUAGE C VOLATILE STRICT;
 
 CREATE FUNCTION sys.ora_dbms_random_seed_number(seed NUMBER)
 RETURNS VOID
 AS 'MODULE_PATHNAME', 'ora_dbms_random_seed_number'
-LANGUAGE C VOLATILE;
+LANGUAGE C VOLATILE STRICT;
 
 CREATE FUNCTION sys.ora_dbms_random_seed_text(seed VARCHAR2)
 RETURNS VOID

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
@@ -42,8 +42,8 @@
 
 #include "../../include/ivorysql_ora.h"
 
-/* Oracle's BINARY_INTEGER range for RANDOM() */
-#define DBMS_RANDOM_MAX_STRING_LEN	32767
+/* Oracle's DBMS_RANDOM.STRING() maximum length */
+#define DBMS_RANDOM_MAX_STRING_LEN	4000
 
 /* Per-backend generator state */
 static pg_prng_state random_state;
@@ -203,17 +203,26 @@ ora_dbms_random_string(PG_FUNCTION_ARGS)
 	const char *charset;
 	size_t		chrset_size;
 	StringInfoData str;
-	char	   *opt;
+	const char *opt;
+	Numeric		truncated_len;
 	int			len;
 	int			i;
 
-	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+	if (PG_ARGISNULL(1))
 		ereport(ERROR,
 				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 				 errmsg("an argument is NULL")));
 
-	opt = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	if (opt[0] == '\0' || opt[1] != '\0')
+	if (PG_ARGISNULL(0))
+		opt = "U";
+	else
+	{
+		opt = text_to_cstring(PG_GETARG_TEXT_PP(0));
+		if (opt[0] == '\0')
+			opt = "U";
+	}
+
+	if (opt[1] != '\0')
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("the character class must be a single character: u, l, a, x or p")));
@@ -252,16 +261,23 @@ ora_dbms_random_string(PG_FUNCTION_ARGS)
 			break;
 	}
 
-	len = DatumGetInt32(DirectFunctionCall1(numeric_int4,
-												NumericGetDatum(PG_GETARG_NUMERIC(1))));
-	if (len < 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("the length must not be negative")));
-	if (len > DBMS_RANDOM_MAX_STRING_LEN)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("the length must not exceed %d", DBMS_RANDOM_MAX_STRING_LEN)));
+	truncated_len = DatumGetNumeric(DirectFunctionCall2(numeric_trunc,
+															NumericGetDatum(PG_GETARG_NUMERIC(1)),
+															Int32GetDatum(0)));
+	if (DatumGetInt32(DirectFunctionCall2(numeric_cmp,
+														NumericGetDatum(truncated_len),
+														DirectFunctionCall1(int4_numeric,
+																			Int32GetDatum(0)))) <= 0)
+		PG_RETURN_NULL();
+
+	if (DatumGetInt32(DirectFunctionCall2(numeric_cmp,
+														NumericGetDatum(truncated_len),
+														DirectFunctionCall1(int4_numeric,
+																			Int32GetDatum(DBMS_RANDOM_MAX_STRING_LEN)))) > 0)
+		len = DBMS_RANDOM_MAX_STRING_LEN;
+	else
+		len = DatumGetInt32(DirectFunctionCall1(numeric_int4,
+														NumericGetDatum(truncated_len)));
 
 	ensure_seeded();
 

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
@@ -315,8 +315,8 @@ ora_dbms_random_value(PG_FUNCTION_ARGS)
 /*
  * DBMS_RANDOM.VALUE(low, high)
  *
- * Returns a random NUMBER in [low, high).  An empty or inverted range cannot
- * satisfy that contract, so report an equivalent parameter error.
+ * Returns a random NUMBER in [low, high) or (high, low] for a reverse range.
+ * Equal bounds do not define a range.
  */
 Datum
 ora_dbms_random_value_range(PG_FUNCTION_ARGS)
@@ -335,8 +335,8 @@ ora_dbms_random_value_range(PG_FUNCTION_ARGS)
 	high = PG_GETARG_NUMERIC(1);
 
 	if (DatumGetInt32(DirectFunctionCall2(numeric_cmp,
-											NumericGetDatum(low),
-											NumericGetDatum(high))) >= 0)
+													NumericGetDatum(low),
+													NumericGetDatum(high))) == 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("the lower bound must not be greater than the upper bound")));

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
@@ -246,12 +246,9 @@ ora_dbms_random_string(PG_FUNCTION_ARGS)
 			chrset_size = strlen(printable);
 			break;
 		default:
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("invalid character class \"%s\"", opt),
-					 errhint("Valid classes are u, l, a, x and p.")));
-			charset = NULL;		/* quieten compiler */
-			chrset_size = 0;
+			/* Oracle defaults an unrecognized option to uppercase letters. */
+			charset = upper_only;
+			chrset_size = 26;
 			break;
 	}
 
@@ -302,34 +299,46 @@ ora_dbms_random_value(PG_FUNCTION_ARGS)
 /*
  * DBMS_RANDOM.VALUE(low, high)
  *
- * Returns a random NUMBER in [low, high).  Oracle raises VALUE_ERROR when
- * low > high; we report an equivalent parameter error.
+ * Returns a random NUMBER in [low, high).  An empty or inverted range cannot
+ * satisfy that contract, so report an equivalent parameter error.
  */
 Datum
 ora_dbms_random_value_range(PG_FUNCTION_ARGS)
 {
-	double		low;
-	double		high;
-	double		val;
+	Numeric		low;
+	Numeric		high;
+	Numeric		fraction;
+	Numeric		range;
+	Numeric		offset;
+	Numeric		result;
 
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_NULL();
 
-	low = DatumGetFloat8(DirectFunctionCall1(numeric_float8,
-											 NumericGetDatum(PG_GETARG_NUMERIC(0))));
-	high = DatumGetFloat8(DirectFunctionCall1(numeric_float8,
-											  NumericGetDatum(PG_GETARG_NUMERIC(1))));
+	low = PG_GETARG_NUMERIC(0);
+	high = PG_GETARG_NUMERIC(1);
 
-	if (low > high)
+	if (DatumGetInt32(DirectFunctionCall2(numeric_cmp,
+											NumericGetDatum(low),
+											NumericGetDatum(high))) >= 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("the lower bound must not be greater than the upper bound")));
 
 	ensure_seeded();
-	val = low + (high - low) * pg_prng_double(&random_state);
+	fraction = DatumGetNumeric(DirectFunctionCall1(float8_numeric,
+													Float8GetDatum(pg_prng_double(&random_state))));
+	range = DatumGetNumeric(DirectFunctionCall2(numeric_sub,
+													NumericGetDatum(high),
+													NumericGetDatum(low)));
+	offset = DatumGetNumeric(DirectFunctionCall2(numeric_mul,
+													 NumericGetDatum(range),
+													 NumericGetDatum(fraction)));
+	result = DatumGetNumeric(DirectFunctionCall2(numeric_add,
+													NumericGetDatum(low),
+													NumericGetDatum(offset)));
 
-	PG_RETURN_DATUM(DirectFunctionCall1(float8_numeric,
-										Float8GetDatum(val)));
+	PG_RETURN_NUMERIC(result);
 }
 
 /*

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
@@ -339,7 +339,7 @@ ora_dbms_random_value_range(PG_FUNCTION_ARGS)
 													NumericGetDatum(high))) == 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("the lower bound must not be greater than the upper bound")));
+				 errmsg("the two bounds must not be equal")));
 
 	ensure_seeded();
 	fraction = DatumGetNumeric(DirectFunctionCall1(float8_numeric,

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
@@ -1,0 +1,346 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Implementation of Oracle's DBMS_RANDOM package.
+ * This module is part of ivorysql_ora extension.
+ *
+ * Provides INITIALIZE, SEED, TERMINATE, NORMAL, RANDOM, STRING and VALUE.
+ * The generator state is per-backend (session-scoped) and seeded from
+ * PostgreSQL's portable PRNG (pg_prng), so a session that calls
+ * INITIALIZE/SEED with a given seed observes a deterministic sequence -
+ * which is what Oracle migrations use these interfaces for.  As with
+ * orafce, the produced sequences are not bit-for-bit identical to
+ * Oracle's proprietary generator.
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "varatt.h"
+
+#include "fmgr.h"
+#include "miscadmin.h"
+#include "common/hashfn.h"
+#include "common/pg_prng.h"
+#include "utils/builtins.h"
+#include "utils/numeric.h"
+#include "utils/timestamp.h"
+
+#include "../../include/ivorysql_ora.h"
+
+/* Oracle's BINARY_INTEGER range for RANDOM() */
+#define DBMS_RANDOM_MAX_STRING_LEN	32767
+
+/* Per-backend generator state */
+static pg_prng_state random_state;
+static bool		state_seeded = false;
+
+/* SQL-callable function declarations */
+PG_FUNCTION_INFO_V1(ora_dbms_random_initialize);
+PG_FUNCTION_INFO_V1(ora_dbms_random_seed_number);
+PG_FUNCTION_INFO_V1(ora_dbms_random_seed_text);
+PG_FUNCTION_INFO_V1(ora_dbms_random_terminate);
+PG_FUNCTION_INFO_V1(ora_dbms_random_normal);
+PG_FUNCTION_INFO_V1(ora_dbms_random_random);
+PG_FUNCTION_INFO_V1(ora_dbms_random_string);
+PG_FUNCTION_INFO_V1(ora_dbms_random_value);
+PG_FUNCTION_INFO_V1(ora_dbms_random_value_range);
+
+/*
+ * ensure_seeded - lazily initialize the generator.
+ *
+ * Oracle initializes DBMS_RANDOM automatically when the session first uses
+ * it; we mirror that by seeding from session-unique entropy on first use.
+ */
+static void
+ensure_seeded(void)
+{
+	if (!state_seeded)
+	{
+		pg_prng_seed(&random_state,
+					 (uint64) GetCurrentTimestamp() ^ ((uint64) MyProcPid << 32));
+		state_seeded = true;
+	}
+}
+
+/*
+ * seed_from_numeric - reseed from a numeric seed value.
+ *
+ * Oracle accepts any NUMBER for INITIALIZE/SEED and truncates it to an
+ * integer seed.
+ */
+static void
+seed_from_numeric(Numeric num)
+{
+	int64		seed;
+
+	seed = DatumGetInt64(DirectFunctionCall1(numeric_int8,
+											 NumericGetDatum(num)));
+	pg_prng_seed(&random_state, (uint64) seed);
+	state_seeded = true;
+}
+
+/*
+ * DBMS_RANDOM.INITIALIZE(seed)
+ *
+ * Initializes the generator with the given seed.  Present for Oracle
+ * compatibility; equivalent to SEED in this implementation.
+ */
+Datum
+ora_dbms_random_initialize(PG_FUNCTION_ARGS)
+{
+	seed_from_numeric(PG_GETARG_NUMERIC(0));
+	PG_RETURN_VOID();
+}
+
+/*
+ * DBMS_RANDOM.SEED(seed)
+ *
+ * Reseeds the generator.  Overloads take NUMBER or VARCHAR2; a string seed
+ * is hashed to 64 bits.
+ */
+Datum
+ora_dbms_random_seed_number(PG_FUNCTION_ARGS)
+{
+	seed_from_numeric(PG_GETARG_NUMERIC(0));
+	PG_RETURN_VOID();
+}
+
+Datum
+ora_dbms_random_seed_text(PG_FUNCTION_ARGS)
+{
+	text	   *seed = PG_GETARG_TEXT_PP(0);
+	const char *bytes = VARDATA_ANY(seed);
+	int			len = VARSIZE_ANY_EXHDR(seed);
+	uint64		hash;
+
+	hash = DatumGetUInt64(hash_any_extended((const unsigned char *) bytes,
+											len, 0));
+	pg_prng_seed(&random_state, hash);
+	state_seeded = true;
+	PG_RETURN_VOID();
+}
+
+/*
+ * DBMS_RANDOM.TERMINATE
+ *
+ * Deprecated by Oracle and a no-op there; retained so migrated code runs.
+ */
+Datum
+ora_dbms_random_terminate(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_VOID();
+}
+
+/*
+ * DBMS_RANDOM.NORMAL
+ *
+ * Returns a random NUMBER from a normal distribution with mean 0 and
+ * standard deviation 1.
+ */
+Datum
+ora_dbms_random_normal(PG_FUNCTION_ARGS)
+{
+	double		val;
+
+	ensure_seeded();
+	val = pg_prng_double_normal(&random_state);
+
+	PG_RETURN_DATUM(DirectFunctionCall1(float8_numeric,
+										Float8GetDatum(val)));
+}
+
+/*
+ * DBMS_RANDOM.RANDOM
+ *
+ * Returns a random BINARY_INTEGER in [-2147483648, 2147483647].
+ */
+Datum
+ora_dbms_random_random(PG_FUNCTION_ARGS)
+{
+	ensure_seeded();
+
+	PG_RETURN_DATUM(DirectFunctionCall1(int4_numeric,
+										Int32GetDatum((int32) pg_prng_uint32(&random_state))));
+}
+
+/*
+ * DBMS_RANDOM.STRING(opt, len)
+ *
+ * Returns a random string of `len` characters drawn from the character
+ * class selected by `opt`:
+ *
+ *   'u', 'U'  uppercase letters
+ *   'l', 'L'  lowercase letters
+ *   'a', 'A'  mixed-case letters
+ *   'x', 'X'  uppercase alphanumeric
+ *   'p', 'P'  any printable character
+ */
+Datum
+ora_dbms_random_string(PG_FUNCTION_ARGS)
+{
+	const char *upper_alnum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	const char *alpha_mixed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	const char *lower_only = "abcdefghijklmnopqrstuvwxyz";
+	const char *upper_only = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	const char *printable = "`1234567890-=qwertyuiop[]asdfghjkl;'zxcvbnm,./"
+							"!@#$%^&*()_+QWERTYUIOP{}|ASDFGHJKL:\"ZXCVBNM<>?"
+							" \\~";
+	const char *charset;
+	size_t		chrset_size;
+	StringInfoData str;
+	char	   *opt;
+	int			len;
+	int			i;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("an argument is NULL")));
+
+	opt = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	if (opt[0] == '\0' || opt[1] != '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("the character class must be a single character: u, l, a, x or p")));
+
+	switch (opt[0])
+	{
+		case 'u':
+		case 'U':
+			charset = upper_only;
+			chrset_size = 26;
+			break;
+		case 'l':
+		case 'L':
+			charset = lower_only;
+			chrset_size = 26;
+			break;
+		case 'a':
+		case 'A':
+			charset = alpha_mixed;
+			chrset_size = 52;
+			break;
+		case 'x':
+		case 'X':
+			charset = upper_alnum;
+			chrset_size = 36;
+			break;
+		case 'p':
+		case 'P':
+			charset = printable;
+			chrset_size = strlen(printable);
+			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid character class \"%s\"", opt),
+					 errhint("Valid classes are u, l, a, x and p.")));
+			charset = NULL;		/* quieten compiler */
+			chrset_size = 0;
+			break;
+	}
+
+	len = DatumGetInt32(DirectFunctionCall1(numeric_int4,
+												NumericGetDatum(PG_GETARG_NUMERIC(1))));
+	if (len < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("the length must not be negative")));
+	if (len > DBMS_RANDOM_MAX_STRING_LEN)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("the length must not exceed %d", DBMS_RANDOM_MAX_STRING_LEN)));
+
+	ensure_seeded();
+
+	initStringInfo(&str);
+	for (i = 0; i < len; i++)
+	{
+		size_t		pos = (size_t) (pg_prng_double(&random_state) * chrset_size);
+
+		/* pg_prng_double() returns [0,1); guard the 1-in-2^53 clamp case */
+		if (pos >= chrset_size)
+			pos = chrset_size - 1;
+		appendStringInfoChar(&str, charset[pos]);
+	}
+
+	PG_RETURN_TEXT_P(cstring_to_text(str.data));
+}
+
+/*
+ * DBMS_RANDOM.VALUE
+ *
+ * One-argument-free form: returns a random NUMBER in [0.0, 1.0).
+ */
+Datum
+ora_dbms_random_value(PG_FUNCTION_ARGS)
+{
+	double		val;
+
+	ensure_seeded();
+	val = pg_prng_double(&random_state);
+
+	PG_RETURN_DATUM(DirectFunctionCall1(float8_numeric,
+										Float8GetDatum(val)));
+}
+
+/*
+ * DBMS_RANDOM.VALUE(low, high)
+ *
+ * Returns a random NUMBER in [low, high).  Oracle raises VALUE_ERROR when
+ * low > high; we report an equivalent parameter error.
+ */
+Datum
+ora_dbms_random_value_range(PG_FUNCTION_ARGS)
+{
+	double		low;
+	double		high;
+	double		val;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+
+	low = DatumGetFloat8(DirectFunctionCall1(numeric_float8,
+											 NumericGetDatum(PG_GETARG_NUMERIC(0))));
+	high = DatumGetFloat8(DirectFunctionCall1(numeric_float8,
+											  NumericGetDatum(PG_GETARG_NUMERIC(1))));
+
+	if (low > high)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("the lower bound must not be greater than the upper bound")));
+
+	ensure_seeded();
+	val = low + (high - low) * pg_prng_double(&random_state);
+
+	PG_RETURN_DATUM(DirectFunctionCall1(float8_numeric,
+										Float8GetDatum(val)));
+}
+
+/*
+ * ora_dbms_random_reset
+ *
+ * Drop the generator state.  Called by DISCARD ALL/PACKAGES so that a
+ * pooled connection does not carry one client's generator sequence to the
+ * next; the next call reseeds from entropy.
+ */
+void
+ora_dbms_random_reset(void)
+{
+	state_seeded = false;
+}

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_random/dbms_random.c
@@ -316,7 +316,7 @@ ora_dbms_random_value(PG_FUNCTION_ARGS)
  * DBMS_RANDOM.VALUE(low, high)
  *
  * Returns a random NUMBER in [low, high) or (high, low] for a reverse range.
- * Equal bounds do not define a range.
+ * Equal bounds return the shared bound.
  */
 Datum
 ora_dbms_random_value_range(PG_FUNCTION_ARGS)
@@ -337,9 +337,7 @@ ora_dbms_random_value_range(PG_FUNCTION_ARGS)
 	if (DatumGetInt32(DirectFunctionCall2(numeric_cmp,
 													NumericGetDatum(low),
 													NumericGetDatum(high))) == 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("the two bounds must not be equal")));
+		PG_RETURN_NUMERIC(low);
 
 	ensure_seeded();
 	fraction = DatumGetNumeric(DirectFunctionCall1(float8_numeric,

--- a/contrib/ivorysql_ora/src/include/ivorysql_ora.h
+++ b/contrib/ivorysql_ora/src/include/ivorysql_ora.h
@@ -55,5 +55,6 @@ extern void ora_dbms_output_reset(void);
 
 /* DBMS_SESSION */
 extern void ora_dbms_session_reset(void);
+extern void ora_dbms_random_reset(void);
 
 #endif	/* IVORYSQL_ORA_H_ */

--- a/contrib/ivorysql_ora/src/include/ivorysql_ora.h
+++ b/contrib/ivorysql_ora/src/include/ivorysql_ora.h
@@ -55,6 +55,8 @@ extern void ora_dbms_output_reset(void);
 
 /* DBMS_SESSION */
 extern void ora_dbms_session_reset(void);
+
+/* DBMS_RANDOM */
 extern void ora_dbms_random_reset(void);
 
 #endif	/* IVORYSQL_ORA_H_ */

--- a/contrib/ivorysql_ora/src/ivorysql_ora.c
+++ b/contrib/ivorysql_ora/src/ivorysql_ora.c
@@ -203,7 +203,8 @@ reject_alter_role_dbtimezone(Node *parsetree)
 /*
  * ProcessUtility hook to intercept DISCARD ALL/PACKAGES commands and
  * ALTER ROLE ... SET ivorysql.dbtimezone.
- * Resets DBMS_OUTPUT buffer state after DISCARD ALL/PACKAGES executes.
+ * Resets DBMS_OUTPUT buffer state, DBMS_SESSION context, and DBMS_RANDOM
+ * generator state after DISCARD ALL/PACKAGES executes.
  */
 static void
 ivorysql_ora_ProcessUtility(PlannedStmt *pstmt,
@@ -237,7 +238,7 @@ ivorysql_ora_ProcessUtility(PlannedStmt *pstmt,
 		standard_ProcessUtility(pstmt, queryString, readOnlyTree,
 								context, params, queryEnv, dest, qc);
 
-	/* Reset DBMS_OUTPUT buffer and DBMS_SESSION context after DISCARD ALL/PACKAGES */
+	/* Reset DBMS_OUTPUT, DBMS_SESSION, and DBMS_RANDOM after DISCARD ALL/PACKAGES */
 	if (is_discard_reset)
 	{
 		ora_dbms_output_reset();

--- a/contrib/ivorysql_ora/src/ivorysql_ora.c
+++ b/contrib/ivorysql_ora/src/ivorysql_ora.c
@@ -242,5 +242,6 @@ ivorysql_ora_ProcessUtility(PlannedStmt *pstmt,
 	{
 		ora_dbms_output_reset();
 		ora_dbms_session_reset();
+		ora_dbms_random_reset();
 	}
 }


### PR DESCRIPTION
## Problem

Fixes #1777

IvorySQL does not currently provide an Oracle-compatible DBMS_RANDOM package. Oracle-migrated applications and test suites rely on its seeded random generator for repeatable test data and on its standard package API for generating numbers and strings.

## Summary

Adds DBMS_RANDOM as a built-in package of ivorysql_ora:

- INITIALIZE and NUMBER/VARCHAR2 SEED overloads for deterministic reseeding.
- TERMINATE as the documented no-op.
- NORMAL, RANDOM, STRING, VALUE, and VALUE(low, high).
- Per-backend state backed by PostgreSQL's portable pg_prng generator.
- Generator-state reset on DISCARD ALL and DISCARD PACKAGES through the existing extension hook.
- sys entry points, PUBLIC EXECUTE grant, package SQL, and Makefile/Meson/SQL merge-list registration.

Seeded sequences are deterministic within IvorySQL; as with orafce, they are not intended to be bit-for-bit identical to Oracle's proprietary generator.

## Testing

The DBMS_RANDOM regression test covers deterministic numeric seeds and seed replay, VARCHAR2 seeds, exact seeded sequences, supported STRING character classes, invalid options and lengths, VALUE bounds and error paths, NORMAL, TERMINATE, and state reset behavior.

## Verification

- Clean GNU make build: passed.
- Extension install: passed.
- Targeted DBMS_RANDOM regression: 1/1 passed.
- git diff --check: passed.
- Final PR scope audit: only DBMS_RANDOM implementation, SQL, tests, and required build/registration/reset wiring are present.

This PR was split from the original combined DBMS_RANDOM/DBMS_ASSERT contribution per maintainer request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Oracle-compatible `DBMS_RANDOM` package.
  * Supports initialization, numeric and text seeding, random and normal values, bounded values, generated strings, and termination.
  * Random state resets correctly after session discard commands.
* **Bug Fixes**
  * Improved validation for invalid ranges, string lengths, and large numeric bounds.
  * Unrecognized string options now generate uppercase letters by default.
  * NULL seed and initialization inputs are handled safely.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->