### PR TITLE
pg_dump: avoid assuming how long pg_proc.protrftypes can be (CVE-2026-19385)

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -1110,35 +1110,126 @@ findOwningExtension(CatalogId catalogId)
 
 /*
  * parseOidArray
- *	  parse a string of numbers delimited by spaces into a character array
+ *	  parse a string of unsigned numbers separated by spaces
+ *	  into an array of OIDs
  *
- * Note: actually this is used for both Oids and potentially-signed
- * attribute numbers.  This should cause no trouble, but we could split
- * the function into two functions with different argument types if it does.
+ * The result is a malloc'd array.
+ *
+ * If arraysize >= 0, we insist that the input contain exactly that many
+ * OIDs, and the allocated array is of that length too.  If arraysize < 0,
+ * we dynamically size the array to have one more entry than the input
+ * provides, and fill the extra entry with zero.
  */
-
-void
-parseOidArray(const char *str, Oid *array, int arraysize)
+Oid *
+parseOidArray(const char *str, int arraysize)
 {
-	int			j,
-				argNum;
-	char		temp[100];
-	char		s;
+	Oid		   *array;
+	int			allocsize,
+				argNum,
+				templen;
+	char		temp[32];
 
-	argNum = 0;
-	j = 0;
-	for (;;)
+	if (arraysize >= 0)
+		allocsize = arraysize;
+	else
 	{
-		s = *str++;
+		/*
+		 * Make enough room for input + one extra entry (could be more than
+		 * enough, if there are redundant spaces in the input).
+		 */
+		allocsize = 2;
+		for (const char *s1 = str; *s1; s1++)
+		{
+			if (*s1 == ' ')
+				allocsize++;
+		}
+	}
+	array = pg_malloc_array(Oid, allocsize);
+	argNum = 0;
+	templen = 0;
+	for (const char *s1 = str;; s1++)
+	{
+		char		s = *s1;
+
 		if (s == ' ' || s == '\0')
 		{
-			if (j > 0)
+			if (templen > 0)
 			{
-				if (argNum >= arraysize)
+				if (arraysize >= 0 && argNum >= arraysize)
 					pg_fatal("could not parse numeric array \"%s\": too many numbers", str);
-				temp[j] = '\0';
+				temp[templen] = '\0';
 				array[argNum++] = atooid(temp);
-				j = 0;
+				templen = 0;
+			}
+			if (s == '\0')
+				break;
+		}
+		else
+		{
+			if (!isdigit((unsigned char) s) ||
+				templen >= sizeof(temp) - 1)
+				pg_fatal("could not parse numeric array \"%s\": invalid character in number", str);
+			temp[templen++] = s;
+		}
+	}
+
+	if (arraysize >= 0 && argNum != arraysize)
+		pg_fatal("could not parse numeric array \"%s\": too few numbers", str);
+
+	while (argNum < allocsize)
+		array[argNum++] = InvalidOid;
+
+	return array;
+}
+
+
+/*
+ * parseIntArray
+ *	  parse a string of possibly-signed numbers separated by spaces
+ *	  into an array of ints
+ *
+ * This is exactly like parseOidArray, but for integers.
+ */
+int *
+parseIntArray(const char *str, int arraysize)
+{
+	int		   *array;
+	int			allocsize,
+				argNum,
+				templen;
+	char		temp[32];
+
+	if (arraysize >= 0)
+		allocsize = arraysize;
+	else
+	{
+		/*
+		 * Make enough room for input + one extra entry (could be more than
+		 * enough, if there are redundant spaces in the input).
+		 */
+		allocsize = 2;
+		for (const char *s1 = str; *s1; s1++)
+		{
+			if (*s1 == ' ')
+				allocsize++;
+		}
+	}
+	array = pg_malloc_array(int, allocsize);
+	argNum = 0;
+	templen = 0;
+	for (const char *s1 = str;; s1++)
+	{
+		char		s = *s1;
+
+		if (s == ' ' || s == '\0')
+		{
+			if (templen > 0)
+			{
+				if (arraysize >= 0 && argNum >= arraysize)
+					pg_fatal("could not parse numeric array \"%s\": too many numbers", str);
+				temp[templen] = '\0';
+				array[argNum++] = atoi(temp);
+				templen = 0;
 			}
 			if (s == '\0')
 				break;
@@ -1146,14 +1237,19 @@ parseOidArray(const char *str, Oid *array, int arraysize)
 		else
 		{
 			if (!(isdigit((unsigned char) s) || s == '-') ||
-				j >= sizeof(temp) - 1)
+				templen >= sizeof(temp) - 1)
 				pg_fatal("could not parse numeric array \"%s\": invalid character in number", str);
-			temp[j++] = s;
+			temp[templen++] = s;
 		}
 	}
 
-	while (argNum < arraysize)
-		array[argNum++] = InvalidOid;
+	if (arraysize >= 0 && argNum != arraysize)
+		pg_fatal("could not parse numeric array \"%s\": too few numbers", str);
+
+	while (argNum < allocsize)
+		array[argNum++] = 0;
+
+	return array;
 }
 
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6987,12 +6987,8 @@ getAggregates(Archive *fout)
 		if (agginfo[i].aggfn.nargs == 0)
 			agginfo[i].aggfn.argtypes = NULL;
 		else
