### PR TITLE
Fix Oracle SUBSTR edge-case semantics

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -88,6 +88,7 @@ ORA_REGRESS = \
 	dbms_utility \
 	ora_dbms_output \
 	ora_ascii \
+	ora_substr_semantics \
 	ora_stragg \
 	dbms_lock \
 	utl_file \

--- a/contrib/ivorysql_ora/expected/ora_substr_semantics.out
+++ b/contrib/ivorysql_ora/expected/ora_substr_semantics.out
@@ -1,0 +1,88 @@
+--
+-- Oracle-compatible SUBSTR character semantics
+--
+SET ivorysql.compatible_mode = oracle;
+SELECT substr('abcdef', 2, 2) AS normal_positive;
+ normal_positive 
+-----------------
+ bc
+(1 row)
+
+SELECT substr('abcdef', 0, 2) AS zero_position;
+ zero_position 
+---------------
+ ab
+(1 row)
+
+SELECT substr('abcdef', -2, 2) AS negative_position;
+ negative_position 
+-------------------
+ ef
+(1 row)
+
+SELECT substr('abcdef', -2) AS negative_without_length;
+ negative_without_length 
+-------------------------
+ ef
+(1 row)
+
+SELECT substr('abcdef', 2, 0) IS NULL AS zero_length_is_null;
+ zero_length_is_null 
+---------------------
+ t
+(1 row)
+
+SELECT substr('abcdef', 2, -1) IS NULL AS negative_length_is_null;
+ negative_length_is_null 
+-------------------------
+ t
+(1 row)
+
+SELECT substr('abcdef', 20) IS NULL AS past_end_is_null;
+ past_end_is_null 
+------------------
+ t
+(1 row)
+
+-- Positions count characters rather than bytes.
+SELECT substr('你好吗', -2, 1) AS multibyte_negative;
+ multibyte_negative 
+--------------------
+ 好
+(1 row)
+
+SELECT substr('你好吗', 0, 2) AS multibyte_zero;
+ multibyte_zero 
+----------------
+ 你好
+(1 row)
+
+-- Numeric positions and lengths retain the existing Oracle coercion path.
+SELECT substr('abcdef', 2.4::number, 2.4::number) AS numeric_arguments;
+ numeric_arguments 
+-------------------
+ bc
+(1 row)
+
+-- The byte-semantic variant remains unchanged.
+SELECT substrb('abcdef', -2, 2) AS substrb_control;
+ substrb_control 
+-----------------
+ ef
+(1 row)
+
+-- PostgreSQL mode must continue using pg_catalog.substr semantics.
+SET ivorysql.compatible_mode = pg;
+SELECT substr('abcdef', 0, 2) AS pg_zero_position;
+ pg_zero_position 
+------------------
+ a
+(1 row)
+
+SELECT substr('abcdef', 2, 0) IS NULL AS pg_zero_length_is_null;
+ pg_zero_length_is_null 
+------------------------
+ f
+(1 row)
+
+RESET ivorysql.compatible_mode;

--- a/contrib/ivorysql_ora/sql/ora_substr_semantics.sql
+++ b/contrib/ivorysql_ora/sql/ora_substr_semantics.sql
@@ -1,0 +1,30 @@
+--
+-- Oracle-compatible SUBSTR character semantics
+--
+
+SET ivorysql.compatible_mode = oracle;
+
+SELECT substr('abcdef', 2, 2) AS normal_positive;
+SELECT substr('abcdef', 0, 2) AS zero_position;
+SELECT substr('abcdef', -2, 2) AS negative_position;
+SELECT substr('abcdef', -2) AS negative_without_length;
+SELECT substr('abcdef', 2, 0) IS NULL AS zero_length_is_null;
+SELECT substr('abcdef', 2, -1) IS NULL AS negative_length_is_null;
+SELECT substr('abcdef', 20) IS NULL AS past_end_is_null;
+
+-- Positions count characters rather than bytes.
+SELECT substr('你好吗', -2, 1) AS multibyte_negative;
+SELECT substr('你好吗', 0, 2) AS multibyte_zero;
+
+-- Numeric positions and lengths retain the existing Oracle coercion path.
+SELECT substr('abcdef', 2.4::number, 2.4::number) AS numeric_arguments;
+
+-- The byte-semantic variant remains unchanged.
+SELECT substrb('abcdef', -2, 2) AS substrb_control;
+
+-- PostgreSQL mode must continue using pg_catalog.substr semantics.
+SET ivorysql.compatible_mode = pg;
+SELECT substr('abcdef', 0, 2) AS pg_zero_position;
+SELECT substr('abcdef', 2, 0) IS NULL AS pg_zero_length_is_null;
+
+RESET ivorysql.compatible_mode;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -663,6 +663,38 @@ PARALLEL SAFE
 STABLE;
 
 /* SR */
