### PR TITLE
Add DBMS_UTILITY timing functions

### DIFF
--- a/contrib/ivorysql_ora/expected/dbms_utility.out
+++ b/contrib/ivorysql_ora/expected/dbms_utility.out
@@ -474,5 +474,195 @@ DROP SCHEMA bug_schema CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function bug_schema.schema_error()
 drop cascades to function bug_schema.schema_caller()
+-- ============================================================
+-- GET_TIME 与 GET_CPU_TIME 测试
+-- ============================================================
+-- 测试 20：内部计时函数必须保持无参数、返回 Oracle NUMBER 且为
+-- VOLATILE 的包契约。
+DO $$
+DECLARE
+  v_total INTEGER;
+  v_number_results INTEGER;
+  v_volatile INTEGER;
+BEGIN
+  SELECT count(*)
+    INTO v_total
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'sys'
+     AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
+     AND p.pronargs = 0;
+  SELECT count(*)
+    INTO v_number_results
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'sys'
+     AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
+     AND p.pronargs = 0
+     AND p.prorettype = 'sys.number'::pg_catalog.regtype;
+  SELECT count(*)
+    INTO v_volatile
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'sys'
+     AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
+     AND p.pronargs = 0
+     AND p.provolatile = 'v';
+  IF v_total != 2 OR v_number_results != 2 OR v_volatile != 2 THEN
+    RAISE EXCEPTION 'timer helper catalog contract mismatch: %, %, %',
+      v_total, v_number_results, v_volatile;
+  END IF;
+  RAISE INFO 'Timer helper catalog contract: OK';
+END;
+$$;
+INFO:  Timer helper catalog contract: OK
+-- 测试 21：两个公开包函数均返回 Oracle NUMBER，且结果处于文档规定的
+-- 有符号 32 位计时器范围内。
+DO $$
+DECLARE
+  v_wall NUMBER;
+  v_cpu NUMBER;
+  v_wall_type TEXT;
+  v_cpu_type TEXT;
+BEGIN
+  v_wall := DBMS_UTILITY.GET_TIME;
+  v_cpu := DBMS_UTILITY.GET_CPU_TIME;
+  SELECT pg_catalog.pg_typeof(sys.ora_get_time())::TEXT
+    INTO v_wall_type;
+  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())::TEXT
+    INTO v_cpu_type;
+  IF v_wall_type != 'sys.number' OR v_cpu_type != 'sys.number' THEN
+    RAISE EXCEPTION 'timer package result type mismatch: %, %',
+      v_wall_type, v_cpu_type;
+  END IF;
+  IF v_wall < -2147483648 OR v_wall > 2147483647 OR
+     v_cpu < -2147483648 OR v_cpu > 2147483647 THEN
+    RAISE EXCEPTION 'timer result outside Oracle signed range';
+  END IF;
+  RAISE INFO 'Timer package result type and range: OK';
+END;
+$$;
+INFO:  Timer package result type and range: OK
+-- 测试 22：GET_TIME 测量实际流逝时间，而不是事务或语句时间。使用宽松
+-- 下限，避免依赖调度器的精确唤醒时刻。
+DO $$
+DECLARE
+  v_start NUMBER;
+  v_finish NUMBER;
+  v_elapsed NUMBER;
+BEGIN
+  v_start := DBMS_UTILITY.GET_TIME;
+  PERFORM pg_catalog.pg_sleep(0.08);
+  v_finish := DBMS_UTILITY.GET_TIME;
+  IF v_finish >= v_start THEN
+    v_elapsed := v_finish - v_start;
+  ELSE
+    v_elapsed := (2147483647 - v_start) +
+                 (v_finish - (-2147483648)) + 1;
+  END IF;
+  IF v_elapsed < 5 THEN
+    RAISE EXCEPTION 'GET_TIME did not measure elapsed wall time: %', v_elapsed;
+  END IF;
+  RAISE INFO 'GET_TIME elapsed wall-time contract: OK';
+END;
+$$;
+INFO:  GET_TIME elapsed wall-time contract: OK
+-- 测试 23：GET_CPU_TIME 包含用户态与系统态 CPU 时间，且不会把休眠
+-- 区间等同为 CPU 工作时间。
+DO $$
+DECLARE
+  v_wall_start NUMBER;
+  v_wall_finish NUMBER;
+  v_cpu_start NUMBER;
+  v_cpu_finish NUMBER;
+  v_wall_elapsed NUMBER;
+  v_cpu_elapsed NUMBER;
+BEGIN
+  v_wall_start := DBMS_UTILITY.GET_TIME;
+  v_cpu_start := DBMS_UTILITY.GET_CPU_TIME;
+  PERFORM pg_catalog.pg_sleep(0.08);
+  v_cpu_finish := DBMS_UTILITY.GET_CPU_TIME;
+  v_wall_finish := DBMS_UTILITY.GET_TIME;
+  IF v_wall_finish >= v_wall_start THEN
+    v_wall_elapsed := v_wall_finish - v_wall_start;
+  ELSE
+    v_wall_elapsed := (2147483647 - v_wall_start) +
+                     (v_wall_finish - (-2147483648)) + 1;
+  END IF;
+  IF v_cpu_finish >= v_cpu_start THEN
+    v_cpu_elapsed := v_cpu_finish - v_cpu_start;
+  ELSE
+    v_cpu_elapsed := (2147483647 - v_cpu_start) +
+                    (v_cpu_finish - (-2147483648)) + 1;
+  END IF;
+  IF v_cpu_elapsed > v_wall_elapsed THEN
+    RAISE EXCEPTION 'sleep consumed more CPU than wall time: CPU %, wall %',
+      v_cpu_elapsed, v_wall_elapsed;
+  END IF;
+  RAISE INFO 'GET_CPU_TIME excludes sleeping wall time: OK';
+END;
+$$;
+INFO:  GET_CPU_TIME excludes sleeping wall time: OK
+-- 测试 24：CPU 密集型工作必须最终使 GET_CPU_TIME 按百分之一秒精度推进。
+-- 即使实现退化为常量，采样上限也能保证循环终止。
+DO $$
+DECLARE
+  v_start NUMBER;
+  v_finish NUMBER;
+  v_elapsed NUMBER;
+  v_checksum NUMBER := 0;
+  v_iterations INTEGER := 0;
+BEGIN
+  v_start := DBMS_UTILITY.GET_CPU_TIME;
+  v_finish := v_start;
+  FOR i IN 1..2000000 LOOP
+    v_checksum := MOD(v_checksum + i, 1000003);
+    v_iterations := i;
+    IF MOD(i, 1000) = 0 THEN
+      v_finish := DBMS_UTILITY.GET_CPU_TIME;
+      EXIT WHEN v_finish != v_start;
+    END IF;
+  END LOOP;
+  IF v_finish >= v_start THEN
+    v_elapsed := v_finish - v_start;
+  ELSE
+    v_elapsed := (2147483647 - v_start) +
+                 (v_finish - (-2147483648)) + 1;
+  END IF;
+  IF v_elapsed < 1 OR v_iterations <= 0 OR v_checksum < 0 THEN
+    RAISE EXCEPTION 'GET_CPU_TIME did not advance during CPU work';
+  END IF;
+  RAISE INFO 'GET_CPU_TIME CPU-work contract: OK';
+END;
+$$;
+INFO:  GET_CPU_TIME CPU-work contract: OK
+-- 测试 25：计时函数可在存储函数内使用，覆盖 Oracle 应用中通过两次
+-- 采样统计代码耗时的常见模式。
+CREATE OR REPLACE FUNCTION test_dbms_utility_timers RETURN BOOLEAN AS
+  v_wall_start NUMBER;
+  v_wall_finish NUMBER;
+  v_cpu_start NUMBER;
+  v_cpu_finish NUMBER;
+BEGIN
+  v_wall_start := DBMS_UTILITY.GET_TIME;
+  v_cpu_start := DBMS_UTILITY.GET_CPU_TIME;
+  v_wall_finish := DBMS_UTILITY.GET_TIME;
+  v_cpu_finish := DBMS_UTILITY.GET_CPU_TIME;
+  RETURN v_wall_start IS NOT NULL AND
+         v_wall_finish IS NOT NULL AND
+         v_cpu_start IS NOT NULL AND
+         v_cpu_finish IS NOT NULL;
+END;
+/
+DO $$
+BEGIN
+  IF NOT test_dbms_utility_timers() THEN
+    RAISE EXCEPTION 'timer function returned NULL in stored function';
+  END IF;
+  RAISE INFO 'Timers in stored function: OK';
+END;
+$$;
+INFO:  Timers in stored function: OK
+DROP FUNCTION test_dbms_utility_timers;
 RESET ivorysql.identifier_case_switch;
 RESET ivorysql.enable_case_switch;

