### PR TITLE
fix(oracle): normalize zero OID CHAR comparisons

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -109,6 +109,44 @@ select not (cast('000' as char(3 char)) <> 0::oid);
  t
 (1 row)
 
+-- Blank-only CHAR values remain distinct from OID zero.
+select not (0::oid = cast('   ' as char(3 char)));
+ ?column? 
+----------
+ t
+(1 row)
+
+select not (cast('   ' as char(3 char)) = 0::oid);
+ ?column? 
+----------
+ t
+(1 row)
+
+select 0::oid <> cast('   ' as char(3 char));
+ ?column? 
+----------
+ t
+(1 row)
+
+select cast('   ' as char(3 char)) <> 0::oid;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Nonzero values still ignore only their leading zeroes.
+select 42::oid = cast('042' as char(3 char));
+ ?column? 
+----------
+ t
+(1 row)
+
+select not (0::oid = cast('007' as char(3 char)));
+ ?column? 
+----------
+ t
+(1 row)
+
 -- The comparison helpers are deterministic and safe for planner use.
 select count(*) = 4 as oid_char_comparisons_are_immutable
 from pg_catalog.pg_proc

--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -84,6 +84,46 @@ ERROR:  syntax error at or near "default"
 LINE 1: ... s1.f_alter(arg1 number, arg2 number, arg3 number default 10...
                                                              ^
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number) compile;
+-- OID comparisons ignore leading zeroes, including the all-zero value.
+select 0::oid = cast('000' as char(3 char));
+ ?column? 
+----------
+ t
+(1 row)
+
+select cast('000' as char(3 char)) = 0::oid;
+ ?column? 
+----------
+ t
+(1 row)
+
+select not (0::oid <> cast('000' as char(3 char)));
+ ?column? 
+----------
+ t
+(1 row)
+
+select not (cast('000' as char(3 char)) <> 0::oid);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- The comparison helpers are deterministic and safe for planner use.
+select count(*) = 4 as oid_char_comparisons_are_immutable
+from pg_catalog.pg_proc
+where oid = any (array['sys.oid_cc_eq(oid,sys.oracharchar)'::regprocedure,
+                       'sys.cc_oid_eq(sys.oracharchar,oid)'::regprocedure,
+                       'sys.oid_cc_ne(oid,sys.oracharchar)'::regprocedure,
+                       'sys.cc_oid_ne(sys.oracharchar,oid)'::regprocedure])
+  and provolatile = 'i'
+  and proisstrict
+  and proparallel = 's';
+ oid_char_comparisons_are_immutable 
+------------------------------------
+ t
+(1 row)
+
 -- clean
 drop table dtos_tb1tidid004134318;
 drop table char_tb2;

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -78,6 +78,16 @@ select cast('000' as char(3 char)) = 0::oid;
 select not (0::oid <> cast('000' as char(3 char)));
 select not (cast('000' as char(3 char)) <> 0::oid);
 
+-- Blank-only CHAR values remain distinct from OID zero.
+select not (0::oid = cast('   ' as char(3 char)));
+select not (cast('   ' as char(3 char)) = 0::oid);
+select 0::oid <> cast('   ' as char(3 char));
+select cast('   ' as char(3 char)) <> 0::oid;
+
+-- Nonzero values still ignore only their leading zeroes.
+select 42::oid = cast('042' as char(3 char));
+select not (0::oid = cast('007' as char(3 char)));
+
 -- The comparison helpers are deterministic and safe for planner use.
 select count(*) = 4 as oid_char_comparisons_are_immutable
 from pg_catalog.pg_proc

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -71,6 +71,23 @@ alter function s1.f_alter(arg1 OUT int) compile;
 alter function s1.f_alter(arg1 text) compile;
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number default 10) compile;
 alter function s1.f_alter(arg1 number, arg2 number, arg3 number) compile;
+
+-- OID comparisons ignore leading zeroes, including the all-zero value.
+select 0::oid = cast('000' as char(3 char));
+select cast('000' as char(3 char)) = 0::oid;
+select not (0::oid <> cast('000' as char(3 char)));
+select not (cast('000' as char(3 char)) <> 0::oid);
+
+-- The comparison helpers are deterministic and safe for planner use.
+select count(*) = 4 as oid_char_comparisons_are_immutable
+from pg_catalog.pg_proc
+where oid = any (array['sys.oid_cc_eq(oid,sys.oracharchar)'::regprocedure,
+                       'sys.cc_oid_eq(sys.oracharchar,oid)'::regprocedure,
+                       'sys.oid_cc_ne(oid,sys.oracharchar)'::regprocedure,
+                       'sys.cc_oid_ne(sys.oracharchar,oid)'::regprocedure])
+  and provolatile = 'i'
+  and proisstrict
+  and proparallel = 's';
 -- clean
 drop table dtos_tb1tidid004134318;
 drop table char_tb2;

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -10599,10 +10599,27 @@ WITH INOUT
 AS IMPLICIT;
 
 /* will move to oracharchar partition */
