### PR TITLE
fix(oracle): preserve characters in CHAR byte casts

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -58,6 +58,40 @@ SELECT cast('abc' AS varchar2(4 byte)) = 'abc';
  t
 (1 row)
 
+-- Explicit CHAR(n BYTE) casts must not split multibyte characters.  CHAR
+-- values are padded back to the declared byte length after clipping.
+SELECT cast('中文' AS char(6 byte)) = '中文'
+       AND lengthb(cast('中文' AS char(6 byte))) = 6;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('中文' AS char(5 byte)) = '中'
+       AND lengthb(cast('中文' AS char(5 byte))) = 5;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT lengthb(cast('中文' AS char(2 byte))) = 2;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('abcdef' AS char(4 byte)) = 'abcd';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cast('abc' AS char(4 byte)) = 'abc';
+ ?column? 
+----------
+ t
+(1 row)
+
 INSERT INTO TEST_ORACHAR SELECT generate_series(1,10), generate_series(1,10);
 INSERT INTO TEST_ORAVARCHAR SELECT generate_series(1,10), generate_series(1,10);
 -- Comparison operator

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -28,6 +28,16 @@ SELECT coalesce(lengthb(cast('中文' AS varchar2(2 byte))), 0) = 0;
 SELECT cast('abcdef' AS varchar2(4 byte)) = 'abcd';
 SELECT cast('abc' AS varchar2(4 byte)) = 'abc';
 
+-- Explicit CHAR(n BYTE) casts must not split multibyte characters.  CHAR
+-- values are padded back to the declared byte length after clipping.
+SELECT cast('中文' AS char(6 byte)) = '中文'
+       AND lengthb(cast('中文' AS char(6 byte))) = 6;
+SELECT cast('中文' AS char(5 byte)) = '中'
+       AND lengthb(cast('中文' AS char(5 byte))) = 5;
+SELECT lengthb(cast('中文' AS char(2 byte))) = 2;
+SELECT cast('abcdef' AS char(4 byte)) = 'abcd';
+SELECT cast('abc' AS char(4 byte)) = 'abc';
+
 INSERT INTO TEST_ORACHAR SELECT generate_series(1,10), generate_series(1,10);
 
 INSERT INTO TEST_ORAVARCHAR SELECT generate_series(1,10), generate_series(1,10);

--- a/contrib/ivorysql_ora/src/datatype/oracharbyte.c
+++ b/contrib/ivorysql_ora/src/datatype/oracharbyte.c
@@ -338,7 +338,7 @@ oracharbyte(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
 					 errmsg("value too long for type char(%d byte)",
 							maxlen)));
-		len = maxlen;	
+		len = pg_mbcliplen(s, len, maxlen);
 	}
 
 	Assert(maxlen >= len);


### PR DESCRIPTION
## Summary

- clip explicit `CHAR(n BYTE)` casts at a complete multibyte-character boundary
- retain fixed-width CHAR semantics by padding the remaining bytes with spaces
- add UTF-8 and ASCII regression cases for exact and partial boundaries

## Why

`oracharbyte()` previously copied exactly `maxlen` bytes for an explicit cast. A byte limit inside a UTF-8 character therefore stored an invalid partial character. This brings fixed-width byte-semantic CHAR casts in line with the complete-character clipping already used by VARCHAR2 byte casts.

## Testing

- `git diff --check`
- verified the branch is based on current upstream `master`
- full regression suite not run locally because a compatible Linux IvorySQL build environment is unavailable; project CI is expected to provide compile and regression validation

Closes #1828

Assisted-by: OpenAI:GPT-5
Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `CHAR(n BYTE)` conversions so multibyte characters are not split when values exceed the declared byte length.
  - Ensured truncated values are padded correctly to the requested byte length.
  - Improved handling of explicit and implicit conversions, including zero-length boundaries.

- **Tests**
  - Added regression coverage for multibyte `CHAR(n BYTE)` casts, truncation, byte-length behavior, and padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->