--- a/contrib/ivorysql_ora/expected/dbms_utility.out
+++ b/contrib/ivorysql_ora/expected/dbms_utility.out
@@ -475,10 +475,10 @@ NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function bug_schema.schema_error()
 drop cascades to function bug_schema.schema_caller()
 -- ============================================================
--- GET_TIME 与 GET_CPU_TIME 测试
+-- GET_TIME and GET_CPU_TIME tests
 -- ============================================================
--- 测试 20：内部计时函数必须保持无参数、返回 Oracle NUMBER 且为
--- VOLATILE 的包契约。
+-- Test 20: Internal timer functions must remain argument-free, return Oracle
+-- NUMBER, and retain the VOLATILE package contract.
 DO $$
 DECLARE
   v_total INTEGER;
@@ -516,8 +516,8 @@ BEGIN
 END;
 $$;
 INFO:  Timer helper catalog contract: OK
--- 测试 21：两个公开包函数均返回 Oracle NUMBER，且结果处于文档规定的
--- 有符号 32 位计时器范围内。
+-- Test 21: Both public package functions return Oracle NUMBER values within
+-- the documented signed 32-bit timer range.
 DO $$
 DECLARE
   v_wall NUMBER;
@@ -543,8 +543,9 @@ BEGIN
 END;
 $$;
 INFO:  Timer package result type and range: OK
--- 测试 22：GET_TIME 测量实际流逝时间，而不是事务或语句时间。使用宽松
--- 下限，避免依赖调度器的精确唤醒时刻。
+-- Test 22: GET_TIME measures real elapsed time rather than transaction or
+-- statement time.  Use a loose lower bound to avoid depending on an exact
+-- scheduler wake-up time.
 DO $$
 DECLARE
   v_start NUMBER;
@@ -567,8 +568,8 @@ BEGIN
 END;
 $$;
 INFO:  GET_TIME elapsed wall-time contract: OK
--- 测试 23：GET_CPU_TIME 包含用户态与系统态 CPU 时间，且不会把休眠
--- 区间等同为 CPU 工作时间。
+-- Test 23: GET_CPU_TIME includes user and system CPU time without treating a
+-- sleeping interval as CPU work.
 DO $$
 DECLARE
   v_wall_start NUMBER;
@@ -595,16 +596,17 @@ BEGIN
     v_cpu_elapsed := (2147483647 - v_cpu_start) +
                     (v_cpu_finish - (-2147483648)) + 1;
   END IF;
-  IF v_cpu_elapsed > v_wall_elapsed THEN
-    RAISE EXCEPTION 'sleep consumed more CPU than wall time: CPU %, wall %',
+  IF v_wall_elapsed < 5 OR v_cpu_elapsed >= v_wall_elapsed THEN
+    RAISE EXCEPTION 'sleep timer separation failed: CPU %, wall %',
       v_cpu_elapsed, v_wall_elapsed;
   END IF;
   RAISE INFO 'GET_CPU_TIME excludes sleeping wall time: OK';
 END;
 $$;
 INFO:  GET_CPU_TIME excludes sleeping wall time: OK
