### PR TITLE
Fix potential buffer overrun in regexp match/split functions (CVE-2026-14664)

### DIFF
--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -2029,23 +2029,24 @@ setup_regexp_matches(text *orig_str, text *pattern, pg_re_flags *re_flags,
 
 	if (eml > 1)
 	{
-		int64		maxsiz = eml * (int64) maxlen;
 		int			conv_bufsiz;
 
 		/*
 		 * Make the conversion buffer large enough for any substring of
-		 * interest.
+		 * interest. We can't use the original string's byte length as a
+		 * tighter bound, because that assumes the input is validly encoded;
+		 * but pg_mb2wchar_with_len() can accept strings that are invalid in
+		 * the database encoding, and converting such a character back to
+		 * multibyte form can take more bytes than it did in the input.
 		 *
-		 * Worst case: assume we need the maximum size (maxlen*eml), but take
-		 * advantage of the fact that the original string length in bytes is
-		 * an upper bound on the byte length of any fetched substring (and we
-		 * know that len+1 is safe to allocate because the varlena header is
-		 * longer than 1 byte).
+		 * This can't overflow, nor exceed what palloc will accept: maxlen is
+		 * at most wide_len, which is at most orig_len, and we have already
+		 * successfully allocated (orig_len + 1) * sizeof(pg_wchar) bytes for
+		 * wide_str. That relies on eml being no more than sizeof(pg_wchar),
+		 * which is true of all supported encodings.
 		 */
-		if (maxsiz > orig_len)
-			conv_bufsiz = orig_len + 1;
-		else
-			conv_bufsiz = maxsiz + 1;	/* safe since maxsiz < 2^30 */
+		Assert(eml <= sizeof(pg_wchar));
+		conv_bufsiz = maxlen * eml + 1;
 
 		matchctx->conv_buf = palloc(conv_bufsiz);
 		matchctx->conv_bufsiz = conv_bufsiz;


### PR DESCRIPTION
Port the CVE-2026-14664 fix (PostgreSQL 18.6, 2026-08-13 security release) to IvorySQL master. Closes #1787.

Upstream commit 343aabf1d95 ported verbatim ("Fix potential buffer
overrun in regexp match/split functions", Backpatch-through: 14).

Summary: setup_regexp_matches() bounded the conversion buffer by the
original string's byte length, which is unsafe for invalidly-encoded
input (pg_mb2wchar_with_len() accepts such bytes; converting them back
produces more bytes than were consumed). Affected: regexp_match(),
regexp_matches(), regexp_split_to_table(), regexp_split_to_array().
The fix always allocates maxlen * eml + 1 bytes.

Notes:
- Oracle-compatible regexp wrappers (regexp_like/replace/substr/instr/count)
  route through the core functions and are covered by this fix; no
  oracle-specific changes needed.
- Verified: make check 249/249; repeat(E'\x80',8000) input no longer
  triggers write-past-chunk-end on assert builds.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression processing for multibyte text.
  * Corrected buffer sizing when handling invalidly encoded input, preventing potential truncation or processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->