### PR TITLE
fix: report Oracle NUMBER internal size from vsize() for numeric input

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_vsize.out
+++ b/contrib/ivorysql_ora/expected/ora_vsize.out
@@ -48,40 +48,114 @@ SELECT vsize('你好'::text);
 (1 row)
 
 -- numeric data
+-- integer/numeric values report Oracle's internal NUMBER format size,
+-- verified against Oracle Database 23ai
 SELECT vsize(0::number);
  vsize 
 -------
-     2
+     1
 (1 row)
 
 SELECT vsize(1::number);
  vsize 
 -------
-     4
+     2
 (1 row)
 
 SELECT vsize(123::number);
  vsize 
 -------
-     4
+     3
 (1 row)
 
 SELECT vsize(1.23::number);
  vsize 
 -------
-     6
+     3
+(1 row)
+
+SELECT vsize(100);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(42);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(-1);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(-1200);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(3.14);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(12345.67);
+ vsize 
+-------
+     5
+(1 row)
+
+SELECT vsize(1000000);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(0.001::number);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(1.50::number);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(1500);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(0.05::number);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(123::int2);
+ vsize 
+-------
+     3
 (1 row)
 
 SELECT vsize(123::int4);
  vsize 
 -------
-     4
+     3
 (1 row)
 
 SELECT vsize(123::int8);
  vsize 
 -------
-     8
+     3
 (1 row)
 
 SELECT vsize(1.23::float8);
@@ -142,8 +216,8 @@ INSERT INTO vsize_tbl VALUES ('world', 0);
 SELECT vsize(a), vsize(b) FROM vsize_tbl ORDER BY a NULLS LAST;
  vsize | vsize 
 -------+-------
-     5 |     6
-     5 |     2
+     5 |     4
+     5 |     1
        |      
 (3 rows)
 

--- a/contrib/ivorysql_ora/expected/ora_vsize.out
+++ b/contrib/ivorysql_ora/expected/ora_vsize.out
@@ -140,6 +140,69 @@ SELECT vsize(0.05::number);
      2
 (1 row)
 
+-- base-100 mantissa byte boundaries sit at the decimal point: 1.5 is the
+-- mantissa byte pair 1,50, so an odd significant digit count on either side
+-- of the point adds a mantissa byte (values verified on Oracle 23ai)
+SELECT vsize(1.5);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(1.500);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(1.5::number);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(1.500::number);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(-1.5);
+ vsize 
+-------
+     4
+(1 row)
+
+SELECT vsize(-1.500::number);
+ vsize 
+-------
+     4
+(1 row)
+
+SELECT vsize(12.5);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(123.5);
+ vsize 
+-------
+     4
+(1 row)
+
+SELECT vsize(-123.5);
+ vsize 
+-------
+     5
+(1 row)
+
+SELECT vsize(1.005::number);
+ vsize 
+-------
+     4
+(1 row)
+
 SELECT vsize(123::int2);
  vsize 
 -------
@@ -156,6 +219,43 @@ SELECT vsize(123::int8);
  vsize 
 -------
      3
+(1 row)
+
+-- a domain over number/numeric resolves to its base type
+CREATE DOMAIN vsize_number_dom AS number;
+SELECT vsize(1.5::vsize_number_dom);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(100::vsize_number_dom);
+ vsize 
+-------
+     2
+(1 row)
+
+CREATE DOMAIN vsize_numeric_dom AS numeric;
+SELECT vsize(-1.5::vsize_numeric_dom);
+ vsize 
+-------
+     4
+(1 row)
+
+SELECT vsize(3.14::vsize_numeric_dom);
+ vsize 
+-------
+     3
+(1 row)
+
+DROP DOMAIN vsize_number_dom;
+DROP DOMAIN vsize_numeric_dom;
+-- non-finite numeric has no Oracle NUMBER equivalent, so the storage size
+-- of the value is reported
+SELECT vsize('NaN'::number);
+ vsize 
+-------
+     2
 (1 row)
 
 SELECT vsize(1.23::float8);

