### PR TITLE
Empty search_path in amcheck (CVE-2026-14673)

### DIFF
--- a/contrib/amcheck/expected/check_btree.out
+++ b/contrib/amcheck/expected/check_btree.out
@@ -186,7 +186,8 @@ SELECT bt_index_check('toasty', true);
 (1 row)
 
 --
--- Check that index expressions and predicates are run as the table's owner
+-- Check that index expressions and predicates are run as the table's owner,
+-- with empty search_path
 --
 TRUNCATE bttest_a;
 INSERT INTO bttest_a SELECT * FROM generate_series(1, 1000);
@@ -194,19 +195,31 @@ ALTER TABLE bttest_a OWNER TO regress_bttest_role;
 -- A dummy index function checking current_user
 CREATE FUNCTION ifun(int8) RETURNS int8 AS $$
 BEGIN
-	ASSERT current_user = 'regress_bttest_role',
+	ASSERT current_setting('search_path') = 'pg_catalog, pg_temp',
+		format('ifun(%s) called with current_schemas %s, search_path %s',
+			$1, current_schemas(true), current_setting('search_path'));
+	ASSERT "current_user"() = 'regress_bttest_role',
 		format('ifun(%s) called by %s', $1, current_user);
 	RETURN $1;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 CREATE INDEX bttest_a_expr_idx ON bttest_a ((ifun(id) + ifun(0)))
 	WHERE ifun(id + 10) > ifun(10);
+BEGIN;
+SET LOCAL check_function_bodies = off;
+CREATE SCHEMA preempt;
+GRANT USAGE ON SCHEMA preempt TO regress_bttest_role;
+SET LOCAL search_path = preempt, pg_catalog, public;
+CREATE FUNCTION "current_user"() RETURNS name AS $$
+	broken
+$$ LANGUAGE sql STABLE PARALLEL SAFE STRICT;
 SELECT bt_index_check('bttest_a_expr_idx', true);
  bt_index_check 
 ----------------
  
 (1 row)
 
+ROLLBACK;
 -- UNIQUE constraint check
 SELECT bt_index_check('bttest_a_idx', heapallindexed => true, checkunique => true);
  bt_index_check 

--- a/contrib/amcheck/sql/check_btree.sql
+++ b/contrib/amcheck/sql/check_btree.sql
@@ -123,7 +123,8 @@ INSERT INTO toast_bug SELECT repeat('a', 2200);
 SELECT bt_index_check('toasty', true);
 
 --
--- Check that index expressions and predicates are run as the table's owner
+-- Check that index expressions and predicates are run as the table's owner,
+-- with empty search_path
 --
 TRUNCATE bttest_a;
 INSERT INTO bttest_a SELECT * FROM generate_series(1, 1000);
@@ -131,7 +132,10 @@ ALTER TABLE bttest_a OWNER TO regress_bttest_role;
 -- A dummy index function checking current_user
 CREATE FUNCTION ifun(int8) RETURNS int8 AS $$
 BEGIN
-	ASSERT current_user = 'regress_bttest_role',
+	ASSERT current_setting('search_path') = 'pg_catalog, pg_temp',
+		format('ifun(%s) called with current_schemas %s, search_path %s',
+			$1, current_schemas(true), current_setting('search_path'));
+	ASSERT "current_user"() = 'regress_bttest_role',
 		format('ifun(%s) called by %s', $1, current_user);
 	RETURN $1;
 END;
@@ -139,8 +143,16 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE INDEX bttest_a_expr_idx ON bttest_a ((ifun(id) + ifun(0)))
 	WHERE ifun(id + 10) > ifun(10);
-
+BEGIN;
+SET LOCAL check_function_bodies = off;
+CREATE SCHEMA preempt;
+GRANT USAGE ON SCHEMA preempt TO regress_bttest_role;
+SET LOCAL search_path = preempt, pg_catalog, public;
+CREATE FUNCTION "current_user"() RETURNS name AS $$
+	broken
+$$ LANGUAGE sql STABLE PARALLEL SAFE STRICT;
 SELECT bt_index_check('bttest_a_expr_idx', true);
+ROLLBACK;
 
 -- UNIQUE constraint check
 SELECT bt_index_check('bttest_a_idx', heapallindexed => true, checkunique => true);

--- a/contrib/amcheck/verify_common.c
+++ b/contrib/amcheck/verify_common.c
@@ -94,6 +94,7 @@ amcheck_lock_relation_and_check(Oid indrelid,
 		SetUserIdAndSecContext(heaprel->rd_rel->relowner,
 							   save_sec_context | SECURITY_RESTRICTED_OPERATION);
 		save_nestlevel = NewGUCNestLevel();
+		RestrictSearchPath();
 	}
 	else
 	{

--- a/src/backend/utils/init/usercontext.c
+++ b/src/backend/utils/init/usercontext.c
@@ -70,6 +70,12 @@ SwitchToUntrustedUser(Oid userid, UserContext *context)
 		 * session state. Also set up a new GUC nest level, so that we can roll
 		 * back any GUC changes that may be made by code running as the target
 		 * user, inasmuch as they could be malicious.
+		 *
+		 * Unlike most use of SECURITY_RESTRICTED_OPERATION, this opts not to
+		 * use RestrictSearchPath().  Calling it would just stop the current
+		 * user from attacking "userid", but we've already established that
+		 * the current user could just SET ROLE to "userid".  Calling it would
+		 * be a compatibility break.
 		 */
 		sec_context |= SECURITY_RESTRICTED_OPERATION;
 		SetUserIdAndSecContext(userid, sec_context);


### PR DESCRIPTION
Closes #1817.

Upstream commit 0fbf785b13e ported verbatim ("Empty search_path in
amcheck"). The usercontext.c comment hunk was applied by hand because
this tree's file drifted slightly.

Summary: amcheck ran index expressions/predicates under the indexes'
owners without restricting search_path, so an EXECUTE grantee could
hijack search_path to run arbitrary functions as the owner. The fix
calls RestrictSearchPath() before evaluation.

Notes:
- No oracle-specific code is involved (amcheck is contrib; the
  usercontext.c change is a comment only).
- Verified: make check 249/249, amcheck suite 4/4.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * B-tree integrity checks now evaluate index expressions and predicates using the table owner’s identity and a restricted search path.
  * Prevents user-provided schemas or shadowed functions from influencing verification behavior.

* **Bug Fixes**
  * Improved protection against search-path manipulation during B-tree checks.

* **Tests**
  * Expanded verification coverage for owner context, search-path restrictions, and shadowed function scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->