--- 测试 24：CPU 密集型工作必须最终使 GET_CPU_TIME 按百分之一秒精度推进。
--- 即使实现退化为常量，采样上限也能保证循环终止。
+-- Test 24: CPU-intensive work must eventually advance GET_CPU_TIME at
+-- centisecond precision.  The sample limit also guarantees termination if an
+-- implementation regresses to a constant value.
 DO $$
 DECLARE
   v_start NUMBER;
@@ -636,8 +638,8 @@ BEGIN
 END;
 $$;
 INFO:  GET_CPU_TIME CPU-work contract: OK
--- 测试 25：计时函数可在存储函数内使用，覆盖 Oracle 应用中通过两次
--- 采样统计代码耗时的常见模式。
+-- Test 25: Timer functions work inside stored functions, covering the common
+-- Oracle application pattern of measuring code with two samples.
 CREATE OR REPLACE FUNCTION test_dbms_utility_timers RETURN BOOLEAN AS
   v_wall_start NUMBER;
   v_wall_finish NUMBER;

--- a/contrib/ivorysql_ora/expected/dbms_utility.out
+++ b/contrib/ivorysql_ora/expected/dbms_utility.out
@@ -532,9 +532,9 @@ BEGIN
   v_wall := DBMS_UTILITY.GET_TIME;
   v_cpu := DBMS_UTILITY.GET_CPU_TIME;
 
-  SELECT pg_catalog.pg_typeof(sys.ora_get_time())
+  SELECT pg_catalog.pg_typeof(DBMS_UTILITY.GET_TIME)
     INTO v_wall_type;
-  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())
+  SELECT pg_catalog.pg_typeof(DBMS_UTILITY.GET_CPU_TIME)
     INTO v_cpu_type;
 
   -- Compare type OIDs because search_path affects displayed type names.

--- a/contrib/ivorysql_ora/expected/dbms_utility.out
+++ b/contrib/ivorysql_ora/expected/dbms_utility.out
@@ -492,6 +492,7 @@ BEGIN
    WHERE n.nspname = 'sys'
      AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
      AND p.pronargs = 0;
+
   SELECT count(*)
     INTO v_number_results
     FROM pg_catalog.pg_proc p
@@ -500,6 +501,7 @@ BEGIN
      AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
      AND p.pronargs = 0
      AND p.prorettype = 'sys.number'::pg_catalog.regtype;
+
   SELECT count(*)
     INTO v_volatile
     FROM pg_catalog.pg_proc p
@@ -508,10 +510,12 @@ BEGIN
      AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
      AND p.pronargs = 0
      AND p.provolatile = 'v';
+
   IF v_total != 2 OR v_number_results != 2 OR v_volatile != 2 THEN
     RAISE EXCEPTION 'timer helper catalog contract mismatch: %, %, %',
       v_total, v_number_results, v_volatile;
   END IF;
+
   RAISE INFO 'Timer helper catalog contract: OK';
 END;
 $$;
@@ -522,23 +526,29 @@ DO $$
 DECLARE
   v_wall NUMBER;
   v_cpu NUMBER;
-  v_wall_type TEXT;
-  v_cpu_type TEXT;
+  v_wall_type pg_catalog.regtype;
+  v_cpu_type pg_catalog.regtype;
 BEGIN
   v_wall := DBMS_UTILITY.GET_TIME;
   v_cpu := DBMS_UTILITY.GET_CPU_TIME;
-  SELECT pg_catalog.pg_typeof(sys.ora_get_time())::TEXT
+
+  SELECT pg_catalog.pg_typeof(sys.ora_get_time())
     INTO v_wall_type;
-  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())::TEXT
+  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())
     INTO v_cpu_type;
-  IF v_wall_type != 'sys.number' OR v_cpu_type != 'sys.number' THEN
+
+  -- Compare type OIDs because search_path affects displayed type names.
+  IF v_wall_type IS DISTINCT FROM 'sys.number'::pg_catalog.regtype OR
+     v_cpu_type IS DISTINCT FROM 'sys.number'::pg_catalog.regtype THEN
     RAISE EXCEPTION 'timer package result type mismatch: %, %',
       v_wall_type, v_cpu_type;
   END IF;
+
   IF v_wall < -2147483648 OR v_wall > 2147483647 OR
      v_cpu < -2147483648 OR v_cpu > 2147483647 THEN
     RAISE EXCEPTION 'timer result outside Oracle signed range';
   END IF;
+
   RAISE INFO 'Timer package result type and range: OK';
 END;
 $$;
@@ -555,15 +565,18 @@ BEGIN
   v_start := DBMS_UTILITY.GET_TIME;
   PERFORM pg_catalog.pg_sleep(0.08);
   v_finish := DBMS_UTILITY.GET_TIME;
+
   IF v_finish >= v_start THEN
     v_elapsed := v_finish - v_start;
   ELSE
     v_elapsed := (2147483647 - v_start) +
                  (v_finish - (-2147483648)) + 1;
   END IF;
+
   IF v_elapsed < 5 THEN
     RAISE EXCEPTION 'GET_TIME did not measure elapsed wall time: %', v_elapsed;
   END IF;
+
   RAISE INFO 'GET_TIME elapsed wall-time contract: OK';
 END;
 $$;
@@ -584,22 +597,26 @@ BEGIN
   PERFORM pg_catalog.pg_sleep(0.08);
   v_cpu_finish := DBMS_UTILITY.GET_CPU_TIME;
   v_wall_finish := DBMS_UTILITY.GET_TIME;
+
   IF v_wall_finish >= v_wall_start THEN
     v_wall_elapsed := v_wall_finish - v_wall_start;
   ELSE
     v_wall_elapsed := (2147483647 - v_wall_start) +
                      (v_wall_finish - (-2147483648)) + 1;
   END IF;
