### PR TITLE
Make ASCIISTR database-encoding aware

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -41,6 +41,7 @@ EXTENSION = ivorysql_ora
 
 # SQL(s) which need to be generated only if which is specified here.
 DATA = ivorysql_ora--1.0.sql
+TAP_TESTS = 1
 
 all: gensql
 

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -66,3 +66,14 @@ install_data(
   'preload_ora_misc.sql',
   install_dir: dir_data,
 )
+
+tests += {
+  'name': 'ivorysql_ora',
+  'sd': meson.current_source_dir(),
+  'bd': meson.current_build_dir(),
+  'tap': {
+    'tests': [
+      't/001_asciistr_encoding.pl',
+    ],
+  },
+}

--- a/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/character_datatype_functions.c
@@ -1950,60 +1950,68 @@ oracle_instr_4 (PG_FUNCTION_ARGS)
  *   where xxxx represents a UTF-16 code unit. 
  ********************************************************************/
 Datum 
-ora_asciistr(PG_FUNCTION_ARGS) {
-	StringInfoData 	output;
-	text 			*str_arg = NULL;
-	char 			*str = NULL;
-    char			*end = NULL;
-	
+ora_asciistr(PG_FUNCTION_ARGS)
+{
+	StringInfoData output;
+	text	   *str_arg = PG_GETARG_TEXT_PP(0);
+	unsigned char *database_str;
+	unsigned char *utf8_str;
+	unsigned char *current;
+	unsigned char *end;
+	int			database_len = VARSIZE_ANY_EXHDR(str_arg);
+	int			utf8_len;
+	text	   *result;
+
+	database_str = (unsigned char *) VARDATA_ANY(str_arg);
+	utf8_str = pg_do_encoding_conversion(database_str, database_len,
+										  GetDatabaseEncoding(), PG_UTF8);
+	utf8_len = (utf8_str == database_str) ? database_len :
+		strlen((char *) utf8_str);
+
 	initStringInfo(&output);
-	str_arg = PG_GETARG_TEXT_PP(0);
-	str = VARDATA_ANY(str_arg);
-	end = str + VARSIZE_ANY_EXHDR(str_arg);
+	current = utf8_str;
+	end = utf8_str + utf8_len;
+	while (current < end)
+	{
+		char32_t	codepoint;
+		int			char_len;
 
-    while (str < end) {
-        unsigned char c = *str;
-        uint32_t codePoint;
-		
-		if (c == '\\') {
-			/* Handle backslash character */
-			appendUTF16Escape(&output, 0x005C);  // UTF-16 representation of backslash
-			str++;
-        } 
-        else if (c < 0x80) {
-            /* ASCII character */
-            appendStringInfoChar(&output, c);
-            str++;
-        } else if ((c & 0xE0) == 0xC0) {
-            /* Two-byte UTF-8 sequence */
-            codePoint = ((c & 0x1F) << 6) | (str[1] & 0x3F);
-            appendUTF16Escape(&output, (uint16_t) codePoint);
-            str += 2;
-        } else if ((c & 0xF0) == 0xE0) {
-            /* Three-byte UTF-8 sequence */
-            codePoint = ((c & 0x0F) << 12) | ((str[1] & 0x3F) << 6) | (str[2] & 0x3F);
-            appendUTF16Escape(&output, (uint16_t) codePoint);
-            str += 3;
-        } else if ((c & 0xF8) == 0xF0) {
-            /* Four-byte UTF-8 sequence */
-			uint16_t highSurrogate, lowSurrogate;
+		if (*current < 0x80)
+		{
+			if (*current == '\\')
+				appendUTF16Escape(&output, 0x005C);
+			else
+				appendStringInfoChar(&output, *current);
+			current++;
+			continue;
+		}
 
-            codePoint = ((c & 0x07) << 18) | ((str[1] & 0x3F) << 12) | ((str[2] & 0x3F) << 6) | (str[3] & 0x3F);
-            codePoint -= 0x10000;
-            highSurrogate = 0xD800 | (codePoint >> 10);
-            lowSurrogate = 0xDC00 | (codePoint & 0x3FF);
-            appendUTF16Escape(&output, highSurrogate);
-            appendUTF16Escape(&output, lowSurrogate);
-            str += 4;
-        } else {
-            /* Invalid UTF-8 byte */
+		/* The server conversion above returns validated UTF-8. */
+		char_len = pg_utf_mblen(current);
+		if (char_len > end - current)
 			ereport(ERROR,
-			(errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("Invalid bytes")));
-            str++;
-        }
-    }
-	
-    PG_RETURN_TEXT_P(cstring_to_text_with_len(output.data, output.len));
+					(errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+					 errmsg("invalid UTF-8 sequence after encoding conversion")));
+		codepoint = utf8_to_unicode(current);
+		if (codepoint <= 0xFFFF)
+			appendUTF16Escape(&output, (uint16_t) codepoint);
+		else
+		{
+			uint32		surrogate = codepoint - 0x10000;
+
+			appendUTF16Escape(&output,
+								(uint16_t) (0xD800 | (surrogate >> 10)));
+			appendUTF16Escape(&output,
+								(uint16_t) (0xDC00 | (surrogate & 0x3FF)));
+		}
+		current += char_len;
+	}
+
+	result = cstring_to_text_with_len(output.data, output.len);
+	pfree(output.data);
+	if (utf8_str != database_str)
+		pfree(utf8_str);
+	PG_RETURN_TEXT_P(result);
 }
 
 