+CREATE FUNCTION sys.substr(varchar, number)
+RETURNS text
+AS 'MODULE_PATHNAME','ora_substr_no_length'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.substr(varchar, number, number)
+RETURNS text
+AS 'MODULE_PATHNAME','ora_substr'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.substr(text, integer)
+RETURNS text
+AS 'MODULE_PATHNAME','ora_substr_no_length_int'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.substr(text, integer, integer)
+RETURNS text
+AS 'MODULE_PATHNAME','ora_substr_int'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
 CREATE FUNCTION sys.substrb(varchar, number)
 RETURNS text
 AS 'MODULE_PATHNAME','ora_substrb_no_length'

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -68,6 +68,10 @@ PG_FUNCTION_INFO_V1(ora_regexp_instr);
 PG_FUNCTION_INFO_V1(ora_regexp_like);
 PG_FUNCTION_INFO_V1(ora_regexp_like_no_flags);
 PG_FUNCTION_INFO_V1(ora_regexp_count);
+PG_FUNCTION_INFO_V1(ora_substr_no_length);
+PG_FUNCTION_INFO_V1(ora_substr);
+PG_FUNCTION_INFO_V1(ora_substr_no_length_int);
+PG_FUNCTION_INFO_V1(ora_substr_int);
 PG_FUNCTION_INFO_V1(ora_substrb_no_length);
 PG_FUNCTION_INFO_V1(ora_substrb);
 PG_FUNCTION_INFO_V1(ora_replace);
@@ -1009,6 +1013,112 @@ ora_regexp_count(PG_FUNCTION_ARGS)
 	pfree(data);
 
 	PG_RETURN_INT32(occurrence_cnt);
