### PR TITLE
Be more wary about constant's datatype in scalarineqsel (CVE-2026-14668)

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -669,7 +669,8 @@ scalarineqsel(PlannerInfo *root, Oid operator, bool isgt, bool iseq,
 		 * make an estimate based on comparing the constant to the table size.
 		 */
 		if (vardata->var && IsA(vardata->var, Var) &&
-			((Var *) vardata->var)->varattno == SelfItemPointerAttributeNumber)
+			((Var *) vardata->var)->varattno == SelfItemPointerAttributeNumber &&
+			consttype == TIDOID)
 		{
 			ItemPointer itemptr;
 			double		block;


### PR DESCRIPTION
Closes #1795.

Upstream commit 8f0c3d2feb9 ported verbatim ("Be more wary about
constant's datatype in scalarineqsel()").

Summary: the ctid-specific estimate in scalarineqsel() was selected
without verifying the constant is of type tid; a malicious operator
could trigger a crash or wrong estimate. The fix adds a
consttype == TIDOID check.

Notes:
- selfuncs.c has no IvorySQL-specific branches; no oracle changes
  needed.
- Verified: make check 249/249.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selectivity estimates for CTID comparisons when statistics are unavailable.
  * Comparisons using constants other than the `tid` type now use a safer default estimate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->