--- a/contrib/ivorysql_ora/t/001_asciistr_encoding.pl
+++ b/contrib/ivorysql_ora/t/001_asciistr_encoding.pl
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, IvorySQL Global Development Team
+
+use strict;
+use warnings FATAL => 'all';
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $node = PostgreSQL::Test::Cluster->new('asciistr');
+$node->init(extra => [ '--locale=C', '--encoding=UTF8', '-m', 'oracle' ]);
+$node->start;
+
+$node->safe_psql('postgres', 'CREATE EXTENSION IF NOT EXISTS ivorysql_ora');
+$node->safe_psql(
+	'postgres',
+	q{CREATE DATABASE asciistr_latin1 WITH TEMPLATE template0
+	   ENCODING 'LATIN1' LC_COLLATE 'C' LC_CTYPE 'C'});
+$node->safe_psql('asciistr_latin1',
+	'CREATE EXTENSION IF NOT EXISTS ivorysql_ora');
+
+my $latin1_result = $node->safe_psql(
+	'asciistr_latin1',
+	q{
+		SELECT sys.asciistr(convert_from(decode('e9', 'hex'), 'LATIN1'))
+		       || '|' ||
+		       sys.asciistr(convert_from(decode('a3', 'hex'), 'LATIN1'))
+		       || '|' ||
+		       sys.asciistr(convert_from(decode('c3a9', 'hex'), 'LATIN1'))
+		       || '|' ||
+		       sys.asciistr(convert_from(decode('e94142', 'hex'), 'LATIN1'))
+	});
+
+is($latin1_result, '\\00E9|\\00A3|\\00C3\\00A9|\\00E9AB',
+	'ASCIISTR converts LATIN1 characters by character, not as UTF-8 bytes');
+
+my $utf8_result = $node->safe_psql(
+	'postgres',
+	q{
+		SELECT sys.asciistr(
+		           convert_from(decode('c384', 'hex'), 'UTF8'))
+		       || '|' ||
+		       sys.asciistr(
+		           convert_from(decode('f09f988a', 'hex'), 'UTF8'))
+	});
+
+is($utf8_result, '\\00C4|\\D83D\\DE0A',
+	'ASCIISTR preserves BMP and surrogate-pair behavior in UTF8');
+
+is($node->safe_psql('postgres', q{SELECT sys.asciistr(E'\\\\')}),
+	'\\005C', 'ASCIISTR preserves the existing backslash escape behavior');
+
+done_testing();


### PR DESCRIPTION
## Summary

- convert `ASCIISTR` input from the database encoding to validated UTF-8 before decoding code points
- emit one UTF-16 escape for BMP characters and surrogate-pair escapes for supplementary characters
- preserve ASCII and existing backslash behavior
- add a self-contained TAP test that creates both UTF8 and LATIN1 databases and checks byte-specific cases
- register the TAP test in both Make and Meson builds

Fixes #1851

## Root cause

`ora_asciistr()` previously read `VARDATA_ANY(str_arg)` and applied UTF-8 lead-byte rules directly. That works only when the database encoding is UTF8. For example, LATIN1 byte `E9` is one `é` character, but the function treated it as the first byte of a three-byte UTF-8 sequence and consumed unrelated following bytes.

The new implementation uses `pg_do_encoding_conversion(..., GetDatabaseEncoding(), PG_UTF8)`, then decodes the validated UTF-8 result with PostgreSQL's multibyte helpers.

## Tests performed

Tested against upstream master `42ed378168266b3744d165ab496aeebb2b4009df` (September 3, 2026).

### Complete module build

Built and linked the complete latest `contrib/ivorysql_ora` module with the normal warning flags, then installed it into the local IvorySQL 19devel test installation. The build completed successfully.

### Formal fresh-cluster LATIN1 reproducer

The original deterministic reproducer initializes a fresh cluster, creates a fresh LATIN1 database, installs/loads `ivorysql_ora`, executes byte-level cases, and records pass/fail rows. After this patch:

```text
label                         | input_hex | expected    | actual      | passed
------------------------------+-----------+-------------+-------------+-------
latin1_a3                     | a3        | \\00A3       | \\00A3       | true
latin1_c3_a9_two_characters   | c3a9      | \\00C3\\00A9  | \\00C3\\00A9  | true
latin1_e9                     | e9        | \\00E9       | \\00E9       | true
latin1_e9_followed_by_ascii   | e94142    | \\00E9AB     | \\00E9AB     | true

passed_count = 4, failed_count = 0, total_count = 4
```

### Committed TAP test

Ran `contrib/ivorysql_ora/t/001_asciistr_encoding.pl` directly with PostgreSQL's test framework:

```text
ok 1 - ASCIISTR converts LATIN1 characters by character, not as UTF-8 bytes
ok 2 - ASCIISTR preserves BMP and surrogate-pair behavior in UTF8
ok 3 - ASCIISTR preserves the existing backslash escape behavior
1..3
All tests successful.
Result: PASS
```

The TAP test explicitly initializes an Oracle-mode cluster, creates a LATIN1 database from `template0`, and also checks UTF8 BMP/supplementary characters. `git diff --check` passes.

## AI assistance disclosure

Assisted-by: OpenAI Codex:gpt-5
Percentage of AI-generated code: 90%

I built the complete module and ran and inspected both the formal reproducer and the committed TAP test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `sys.asciistr` handling for LATIN1 and UTF8 input, ensuring characters are converted individually rather than interpreted as raw UTF8 bytes.
  * Corrected Unicode escape output for basic multilingual characters and supplementary characters represented by surrogate pairs.
  * Preserved existing backslash escaping behavior.
  * Invalid UTF8 sequences after conversion now produce a clear character-encoding error.

* **Tests**
  * Added automated coverage for encoding conversion across LATIN1 and UTF8 databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->