### PR TITLE
fix(oracle): guard SUBSTRB end boundary

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -1705,6 +1705,12 @@ SELECT SUBSTRB('ABCDEFG',5) "Substring with bytes" FROM DUAL;
  EFG
 (1 row)
 
+SELECT SUBSTRB('你好',1,6) = '你好' AS complete_boundary FROM DUAL;
+ complete_boundary 
+-------------------
+ t
+(1 row)
+
 /*
  * instrb
  */

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -832,6 +832,7 @@ DROP TABLE regexp_temp;
  */
 SELECT SUBSTRB('ABCDEFG',5,4.2) "Substring with bytes" FROM DUAL;
 SELECT SUBSTRB('ABCDEFG',5) "Substring with bytes" FROM DUAL;
+SELECT SUBSTRB('你好',1,6) = '你好' AS complete_boundary FROM DUAL;
 
 /*
  * instrb

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -1354,7 +1354,8 @@ text_substring_byte(Datum str, int32 start, int32 length, bool length_not_specif
 		}
 
 		subStrEnd = subStrBegin;
-		while (subStrEnd + pg_mblen(subStrEnd) <= sliceBegin + E1 - 1)
+		while (subStrEnd < sliceBegin + E1 - 1 &&
+			   subStrEnd + pg_mblen(subStrEnd) <= sliceBegin + E1 - 1)
 			subStrEnd += pg_mblen(subStrEnd);
 
 		if (subStrEnd < sliceBegin + E1 - 1)


### PR DESCRIPTION
## Summary

- stop `SUBSTRB` from calling `pg_mblen()` after its scan pointer reaches the end of the varlena payload
- keep the existing byte-substring result unchanged
- exercise the exact-end UTF-8 boundary path in regression coverage

## Why

When the requested byte range ends exactly at the source boundary, the loop advances `subStrEnd` to the one-past-end pointer. The old loop condition then evaluates `pg_mblen(subStrEnd)` before determining that another character cannot fit. Because a multibyte character length is always positive, this usually does not change the returned value; the defect is the out-of-bounds read itself, which depends on the adjacent memory layout and is not reliably observable in a normal result assertion.

The added regression case exercises this boundary and protects the expected result. Detecting the old read directly requires an instrumented memory-safety build.

## Testing

- `git diff --check`
- the boundary regression preserves the complete UTF-8 result
- an independent aarch64 Linux verification reported the full `oracle-check` suite passing 28/28 with `ENCODING=UTF8`

Closes #1844

Assisted-by: OpenAI:GPT-5
Percentage of AI-generated code: 100%