### PR TITLE
fix(sysview): preserve long case transformations

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_sysview.out
+++ b/contrib/ivorysql_ora/expected/ora_sysview.out
@@ -13,6 +13,16 @@ SHOW IVORYSQL.IDENTIFIER_CASE_SWITCH;
  interchange
 (1 row)
 
+-- ORA_CASE_TRANS accepts VARCHAR2 values and must not truncate them as names.
+SELECT length(sys.ora_case_trans(repeat('a', 80)::varchar2)) = 80
+       AND sys.ora_case_trans(repeat('a', 80)::varchar2) = repeat('A', 80)::varchar2
+       AND sys.ora_case_trans(repeat('A', 80)::varchar2) = repeat('a', 80)::varchar2
+       AS preserves_long_values;
+ preserves_long_values 
+-----------------------
+ t
+(1 row)
+
 -- create a procedure
 CREATE TABLE TB_TODEL(ID INT);
 CREATE OR REPLACE PROCEDURE PROC_DEL_TB(I INT) IS

--- a/contrib/ivorysql_ora/expected/ora_sysview.out
+++ b/contrib/ivorysql_ora/expected/ora_sysview.out
@@ -23,6 +23,18 @@ SELECT length(sys.ora_case_trans(repeat('a', 80)::varchar2)) = 80
  t
 (1 row)
 
+CREATE VIEW V_CASE_TRANS_LONG AS
+SELECT repeat('a', 80)::varchar2 AS value;
+SELECT length(sys.ora_case_trans(pg_get_viewdef('V_CASE_TRANS_LONG'::regclass)::varchar2)) =
+       length(pg_get_viewdef('V_CASE_TRANS_LONG'::regclass))
+       AND length(pg_get_viewdef('V_CASE_TRANS_LONG'::regclass)) > 63
+       AS preserves_long_view_text;
+ preserves_long_view_text 
+--------------------------
+ t
+(1 row)
+
+DROP VIEW V_CASE_TRANS_LONG;
 -- create a procedure
 CREATE TABLE TB_TODEL(ID INT);
 CREATE OR REPLACE PROCEDURE PROC_DEL_TB(I INT) IS

--- a/contrib/ivorysql_ora/sql/ora_sysview.sql
+++ b/contrib/ivorysql_ora/sql/ora_sysview.sql
@@ -11,6 +11,14 @@ SELECT length(sys.ora_case_trans(repeat('a', 80)::varchar2)) = 80
        AND sys.ora_case_trans(repeat('A', 80)::varchar2) = repeat('a', 80)::varchar2
        AS preserves_long_values;
 
+CREATE VIEW V_CASE_TRANS_LONG AS
+SELECT repeat('a', 80)::varchar2 AS value;
+SELECT length(sys.ora_case_trans(pg_get_viewdef('V_CASE_TRANS_LONG'::regclass)::varchar2)) =
+       length(pg_get_viewdef('V_CASE_TRANS_LONG'::regclass))
+       AND length(pg_get_viewdef('V_CASE_TRANS_LONG'::regclass)) > 63
+       AS preserves_long_view_text;
+DROP VIEW V_CASE_TRANS_LONG;
+
 -- create a procedure
 CREATE TABLE TB_TODEL(ID INT);
 CREATE OR REPLACE PROCEDURE PROC_DEL_TB(I INT) IS

--- a/contrib/ivorysql_ora/sql/ora_sysview.sql
+++ b/contrib/ivorysql_ora/sql/ora_sysview.sql
@@ -5,6 +5,12 @@ SHOW IVORYSQL.COMPATIBLE_MODE;
 SET IVORYSQL.IDENTIFIER_CASE_SWITCH = INTERCHANGE;
 SHOW IVORYSQL.IDENTIFIER_CASE_SWITCH;
 
+-- ORA_CASE_TRANS accepts VARCHAR2 values and must not truncate them as names.
+SELECT length(sys.ora_case_trans(repeat('a', 80)::varchar2)) = 80
+       AND sys.ora_case_trans(repeat('a', 80)::varchar2) = repeat('A', 80)::varchar2
+       AND sys.ora_case_trans(repeat('A', 80)::varchar2) = repeat('a', 80)::varchar2
+       AS preserves_long_values;
+
 -- create a procedure
 CREATE TABLE TB_TODEL(ID INT);
 CREATE OR REPLACE PROCEDURE PROC_DEL_TB(I INT) IS

--- a/contrib/ivorysql_ora/src/sysview/sysview_functions.c
+++ b/contrib/ivorysql_ora/src/sysview/sysview_functions.c
@@ -34,6 +34,38 @@
 #include "utils/builtins.h"
 
 PG_FUNCTION_INFO_V1(ora_case_trans);
+
+static char *
+case_transform_text(const char *ident, int len)
+{
+	char	   *upper_ident;
+	char	   *lower_ident;
+	char	   *result;
+
+	/* This operates on VARCHAR2 values, so identifier truncation is wrong. */
+	upper_ident = upcase_identifier(ident, len, false, false);
+	lower_ident = downcase_identifier(ident, len, false, false);
+
+	if (strcmp(upper_ident, ident) == 0)
+	{
+		result = lower_ident;
+		pfree(upper_ident);
+	}
+	else if (strcmp(lower_ident, ident) == 0)
+	{
+		result = upper_ident;
+		pfree(lower_ident);
+	}
+	else
+	{
+		result = pnstrdup(ident, len);
+		pfree(upper_ident);
+		pfree(lower_ident);
+	}
+
+	return result;
+}
+
 Datum
 ora_case_trans(PG_FUNCTION_ARGS)
 {
@@ -45,7 +77,7 @@ ora_case_trans(PG_FUNCTION_ARGS)
 
 	string = (char *) TextDatumGetCString(PG_GETARG_DATUM(0));
 
-	retval = identifier_case_transform(string, strlen(string));
+	retval = case_transform_text(string, strlen(string));
 
 	PG_RETURN_TEXT_P(cstring_to_text(retval));
 }


### PR DESCRIPTION
## Summary
- perform ORA_CASE_TRANS case folding without identifier-length truncation
- preserve existing uppercase, lowercase, and mixed-case behavior
- add coverage for VARCHAR2 values longer than NAMEDATALEN

## Testing
- git diff --check

Closes #1845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `ora_case_trans` so case conversion preserves long `VARCHAR2` values without truncation.
  - Improved lowercase and uppercase conversion for values longer than 63 characters.
  - Preserved mixed-case values when no single-direction conversion applies.
  - Ensured view definitions exceeding 63 characters retain their full length during conversion.

- **Tests**
  - Added regression coverage for long-value case conversion and view-definition length preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->