+}
+
+/***********************************************************************
+ * ora_substr
+ *
+ * Oracle character-semantic SUBSTR implementation.  PostgreSQL's
+ * text_substring() intentionally rejects negative lengths and treats a
+ * negative start differently, so keep this behavior local to Oracle mode.
+ ***********************************************************************/
+static text *
+ora_text_substring(Datum str, int32 start, int32 length, bool length_not_specified)
+{
+	text	   *source = DatumGetTextPP(str);
+	char	   *data = VARDATA_ANY(source);
+	int32		data_len = VARSIZE_ANY_EXHDR(source);
+	int32		chars = pg_mbstrlen_with_len(data, data_len);
+	int32		first = (start < 0) ? chars + start + 1 : Max(start, 1);
+	int32		count;
+	int32		begin_byte;
+	int32		end_byte;
+	int32		i;
+	char	   *ptr;
+
+	if (first < 1)
+		first = 1;
+	if (!length_not_specified && length < 1)
+		return cstring_to_text("");
+	if (first > chars)
+		return cstring_to_text("");
+
+	count = length_not_specified ? chars - first + 1 :
+		Min(length, chars - first + 1);
+	ptr = data;
+	for (i = 1; i < first; i++)
+		ptr += pg_mblen(ptr);
+	begin_byte = ptr - data;
+	for (i = 0; i < count; i++)
+		ptr += pg_mblen(ptr);
+	end_byte = ptr - data;
+
+	return cstring_to_text_with_len(data + begin_byte,
+									 end_byte - begin_byte);
+}
+
+Datum
+ora_substr(PG_FUNCTION_ARGS)
+{
+	int32		start = DatumGetInt32(DirectFunctionCall1(numeric_int4,
+													 PG_GETARG_DATUM(1)));
+	int32		length = DatumGetInt32(DirectFunctionCall1(numeric_int4,
+													  PG_GETARG_DATUM(2)));
+	text	   *result;
+
+	result = ora_text_substring(PG_GETARG_DATUM(0), start, length, false);
+	if (VARSIZE_ANY_EXHDR(result) == 0)
+	{
+		pfree(result);
+		PG_RETURN_NULL();
+	}
+	PG_RETURN_TEXT_P(result);
+}
+
+Datum
+ora_substr_no_length(PG_FUNCTION_ARGS)
+{
+	int32		start = DatumGetInt32(DirectFunctionCall1(numeric_int4,
+													 PG_GETARG_DATUM(1)));
+	text	   *result;
+
+	result = ora_text_substring(PG_GETARG_DATUM(0), start, -1, true);
+	if (VARSIZE_ANY_EXHDR(result) == 0)
+	{
+		pfree(result);
+		PG_RETURN_NULL();
+	}
+	PG_RETURN_TEXT_P(result);
+}
+
+Datum
+ora_substr_int(PG_FUNCTION_ARGS)
+{
+	text	   *result;
+
+	result = ora_text_substring(PG_GETARG_DATUM(0), PG_GETARG_INT32(1),
+								PG_GETARG_INT32(2), false);
+	if (VARSIZE_ANY_EXHDR(result) == 0)
+	{
+		pfree(result);
+		PG_RETURN_NULL();
+	}
+	PG_RETURN_TEXT_P(result);
+}
+
+Datum
+ora_substr_no_length_int(PG_FUNCTION_ARGS)
+{
+	text	   *result;
+
+	result = ora_text_substring(PG_GETARG_DATUM(0), PG_GETARG_INT32(1),
+								-1, true);
+	if (VARSIZE_ANY_EXHDR(result) == 0)
+	{
+		pfree(result);
+		PG_RETURN_NULL();
+	}
+	PG_RETURN_TEXT_P(result);
 }
 
 /***********************************************************************
@@ -2644,4 +2754,3 @@ ora_listagg_check (PG_FUNCTION_ARGS)
          }
 
 }
-


### PR DESCRIPTION
## Summary

- add Oracle-compatible character-semantic `SUBSTR` overloads in the implicit `sys` schema
- treat position zero as one and negative positions as offsets from the end
- return `NULL` for nonpositive lengths and empty results
- count multibyte input by characters, while leaving `SUBSTRB` unchanged
- preserve PostgreSQL `pg_catalog.substr` behavior when `ivorysql.compatible_mode = pg`
- add a dedicated Oracle regression test covering integer/numeric arguments, multibyte text, edge cases, and PG-mode controls

Fixes #1850

## Why separate functions are needed

Changing `text_substring()` in `src/backend/utils/adt/varlena.c` would alter PostgreSQL behavior globally. This patch instead defines Oracle-only overloads in `sys`, which IvorySQL implicitly searches before `pg_catalog` in Oracle mode. Exact `text, integer` overloads are provided so ordinary calls do not continue selecting the identically typed `pg_catalog.substr`; numeric overloads preserve Oracle numeric argument coercion.

## Tests performed

Tested from a fresh temporary cluster against upstream master `42ed378168266b3744d165ab496aeebb2b4009df` (September 3, 2026):

1. Built the complete latest `contrib/ivorysql_ora` module with PGXS and compiler warnings enabled.
2. Installed the newly built extension into the local IvorySQL 19devel test installation.
3. Initialized a new cluster and database, then executed the new project SQL test with `ON_ERROR_STOP=1`.
4. Re-ran the original formal reproducer.

Verified Oracle-mode results:

```text
substr('abcdef', 2, 2)       = bc
substr('abcdef', 0, 2)       = ab
substr('abcdef', -2, 2)      = ef
substr('abcdef', -2)         = ef
substr('abcdef', 2, 0)       IS NULL
substr('abcdef', 2, -1)      IS NULL
substr('abcdef', 20)         IS NULL
substr('你好吗', -2, 1)       = 好
substr('你好吗', 0, 2)        = 你好
substr('abcdef', 2.4, 2.4)   = bc
```

Verified controls:

```text
Oracle mode: substrb('abcdef', -2, 2) = ef
PG mode:     substr('abcdef', 0, 2) = a
PG mode:     substr('abcdef', 2, 0) IS NULL = false
PG mode:     negative length still raises substring_error
```

The fresh-cluster test completed without an SQL error. `git diff --check` also passes.

## AI assistance disclosure

Assisted-by: OpenAI Codex:gpt-5
Percentage of AI-generated code: 90%

I ran and inspected the build and all test results described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Oracle-compatible `SUBSTR` behavior with character-based indexing.
  * Supports positive and negative positions, numeric arguments, omitted lengths, and multibyte characters.
  * Returns `NULL` for zero or negative lengths and out-of-range positions.
  * Preserves byte-based behavior for `SUBSTRB` and PostgreSQL-mode semantics.

* **Tests**
  * Added regression coverage for Oracle `SUBSTR` edge cases, coercion, multibyte strings, and compatibility modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->