+
   IF v_cpu_finish >= v_cpu_start THEN
     v_cpu_elapsed := v_cpu_finish - v_cpu_start;
   ELSE
     v_cpu_elapsed := (2147483647 - v_cpu_start) +
                     (v_cpu_finish - (-2147483648)) + 1;
   END IF;
+
   IF v_wall_elapsed < 5 OR v_cpu_elapsed >= v_wall_elapsed THEN
     RAISE EXCEPTION 'sleep timer separation failed: CPU %, wall %',
       v_cpu_elapsed, v_wall_elapsed;
   END IF;
+
   RAISE INFO 'GET_CPU_TIME excludes sleeping wall time: OK';
 END;
 $$;
@@ -617,23 +634,28 @@ DECLARE
 BEGIN
   v_start := DBMS_UTILITY.GET_CPU_TIME;
   v_finish := v_start;
+
   FOR i IN 1..2000000 LOOP
     v_checksum := MOD(v_checksum + i, 1000003);
     v_iterations := i;
+
     IF MOD(i, 1000) = 0 THEN
       v_finish := DBMS_UTILITY.GET_CPU_TIME;
       EXIT WHEN v_finish != v_start;
     END IF;
   END LOOP;
+
   IF v_finish >= v_start THEN
     v_elapsed := v_finish - v_start;
   ELSE
     v_elapsed := (2147483647 - v_start) +
                  (v_finish - (-2147483648)) + 1;
   END IF;
+
   IF v_elapsed < 1 OR v_iterations <= 0 OR v_checksum < 0 THEN
     RAISE EXCEPTION 'GET_CPU_TIME did not advance during CPU work';
   END IF;
+
   RAISE INFO 'GET_CPU_TIME CPU-work contract: OK';
 END;
 $$;
@@ -661,6 +683,7 @@ BEGIN
   IF NOT test_dbms_utility_timers() THEN
     RAISE EXCEPTION 'timer function returned NULL in stored function';
   END IF;
+
   RAISE INFO 'Timers in stored function: OK';
 END;
 $$;

--- a/contrib/ivorysql_ora/sql/dbms_utility.sql
+++ b/contrib/ivorysql_ora/sql/dbms_utility.sql
@@ -506,11 +506,11 @@ CALL bug_schema.schema_caller();
 DROP SCHEMA bug_schema CASCADE;
 
 -- ============================================================
--- GET_TIME 与 GET_CPU_TIME 测试
+-- GET_TIME and GET_CPU_TIME tests
 -- ============================================================
 
--- 测试 20：内部计时函数必须保持无参数、返回 Oracle NUMBER 且为
--- VOLATILE 的包契约。
+-- Test 20: Internal timer functions must remain argument-free, return Oracle
+-- NUMBER, and retain the VOLATILE package contract.
 DO $$
 DECLARE
   v_total INTEGER;
@@ -552,8 +552,8 @@ BEGIN
 END;
 $$;
 
--- 测试 21：两个公开包函数均返回 Oracle NUMBER，且结果处于文档规定的
--- 有符号 32 位计时器范围内。
+-- Test 21: Both public package functions return Oracle NUMBER values within
+-- the documented signed 32-bit timer range.
 DO $$
 DECLARE
   v_wall NUMBER;
@@ -583,8 +583,9 @@ BEGIN
 END;
 $$;
 
--- 测试 22：GET_TIME 测量实际流逝时间，而不是事务或语句时间。使用宽松
--- 下限，避免依赖调度器的精确唤醒时刻。
+-- Test 22: GET_TIME measures real elapsed time rather than transaction or
+-- statement time.  Use a loose lower bound to avoid depending on an exact
+-- scheduler wake-up time.
 DO $$
 DECLARE
   v_start NUMBER;
@@ -610,8 +611,8 @@ BEGIN
 END;
 $$;
 
--- 测试 23：GET_CPU_TIME 包含用户态与系统态 CPU 时间，且不会把休眠
--- 区间等同为 CPU 工作时间。
+-- Test 23: GET_CPU_TIME includes user and system CPU time without treating a
+-- sleeping interval as CPU work.
 DO $$
 DECLARE
   v_wall_start NUMBER;
@@ -641,8 +642,8 @@ BEGIN
                     (v_cpu_finish - (-2147483648)) + 1;
   END IF;
 
-  IF v_cpu_elapsed > v_wall_elapsed THEN
-    RAISE EXCEPTION 'sleep consumed more CPU than wall time: CPU %, wall %',
+  IF v_wall_elapsed < 5 OR v_cpu_elapsed >= v_wall_elapsed THEN
+    RAISE EXCEPTION 'sleep timer separation failed: CPU %, wall %',
       v_cpu_elapsed, v_wall_elapsed;
   END IF;
 
@@ -650,8 +651,9 @@ BEGIN
 END;
 $$;
 
--- 测试 24：CPU 密集型工作必须最终使 GET_CPU_TIME 按百分之一秒精度推进。
--- 即使实现退化为常量，采样上限也能保证循环终止。
+-- Test 24: CPU-intensive work must eventually advance GET_CPU_TIME at
+-- centisecond precision.  The sample limit also guarantees termination if an
+-- implementation regresses to a constant value.
 DO $$
 DECLARE
   v_start NUMBER;
@@ -688,8 +690,8 @@ BEGIN
 END;
 $$;
 
--- 测试 25：计时函数可在存储函数内使用，覆盖 Oracle 应用中通过两次
--- 采样统计代码耗时的常见模式。
+-- Test 25: Timer functions work inside stored functions, covering the common
+-- Oracle application pattern of measuring code with two samples.
 CREATE OR REPLACE FUNCTION test_dbms_utility_timers RETURN BOOLEAN AS
   v_wall_start NUMBER;
   v_wall_finish NUMBER;

--- a/contrib/ivorysql_ora/sql/dbms_utility.sql
+++ b/contrib/ivorysql_ora/sql/dbms_utility.sql
@@ -505,5 +505,220 @@ END;
 CALL bug_schema.schema_caller();
 DROP SCHEMA bug_schema CASCADE;
 
