### PR TITLE
fix(oracle): mark datetime length functions stable

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2919,21 +2919,28 @@ DETAIL:  Oracle's LENGTHC accepts only CHAR, VARCHAR2, NCHAR and NVARCHAR2.
 -- their answer is whatever nls_date_format says, so an index over them would
 -- go stale on the next alter session, and CREATE INDEX has to refuse it.
 --
--- length(d) is shown alongside to record that it does NOT refuse it yet.
--- sys.length/sys.lengthb declare their own datetime wrappers IMMUTABLE
--- (builtin_functions--1.0.sql:1429-1448, 1470-1485) even though the cast
--- inside them reaches the STABLE sys.oradate_out(); the wrapper hides that
--- from contain_mutable_functions(), which never looks inside a SQL function
--- body.  Fixing those is a separate change -- they are three whole function
--- families' worth of user-visible behaviour -- so the asymmetry is pinned
--- down here rather than left to be discovered.
+-- LENGTH and LENGTHB datetime overloads follow the same rule because their
+-- implicit text conversion also depends on the session's NLS formats.
 CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50), d date);
 CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
 CREATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d));
 ERROR:  functions in index expression must be marked IMMUTABLE
 LINE 1: ...ATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d)...
                                                              ^
-CREATE INDEX TEST_LENGTHC_IDX_L ON TEST_LENGTHC_IDX (length(d));
+SELECT count(*) = 6 AS datetime_lengths_are_stable
+FROM pg_catalog.pg_proc
+WHERE oid = ANY (ARRAY['sys.length(sys.oradate)'::regprocedure,
+                       'sys.length(sys.oratimestamp)'::regprocedure,
+                       'sys.length(sys.oratimestamptz)'::regprocedure,
+                       'sys.lengthb(sys.oradate)'::regprocedure,
+                       'sys.lengthb(sys.oratimestamp)'::regprocedure,
+                       'sys.lengthb(sys.oratimestamptz)'::regprocedure])
+  AND provolatile = 's';
+ datetime_lengths_are_stable 
+-----------------------------
+ t
+(1 row)
+
 DROP TABLE TEST_LENGTHC_IDX;
 /*
  * round

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -2927,6 +2927,14 @@ CREATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d));
 ERROR:  functions in index expression must be marked IMMUTABLE
 LINE 1: ...ATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d)...
                                                              ^
+CREATE INDEX TEST_LENGTHC_IDX_D_LEN ON TEST_LENGTHC_IDX (length(d));
+ERROR:  functions in index expression must be marked IMMUTABLE
+LINE 1: ...INDEX TEST_LENGTHC_IDX_D_LEN ON TEST_LENGTHC_IDX (length(d)...
+                                                             ^
+CREATE INDEX TEST_LENGTHC_IDX_D_LENB ON TEST_LENGTHC_IDX (lengthb(d));
+ERROR:  functions in index expression must be marked IMMUTABLE
+LINE 1: ...NDEX TEST_LENGTHC_IDX_D_LENB ON TEST_LENGTHC_IDX (lengthb(d...
+                                                             ^
 SELECT count(*) = 6 AS datetime_lengths_are_stable
 FROM pg_catalog.pg_proc
 WHERE oid = ANY (ARRAY['sys.length(sys.oradate)'::regprocedure,

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1275,18 +1275,20 @@ select lengthc(cast('abc'::bytea as blob)) from dual;
 -- their answer is whatever nls_date_format says, so an index over them would
 -- go stale on the next alter session, and CREATE INDEX has to refuse it.
 --
--- length(d) is shown alongside to record that it does NOT refuse it yet.
--- sys.length/sys.lengthb declare their own datetime wrappers IMMUTABLE
--- (builtin_functions--1.0.sql:1429-1448, 1470-1485) even though the cast
--- inside them reaches the STABLE sys.oradate_out(); the wrapper hides that
--- from contain_mutable_functions(), which never looks inside a SQL function
--- body.  Fixing those is a separate change -- they are three whole function
--- families' worth of user-visible behaviour -- so the asymmetry is pinned
--- down here rather than left to be discovered.
+-- LENGTH and LENGTHB datetime overloads follow the same rule because their
+-- implicit text conversion also depends on the session's NLS formats.
 CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50), d date);
 CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
 CREATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d));
-CREATE INDEX TEST_LENGTHC_IDX_L ON TEST_LENGTHC_IDX (length(d));
+SELECT count(*) = 6 AS datetime_lengths_are_stable
+FROM pg_catalog.pg_proc
+WHERE oid = ANY (ARRAY['sys.length(sys.oradate)'::regprocedure,
+                       'sys.length(sys.oratimestamp)'::regprocedure,
+                       'sys.length(sys.oratimestamptz)'::regprocedure,
+                       'sys.lengthb(sys.oradate)'::regprocedure,
+                       'sys.lengthb(sys.oratimestamp)'::regprocedure,
+                       'sys.lengthb(sys.oratimestamptz)'::regprocedure])
+  AND provolatile = 's';
 DROP TABLE TEST_LENGTHC_IDX;
 
 /*

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1280,6 +1280,8 @@ select lengthc(cast('abc'::bytea as blob)) from dual;
 CREATE TABLE TEST_LENGTHC_IDX(c varchar2(50), d date);
 CREATE INDEX TEST_LENGTHC_IDX_I ON TEST_LENGTHC_IDX (lengthc(c));
 CREATE INDEX TEST_LENGTHC_IDX_D ON TEST_LENGTHC_IDX (lengthc(d));
+CREATE INDEX TEST_LENGTHC_IDX_D_LEN ON TEST_LENGTHC_IDX (length(d));
+CREATE INDEX TEST_LENGTHC_IDX_D_LENB ON TEST_LENGTHC_IDX (lengthb(d));
 SELECT count(*) = 6 AS datetime_lengths_are_stable
 FROM pg_catalog.pg_proc
 WHERE oid = ANY (ARRAY['sys.length(sys.oradate)'::regprocedure,

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1451,22 +1451,17 @@ CREATE OR REPLACE FUNCTION sys.length(sys.oradate)
 RETURNS integer
 AS 'select sys.length($1::sys.oravarcharchar)'
 LANGUAGE SQL
-IMMUTABLE PARALLEL SAFE STRICT;
-
-CREATE OR REPLACE FUNCTION sys.length(sys.oradate)
-RETURNS integer
-AS 'select sys.length($1::sys.oravarcharchar)'
-LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+STABLE PARALLEL SAFE STRICT;
 
 CREATE OR REPLACE FUNCTION sys.length(sys.oratimestamp)
 RETURNS integer
 AS 'select sys.length($1::sys.oravarcharchar)'
-LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
 
 CREATE OR REPLACE FUNCTION sys.length(sys.oratimestamptz)
 RETURNS integer
 AS 'select sys.length($1::sys.oravarcharchar)'
-LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
 
 
 --lengthb
@@ -1491,17 +1486,17 @@ IMMUTABLE PARALLEL SAFE STRICT;
 CREATE OR REPLACE FUNCTION sys.lengthb(sys.oradate)
 RETURNS integer
 AS 'select sys.lengthb($1::sys.oravarcharchar)'
-LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
 
 CREATE OR REPLACE FUNCTION sys.lengthb(sys.oratimestamp)
 RETURNS integer
 AS 'select sys.lengthb($1::sys.oravarcharchar)'
-LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
 
 CREATE OR REPLACE FUNCTION sys.lengthb(sys.oratimestamptz)
 RETURNS integer
 AS 'select sys.lengthb($1::sys.oravarcharchar)'
-LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
 
 CREATE FUNCTION sys.lengthb(text)
 RETURNS integer


### PR DESCRIPTION
## Summary

- mark the `DATE`, `TIMESTAMP`, and `TIMESTAMP WITH TIME ZONE` overloads of `LENGTH` and `LENGTHB` as `STABLE`
- remove the duplicate `LENGTH(oradate)` declaration from the extension install script
- add regression coverage for all six catalog volatility entries

## Why

These overloads convert datetime values through Oracle character output, which depends on the session NLS datetime formats. Declaring them `IMMUTABLE` allows them in expression indexes even though a later `ALTER SESSION` can change their result.

## Testing

- `git diff --check`
- verified the branch is based on current upstream `master`
- full regression suite not run locally because a compatible Linux IvorySQL build environment is unavailable; project CI is expected to provide compile and regression validation

Closes #1830

Assisted-by: OpenAI:GPT-5
Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the volatility classification for date and timestamp variants of `LENGTH` and `LENGTHB` to account for session-specific NLS formatting.
  - These functions are now treated as stable rather than immutable, preventing their use where immutable behavior is required.

- **Tests**
  - Added coverage verifying the volatility of all six date and timestamp overloads.
  - Added checks confirming that indexes using these non-immutable expressions are rejected with the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->