### PR TITLE
fix(oracle): preserve characters in LONG casts

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_raw_long.out
+++ b/contrib/ivorysql_ora/expected/ora_raw_long.out
@@ -141,6 +141,68 @@ select 'ff'::text = 'ff'::long(2);
  t
 (1 row)
 
+-- Explicit LONG(n) casts retain only complete multibyte characters.
+SELECT cast('中文' AS long(6)) = '中文'
+       AND lengthb(cast('中文' AS long(6))) = 6;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('中文' AS long(5)) = '中'
+       AND lengthb(cast('中文' AS long(5))) = 3;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT coalesce(lengthb(cast('中文' AS long(2))), 0) = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('abcdef' AS long(4)) = 'abcd';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('abc' AS long(4)) = 'abc';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Explicit bytea -> RAW(n) casts truncate by bytes, not by characters.
+SELECT cast('\xDEADBEEF'::bytea AS raw(4)) = '\xDEADBEEF'::bytea
+       AND lengthb(cast('\xDEADBEEF'::bytea AS raw(4))) = 4;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('\xDEADBEEF'::bytea AS raw(3)) = '\xDEADBE'::bytea
+       AND lengthb(cast('\xDEADBEEF'::bytea AS raw(3))) = 3;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('\x'::bytea AS raw(4)) = '\x'::bytea
+       AND lengthb(cast('\x'::bytea AS raw(4))) = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('\x00FF10'::bytea AS raw(2)) = '\x00FF'::bytea
+       AND lengthb(cast('\x00FF10'::bytea AS raw(2))) = 2;
+ ?column? 
+----------
+ t
+(1 row)
+
 DELETE FROM RW_TEXT;
 CREATE INDEX test_orachar_btree ON RW_TEXT(a);
 INSERT INTO RW_TEXT VALUES(3,'\xFF');

--- a/contrib/ivorysql_ora/sql/ora_raw_long.sql
+++ b/contrib/ivorysql_ora/sql/ora_raw_long.sql
@@ -26,6 +26,26 @@ select '123'::raw = '123'::bytea;
 select '123'::raw(2) = '123'::bytea;
 select '\xff'::bytea = '\xff'::raw(2);
 select 'ff'::text = 'ff'::long(2);
+
+-- Explicit LONG(n) casts retain only complete multibyte characters.
+SELECT cast('中文' AS long(6)) = '中文'
+       AND lengthb(cast('中文' AS long(6))) = 6;
+SELECT cast('中文' AS long(5)) = '中'
+       AND lengthb(cast('中文' AS long(5))) = 3;
+SELECT coalesce(lengthb(cast('中文' AS long(2))), 0) = 0;
+SELECT cast('abcdef' AS long(4)) = 'abcd';
+SELECT cast('abc' AS long(4)) = 'abc';
+
+-- Explicit bytea -> RAW(n) casts truncate by bytes, not by characters.
+SELECT cast('\xDEADBEEF'::bytea AS raw(4)) = '\xDEADBEEF'::bytea
+       AND lengthb(cast('\xDEADBEEF'::bytea AS raw(4))) = 4;
+SELECT cast('\xDEADBEEF'::bytea AS raw(3)) = '\xDEADBE'::bytea
+       AND lengthb(cast('\xDEADBEEF'::bytea AS raw(3))) = 3;
+SELECT cast('\x'::bytea AS raw(4)) = '\x'::bytea
+       AND lengthb(cast('\x'::bytea AS raw(4))) = 0;
+SELECT cast('\x00FF10'::bytea AS raw(2)) = '\x00FF'::bytea
+       AND lengthb(cast('\x00FF10'::bytea AS raw(2))) = 2;
+
 DELETE FROM RW_TEXT;
 CREATE INDEX test_orachar_btree ON RW_TEXT(a);
 INSERT INTO RW_TEXT VALUES(3,'\xFF');

--- a/contrib/ivorysql_ora/src/datatype/raw_long.c
+++ b/contrib/ivorysql_ora/src/datatype/raw_long.c
@@ -223,7 +223,7 @@ orachar_to_long_with_typmod(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
 					 errmsg("value too long for type long(%d)",
 							maxlen)));
-		len = maxlen;	
+		len = pg_mbcliplen(s, len, maxlen);
 	}
 
 	Assert(maxlen >= len);


### PR DESCRIPTION
## Summary

- clip explicit `LONG(n)` casts at a complete multibyte-character boundary
- preserve existing byte limits and ASCII truncation behavior
- add UTF-8 and ASCII regression cases for exact, partial, and zero-character prefixes

## Why

`orachar_to_long_with_typmod()` previously assigned `len = maxlen` before copying the payload. If the byte limit fell inside a UTF-8 character, the resulting LONG value contained an invalid partial character.

## Testing

- `git diff --check`
- verified the branch is based on current upstream `master`
- full regression suite not run locally because a compatible Linux IvorySQL build environment is unavailable; project CI is expected to provide compile and regression validation

Closes #1831

Assisted-by: OpenAI:GPT-5
Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `RAW(n)` casts to truncate input by bytes while preserving arbitrary byte values and exact byte limits.
  - Ensured zero-byte inputs produce empty results with the correct byte length.
  - Fixed `LONG(n)` casts to truncate multibyte text only at complete character boundaries.
  - Preserved expected behavior for ASCII text and values shorter than the limit.

- **Tests**
  - Added coverage for `RAW(n)` byte truncation, zero-byte inputs, and byte-length results.
  - Added coverage for multibyte and ASCII `LONG(n)` cast scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->