### PR TITLE
fix(oracle): validate REGEXP_INSTR return option

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -1366,6 +1366,9 @@ select regexp_instr('barbar', 'b[^b]+', 1, 1, 1, 'i',0) from dual;
  4
 (1 row)
 
+-- return_option accepts only 0 (start) or 1 (end).
+select regexp_instr('barbar', 'b[^b]+', 1, 1, 2, 'i',0) from dual;
+ERROR:  argument '2' is out of range
 select regexp_instr('barbar', '(b[^b]+)', 1, 2, 0, 'i',0) from dual;
  regexp_instr 
 --------------

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -738,6 +738,9 @@ select regexp_instr('barbar', 'b[^b]+', 1, 1, 0, 'i',0) from dual;
 
 select regexp_instr('barbar', 'b[^b]+', 1, 1, 1, 'i',0) from dual;
 
+-- return_option accepts only 0 (start) or 1 (end).
+select regexp_instr('barbar', 'b[^b]+', 1, 1, 2, 'i',0) from dual;
+
 select regexp_instr('barbar', '(b[^b]+)', 1, 2, 0, 'i',0) from dual;
 
 select regexp_instr('barbar', '(b[^b]+)', 1, 2, 1, 'i',0) from dual;

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -541,7 +541,7 @@ ora_regexp_instr(PG_FUNCTION_ARGS)
 		if(!PG_ARGISNULL(4))
 		{
 			ret_opt = PG_GETARG_INT32(4);
-			if(ret_opt < 0)
+			if(ret_opt < 0 || ret_opt > 1)
 				ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					errmsg("argument '%d' is out of range",ret_opt)));


### PR DESCRIPTION
## Summary

- reject REGEXP_INSTR return_option values outside 0 and 1
- add regression coverage for return_option 2

## Root cause

The validation checked only the lower bound, while the execution path treated every nonzero value as the end-of-match option.

## Validation

- git diff --check
- Added focused ora_character_datatype_functions regression coverage; full execution is delegated to the upstream Linux CI because the local Windows environment does not have the IvorySQL build toolchain.

Closes #1799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `regexp_instr` validation so the `return_option` accepts only `0` or `1`.
  * Invalid values, such as `2`, now return an appropriate out-of-range error.

* **Tests**
  * Added regression coverage confirming invalid `return_option` values are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->