+-- ============================================================
+-- GET_TIME 与 GET_CPU_TIME 测试
+-- ============================================================
+
+-- 测试 20：内部计时函数必须保持无参数、返回 Oracle NUMBER 且为
+-- VOLATILE 的包契约。
+DO $$
+DECLARE
+  v_total INTEGER;
+  v_number_results INTEGER;
+  v_volatile INTEGER;
+BEGIN
+  SELECT count(*)
+    INTO v_total
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'sys'
+     AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
+     AND p.pronargs = 0;
+
+  SELECT count(*)
+    INTO v_number_results
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'sys'
+     AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
+     AND p.pronargs = 0
+     AND p.prorettype = 'sys.number'::pg_catalog.regtype;
+
+  SELECT count(*)
+    INTO v_volatile
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'sys'
+     AND p.proname IN ('ora_get_time', 'ora_get_cpu_time')
+     AND p.pronargs = 0
+     AND p.provolatile = 'v';
+
+  IF v_total != 2 OR v_number_results != 2 OR v_volatile != 2 THEN
+    RAISE EXCEPTION 'timer helper catalog contract mismatch: %, %, %',
+      v_total, v_number_results, v_volatile;
+  END IF;
+
+  RAISE INFO 'Timer helper catalog contract: OK';
+END;
+$$;
+
+-- 测试 21：两个公开包函数均返回 Oracle NUMBER，且结果处于文档规定的
+-- 有符号 32 位计时器范围内。
+DO $$
+DECLARE
+  v_wall NUMBER;
+  v_cpu NUMBER;
+  v_wall_type TEXT;
+  v_cpu_type TEXT;
+BEGIN
+  v_wall := DBMS_UTILITY.GET_TIME;
+  v_cpu := DBMS_UTILITY.GET_CPU_TIME;
+
+  SELECT pg_catalog.pg_typeof(sys.ora_get_time())::TEXT
+    INTO v_wall_type;
+  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())::TEXT
+    INTO v_cpu_type;
+
+  IF v_wall_type != 'sys.number' OR v_cpu_type != 'sys.number' THEN
+    RAISE EXCEPTION 'timer package result type mismatch: %, %',
+      v_wall_type, v_cpu_type;
+  END IF;
+
+  IF v_wall < -2147483648 OR v_wall > 2147483647 OR
+     v_cpu < -2147483648 OR v_cpu > 2147483647 THEN
+    RAISE EXCEPTION 'timer result outside Oracle signed range';
+  END IF;
+
+  RAISE INFO 'Timer package result type and range: OK';
+END;
+$$;
+
+-- 测试 22：GET_TIME 测量实际流逝时间，而不是事务或语句时间。使用宽松
+-- 下限，避免依赖调度器的精确唤醒时刻。
+DO $$
+DECLARE
+  v_start NUMBER;
+  v_finish NUMBER;
+  v_elapsed NUMBER;
+BEGIN
+  v_start := DBMS_UTILITY.GET_TIME;
+  PERFORM pg_catalog.pg_sleep(0.08);
+  v_finish := DBMS_UTILITY.GET_TIME;
+
+  IF v_finish >= v_start THEN
+    v_elapsed := v_finish - v_start;
+  ELSE
+    v_elapsed := (2147483647 - v_start) +
+                 (v_finish - (-2147483648)) + 1;
+  END IF;
+
+  IF v_elapsed < 5 THEN
+    RAISE EXCEPTION 'GET_TIME did not measure elapsed wall time: %', v_elapsed;
+  END IF;
+
+  RAISE INFO 'GET_TIME elapsed wall-time contract: OK';
+END;
+$$;
+
+-- 测试 23：GET_CPU_TIME 包含用户态与系统态 CPU 时间，且不会把休眠
+-- 区间等同为 CPU 工作时间。
+DO $$
+DECLARE
+  v_wall_start NUMBER;
+  v_wall_finish NUMBER;
+  v_cpu_start NUMBER;
+  v_cpu_finish NUMBER;
+  v_wall_elapsed NUMBER;
+  v_cpu_elapsed NUMBER;
+BEGIN
+  v_wall_start := DBMS_UTILITY.GET_TIME;
+  v_cpu_start := DBMS_UTILITY.GET_CPU_TIME;
+  PERFORM pg_catalog.pg_sleep(0.08);
+  v_cpu_finish := DBMS_UTILITY.GET_CPU_TIME;
+  v_wall_finish := DBMS_UTILITY.GET_TIME;
+
+  IF v_wall_finish >= v_wall_start THEN
+    v_wall_elapsed := v_wall_finish - v_wall_start;
+  ELSE
+    v_wall_elapsed := (2147483647 - v_wall_start) +
+                     (v_wall_finish - (-2147483648)) + 1;
+  END IF;
+
+  IF v_cpu_finish >= v_cpu_start THEN
+    v_cpu_elapsed := v_cpu_finish - v_cpu_start;
+  ELSE
+    v_cpu_elapsed := (2147483647 - v_cpu_start) +
+                    (v_cpu_finish - (-2147483648)) + 1;
+  END IF;
+
+  IF v_cpu_elapsed > v_wall_elapsed THEN
+    RAISE EXCEPTION 'sleep consumed more CPU than wall time: CPU %, wall %',
+      v_cpu_elapsed, v_wall_elapsed;
+  END IF;
+
+  RAISE INFO 'GET_CPU_TIME excludes sleeping wall time: OK';
+END;
+$$;
+
+-- 测试 24：CPU 密集型工作必须最终使 GET_CPU_TIME 按百分之一秒精度推进。
+-- 即使实现退化为常量，采样上限也能保证循环终止。
+DO $$
+DECLARE
+  v_start NUMBER;
+  v_finish NUMBER;
+  v_elapsed NUMBER;
+  v_checksum NUMBER := 0;
+  v_iterations INTEGER := 0;
+BEGIN
+  v_start := DBMS_UTILITY.GET_CPU_TIME;
+  v_finish := v_start;
+
+  FOR i IN 1..2000000 LOOP
+    v_checksum := MOD(v_checksum + i, 1000003);
+    v_iterations := i;
+
+    IF MOD(i, 1000) = 0 THEN
+      v_finish := DBMS_UTILITY.GET_CPU_TIME;
+      EXIT WHEN v_finish != v_start;
+    END IF;
+  END LOOP;
+
+  IF v_finish >= v_start THEN
+    v_elapsed := v_finish - v_start;
+  ELSE
+    v_elapsed := (2147483647 - v_start) +
+                 (v_finish - (-2147483648)) + 1;
+  END IF;
+
+  IF v_elapsed < 1 OR v_iterations <= 0 OR v_checksum < 0 THEN
+    RAISE EXCEPTION 'GET_CPU_TIME did not advance during CPU work';
+  END IF;
+
+  RAISE INFO 'GET_CPU_TIME CPU-work contract: OK';
+END;
+$$;
+
+-- 测试 25：计时函数可在存储函数内使用，覆盖 Oracle 应用中通过两次
+-- 采样统计代码耗时的常见模式。
+CREATE OR REPLACE FUNCTION test_dbms_utility_timers RETURN BOOLEAN AS
+  v_wall_start NUMBER;
+  v_wall_finish NUMBER;
+  v_cpu_start NUMBER;
+  v_cpu_finish NUMBER;
+BEGIN
+  v_wall_start := DBMS_UTILITY.GET_TIME;
+  v_cpu_start := DBMS_UTILITY.GET_CPU_TIME;
+  v_wall_finish := DBMS_UTILITY.GET_TIME;
+  v_cpu_finish := DBMS_UTILITY.GET_CPU_TIME;
+
+  RETURN v_wall_start IS NOT NULL AND
+         v_wall_finish IS NOT NULL AND
+         v_cpu_start IS NOT NULL AND
+         v_cpu_finish IS NOT NULL;
+END;
+/
+
+DO $$
+BEGIN
+  IF NOT test_dbms_utility_timers() THEN
+    RAISE EXCEPTION 'timer function returned NULL in stored function';
+  END IF;
+
+  RAISE INFO 'Timers in stored function: OK';
+END;
+$$;
+
+DROP FUNCTION test_dbms_utility_timers;
+
 RESET ivorysql.identifier_case_switch;
 RESET ivorysql.enable_case_switch;