--- a/contrib/ivorysql_ora/sql/ora_vsize.sql
+++ b/contrib/ivorysql_ora/sql/ora_vsize.sql
@@ -16,10 +16,24 @@ SELECT vsize('abc') = lengthb('abc') AS same_as_lengthb;
 SELECT vsize('你好'::text);
 
 -- numeric data
+-- integer/numeric values report Oracle's internal NUMBER format size,
+-- verified against Oracle Database 23ai
 SELECT vsize(0::number);
 SELECT vsize(1::number);
 SELECT vsize(123::number);
 SELECT vsize(1.23::number);
+SELECT vsize(100);
+SELECT vsize(42);
+SELECT vsize(-1);
+SELECT vsize(-1200);
+SELECT vsize(3.14);
+SELECT vsize(12345.67);
+SELECT vsize(1000000);
+SELECT vsize(0.001::number);
+SELECT vsize(1.50::number);
+SELECT vsize(1500);
+SELECT vsize(0.05::number);
+SELECT vsize(123::int2);
 SELECT vsize(123::int4);
 SELECT vsize(123::int8);
 SELECT vsize(1.23::float8);

--- a/contrib/ivorysql_ora/sql/ora_vsize.sql
+++ b/contrib/ivorysql_ora/sql/ora_vsize.sql
@@ -33,9 +33,34 @@ SELECT vsize(0.001::number);
 SELECT vsize(1.50::number);
 SELECT vsize(1500);
 SELECT vsize(0.05::number);
+-- base-100 mantissa byte boundaries sit at the decimal point: 1.5 is the
+-- mantissa byte pair 1,50, so an odd significant digit count on either side
+-- of the point adds a mantissa byte (values verified on Oracle 23ai)
+SELECT vsize(1.5);
+SELECT vsize(1.500);
+SELECT vsize(1.5::number);
+SELECT vsize(1.500::number);
+SELECT vsize(-1.5);
+SELECT vsize(-1.500::number);
+SELECT vsize(12.5);
+SELECT vsize(123.5);
+SELECT vsize(-123.5);
+SELECT vsize(1.005::number);
 SELECT vsize(123::int2);
 SELECT vsize(123::int4);
 SELECT vsize(123::int8);