-		{
-			agginfo[i].aggfn.argtypes = pg_malloc_array(Oid, agginfo[i].aggfn.nargs);
-			parseOidArray(PQgetvalue(res, i, i_proargtypes),
-						  agginfo[i].aggfn.argtypes,
-						  agginfo[i].aggfn.nargs);
-		}
+			agginfo[i].aggfn.argtypes = parseOidArray(PQgetvalue(res, i, i_proargtypes),
+													  agginfo[i].aggfn.nargs);
 		agginfo[i].aggfn.postponed_def = false; /* might get set during sort */
 
 		/* Decide whether we want to dump it */
@@ -7180,11 +7176,8 @@ getFuncs(Archive *fout)
 		if (finfo[i].nargs == 0)
 			finfo[i].argtypes = NULL;
 		else
-		{
-			finfo[i].argtypes = pg_malloc_array(Oid, finfo[i].nargs);
-			parseOidArray(PQgetvalue(res, i, i_proargtypes),
-						  finfo[i].argtypes, finfo[i].nargs);
-		}
+			finfo[i].argtypes = parseOidArray(PQgetvalue(res, i, i_proargtypes),
+											  finfo[i].nargs);
 		finfo[i].postponed_def = false; /* might get set during sort */
 
 		/* Decide whether we want to dump it */
@@ -8364,9 +8357,8 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 			indxinfo[j].indreloptions = pg_strdup(PQgetvalue(res, j, i_indreloptions));
 			indxinfo[j].indstatcols = pg_strdup(PQgetvalue(res, j, i_indstatcols));
 			indxinfo[j].indstatvals = pg_strdup(PQgetvalue(res, j, i_indstatvals));
-			indxinfo[j].indkeys = pg_malloc_array(Oid, indxinfo[j].indnattrs);
-			parseOidArray(PQgetvalue(res, j, i_indkey),
-						  indxinfo[j].indkeys, indxinfo[j].indnattrs);
+			indxinfo[j].indkeys = parseIntArray(PQgetvalue(res, j, i_indkey),
+												indxinfo[j].indnattrs);
 			indxinfo[j].indisclustered = (PQgetvalue(res, j, i_indisclustered)[0] == 't');
 			indxinfo[j].indisreplident = (PQgetvalue(res, j, i_indisreplident)[0] == 't');
 			indxinfo[j].indnullsnotdistinct = (PQgetvalue(res, j, i_indnullsnotdistinct)[0] == 't');
