### PR TITLE
Use value of scram_iterations in mock_scram_secret (CVE-2026-14672)

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1172,6 +1172,19 @@ include_dir 'conf.d'
         time of encryption. In order to make use of a changed value, a new
         password must be set.
        </para>
+       <note>
+        <para>
+         If a role password was created with a different iteration count than
+         the value of <literal>scram_iterations</literal> specified in the
+         <filename>postgresql.conf</filename> file or on the server command
+         line, an unauthenticated user can discern the existence of the role by
+         observing discrepancies in the server's responses to connection
+         attempts.  If you find this concerning, ensure that all role passwords
+         are created with <literal>scram_iterations</literal> set to the value
+         specified in the <filename>postgresql.conf</filename> file or on the
+         server command line.
+        </para>
+       </note>
       </listitem>
      </varlistentry>
 

--- a/src/backend/libpq/auth-scram.c
+++ b/src/backend/libpq/auth-scram.c
@@ -727,7 +727,7 @@ mock_scram_secret(const char *username, pg_cryptohash_type *hash_type,
 	encoded_salt[encoded_len] = '\0';
 
 	*salt = encoded_salt;
-	*iterations = SCRAM_SHA_256_DEFAULT_ITERATIONS;
+	*iterations = scram_sha_256_iterations;
 
 	/* StoredKey and ServerKey are not used in a doomed authentication */
 	memset(stored_key, 0, SCRAM_MAX_KEY_LEN);


### PR DESCRIPTION
Closes #1811.

Upstream commit feb8b0182ff ported verbatim ("Use value of
scram_iterations in mock_scram_secret().").

Summary: the mock SCRAM secret for non-existent roles used the default
iteration count, making real vs. fake handshakes distinguishable when
scram_iterations is non-default, leaking role existence. The fix uses
the configured value.

Notes:
- IvorySQL adds auth-oauth.c but auth-scram.c is untouched here; no
  oracle changes needed.
- Verified: make check 249/249.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security note explaining how differing SCRAM iteration counts may reveal whether a role exists.
  * Recommended creating role passwords with the configured SCRAM iteration count.

* **Bug Fixes**
  * Mock SCRAM authentication now honors the configured iteration count, matching real password secret generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->