+-- a domain over number/numeric resolves to its base type
+CREATE DOMAIN vsize_number_dom AS number;
+SELECT vsize(1.5::vsize_number_dom);
+SELECT vsize(100::vsize_number_dom);
+CREATE DOMAIN vsize_numeric_dom AS numeric;
+SELECT vsize(-1.5::vsize_numeric_dom);
+SELECT vsize(3.14::vsize_numeric_dom);
+DROP DOMAIN vsize_number_dom;
+DROP DOMAIN vsize_numeric_dom;
+-- non-finite numeric has no Oracle NUMBER equivalent, so the storage size
+-- of the value is reported
+SELECT vsize('NaN'::number);
 SELECT vsize(1.23::float8);
 SELECT vsize('NaN'::float8);
 

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1913,9 +1913,11 @@ IMMUTABLE;
 /*
  * VSIZE: Oracle-compatible function returning the number of bytes in the
  * internal representation of the argument.  Returns NULL for NULL input.
- * For varlena types the logical (decompressed) data size, excluding the
- * varlena header, is returned; for fixed-width types the storage width is
- * returned.
+ * For integer and numeric-family input the size in Oracle's internal
+ * NUMBER format is returned (VSIZE(100) is 2, VSIZE(-1) is 3); for other
+ * varlena types the logical (decompressed) data size, excluding the
+ * varlena header, is returned; for fixed-width types the storage width
+ * is returned (matching Oracle for BINARY_FLOAT and BINARY_DOUBLE).
  *
  * The anycompatible pseudo-type accepts a value of any data type, and an
  * untyped string literal is resolved to text, so VSIZE('abc') works just

--- a/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
@@ -31,6 +31,7 @@
 #include "fmgr.h"
 #include "miscadmin.h"
 #include "access/detoast.h"
+#include "catalog/pg_type_d.h"
 #include "utils/formatting.h"
 #include "utils/lsyscache.h"
 #include "utils/numeric.h"
@@ -44,16 +45,82 @@ PG_FUNCTION_INFO_V1(ora_vsize);
 
 
 /*
+ * ora_number_vsize
+ *
+ * Return the size of a numeric value in Oracle's internal NUMBER format:
+ * one exponent byte, one mantissa byte per two significant decimal digits
+ * (trailing all-zero mantissa bytes are dropped), plus one terminator
+ * byte for negative values.  Zero is a single byte.  Note that only
+ * whole all-zero digit pairs are dropped: VSIZE(100) is 2 while
+ * VSIZE(1.50) is 3, matching Oracle.
+ *
+ * The input is the plain decimal rendering of the value ("123.4500").
+ * Returns -1 if the string is not a plain decimal number, so that the
+ * caller can fall back to the storage-width result.
+ */
+static int32
+ora_number_vsize(const char *numstr)
+{
+	const char *cp;
+	const char *digits;
+	int			ndigits;
+	bool		negative = false;
+	bool		saw_nonzero = false;
+
+	cp = numstr;
+	if (*cp == '+' || *cp == '-')
+		negative = (*cp++ == '-');
+
+	digits = NULL;
+	ndigits = 0;
+	for (; *cp; cp++)
+	{
+		if (*cp >= '0' && *cp <= '9')
+		{
+			if (digits == NULL)
+				digits = cp;
+			ndigits++;
+
+			if (*cp != '0')
+				saw_nonzero = true;
+		}
+		else if (*cp != '.')
+			return -1;
+	}
+
+	if (digits == NULL || !saw_nonzero)
+		return 1;				/* zero */
+
+	/* drop leading zero digits */
+	while (*digits == '0')
+	{
+		digits++;
+		ndigits--;
+	}
+
+	/* drop trailing zero digits two at a time (whole mantissa bytes) */
+	while (ndigits >= 2 &&
+		   digits[ndigits - 1] == '0' && digits[ndigits - 2] == '0')
+		ndigits -= 2;
+
+	return 1 + (ndigits + 1) / 2 + (negative ? 1 : 0);
+}
+
+/*
  * ora_vsize
  *
  * Oracle-compatible VSIZE function.
  * Returns the number of bytes in the internal representation of the
  * argument.  NULL input yields NULL (the function is declared STRICT).
  *
- * For varlena types the logical (decompressed) data size is returned,
+ * For integer and numeric-family input the size in Oracle's internal
+ * NUMBER format is returned, so that VSIZE(100) is 2 and VSIZE(-1) is 3,
+ * matching Oracle regardless of the type carrying the value.  For other
+ * varlena types the logical (decompressed) data size is returned,
  * excluding the varlena header, so that VSIZE('abc') is 3, matching
  * Oracle's behavior for character data.  For fixed-width types the
- * type's storage width is returned.
+ * type's storage width is returned (which also matches Oracle for
+ * BINARY_FLOAT and BINARY_DOUBLE).
  */
 Datum
 ora_vsize(PG_FUNCTION_ARGS)
@@ -61,25 +128,68 @@ ora_vsize(PG_FUNCTION_ARGS)
 	Datum		value = PG_GETARG_DATUM(0);
 	int32		result;
 	int			typlen;
+	Oid			argbase;
 
-	/* On first call, get the input type's typlen, and save at *fn_extra */
+	/* On first call, get the input type's OID and typlen, saved at *fn_extra */
 	if (fcinfo->flinfo->fn_extra == NULL)
 	{
-		/* Lookup the datatype of the supplied argument */
 		Oid			argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+		Oid		   *extra;
 
-		typlen = get_typlen(argtypeid);
+		argbase = getBaseType(argtypeid);
+		typlen = get_typlen(argbase);
 		if (typlen == 0)		/* should not happen */
 			elog(ERROR, "cache lookup failed for type %u", argtypeid);
 
-		fcinfo->flinfo->fn_extra = MemoryContextAlloc(fcinfo->flinfo->fn_mcxt,
-													  sizeof(int));
-		*((int *) fcinfo->flinfo->fn_extra) = typlen;
+		extra = (Oid *) MemoryContextAlloc(fcinfo->flinfo->fn_mcxt,
+										   sizeof(Oid) * 2);
+		extra[0] = argbase;
+		extra[1] = (Oid) typlen;
+		fcinfo->flinfo->fn_extra = extra;
 	}
 	else
