### PR TITLE
psql: don't do backquote expansion in \unrestrict (CVE-2026-18408)

### DIFF
--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -3858,6 +3858,11 @@ SELECT 1 \bind \sendpipeline
         <application>pg_dumpall</application>, and
         <application>pg_restore</application>, but it may be useful elsewhere.
         </para>
+        <para>
+        Unlike most other meta-commands, the entire remainder of the line is
+        always taken to be the argument of <command>\unrestrict</command>, and
+        neither variable interpolation nor backquote expansion are performed.
+        </para>
         </listitem>
       </varlistentry>
 

--- a/src/bin/psql/command.c
+++ b/src/bin/psql/command.c
@@ -2818,6 +2818,12 @@ exec_command_restrict(PsqlScanState scan_state, bool active_branch,
 
 		Assert(!restricted);
 
+		/*
+		 * Unlike \unrestrict, this argument may safely undergo backquote and
+		 * variable expansion: HandleSlashCmds() rejects \restrict in
+		 * restricted mode before its argument is scanned, so we only get here
+		 * when the input could execute such things anyway.
+		 */
 		opt = psql_scan_slash_option(scan_state, OT_NORMAL, NULL, true);
 		if (opt == NULL || opt[0] == '\0')
 		{
@@ -3226,7 +3232,7 @@ exec_command_unrestrict(PsqlScanState scan_state, bool active_branch,
 	{
 		char	   *opt;
 
-		opt = psql_scan_slash_option(scan_state, OT_NORMAL, NULL, true);
+		opt = psql_scan_slash_option(scan_state, OT_WHOLE_LINE, NULL, true);
 		if (opt == NULL || opt[0] == '\0')
 		{
 			pg_log_error("\\%s: missing required argument", cmd);
@@ -3250,7 +3256,7 @@ exec_command_unrestrict(PsqlScanState scan_state, bool active_branch,
 		}
 	}
 	else
-		ignore_slash_options(scan_state);
+		ignore_slash_whole_line(scan_state);
 
 	return PSQL_CMD_SKIP_LINE;
 }

--- a/src/bin/psql/t/001_basic.pl
+++ b/src/bin/psql/t/001_basic.pl
@@ -540,4 +540,11 @@ psql_fails_like(
 	qr/backslash commands are restricted; only \\unrestrict is allowed/,
 	'meta-command in restrict mode fails');
 
+psql_fails_like(
+	$node,
+	qq{\\restrict test
+\\unrestrict `echo test`},
+	qr/wrong key/,
+	'\unrestrict does not do backquote expansion');
+
 done_testing();


### PR DESCRIPTION
Closes #1797.

Upstream commit 086f6f17601 ported verbatim ("psql: Don't do backquote
expansion in \unrestrict.").

Summary: \unrestrict scanned its argument with OT_NORMAL, so crafted
server output could trigger backquote expansion / shell execution at
restore time (follow-up to CVE-2025-8714). The fix switches to
OT_WHOLE_LINE and documents the behavior.

Notes:
- psql has no IvorySQL-specific branches here; no oracle changes
  needed.
- Verified: make check 249/249. The added psql TAP case is
  syntax-checked; full TAP requires --enable-tap-tests.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `\unrestrict` so its entire argument is treated literally.
  * Backquote expansion and variable interpolation are no longer performed for `\unrestrict` arguments.
  * Improved handling of `\unrestrict` when restrictions are inactive.

* **Documentation**
  * Clarified the argument-processing behavior of `\unrestrict` in the psql reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->