### PR TITLE
fix(oracle): normalize invalid SYS_CONTEXT lengths

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -5,6 +5,22 @@ SET nls_date_format = 'DD-MON-YY';
 SET nls_timestamp_format = 'DD-MON-YY HH24:MI:SS.US';
 SET nls_timestamp_tz_format = 'DD-MON-YY HH24:MI:SS.US TZ';
 set default_text_search_config = 'pg_catalog.simple';
+-- SYS_CONTEXT uses the default length (256) for an invalid length argument.
+SELECT set_config('length_test.value', repeat('x', 300), false) IS NOT NULL AS context_set;
+ context_set 
+-------------
+ t
+(1 row)
+
+SELECT length(sys_context('length_test', 'value', 12)) AS valid_length,
+       length(sys_context('length_test', 'value', 0)) AS zero_length,
+       length(sys_context('length_test', 'value', 4001)) AS oversized_length;
+ valid_length | zero_length | oversized_length 
+--------------+-------------+------------------
+           12 |         256 |              256
+(1 row)
+
+RESET length_test.value;
 -- error
 select decode(NULL, 1, 2018, 2, timestamp'2018-2-1 00:00:00', timestamp'2018-5-1 00:00:00');
 ERROR:  DECODE could not convert type timestamp to number

--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -20,6 +20,27 @@ SELECT length(sys_context('length_test', 'value', 12)) AS valid_length,
            12 |         256 |              256
 (1 row)
 
+SELECT length(sys_context('length_test', 'value', NULL)) AS null_length,
+       length(sys_context('length_test', 'value', 0.5)) AS fractional_invalid_length,
+       length(sys_context('length_test', 'value', 2147483648)) AS integer_overflow_length,
+       length(sys_context('length_test', 'value', 12.9)) AS fractional_valid_length;
+ null_length | fractional_invalid_length | integer_overflow_length | fractional_valid_length 
+-------------+---------------------------+-------------------------+-------------------------
+         256 |                       256 |                     256 |                      12
+(1 row)
+
+SELECT set_config('length_test.value', repeat('界', 100), false) IS NOT NULL AS multibyte_context_set;
+ multibyte_context_set 
+-----------------------
+ t
+(1 row)
+
+SELECT octet_length(sys_context('length_test', 'value', 5)) <= 5 AS multibyte_within_limit;
+ multibyte_within_limit 
+------------------------
+ t
+(1 row)
+
 RESET length_test.value;
 -- error
 select decode(NULL, 1, 2018, 2, timestamp'2018-2-1 00:00:00', timestamp'2018-5-1 00:00:00');

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -11,6 +11,12 @@ SELECT set_config('length_test.value', repeat('x', 300), false) IS NOT NULL AS c
 SELECT length(sys_context('length_test', 'value', 12)) AS valid_length,
        length(sys_context('length_test', 'value', 0)) AS zero_length,
        length(sys_context('length_test', 'value', 4001)) AS oversized_length;
+SELECT length(sys_context('length_test', 'value', NULL)) AS null_length,
+       length(sys_context('length_test', 'value', 0.5)) AS fractional_invalid_length,
+       length(sys_context('length_test', 'value', 2147483648)) AS integer_overflow_length,
+       length(sys_context('length_test', 'value', 12.9)) AS fractional_valid_length;
+SELECT set_config('length_test.value', repeat('界', 100), false) IS NOT NULL AS multibyte_context_set;
+SELECT octet_length(sys_context('length_test', 'value', 5)) <= 5 AS multibyte_within_limit;
 RESET length_test.value;
 
 -- error

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -6,6 +6,13 @@ SET nls_timestamp_format = 'DD-MON-YY HH24:MI:SS.US';
 SET nls_timestamp_tz_format = 'DD-MON-YY HH24:MI:SS.US TZ';
 set default_text_search_config = 'pg_catalog.simple';
 
+-- SYS_CONTEXT uses the default length (256) for an invalid length argument.
+SELECT set_config('length_test.value', repeat('x', 300), false) IS NOT NULL AS context_set;
+SELECT length(sys_context('length_test', 'value', 12)) AS valid_length,
+       length(sys_context('length_test', 'value', 0)) AS zero_length,
+       length(sys_context('length_test', 'value', 4001)) AS oversized_length;
+RESET length_test.value;
+
 -- error
 select decode(NULL, 1, 2018, 2, timestamp'2018-2-1 00:00:00', timestamp'2018-5-1 00:00:00');
 select decode('abc', 123, 123,4, date'2018-8-1', 5) from dual;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1778,8 +1778,13 @@ CREATE or REPLACE FUNCTION sys.sys_context(a varchar2, b varchar2, c number)
 RETURNS varchar2 AS $$
 DECLARE
 	res varchar2;
+	requested_length integer := c::integer;
 BEGIN
-	SELECT left(sys.sys_context(a, b), c::integer) INTO res;
+	/* Oracle ignores an out-of-range length and uses the default of 256. */
+	IF requested_length < 1 OR requested_length > 4000 THEN
+		requested_length := 256;
+	END IF;
+	SELECT left(sys.sys_context(a, b), requested_length) INTO res;
 	RETURN res;
 END;
 $$ LANGUAGE plisql SECURITY INVOKER;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1778,13 +1778,13 @@ CREATE or REPLACE FUNCTION sys.sys_context(a varchar2, b varchar2, c number)
 RETURNS varchar2 AS $$
 DECLARE
 	res varchar2;
-	requested_length integer := c::integer;
+	requested_length integer := 256;
 BEGIN
 	/* Oracle ignores an out-of-range length and uses the default of 256. */
-	IF requested_length < 1 OR requested_length > 4000 THEN
-		requested_length := 256;
+	IF c IS NOT NULL AND c >= 1 AND c <= 4000 THEN
+		requested_length := trunc(c)::integer;
 	END IF;
-	SELECT left(sys.sys_context(a, b), requested_length) INTO res;
+	SELECT sys.substrb(sys.sys_context(a, b), 1, requested_length) INTO res;
 	RETURN res;
 END;
 $$ LANGUAGE plisql SECURITY INVOKER;


### PR DESCRIPTION
## Summary

- normalize SYS_CONTEXT length values outside 1..4000 to the Oracle default of 256
- add regression coverage for valid, zero, and oversized values

## Root cause

The three-argument wrapper passed the requested length directly to left(). Oracle instead ignores an invalid length and uses 256.

## Validation

- git diff --check
- Added focused ora_misc_functions regression coverage; full execution is delegated to the upstream Linux CI because the local Windows environment does not have the IvorySQL build toolchain.

Closes #1802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `SYS_CONTEXT` length handling to better match Oracle behavior.
  * Invalid, null, fractional, or out-of-range lengths now use the default limit of 256.
  * Valid lengths are truncated by bytes, including for multibyte values.

* **Tests**
  * Added regression coverage for valid, fractional, null, zero, and out-of-range length arguments.
  * Added tests verifying byte-based truncation of multibyte context values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->