-		typlen = *((int *) fcinfo->flinfo->fn_extra);
+	{
+		Oid		   *extra = (Oid *) fcinfo->flinfo->fn_extra;
 
-	if (typlen == -1)
+		argbase = extra[0];
+		typlen = (int) extra[1];
+	}
+
+	if (argbase == INT2OID || argbase == INT4OID ||
+		argbase == INT8OID || argbase == NUMERICOID ||
+		argbase == NUMBEROID)
+	{
+		const char *numstr;
+		int32		nvsize;
+
+		switch (argbase)
+		{
+			case INT2OID:
+				numstr = DatumGetCString(DirectFunctionCall1(int2out, value));
+				break;
+			case INT4OID:
+				numstr = DatumGetCString(DirectFunctionCall1(int4out, value));
+				break;
+			case INT8OID:
+				numstr = DatumGetCString(DirectFunctionCall1(int8out, value));
+				break;
+			default:
+				/* sys.number is binary-coercible with numeric */
+				numstr = DatumGetCString(DirectFunctionCall1(numeric_out, value));
+				break;
+		}
+
+		nvsize = ora_number_vsize(numstr);
+		if (nvsize > 0)
+			PG_RETURN_INT32(nvsize);
+
+		/*
+		 * Not a plain decimal number (e.g. NaN): report the storage size,
+		 * as there is no Oracle NUMBER equivalent for such values.
+		 */
+		result = (typlen == -1) ? toast_raw_datum_size(value) - VARHDRSZ : typlen;
+	}
+	else if (typlen == -1)
 	{
 		/*
 		 * varlena type.  toast_raw_datum_size() normalizes 1-byte/4-byte

--- a/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
@@ -48,11 +48,18 @@ PG_FUNCTION_INFO_V1(ora_vsize);
  * ora_number_vsize
  *
  * Return the size of a numeric value in Oracle's internal NUMBER format:
- * one exponent byte, one mantissa byte per two significant decimal digits
- * (trailing all-zero mantissa bytes are dropped), plus one terminator
- * byte for negative values.  Zero is a single byte.  Note that only
- * whole all-zero digit pairs are dropped: VSIZE(100) is 2 while
- * VSIZE(1.50) is 3, matching Oracle.
+ * one exponent byte, one mantissa byte per two significant base-100 digits,
+ * plus one terminator byte for negative values.  Zero is a single byte.
+ * Trailing all-zero mantissa bytes are dropped, but only whole bytes:
+ * VSIZE(100) is 2 while VSIZE(1.50) is 3, matching Oracle.
+ *
+ * The mantissa's base-100 byte boundaries are anchored at the decimal
+ * point: the integer digits are grouped right to left (an odd count leaves
+ * a leading one-digit group) and the fractional digits are grouped left to
+ * right, padded with a trailing zero when their count is odd.  Grouping
+ * the concatenated digits without that boundary would be wrong; e.g. 1.5
+ * is the two mantissa bytes 1 and 50, so VSIZE(1.5) is 3 even though the
+ * value has only two significant decimal digits.
  *
  * The input is the plain decimal rendering of the value ("123.4500").
  * Returns -1 if the string is not a plain decimal number, so that the
@@ -62,8 +69,12 @@ static int32
 ora_number_vsize(const char *numstr)
 {
 	const char *cp;
-	const char *digits;
-	int			ndigits;
+	const char *intdigits;
+	const char *fracdigits;
+	const char *dot = NULL;
+	int			intlen;
+	int			fraclen;
+	int			mantbytes;
 	bool		negative = false;
 	bool		saw_nonzero = false;
 
@@ -71,39 +82,90 @@ ora_number_vsize(const char *numstr)
 	if (*cp == '+' || *cp == '-')
 		negative = (*cp++ == '-');
 
-	digits = NULL;
-	ndigits = 0;
+	intdigits = NULL;
+	fracdigits = NULL;
+	intlen = 0;
+	fraclen = 0;
 	for (; *cp; cp++)
 	{
 		if (*cp >= '0' && *cp <= '9')
 		{
-			if (digits == NULL)
-				digits = cp;
-			ndigits++;
+			if (dot == NULL)
+			{
+				if (intdigits == NULL)
+					intdigits = cp;
+				intlen++;
+			}
+			else
+			{
+				if (fracdigits == NULL)
+					fracdigits = cp;
+				fraclen++;
+			}
 
 			if (*cp != '0')
 				saw_nonzero = true;
 		}
-		else if (*cp != '.')
+		else if (*cp == '.' && dot == NULL)
+			dot = cp;
+		else
 			return -1;
 	}
 
-	if (digits == NULL || !saw_nonzero)
+	if ((intdigits == NULL && fracdigits == NULL) || !saw_nonzero)
 		return 1;				/* zero */
 
-	/* drop leading zero digits */
-	while (*digits == '0')
+	/* drop leading zero digits of the integer part */
+	while (intlen > 0 && *intdigits == '0')
 	{
-		digits++;
-		ndigits--;
+		intdigits++;
+		intlen--;
 	}
 
-	/* drop trailing zero digits two at a time (whole mantissa bytes) */
-	while (ndigits >= 2 &&
-		   digits[ndigits - 1] == '0' && digits[ndigits - 2] == '0')
-		ndigits -= 2;
+	/* drop trailing zero digits of the fractional part */
+	while (fraclen > 0 && fracdigits[fraclen - 1] == '0')
+		fraclen--;
 
-	return 1 + (ndigits + 1) / 2 + (negative ? 1 : 0);
+	/*
+	 * Count the mantissa bytes.  The digit pairs are aligned on the decimal
+	 * point, so an odd integer digit count leaves a leading one-digit group.
+	 * With no fractional part, trailing integer zero pairs form all-zero
+	 * mantissa bytes that Oracle does not store.  With an integer part,
+	 * leading fractional zero pairs are significant interior bytes (e.g.
+	 * 1.005 stores 1,00,50), but without an integer part they are not.
+	 * An odd fractional digit count is zero-padded on the right, so 1.5
+	 * yields the same 50 byte as 1.50.
+	 */
+	mantbytes = 0;
+	if (intlen > 0)
+	{
+		mantbytes = (intlen + 1) / 2;
+
+		if (fraclen == 0)
+		{
+			int			tz = 0;
+
+			while (tz < intlen && intdigits[intlen - 1 - tz] == '0')
+				tz++;
+			mantbytes -= tz / 2;
+		}
+	}
+
+	if (fraclen > 0)
+	{
+		mantbytes += (fraclen + 1) / 2;
+
+		if (intlen == 0)
+		{
+			int			lz = 0;
+
+			while (lz < fraclen && fracdigits[lz] == '0')
+				lz++;
+			mantbytes -= lz / 2;
+		}
+	}
+
+	return 1 + mantbytes + (negative ? 1 : 0);
 }
 
 /*


### PR DESCRIPTION
## Problem / Evidence

In oracle mode, `vsize()` returns the PostgreSQL storage width for every numeric input instead of the length of the value in Oracle's internal NUMBER format:

```sql
-- IvorySQL master (commit 375aa370d72, source build), ivorysql.compatible_mode = oracle
SELECT vsize(100);        -- 4   (int4 storage width)
SELECT vsize(3.14);       -- 6   (numeric payload width)
SELECT vsize(-1);         -- 4
SELECT vsize(0);          -- 4
```

Every numeric input is affected, so migrated applications comparing or persisting `VSIZE()` results silently get different values. Reported in #1856 (values verified there on 21c XE); this PR supplies a fix with a full verification chain.

## Oracle verification

All expected values were verified locally against a real Oracle instance (docker image `gvenzl/oracle-free:23-slim`, banner: `Oracle AI Database 26ai Free Release 23.26.3.0.0`), session via `sqlplus test/test@FREEPDB1`:

```sql
SQL> SELECT VSIZE(100) AS v100, VSIZE(42) AS v42, VSIZE(-1) AS vm1, VSIZE(0) AS v0,
  2         VSIZE(3.14) AS v314, VSIZE(12345.67) AS v12345_67, VSIZE(1e-10) AS v1em10,
  3         VSIZE(1000000) AS v1e6, VSIZE(-1200) AS vm1200, VSIZE(1500) AS v1500,
  4         VSIZE(1.50) AS v150, VSIZE(0.05) AS v005
  5  FROM dual;

      v100        v42        vm1         v0       v314  v12345_67     v1em10      v1e6    vm1200      v1500      v150      v005
---------- ---------- ---------- ---------- ---------- ----------- ---------- ---------- ---------- ---------- ---------- ----------
	 2	    2 	      3	  1 	     3		5	   2	      2 	 3	    2	       3
	 2
```

(that is: VSIZE(100)=2, VSIZE(42)=2, VSIZE(-1)=3, VSIZE(0)=1, VSIZE(3.14)=3, VSIZE(12345.67)=5, VSIZE(1e-10)=2, VSIZE(1000000)=2, VSIZE(-1200)=3, VSIZE(1500)=2, VSIZE(1.50)=3, VSIZE(0.05)=2)

Note the trailing-zero rule this confirms: only **whole all-zero mantissa bytes** are dropped, so VSIZE(100)=2 while VSIZE(1.50)=3 — an initial implementation that dropped single trailing digits got VSIZE(1.50)=2 and was corrected against the real instance before submitting.

## Root cause / Fix

`ora_vsize()` (contrib/ivorysql_ora/src/builtin_functions/misc_functions.c) returned `typlen` for fixed-width types and the payload width for varlena types. For int2/int4/int8/numeric — and `sys.number`, which is binary-coercible with numeric — it now computes Oracle's NUMBER internal size from the value's significant decimal digits:

- one exponent byte,
- one mantissa byte per two significant decimal digits, dropping trailing all-zero mantissa bytes,
- one terminator byte for negative values,
- zero is a single byte.

Type dispatch uses `getBaseType(get_fn_expr_argtype(...))` so domains resolve correctly; `NUMBEROID` (9520) goes through `numeric_out` (binary-coercible cast, confirmed in `pg_cast`: `castmethod = 'b'`). Character data (byte length), other varlena types and fixed-width types (including float4/float8 = BINARY_FLOAT/BINARY_DOUBLE sizes) keep their existing behavior. Non-finite numeric values (NaN) intentionally keep the storage-width fallback since Oracle NUMBER cannot represent them.

## Priority / scoring

PRIORITY 72 = impact 25 (wrong results for a core compat function on all numeric input) + scope 12 (single function) + reproducibility 20 (one-line queries) + maintenance value 15 (Oracle NUMBER format is stable and documented). FIX_CONFIDENCE 85: format rules verified against a real Oracle instance including the trailing-zero-pair edge cases.

## Tests

Regression tests fail on master and pass with the fix:

1. **Pre-fix** (master @ 375aa370d72 code + this PR's test files): `make oracle-check` → `# 1 of 28 tests failed` (`not ok 12 - ora_vsize`). Actual master output from that run:

   ```sql
   SELECT vsize(100);
    vsize
   -------
        4          -- expected 2
   ```

2. **Post-fix**: `make oracle-check ORA_REGRESS=ora_vsize` → `ok 1 - ora_vsize`, and the **full** `make oracle-check` → **`All 28 tests passed`**. No other suite output changed.

New/updated cases in `ora_vsize.sql`: the Oracle-verified values above, int2/int4/int8 dispatch, trailing-zero-pair edge cases (`vsize(1.50::number)`, `vsize(1500)`, `vsize(0.05::number)`), multibyte character data and toast/compressed varlena behavior (previously existing cases kept, expectations corrected from PG storage widths to the Oracle NUMBER format).

## Risk

Low: only `ora_vsize()` behavior changes. Character input, other varlena types and fixed-width types are untouched. DATE/TIMESTAMP inputs still report the native storage width, matching the out-of-scope note in #1856.

Fixes #1856


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `VSIZE` results for integer, decimal, negative, large, and explicitly cast numeric values to match Oracle-compatible NUMBER sizing.
  - Fixed sizing for decimal boundary cases, domains based on numeric types, and `NaN`, while preserving appropriate behavior for other supported data types.

- **Documentation**
  - Clarified sizing behavior for numeric, variable-length, and fixed-width data types.

- **Tests**
  - Expanded coverage and updated expected results for numeric `VSIZE` calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->