-create or replace function sys.oid_cc_eq(oid_l pg_catalog.oid, cc_r sys.oracharchar) RETURNS BOOLEAN AS $$ SELECT $1::sys.oracharchar=trim(leading '0' from $2) $$ LANGUAGE SQL;
-create or replace function sys.cc_oid_eq(cc_l sys.oracharchar, oid_r pg_catalog.oid) RETURNS BOOLEAN AS $$ SELECT trim(leading '0' from $1)=$2::sys.oracharchar $$ LANGUAGE SQL;
-create or replace function sys.oid_cc_ne(oid_l pg_catalog.oid, cc_r sys.oracharchar) RETURNS BOOLEAN AS $$ SELECT not sys.oid_cc_eq(oid_l, cc_r) $$ LANGUAGE SQL;
-create or replace function sys.cc_oid_ne(cc_l sys.oracharchar, oid_r pg_catalog.oid) RETURNS BOOLEAN AS $$ SELECT not sys.cc_oid_eq(cc_l, oid_r) $$ LANGUAGE SQL;
+create or replace function sys.oid_cc_eq(oid_l pg_catalog.oid, cc_r sys.oracharchar)
+RETURNS BOOLEAN AS $$
+SELECT $1::sys.oracharchar =
+	coalesce(nullif(trim(leading '0' from $2), ''), '0')
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+create or replace function sys.cc_oid_eq(cc_l sys.oracharchar, oid_r pg_catalog.oid)
+RETURNS BOOLEAN AS $$
+SELECT coalesce(nullif(trim(leading '0' from $1), ''), '0') =
+	$2::sys.oracharchar
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+create or replace function sys.oid_cc_ne(oid_l pg_catalog.oid, cc_r sys.oracharchar)
+RETURNS BOOLEAN AS $$
+SELECT not sys.oid_cc_eq(oid_l, cc_r)
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
+create or replace function sys.cc_oid_ne(cc_l sys.oracharchar, oid_r pg_catalog.oid)
+RETURNS BOOLEAN AS $$
+SELECT not sys.cc_oid_eq(cc_l, oid_r)
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
 create operator = (procedure=sys.oid_cc_eq, LEFTARG=pg_catalog.oid, RIGHTARG=sys.oracharchar);
 create operator = (procedure=sys.cc_oid_eq, LEFTARG=sys.oracharchar, RIGHTARG=pg_catalog.oid);
 create operator <> (procedure=sys.oid_cc_ne, LEFTARG=pg_catalog.oid, RIGHTARG=sys.oracharchar);

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -10599,16 +10599,27 @@ WITH INOUT
 AS IMPLICIT;
 
 /* will move to oracharchar partition */
+-- NOTE: an all-blank oracharchar holds no digits, so it must not compare equal
+-- to OID zero, while '000' must.  The two are told apart by the length of the
+-- value: trimming every leading zero leaves the empty string in both cases.
+-- '' is not used as a literal here, because in Oracle mode it is NULL.
 create or replace function sys.oid_cc_eq(oid_l pg_catalog.oid, cc_r sys.oracharchar)
 RETURNS BOOLEAN AS $$
-SELECT $1::sys.oracharchar =
-	coalesce(nullif(trim(leading '0' from $2), ''), '0')
+SELECT length($2::pg_catalog.text) > 0 AND
+	   $1::sys.oracharchar =
+	   CASE WHEN length(trim(leading '0' from $2)) = 0
+			THEN '0'
+			ELSE trim(leading '0' from $2)
+	   END
 $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
 
 create or replace function sys.cc_oid_eq(cc_l sys.oracharchar, oid_r pg_catalog.oid)
 RETURNS BOOLEAN AS $$
-SELECT coalesce(nullif(trim(leading '0' from $1), ''), '0') =
-	$2::sys.oracharchar
+SELECT length($1::pg_catalog.text) > 0 AND
+	   CASE WHEN length(trim(leading '0' from $1)) = 0
+			THEN '0'
+			ELSE trim(leading '0' from $1)
+	   END = $2::sys.oracharchar
 $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
 
 create or replace function sys.oid_cc_ne(oid_l pg_catalog.oid, cc_r sys.oracharchar)


### PR DESCRIPTION
## Summary

- preserve a single zero when normalizing all-zero Oracle CHAR values for OID comparisons
- apply the fix in both operand directions and their not-equal wrappers
- mark the four deterministic helpers immutable, strict, and parallel safe
- add comparison and catalog-metadata regression coverage

## Why

Removing every leading zero from `CHAR '000'` produced an empty value, so it did not compare equal to OID 0. The SQL comparison helpers also retained the default volatile and parallel-unsafe metadata despite having deterministic behavior.

## Testing

- `git diff --check`
- verified the branch is based on current upstream `master`
- full regression suite not run locally because a compatible Linux IvorySQL build environment is unavailable; project CI is expected to provide compile and regression validation

Closes #1829

Assisted-by: OpenAI:GPT-5
Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OID-to-character comparisons now correctly ignore leading zeroes, including all-zero values.
  - Blank-only character values remain distinct from OID zero.
  - Equality and inequality comparisons return consistent results regardless of operand order.
  - Nonzero OID values compare correctly when character values contain leading zeroes.

- **Performance and Reliability**
  - Comparison operations retain immutable, strict, and parallel-safe behavior.

- **Tests**
  - Added coverage for zero-padded OID comparisons and comparison-function properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->