--- a/contrib/ivorysql_ora/sql/dbms_utility.sql
+++ b/contrib/ivorysql_ora/sql/dbms_utility.sql
@@ -558,18 +558,20 @@ DO $$
 DECLARE
   v_wall NUMBER;
   v_cpu NUMBER;
-  v_wall_type TEXT;
-  v_cpu_type TEXT;
+  v_wall_type pg_catalog.regtype;
+  v_cpu_type pg_catalog.regtype;
 BEGIN
   v_wall := DBMS_UTILITY.GET_TIME;
   v_cpu := DBMS_UTILITY.GET_CPU_TIME;
 
-  SELECT pg_catalog.pg_typeof(sys.ora_get_time())::TEXT
+  SELECT pg_catalog.pg_typeof(sys.ora_get_time())
     INTO v_wall_type;
-  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())::TEXT
+  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())
     INTO v_cpu_type;
 
-  IF v_wall_type != 'sys.number' OR v_cpu_type != 'sys.number' THEN
+  -- Compare type OIDs because search_path affects displayed type names.
+  IF v_wall_type IS DISTINCT FROM 'sys.number'::pg_catalog.regtype OR
+     v_cpu_type IS DISTINCT FROM 'sys.number'::pg_catalog.regtype THEN
     RAISE EXCEPTION 'timer package result type mismatch: %, %',
       v_wall_type, v_cpu_type;
   END IF;

--- a/contrib/ivorysql_ora/sql/dbms_utility.sql
+++ b/contrib/ivorysql_ora/sql/dbms_utility.sql
@@ -564,9 +564,9 @@ BEGIN
   v_wall := DBMS_UTILITY.GET_TIME;
   v_cpu := DBMS_UTILITY.GET_CPU_TIME;
 
-  SELECT pg_catalog.pg_typeof(sys.ora_get_time())
+  SELECT pg_catalog.pg_typeof(DBMS_UTILITY.GET_TIME)
     INTO v_wall_type;
-  SELECT pg_catalog.pg_typeof(sys.ora_get_cpu_time())
+  SELECT pg_catalog.pg_typeof(DBMS_UTILITY.GET_CPU_TIME)
     INTO v_cpu_type;
 
   -- Compare type OIDs because search_path affects displayed type names.

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility--1.0.sql
@@ -19,15 +19,27 @@ CREATE FUNCTION sys.ora_format_call_stack() RETURNS TEXT
 AS 'MODULE_PATHNAME', 'ora_format_call_stack'
 LANGUAGE C VOLATILE;
 
+CREATE FUNCTION sys.ora_get_time() RETURNS sys.number
+AS 'MODULE_PATHNAME', 'ora_get_time'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION sys.ora_get_cpu_time() RETURNS sys.number
+AS 'MODULE_PATHNAME', 'ora_get_cpu_time'
+LANGUAGE C VOLATILE;
+
 COMMENT ON FUNCTION sys.ora_format_error_backtrace() IS 'Internal function for DBMS_UTILITY.FORMAT_ERROR_BACKTRACE';
 COMMENT ON FUNCTION sys.ora_format_error_stack() IS 'Internal function for DBMS_UTILITY.FORMAT_ERROR_STACK';
 COMMENT ON FUNCTION sys.ora_format_call_stack() IS 'Internal function for DBMS_UTILITY.FORMAT_CALL_STACK';
