### PR TITLE
Reject GSSEncRequest after direct SSL connection (CVE-2026-14681)

### DIFF
--- a/src/backend/tcop/backend_startup.c
+++ b/src/backend/tcop/backend_startup.c
@@ -693,8 +693,13 @@ ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done)
 		char		GSSok = 'N';
 
 #ifdef ENABLE_GSS
-		/* No GSSAPI encryption when on Unix socket */
-		if (port->laddr.addr.ss_family != AF_UNIX)
+
+		/*
+		 * No GSSAPI encryption when on Unix socket.
+		 *
+		 * Also no GSS negotiation if we already have a direct SSL connection.
+		 */
+		if (port->laddr.addr.ss_family != AF_UNIX && !port->ssl_in_use)
 			GSSok = 'G';
 #endif
 


### PR DESCRIPTION
Closes #1809.

Upstream commit 3bf185b4bb6 ported verbatim ("Reject GSSEncRequest
after direct SSL connection").

Summary: after TLS is established the server still answered
GSSEncRequest, leaving the connection treated as GSSAPI-encrypted
while actually using TLS. The fix suppresses the GSS-encryption
option when port->ssl_in_use is set.

Notes:
- backend_startup.c has no IvorySQL-specific branches; no oracle
  changes needed.
- Verified: make check 249/249.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection security negotiation by preventing GSSAPI encryption from being selected when a direct SSL connection is already established.
  * Preserved existing behavior that disables GSSAPI encryption for Unix socket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->