@@ -14139,12 +14131,10 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 
 	if (*protrftypes)
 	{
-		Oid		   *typeids = pg_malloc_array(Oid, FUNC_MAX_ARGS);
-		int			i;
+		Oid		   *typeids = parseOidArray(protrftypes, -1);
 
 		appendPQExpBufferStr(q, " TRANSFORM ");
-		parseOidArray(protrftypes, typeids, FUNC_MAX_ARGS);
-		for (i = 0; typeids[i]; i++)
+		for (int i = 0; typeids[i]; i++)
 		{
 			if (i != 0)
 				appendPQExpBufferStr(q, ", ");
@@ -19411,7 +19401,7 @@ dumpConstraint(Archive *fout, const ConstraintInfo *coninfo)
 			appendPQExpBufferStr(q, " (");
 			for (k = 0; k < indxinfo->indnkeyattrs; k++)
 			{
-				int			indkey = (int) indxinfo->indkeys[k];
+				int			indkey = indxinfo->indkeys[k];
 				const char *attname;
 
 				if (indkey == InvalidAttrNumber)
@@ -19430,7 +19420,7 @@ dumpConstraint(Archive *fout, const ConstraintInfo *coninfo)
 
 			for (k = indxinfo->indnkeyattrs; k < indxinfo->indnattrs; k++)
 			{
-				int			indkey = (int) indxinfo->indkeys[k];
+				int			indkey = indxinfo->indkeys[k];
 				const char *attname;
 
 				if (indkey == InvalidAttrNumber)

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -442,7 +442,7 @@ typedef struct _indxInfo
 	char	   *indstatvals;	/* statistic values for columns */
 	int			indnkeyattrs;	/* number of index key attributes */
 	int			indnattrs;		/* total number of index attributes */
-	Oid		   *indkeys;		/* In spite of the name 'indkeys' this field
+	int		   *indkeys;		/* In spite of the name 'indkeys' this field
 								 * contains both key and nonkey attributes */
 	bool		indisclustered;
 	bool		indisreplident;
@@ -798,7 +798,8 @@ extern SubscriptionInfo *findSubscriptionByOid(Oid oid);
 extern void recordExtensionMembership(CatalogId catId, ExtensionInfo *ext);
 extern ExtensionInfo *findOwningExtension(CatalogId catalogId);
 
-extern void parseOidArray(const char *str, Oid *array, int arraysize);
+extern Oid *parseOidArray(const char *str, int arraysize);
+extern int *parseIntArray(const char *str, int arraysize);
 
 extern void sortDumpableObjects(DumpableObject **objs, int numObjs,
 								DumpId preBoundaryId, DumpId postBoundaryId);

--- a/src/test/regress/expected/object_address.out
+++ b/src/test/regress/expected/object_address.out
@@ -44,6 +44,10 @@ ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user REVOKE DELETE ON TABLES FROM
 CREATE TRANSFORM FOR int LANGUAGE SQL (
     FROM SQL WITH FUNCTION prsd_lextype(internal),
     TO SQL WITH FUNCTION int4recv(internal));
+-- make a function that uses it too, mainly to exercise pg_dump
+CREATE FUNCTION public.sql_func_with_transform(int) RETURNS int LANGUAGE sql
+AS 'select $1 + 1'
+TRANSFORM FOR TYPE int;
 -- suppress warning that depends on wal_level
 SET client_min_messages = 'ERROR';
 CREATE PUBLICATION addr_pub FOR TABLE addr_nsp.gentable;

--- a/src/test/regress/sql/object_address.sql
+++ b/src/test/regress/sql/object_address.sql
@@ -47,6 +47,10 @@ ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user REVOKE DELETE ON TABLES FROM
 CREATE TRANSFORM FOR int LANGUAGE SQL (
     FROM SQL WITH FUNCTION prsd_lextype(internal),
     TO SQL WITH FUNCTION int4recv(internal));
+-- make a function that uses it too, mainly to exercise pg_dump
+CREATE FUNCTION public.sql_func_with_transform(int) RETURNS int LANGUAGE sql
+AS 'select $1 + 1'
+TRANSFORM FOR TYPE int;
 -- suppress warning that depends on wal_level
 SET client_min_messages = 'ERROR';
 CREATE PUBLICATION addr_pub FOR TABLE addr_nsp.gentable;


### PR DESCRIPTION
Closes #1807.

Upstream commit 13bb73aeb68 ported verbatim ("pg_dump: avoid assuming
how long pg_proc.protrftypes can be.").

Summary: parseOidArray() used a FUNC_MAX_ARGS-sized fixed buffer for
pg_proc.protrftypes, but the array can exceed that with input+output
arguments, causing overflow/truncation. The fix allocates the result
dynamically from the input and updates all call sites.

Notes:
- IvorySQL's oracle pg_dump additions do not touch these call sites;
  no oracle changes needed.
- Verified: make check 249/249 (includes new object_address case).

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pg_dump` parsing of OID and integer arrays, including validation of array lengths and supported values.
  * Correctly handles index attribute numbers as integers during dumps.
  * Preserves dump behavior while improving handling of aggregate, function, transform, and constraint metadata.

* **Tests**
  * Added regression coverage for SQL functions using type transforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->