+COMMENT ON FUNCTION sys.ora_get_time() IS 'DBMS_UTILITY.GET_TIME 的内部实现';
+COMMENT ON FUNCTION sys.ora_get_cpu_time() IS 'DBMS_UTILITY.GET_CPU_TIME 的内部实现';
 
 -- DBMS_UTILITY Package Definition
 CREATE OR REPLACE PACKAGE dbms_utility IS
   FUNCTION FORMAT_ERROR_BACKTRACE RETURN TEXT;
   FUNCTION FORMAT_ERROR_STACK RETURN TEXT;
   FUNCTION FORMAT_CALL_STACK RETURN TEXT;
+  FUNCTION GET_TIME RETURN NUMBER;
+  FUNCTION GET_CPU_TIME RETURN NUMBER;
 END dbms_utility;
 
 CREATE OR REPLACE PACKAGE BODY dbms_utility IS
@@ -44,5 +56,15 @@ CREATE OR REPLACE PACKAGE BODY dbms_utility IS
   FUNCTION FORMAT_CALL_STACK RETURN TEXT IS
   BEGIN
     RETURN sys.ora_format_call_stack();
+  END;
+
+  FUNCTION GET_TIME RETURN NUMBER IS
+  BEGIN
+    RETURN sys.ora_get_time();
+  END;
+
+  FUNCTION GET_CPU_TIME RETURN NUMBER IS
+  BEGIN
+    RETURN sys.ora_get_cpu_time();
   END;
 END dbms_utility;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility--1.0.sql
@@ -30,8 +30,8 @@ LANGUAGE C VOLATILE;
 COMMENT ON FUNCTION sys.ora_format_error_backtrace() IS 'Internal function for DBMS_UTILITY.FORMAT_ERROR_BACKTRACE';
 COMMENT ON FUNCTION sys.ora_format_error_stack() IS 'Internal function for DBMS_UTILITY.FORMAT_ERROR_STACK';
 COMMENT ON FUNCTION sys.ora_format_call_stack() IS 'Internal function for DBMS_UTILITY.FORMAT_CALL_STACK';
-COMMENT ON FUNCTION sys.ora_get_time() IS 'DBMS_UTILITY.GET_TIME 的内部实现';
-COMMENT ON FUNCTION sys.ora_get_cpu_time() IS 'DBMS_UTILITY.GET_CPU_TIME 的内部实现';
+COMMENT ON FUNCTION sys.ora_get_time() IS 'Internal implementation of DBMS_UTILITY.GET_TIME';
+COMMENT ON FUNCTION sys.ora_get_cpu_time() IS 'Internal implementation of DBMS_UTILITY.GET_CPU_TIME';
 
 -- DBMS_UTILITY Package Definition
 CREATE OR REPLACE PACKAGE dbms_utility IS

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
@@ -54,7 +54,7 @@ PG_FUNCTION_INFO_V1(ora_get_cpu_time);
 #define MICROSECONDS_PER_CENTISECOND INT64CONST(10000)
 #define ORACLE_TIMER_MODULUS UINT64CONST(0x100000000)
 
-/* GET_TIME 使用后端本地起点；Oracle 只保证起点任意且差值可用。 */
+/* GET_TIME uses a backend-local epoch; Oracle only guarantees usable deltas. */
 static instr_time get_time_epoch;
 static bool get_time_epoch_initialized = false;
 static TimingClockSourceType get_time_clock_source;
@@ -79,8 +79,9 @@ static plisql_get_call_stack_fn get_call_stack_fn = NULL;
 static bool lookup_attempted = false;
 
 /*
- * 将非负的百分之一秒计数转换为 Oracle 计时器的有符号 32 位范围。
- * 显式计算负半区，避免依赖无符号整数转有符号整数的实现定义行为。
+ * Convert a nonnegative centisecond count to Oracle's signed 32-bit timer
+ * range.  Compute the negative half explicitly instead of relying on an
+ * implementation-defined unsigned-to-signed conversion.
  */
 static Numeric
 oracle_timer_number(uint64 centiseconds)
@@ -549,10 +550,11 @@ ora_format_call_stack(PG_FUNCTION_ARGS)
 }
 
 /*
- * ora_get_time - DBMS_UTILITY.GET_TIME 的实现
+ * ora_get_time - implementation of DBMS_UTILITY.GET_TIME
  *
- * 返回从后端本地任意起点开始计算的百分之一秒数。instr_time 在支持的
- * 平台上使用单调时钟，因此系统时间调整不会破坏短区间的耗时测量。
+ * Return centiseconds from an arbitrary backend-local epoch.  instr_time uses
+ * a monotonic clock on supported platforms, so system clock adjustments do
+ * not invalidate short elapsed-time measurements.
  */
 Datum
 ora_get_time(PG_FUNCTION_ARGS)
@@ -576,7 +578,7 @@ ora_get_time(PG_FUNCTION_ARGS)
 	INSTR_TIME_SUBTRACT(now, get_time_epoch);
 	elapsed_ns = INSTR_TIME_GET_NANOSEC(now);
 
-	/* 相同计时源相减不应为负；防御异常计时源切换造成的倒退。 */
+	/* Guard against a backward jump caused by an unexpected clock change. */
 	if (elapsed_ns < 0)
 		elapsed_ns = 0;
 
@@ -585,10 +587,11 @@ ora_get_time(PG_FUNCTION_ARGS)
 }
 
 /*
- * ora_get_cpu_time - DBMS_UTILITY.GET_CPU_TIME 的实现
+ * ora_get_cpu_time - implementation of DBMS_UTILITY.GET_CPU_TIME
  *
- * Oracle 的 CPU 时间包括当前进程消耗的用户态与系统态时间。PostgreSQL
- * 为 Windows 提供 getrusage 兼容层，因此这里无需维护平台专用分支。
+ * Oracle CPU time includes user and system time consumed by the current
+ * process.  PostgreSQL provides a getrusage compatibility layer for Windows,
+ * so no platform-specific branch is required here.
  */
 Datum
 ora_get_cpu_time(PG_FUNCTION_ARGS)

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_utility/dbms_utility.c
@@ -27,10 +27,15 @@
  */
 
 #include "postgres.h"
