### PR TITLE
fix(oracle): honor nondeterministic VARCHAR2 collations

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -94,3 +94,29 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+
+-- VARCHAR2 equality and hashing must honor nondeterministic collations.
+DO $$
+DECLARE
+  equal_result boolean;
+  hash_result boolean;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_collation WHERE collprovider = 'i') THEN
+    EXECUTE 'CREATE COLLATION ora_varchar_nondet '
+            '(provider = icu, locale = ''und-u-ks-level1'', deterministic = false)';
+    EXECUTE 'SELECT ''A''::sys.oravarcharchar COLLATE ora_varchar_nondet = '
+            '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet'
+      INTO equal_result;
+    EXECUTE 'SELECT sys.hashoravarchar('
+            '''A''::sys.oravarcharchar COLLATE ora_varchar_nondet) = '
+            'sys.hashoravarchar('
+            '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet)'
+      INTO hash_result;
+    IF NOT equal_result OR NOT hash_result THEN
+      RAISE EXCEPTION 'VARCHAR2 nondeterministic collation mismatch';
+    END IF;
+    EXECUTE 'DROP COLLATION ora_varchar_nondet';
+  END IF;
+END
+$$;
+DO

--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -99,6 +99,7 @@ drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
 DO $$
 DECLARE
   equal_result boolean;
+  not_equal_result boolean;
   hash_result boolean;
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_collation WHERE collprovider = 'i') THEN
@@ -107,12 +108,16 @@ BEGIN
     EXECUTE 'SELECT ''A''::sys.oravarcharchar COLLATE ora_varchar_nondet = '
             '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet'
       INTO equal_result;
+    EXECUTE 'SELECT ''A''::sys.oravarcharchar COLLATE ora_varchar_nondet <> '
+            '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet'
+      INTO not_equal_result;
     EXECUTE 'SELECT sys.hashoravarchar('
             '''A''::sys.oravarcharchar COLLATE ora_varchar_nondet) = '
             'sys.hashoravarchar('
             '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet)'
       INTO hash_result;
-    IF NOT equal_result OR NOT hash_result THEN
+    IF equal_result IS NOT TRUE OR not_equal_result IS NOT FALSE OR
+       hash_result IS NOT TRUE THEN
       RAISE EXCEPTION 'VARCHAR2 nondeterministic collation mismatch';
     END IF;
     EXECUTE 'DROP COLLATION ora_varchar_nondet';

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -86,6 +86,7 @@ drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
 DO $$
 DECLARE
   equal_result boolean;
+  not_equal_result boolean;
   hash_result boolean;
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_collation WHERE collprovider = 'i') THEN
@@ -94,12 +95,16 @@ BEGIN
     EXECUTE 'SELECT ''A''::sys.oravarcharchar COLLATE ora_varchar_nondet = '
             '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet'
       INTO equal_result;
