### PR TITLE
fix: prevent heap buffer overflow in XML namespace registration

### DIFF
--- a/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
+++ b/contrib/ivorysql_ora/src/xml_functions/ora_xml_functions.c
@@ -551,20 +551,21 @@ register_ns_from_csting(xmlXPathContextPtr xpathCtx, char* nsList)
 			elog(ERROR, "Invalid namespace");
 
 		appendStringInfoString(&tmp, sub);
-		appendStringInfoString(&prefix, "");
-		appendStringInfoString(&url, "");
 
 		/* get the prefix */
 		start = strchr(tmp.data, (int)':');
 		end = strchr(tmp.data, (int)'=');
-		memcpy(prefix.data, start + 1, end - start);
-		prefix.data[end - start -1] = '\0';
+		if (start == NULL || end == NULL || end <= start)
+			elog(ERROR, "Invalid namespace");
+		/* appendBinaryStringInfo() grows the buffer as needed, avoiding overflow */
+		appendBinaryStringInfo(&prefix, start + 1, end - start - 1);
 
 		/* get the url */
 		p1 = strstr(tmp.data, "=");
 		l1 = strlen(p1);
-		memcpy(url.data, p1 + 2, l1 - 3);
-		url.data[l1 - 3] = '\0';
+		if (l1 < 3)
+			elog(ERROR, "Invalid namespace");
+		appendBinaryStringInfo(&url, p1 + 2, l1 - 3);
 
 		/* do register namespace */
 		if (xmlXPathRegisterNs(xpathCtx, (xmlChar *)prefix.data, (xmlChar *)url.data) != 0)


### PR DESCRIPTION
close #1824 
register_ns_from_csting() allocated fixed 1024-byte StringInfo buffers for the namespace prefix/URL but only ever appended empty strings via appendStringInfoString(&prefix, ""), so the buffers never grew. The actual prefix/URL bytes were then written with memcpy() using lengths taken directly from the user-supplied namespace string (e.g. the third argument to EXTRACTVALUE/XMLType XPath functions), with no bounds check, allowing a heap buffer overflow and backend crash (or worse) when the prefix or URL exceeded 1024 bytes.

Replace the raw memcpy() calls with appendBinaryStringInfo(), which grows the buffer as needed, and add validation for the delimiter lookups so malformed namespace strings raise a clean error instead of dereferencing NULL/negative offsets.

Reported via CNVD (CNCERT) as a heap buffer overflow in IvorySQL's Oracle-compatible XML namespace parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML namespace parsing and validation.
  * Prevented malformed namespace declarations and short URLs from being processed incorrectly.
  * Improved handling of namespace prefixes and URLs of varying lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->