+
+#include <sys/resource.h>
+
 #include "fmgr.h"
+#include "portability/instr_time.h"
 #include "utils/builtins.h"
 #include "utils/errcodes.h"
 #include "utils/guc.h"
+#include "utils/numeric.h"
 #include "utils/ora_compatible.h"
 #include "parser/scansup.h"
 #include "port.h"
@@ -42,6 +47,17 @@
 PG_FUNCTION_INFO_V1(ora_format_error_backtrace);
 PG_FUNCTION_INFO_V1(ora_format_error_stack);
 PG_FUNCTION_INFO_V1(ora_format_call_stack);
+PG_FUNCTION_INFO_V1(ora_get_time);
+PG_FUNCTION_INFO_V1(ora_get_cpu_time);
+
+#define NANOSECONDS_PER_CENTISECOND INT64CONST(10000000)
+#define MICROSECONDS_PER_CENTISECOND INT64CONST(10000)
+#define ORACLE_TIMER_MODULUS UINT64CONST(0x100000000)
+
+/* GET_TIME 使用后端本地起点；Oracle 只保证起点任意且差值可用。 */
+static instr_time get_time_epoch;
+static bool get_time_epoch_initialized = false;
+static TimingClockSourceType get_time_clock_source;
 
 /*
  * Function pointer types for plisql API functions.
@@ -61,6 +77,24 @@ static plisql_get_message_fn get_exception_message_fn = NULL;
 static plisql_get_sqlerrcode_fn get_exception_sqlerrcode_fn = NULL;
 static plisql_get_call_stack_fn get_call_stack_fn = NULL;
 static bool lookup_attempted = false;
+
+/*
+ * 将非负的百分之一秒计数转换为 Oracle 计时器的有符号 32 位范围。
+ * 显式计算负半区，避免依赖无符号整数转有符号整数的实现定义行为。
+ */
+static Numeric
+oracle_timer_number(uint64 centiseconds)
+{
+	uint32		wrapped = (uint32) (centiseconds % ORACLE_TIMER_MODULUS);
+	int64		result;
+
+	if (wrapped <= PG_INT32_MAX)
+		result = wrapped;
+	else
+		result = (int64) wrapped - (int64) ORACLE_TIMER_MODULUS;
+
+	return int64_to_numeric(result);
+}
 
 /*
  * Look up the plisql API functions dynamically.
@@ -512,4 +546,67 @@ ora_format_call_stack(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_TEXT_P(cstring_to_text(result.data));
+}
+
+/*
+ * ora_get_time - DBMS_UTILITY.GET_TIME 的实现
+ *
+ * 返回从后端本地任意起点开始计算的百分之一秒数。instr_time 在支持的
+ * 平台上使用单调时钟，因此系统时间调整不会破坏短区间的耗时测量。
+ */
+Datum
+ora_get_time(PG_FUNCTION_ARGS)
+{
+	instr_time	now;
+	TimingClockSourceType current_clock_source;
+	int64		elapsed_ns;
+	uint64		centiseconds;
+
+	INSTR_TIME_SET_CURRENT(now);
+	current_clock_source = pg_current_timing_clock_source();
+
+	if (!get_time_epoch_initialized ||
+		get_time_clock_source != current_clock_source)
+	{
+		get_time_epoch = now;
+		get_time_clock_source = current_clock_source;
+		get_time_epoch_initialized = true;
+	}
+
+	INSTR_TIME_SUBTRACT(now, get_time_epoch);
+	elapsed_ns = INSTR_TIME_GET_NANOSEC(now);
+
+	/* 相同计时源相减不应为负；防御异常计时源切换造成的倒退。 */
+	if (elapsed_ns < 0)
+		elapsed_ns = 0;
+
+	centiseconds = (uint64) elapsed_ns / NANOSECONDS_PER_CENTISECOND;
+	PG_RETURN_NUMERIC(oracle_timer_number(centiseconds));
+}
+
+/*
+ * ora_get_cpu_time - DBMS_UTILITY.GET_CPU_TIME 的实现
+ *
+ * Oracle 的 CPU 时间包括当前进程消耗的用户态与系统态时间。PostgreSQL
+ * 为 Windows 提供 getrusage 兼容层，因此这里无需维护平台专用分支。
+ */
+Datum
+ora_get_cpu_time(PG_FUNCTION_ARGS)
+{
+	struct rusage usage;
+	uint64		microseconds;
+	uint64		centiseconds;
+
+	if (getrusage(RUSAGE_SELF, &usage) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read process CPU usage: %m")));
+
+	microseconds = ((uint64) usage.ru_utime.tv_sec +
+					(uint64) usage.ru_stime.tv_sec) * UINT64CONST(1000000);
+	microseconds += (uint64) usage.ru_utime.tv_usec +
+					(uint64) usage.ru_stime.tv_usec;
+	centiseconds = microseconds / MICROSECONDS_PER_CENTISECOND;
+
+	PG_RETURN_NUMERIC(oracle_timer_number(centiseconds));
 }


### PR DESCRIPTION
## What

- Add Oracle-compatible `DBMS_UTILITY.GET_TIME` and `GET_CPU_TIME`.
- Return centiseconds with Oracle signed 32-bit wraparound semantics.
- Cover catalog contracts, value ranges, elapsed/CPU behavior, and stored-function calls.

## Checks

- `git diff --check`
- Regression tests were not run locally; CI will validate them.

Refs #1052

Assisted-by: OpenAI:GPT-5

Percentage of AI-generated code: 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `DBMS_UTILITY.GET_TIME` for elapsed wall-clock timing.
  * Added `DBMS_UTILITY.GET_CPU_TIME` for measuring process CPU time, excluding time spent sleeping.
  * Timer results are returned as Oracle `NUMBER` values within signed 32-bit ranges.
  * Both timers are available for use within stored functions.

* **Tests**
  * Added coverage for timer accuracy, sleep behavior, CPU-intensive workloads, supported ranges, and stored-function usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->