### PR TITLE
Obstruct EXTRACT() field name deparse injection (CVE-2026-15741)

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -12301,7 +12301,7 @@ get_func_sql_syntax(FuncExpr *expr, deparse_context *context)
 				Assert(IsA(con, Const) &&
 					   con->consttype == TEXTOID &&
 					   !con->constisnull);
-				appendStringInfoString(buf, TextDatumGetCString(con->constvalue));
+				appendStringInfoString(buf, quote_identifier(TextDatumGetCString(con->constvalue)));
 			}
 			appendStringInfoString(buf, " FROM ");
 			get_rule_expr((Node *) lsecond(expr->args), context, false);
@@ -12321,6 +12321,7 @@ get_func_sql_syntax(FuncExpr *expr, deparse_context *context)
 				Assert(IsA(con, Const) &&
 					   con->consttype == TEXTOID &&
 					   !con->constisnull);
+				/* NB: safe because no allowed words need quoted/escaped */
 				appendStringInfo(buf, " %s",
 								 TextDatumGetCString(con->constvalue));
 			}


### PR DESCRIPTION
Port the CVE-2026-15741 fix (PostgreSQL 18.6, 2026-08-13 security release) to IvorySQL master. Closes #1791.

Upstream commit f9729b5078d ported verbatim ("Obstruct EXTRACT()
field name deparse injection").

Summary: the parser accepts any string literal as an EXTRACT() field
name; get_func_sql_syntax() deparsed it without quoting, so unusual
field names changed meaning on pg_dump restore or injected unintended
SQL. The fix quotes the field name with quote_identifier().

Notes:
- ruleutils.c is not touched by IvorySQL-specific code here; no oracle
  changes needed.
- Verified: make check 249/249; pg_get_viewdef() now renders
  EXTRACT("weird field name" FROM ...).

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL generation for `EXTRACT` expressions by correctly quoting date/time field names.
  - Preserved valid syntax for `IS ... NORMALIZED` expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->