### PR TITLE
fix(xml): handle empty serialized results

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_xml_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_xml_functions.out
@@ -26,6 +26,14 @@ INSERT INTO xmlnstest VALUES(1, xmltype('<soapenv:Envelope xmlns:soapenv="http:/
 --
 -- extrct(XML)
 --
+-- An XPath with no matches produces an empty XML value.  Keep the
+-- trailing-newline cleanup path safe for that zero-length result.
+SELECT pg_catalog.octet_length(sys.extract('<a/>'::sys.xmltype, '/missing')::text) AS empty_length;
+ empty_length 
+--------------
+            0
+(1 row)
+
 SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA/ID') from dual;
 ERROR:  syntax error at or near "("
 LINE 1: SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA/ID') fro...

--- a/contrib/ivorysql_ora/sql/ora_xml_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_xml_functions.sql
@@ -21,6 +21,10 @@ INSERT INTO xmlnstest VALUES(1, xmltype('<soapenv:Envelope xmlns:soapenv="http:/
 --
 -- extrct(XML)
 --
+-- An XPath with no matches produces an empty XML value.  Keep the
+-- trailing-newline cleanup path safe for that zero-length result.
+SELECT pg_catalog.octet_length(sys.extract('<a/>'::sys.xmltype, '/missing')::text) AS empty_length;
+
 SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA/ID') from dual;
 
 SELECT extract(XMLType('<AA><ID>1</ID></AA>'), '/AA') from dual;

--- a/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
+++ b/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
@@ -414,7 +414,7 @@ rv_newline(text *tv)
 
 	tmp = text_to_cstring(tv);
 	len = strlen(tmp);
-	if (tmp[len-1] == '\n')
+	if (len > 0 && tmp[len-1] == '\n')
 		tmp[len-1] = '\0';
 	ret = cstring_to_text(tmp);
 


### PR DESCRIPTION
## Summary

- guard the XML trailing-newline cleanup against zero-length output
- cover an XPath expression with no matching nodes

## Root cause

rv_newline() read tmp[len - 1] even when serialization produced an empty string, causing an out-of-bounds read before the buffer.

## Validation

- git diff --check
- Added focused ora_xml_functions regression coverage; full execution is delegated to the upstream Linux CI because the local Windows environment does not have the IvorySQL build toolchain.

Closes #1801