+    EXECUTE 'SELECT ''A''::sys.oravarcharchar COLLATE ora_varchar_nondet <> '
+            '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet'
+      INTO not_equal_result;
     EXECUTE 'SELECT sys.hashoravarchar('
             '''A''::sys.oravarcharchar COLLATE ora_varchar_nondet) = '
             'sys.hashoravarchar('
             '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet)'
       INTO hash_result;
-    IF NOT equal_result OR NOT hash_result THEN
+    IF equal_result IS NOT TRUE OR not_equal_result IS NOT FALSE OR
+       hash_result IS NOT TRUE THEN
       RAISE EXCEPTION 'VARCHAR2 nondeterministic collation mismatch';
     END IF;
     EXECUTE 'DROP COLLATION ora_varchar_nondet';

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -81,3 +81,28 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+
+-- VARCHAR2 equality and hashing must honor nondeterministic collations.
+DO $$
+DECLARE
+  equal_result boolean;
+  hash_result boolean;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_collation WHERE collprovider = 'i') THEN
+    EXECUTE 'CREATE COLLATION ora_varchar_nondet '
+            '(provider = icu, locale = ''und-u-ks-level1'', deterministic = false)';
+    EXECUTE 'SELECT ''A''::sys.oravarcharchar COLLATE ora_varchar_nondet = '
+            '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet'
+      INTO equal_result;
+    EXECUTE 'SELECT sys.hashoravarchar('
+            '''A''::sys.oravarcharchar COLLATE ora_varchar_nondet) = '
+            'sys.hashoravarchar('
+            '''a''::sys.oravarcharchar COLLATE ora_varchar_nondet)'
+      INTO hash_result;
+    IF NOT equal_result OR NOT hash_result THEN
+      RAISE EXCEPTION 'VARCHAR2 nondeterministic collation mismatch';
+    END IF;
+    EXECUTE 'DROP COLLATION ora_varchar_nondet';
+  END IF;
+END
+$$;

--- a/contrib/ivorysql_ora/src/datatype/oravarcharchar.c
+++ b/contrib/ivorysql_ora/src/datatype/oravarcharchar.c
@@ -36,6 +36,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/ora_compatible.h"
+#include "utils/pg_locale.h"
 #include "mb/pg_wchar.h"
 #include "utils/varlena.h"
 #include "fmgr.h"
@@ -351,11 +352,19 @@ oravarcharchar_cmp(VarChar *arg1, VarChar *arg2, Oid collid)
 Datum
 oravarchareq(PG_FUNCTION_ARGS)
 {
+	Oid			collid = PG_GET_COLLATION();
+	pg_locale_t mylocale;
 	Datum		arg1 = PG_GETARG_DATUM(0);
 	Datum		arg2 = PG_GETARG_DATUM(1);
 	bool		result;
 	Size		len1,
 				len2;
+
+	check_collation_set(collid);
+	mylocale = pg_newlocale_from_collation(collid);
+
+	if (!mylocale->deterministic)
+		return DirectFunctionCall2Coll(texteq, collid, arg1, arg2);
 
 	len1 = toast_raw_datum_size(arg1);
 	len2 = toast_raw_datum_size(arg2);
@@ -379,11 +388,19 @@ oravarchareq(PG_FUNCTION_ARGS)
 Datum
 oravarcharne(PG_FUNCTION_ARGS)
 {
+	Oid			collid = PG_GET_COLLATION();
+	pg_locale_t mylocale;
 	Datum		arg1 = PG_GETARG_DATUM(0);
 	Datum		arg2 = PG_GETARG_DATUM(1);
 	bool		result;
 	Size		len1,
 				len2;
+
+	check_collation_set(collid);
+	mylocale = pg_newlocale_from_collation(collid);
+
+	if (!mylocale->deterministic)
+		return DirectFunctionCall2Coll(textne, collid, arg1, arg2);
 
 	len1 = toast_raw_datum_size(arg1);
 	len2 = toast_raw_datum_size(arg2);
@@ -576,15 +593,19 @@ Datum
 hashoravarchar(PG_FUNCTION_ARGS)
 {
 	VarChar	   *key = PG_GETARG_VARCHAR_PP(0);
+	Oid			collid = PG_GET_COLLATION();
+	pg_locale_t mylocale;
 	Datum		result;
 
-	/*
-	 * Note: this is currently identical in behavior to hashvarlena, but keep
-	 * it as a separate function in case we someday want to do something
-	 * different in non-C locales.  (See also hashbpchar, if so.)
-	 */
-	result = hash_any((unsigned char *) VARDATA_ANY(key),
-					  VARSIZE_ANY_EXHDR(key));
+	check_collation_set(collid);
+	mylocale = pg_newlocale_from_collation(collid);
+
+	if (mylocale->deterministic)
+		result = hash_any((unsigned char *) VARDATA_ANY(key),
+						  VARSIZE_ANY_EXHDR(key));
+	else
+		result = DirectFunctionCall1Coll(hashtext, collid,
+									   PointerGetDatum(key));
 
 	/* Avoid leaking memory for toasted inputs */
 	PG_FREE_IF_COPY(key, 0);


### PR DESCRIPTION
## Summary

- honor nondeterministic collations in VARCHAR2 equality and inequality
- generate compatible 32-bit hash keys from collation sort keys
- retain bytewise fast paths for deterministic collations
- add ICU-conditional regression coverage for equality and hashing

Closes #1864

## Testing

- `git diff --check upstream/master...HEAD`
- regression coverage added; full IvorySQL regression suite will run in project CI after maintainer approval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `VARCHAR2` comparisons under nondeterministic ICU collations, including correct case-insensitive equality and inequality behavior.
  - Updated hashing to remain consistent with collation-aware comparisons, ensuring equivalent values produce matching hashes.
  - Preserved existing behavior for deterministic collations.

- **Tests**
  - Added regression coverage for equality, inequality, and hashing with nondeterministic collations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->