### PR TITLE
Raise NO_DATA_FOUND when UTL_FILE.GET_LINE reads past EOF

### DIFF
--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -47,12 +47,22 @@ begin
     utl_file.get_line(f, line);
     while line is not null and i < 11 loop
         raise notice '[%] >>%<<', i, line;
-        utl_file.get_line(f, line);
+        begin
+            utl_file.get_line(f, line);
+        exception
+            when NO_DATA_FOUND then
+                line := null;
+        end;
         i:=i+1;
     end loop;
     while line is not null loop
         raise notice '[%] >>%<<', i, line;
-        utl_file.get_line(f, line, 3);
+        begin
+            utl_file.get_line(f, line, 3);
+        exception
+            when NO_DATA_FOUND then
+                line := null;
+        end;
         i:=i+1;
     end loop;
     raise notice '>>%<<', line;
@@ -120,10 +130,20 @@ begin
     end loop;
     -- data reading before fflush
     raise notice 'data read before fflush';
-    utl_file.get_line(f1, line);
+    begin
+        utl_file.get_line(f1, line);
+    exception
+        when NO_DATA_FOUND then
+            line := null;
+    end;
     while line is not null loop
         raise notice '>>%<<', line;
-        utl_file.get_line(f1, line);
+            begin
+                utl_file.get_line(f1, line);
+            exception
+                when NO_DATA_FOUND then
+                    line := null;
+            end;
     end loop;
     raise notice '>>%<<', line;
     utl_file.fflush(f);
@@ -134,7 +154,12 @@ begin
     line2_pos := utl_file.fgetpos(f1); -- after reading line 1, get position
     while line is not null loop
         raise notice '>>%<<', line;
-        utl_file.get_line(f1, line);
+            begin
+                utl_file.get_line(f1, line);
+            exception
+                when NO_DATA_FOUND then
+                    line := null;
+            end;
     end loop;
     raise notice '>>%<<', line;
     raise notice 'lets print line#2 again';
@@ -169,6 +194,49 @@ NOTICE:  lets print line#2 again
 NOTICE:  >>line 2<<
 NOTICE:  lets print line#2 again via relative seek
 NOTICE:  >>line 2<<
+-- GET_LINE raises NO_DATA_FOUND when no text was read because of end of
+-- file, including the first read of an empty file; PL/iSQL callers can
+-- catch it explicitly (matching Oracle)
+declare
+    f sys.ora_utl_file_file_type;
+    line text;
+begin
+    f := utl_file.fopen('data_directory', 'regress_eof.txt', 'w');
+    utl_file.put_line(f, 'first');
+    utl_file.put_line(f, 'second');
+    utl_file.fclose(f);
+    f := utl_file.fopen('data_directory', 'regress_eof.txt', 'r');
+    utl_file.get_line(f, line);
+    raise notice 'eof-file line1=[%]', line;
+    utl_file.get_line(f, line);
+    raise notice 'eof-file line2=[%]', line;
+    utl_file.get_line(f, line);
+    raise notice 'eof-file line3=[%] (not reached)', line;
+exception
+    when NO_DATA_FOUND then
+        raise notice 'caught NO_DATA_FOUND at eof, sqlerrm=[%]', sqlerrm;
+    when others then
+        raise notice 'unexpected exception: %', sqlerrm;
+end;
+/
+NOTICE:  eof-file line1=[first]
+NOTICE:  eof-file line2=[second]
+NOTICE:  caught NO_DATA_FOUND at eof, sqlerrm=[no data found]
+declare
+    f sys.ora_utl_file_file_type;
+    line text;
+begin
+    f := utl_file.fopen('data_directory', 'regress_empty.txt', 'w');
+    utl_file.fclose(f);
+    f := utl_file.fopen('data_directory', 'regress_empty.txt', 'r');
+    utl_file.get_line(f, line);
+    raise notice 'empty-file line=[%] (not reached)', line;
+exception
+    when NO_DATA_FOUND then
+        raise notice 'caught NO_DATA_FOUND on empty file, sqlerrm=[%]', sqlerrm;
+end;
+/
+NOTICE:  caught NO_DATA_FOUND on empty file, sqlerrm=[no data found]
 -- test cases for automatic file closing on session terminated/rollback etc
 declare
     f sys.ora_utl_file_file_type;

--- a/contrib/ivorysql_ora/sql/utl_file.sql
+++ b/contrib/ivorysql_ora/sql/utl_file.sql
@@ -48,14 +48,24 @@ begin
     utl_file.get_line(f, line);
     while line is not null and i < 11 loop
         raise notice '[%] >>%<<', i, line;
-        utl_file.get_line(f, line);
+        begin
+            utl_file.get_line(f, line);
+        exception
+            when NO_DATA_FOUND then
+                line := null;
+        end;
         i:=i+1;
 
     end loop;
 
     while line is not null loop
         raise notice '[%] >>%<<', i, line;
-        utl_file.get_line(f, line, 3);
+        begin
+            utl_file.get_line(f, line, 3);
+        exception
+            when NO_DATA_FOUND then
+                line := null;
+        end;
         i:=i+1;
     end loop;
 
