### PR TITLE
fix(oracle): allow binary conversions in parallel workers

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_binary_float.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_float.out
@@ -703,3 +703,20 @@ SELECT 1f + 1e-10d;
  1.0000000001
 (1 row)
 
+-- Text conversion overloads perform only local computation and are parallel safe.
+DO $$
+DECLARE
+  safe_count integer;
+BEGIN
+  SELECT count(*) INTO safe_count
+  FROM pg_proc
+  WHERE pronamespace = 'sys'::regnamespace
+    AND proname IN ('to_binary_float', 'to_binary_double')
+    AND proargtypes IN ('25'::oidvector, '25 25'::oidvector)
+    AND proparallel = 's';
+
+  IF safe_count <> 4 THEN
+    RAISE EXCEPTION 'expected four parallel-safe text conversion overloads';
+  END IF;
+END
+$$;

--- a/contrib/ivorysql_ora/sql/ora_binary_float.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_float.sql
@@ -240,3 +240,21 @@ SELECT 3.4e38f * 10d;
 SELECT 10d * 3.4e38f;
 SELECT 1f + 1e-10d;
 
+
+-- Text conversion overloads perform only local computation and are parallel safe.
+DO $$
+DECLARE
+  safe_count integer;
+BEGIN
+  SELECT count(*) INTO safe_count
+  FROM pg_proc
+  WHERE pronamespace = 'sys'::regnamespace
+    AND proname IN ('to_binary_float', 'to_binary_double')
+    AND proargtypes IN ('25'::oidvector, '25 25'::oidvector)
+    AND proparallel = 's';
+
+  IF safe_count <> 4 THEN
+    RAISE EXCEPTION 'expected four parallel-safe text conversion overloads';
+  END IF;
+END
+$$;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1226,6 +1226,7 @@ RETURNS sys.binary_float
 AS 'MODULE_PATHNAME','ora_to_binary_float'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE FUNCTION sys.to_binary_float(text)
@@ -1233,6 +1234,7 @@ RETURNS sys.binary_float
 AS 'MODULE_PATHNAME','ora_to_binary_float'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.to_binary_float(number)
@@ -1256,6 +1258,7 @@ RETURNS sys.binary_double
 AS 'MODULE_PATHNAME','ora_to_binary_double'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE FUNCTION sys.to_binary_double(text)
@@ -1263,6 +1266,7 @@ RETURNS sys.binary_double
 AS 'MODULE_PATHNAME','ora_to_binary_double'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION sys.to_binary_double(number)


### PR DESCRIPTION
## Summary

- mark the text overloads of `TO_BINARY_FLOAT` as parallel safe
- mark the text overloads of `TO_BINARY_DOUBLE` as parallel safe
- add a catalog regression assertion covering all four overloads

The implementations perform argument parsing and immutable numeric conversion only, matching the existing parallel-safe declarations on the number and binary overloads.

Closes #1865

## Testing

- `git diff --check upstream/master...HEAD`
- regression coverage added; full IvorySQL regression suite will run in project CI after maintainer approval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Text conversion functions for binary float and binary double values are now safe for parallel query execution across supported one- and two-argument forms.
  * This enables these conversions to participate in parallel query plans where applicable.

* **Tests**
  * Added regression coverage confirming that all four supported text conversion overloads have the expected parallel-safety classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->