### PR TITLE
pg_stat_statements: fix buffer overflow with query normalization (CVE-2026-14676)

### DIFF
--- a/contrib/pg_stat_statements/pg_stat_statements.c
+++ b/contrib/pg_stat_statements/pg_stat_statements.c
@@ -2826,16 +2826,21 @@ static char *
 generate_normalized_query(const JumbleState *jstate, const char *query,
 						  int query_loc, int *query_len_p)
 {
-	char	   *norm_query;
+	StringInfoData norm_query;
 	int			query_len = *query_len_p;
-	int			norm_query_buflen,	/* Space allowed for norm_query */
-				len_to_wrt,		/* Length (in bytes) to write */
+	int			len_to_wrt,		/* Length (in bytes) to write */
 				quer_loc = 0,	/* Source query byte location */
-				n_quer_loc = 0, /* Normalized query byte location */
 				last_off = 0,	/* Offset from start for previous tok */
 				last_tok_len = 0;	/* Length (in bytes) of that tok */
 	int			num_constants_replaced = 0;
 	LocationLen *locs = NULL;
+
+	/*
+	 * Our output buffer is an expansible StringInfo, but avoid enlarging it
+	 * in most cases by reserving extra space for each constant location.
+	 */
+	Assert(jstate->clocations_count > 0);
+	initStringInfoExt(&norm_query, query_len + jstate->clocations_count * 10);
 
 	/*
 	 * Determine constants' lengths (core system only gives us locations), and
@@ -2844,18 +2849,6 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 	 * Oracle compatible mode can use the Oracle parser's scanner.
 	 */
 	locs = fill_in_constant_lengths(jstate, query, query_loc);
-
-	/*
-	 * Allow for $n symbols to be longer than the constants they replace.
-	 * Constants must take at least one byte in text form, while a $n symbol
-	 * certainly isn't more than 11 bytes, even if n reaches INT_MAX.  We
-	 * could refine that limit based on the max value of n for the current
-	 * query, but it hardly seems worth any extra effort to do so.
-	 */
-	norm_query_buflen = query_len + jstate->clocations_count * 10;
-
-	/* Allocate result buffer */
-	norm_query = palloc(norm_query_buflen + 1);
 
 	for (int i = 0; i < jstate->clocations_count; i++)
 	{
@@ -2886,17 +2879,16 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 		len_to_wrt = off - last_off;
 		len_to_wrt -= last_tok_len;
 		Assert(len_to_wrt >= 0);
-		memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
-		n_quer_loc += len_to_wrt;
+		appendBinaryStringInfo(&norm_query, query + quer_loc, len_to_wrt);
 
 		/*
 		 * And insert a param symbol in place of the constant token; and, if
 		 * we have a squashable list, insert a placeholder comment starting
 		 * from the list's second value.
 		 */
-		n_quer_loc += sprintf(norm_query + n_quer_loc, "$%d%s",
-							  num_constants_replaced + 1 + jstate->highest_extern_param_id,
-							  locs[i].squashed ? " /*, ... */" : "");
+		appendStringInfo(&norm_query, "$%d%s",
+						 num_constants_replaced + 1 + jstate->highest_extern_param_id,
+						 locs[i].squashed ? " /*, ... */" : "");
 		num_constants_replaced++;
 
 		/* move forward */
@@ -2916,14 +2908,10 @@ generate_normalized_query(const JumbleState *jstate, const char *query,
 	len_to_wrt = query_len - quer_loc;
 
 	Assert(len_to_wrt >= 0);
-	memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
-	n_quer_loc += len_to_wrt;
+	appendBinaryStringInfo(&norm_query, query + quer_loc, len_to_wrt);
 
-	Assert(n_quer_loc <= norm_query_buflen);
-	norm_query[n_quer_loc] = '\0';
-
-	*query_len_p = n_quer_loc;
-	return norm_query;
+	*query_len_p = norm_query.len;
+	return norm_query.data;
 }
 
 /*


### PR DESCRIPTION
Closes #1813.

Same fix as upstream commit 1e2795ddeaf ("pg_stat_statements: Fix
buffer overflow with query normalization", PostgreSQL 18.6,
2026-08-13), hand-adapted: this tree's generate_normalized_query()
routes constant-length computation through the IvorySQL-specific
fill_in_constant_lengths() wrapper (for Oracle-parser mode), which is
preserved; the buffer itself is converted from fixed-size to an
expansible StringInfo exactly as upstream.

Summary: normalization sized the buffer without accounting for the
"/*, ... */" comment appended per squashed list, overrunning it for
queries with many squashable lists.

Notes:
- No other oracle-specific code touched.
- Verified: make check 249/249; long IN/VALUES queries normalize with
  squash comments and no allocator warning on assert builds.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of normalized query strings.
  * Preserved existing query normalization behavior while simplifying memory management and string construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->