### PR TITLE
Cross-check the type of a portal running EXECUTE or FETCH (CVE-2026-16239)

### DIFF
--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1154,8 +1154,8 @@ FillPortalStore(Portal portal, bool isTopLevel)
 									portal->holdStore,
 									portal->holdContext,
 									false,
-									NULL,
-									NULL);
+									portal->tupDesc,
+									gettext_noop("query result type does not match portal result type"));
 
 	switch (portal->strategy)
 	{


### PR DESCRIPTION
Port the CVE-2026-16239 fix (PostgreSQL 18.6, 2026-08-13 security release) to IvorySQL master. Closes #1789.

Upstream commit 9e02e2e1822 ported verbatim ("Cross-check the type of
a portal running EXECUTE or FETCH").

Summary: EXECUTE/FETCH use an outer and an inner portal; the outer
portal's rows were read without cross-checking against the inner
portal's tuple descriptor, so a client could receive rows of a type
that does not match the executed query. The fix passes the portal's
tupDesc into the row-type cross-check, rejecting mismatches with
"query result type does not match portal result type".

Notes:
- No oracle-specific code is involved (tcop/pquery.c is untouched by
  IvorySQL); no oracle changes needed.
- Verified: make check 249/249; the fix is a verbatim 2-line change
  with no applicable upstream regression test.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portal result handling by validating returned data against the expected structure.
  * Added a clearer error message when result types do not match expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->