@@ -109,10 +119,20 @@ begin
 
     -- data reading before fflush
     raise notice 'data read before fflush';
-    utl_file.get_line(f1, line);
+    begin
+        utl_file.get_line(f1, line);
+    exception
+        when NO_DATA_FOUND then
+            line := null;
+    end;
     while line is not null loop
         raise notice '>>%<<', line;
-        utl_file.get_line(f1, line);
+            begin
+                utl_file.get_line(f1, line);
+            exception
+                when NO_DATA_FOUND then
+                    line := null;
+            end;
     end loop;
     raise notice '>>%<<', line;
 
@@ -125,7 +145,12 @@ begin
     line2_pos := utl_file.fgetpos(f1); -- after reading line 1, get position
     while line is not null loop
         raise notice '>>%<<', line;
-        utl_file.get_line(f1, line);
+            begin
+                utl_file.get_line(f1, line);
+            exception
+                when NO_DATA_FOUND then
+                    line := null;
+            end;
     end loop;
     raise notice '>>%<<', line;
     raise notice 'lets print line#2 again';
@@ -147,6 +172,49 @@ begin
             utl_file.fclose_all();
             raise notice 'is_open(f) = %', utl_file.is_open(f);
             raise notice 'is_open(f1) = %', utl_file.is_open(f1);
+end;
+/
+
+-- GET_LINE raises NO_DATA_FOUND when no text was read because of end of
+-- file, including the first read of an empty file; PL/iSQL callers can
+-- catch it explicitly (matching Oracle)
+declare
+    f sys.ora_utl_file_file_type;
+    line text;
+begin
+    f := utl_file.fopen('data_directory', 'regress_eof.txt', 'w');
+    utl_file.put_line(f, 'first');
+    utl_file.put_line(f, 'second');
+    utl_file.fclose(f);
+
+    f := utl_file.fopen('data_directory', 'regress_eof.txt', 'r');
+    utl_file.get_line(f, line);
+    raise notice 'eof-file line1=[%]', line;
+    utl_file.get_line(f, line);
+    raise notice 'eof-file line2=[%]', line;
+    utl_file.get_line(f, line);
+    raise notice 'eof-file line3=[%] (not reached)', line;
+exception
+    when NO_DATA_FOUND then
+        raise notice 'caught NO_DATA_FOUND at eof, sqlerrm=[%]', sqlerrm;
+    when others then
+        raise notice 'unexpected exception: %', sqlerrm;
+end;
+/
+
+declare
+    f sys.ora_utl_file_file_type;
+    line text;
+begin
+    f := utl_file.fopen('data_directory', 'regress_empty.txt', 'w');
+    utl_file.fclose(f);
+
+    f := utl_file.fopen('data_directory', 'regress_empty.txt', 'r');
+    utl_file.get_line(f, line);
+    raise notice 'empty-file line=[%] (not reached)', line;
+exception
+    when NO_DATA_FOUND then
+        raise notice 'caught NO_DATA_FOUND on empty file, sqlerrm=[%]', sqlerrm;
 end;
 /
 

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_file/utl_file.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_file/utl_file.c
@@ -751,13 +751,15 @@ ora_utl_file_get_line(PG_FUNCTION_ARGS)
 
 	result = get_line(fd, max_linesize, encoding, &iseof);
 
+	/*
+	 * Oracle raises NO_DATA_FOUND (ORA-01403) when no text was read
+	 * because of end of file, so PL/iSQL callers can catch it explicitly.
+	 */
 	if (iseof)
 	{
-		ereport(LOG,
-			(errcode(ERRCODE_NO_DATA_FOUND),
-					errmsg("no data found")));
-
-		PG_RETURN_NULL();
+		ereport(ERROR,
+				(errcode(ERRCODE_NO_DATA_FOUND),
+						errmsg("no data found")));
 	}
 
 	PG_RETURN_TEXT_P(result);


### PR DESCRIPTION
## Summary

UTL_FILE.GET_LINE listed NO_DATA_FOUND among its exceptions but only
logged it at LOG level and returned NULL when no text was read because
of end of file.  As a result PL/iSQL callers could not end read loops
with WHEN NO_DATA_FOUND, and every read past EOF also emitted a
"no data found" line into the server log.

Oracle documents for GET_LINE: "If no text was read due to end of file,
the NO_DATA_FOUND exception is raised."

The EOF branch now raises the exception, using the same pattern PL/iSQL
already uses for strict SELECT INTO (ereport(ERROR,
ERRCODE_NO_DATA_FOUND)).  The read loops in the existing regression
tests catch NO_DATA_FOUND per call, so their output is unchanged; new
cases pin the exception on a two-line file and on the first read of an
empty file, including the exact sqlerrm.

Note this is a deliberate behaviour change for callers that relied on
NULL at EOF.

## Testing

- oracle regression suite: 28/28 in a C locale, a UTF8 locale, and the
  default locale
- make check: 249/249
- full-tree Meson/Ninja build: 2729/2729 targets

Fixes #1840


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `utl_file.get_line` now raises `NO_DATA_FOUND` when reading beyond the end of a file or from an empty file.
  * End-of-file handling in affected file-reading scenarios now terminates cleanly instead of returning `NULL`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->