### PR TITLE
fix(oracle): reject datetime zone conversion overflow

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -579,6 +579,8 @@ SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '3:00') FROM DUAL;
  03-27-2000 21:00:00.000000000 -08:00
 (1 row)
 
+SELECT FROM_TZ(TIMESTAMP '294276-12-31 23:00:00', '-12:00') FROM DUAL;
+ERROR:  timestamp out of range
   
 --sessiontimezone
 set timezone = 'Asia/Hong_Kong';

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -328,6 +328,7 @@ drop table datetest;
 
 --from_tz
 SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '3:00') FROM DUAL;
+SELECT FROM_TZ(TIMESTAMP '294276-12-31 23:00:00', '-12:00') FROM DUAL;
   
 --sessiontimezone
 set timezone = 'Asia/Hong_Kong';

--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -631,7 +631,10 @@ ora_new_time(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 	tz1 = tz1 - tz2;
-	tm2timestamp(tm, fsec, &tz1, &result);
+	if (tm2timestamp(tm, fsec, &tz1, &result) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("timestamp out of range")));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -769,7 +772,10 @@ ora_from_tz(PG_FUNCTION_ARGS)
 				 errmsg("timestamp out of range")));
 
 	tz = DetermineTimeZoneOffset(tm, timezonedat);
-	tm2timestamp(tm, fsec, &tz, &result);
+	if (tm2timestamp(tm, fsec, &tz, &result) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("timestamp out of range")));
 
 	PG_RETURN_TIMESTAMPTZ(result);
 }


### PR DESCRIPTION
## Summary

`NEW_TIME` and `FROM_TZ` apply a time-zone offset and then call `tm2timestamp()` without checking its result. Near the supported timestamp boundary the offset moves an otherwise valid input out of range, and the uninitialised `result` is returned as if it were a real timestamp.

Both call sites now check the return value and raise `ERRCODE_DATETIME_VALUE_OUT_OF_RANGE`, which is what the other seven `tm2timestamp()` call sites in this file already do.

## Measurement

Same cluster, same session, only the shared library swapped (`ivorysql_ora.so` md5 `a6741ce3` vs `155ad8b4`), Oracle mode:

```
select from_tz(timestamp '294276-12-31 23:00:00','-12:00') from dual;
  before: 2000-01-01 08:00:00.000000 +08:00     <-- silently wrong, no error
  after : ERROR:  timestamp out of range
```

So the failure mode is not "raises the wrong error" but "returns a bogus timestamp".

## Testing

Rebased onto `master` (`03b24b1c46`) and run on Ubuntu 22.04 with that branch applied:

```
$ make -C contrib/ivorysql_ora oracle-check
ok: 28   not ok: 1
not ok 17    - ora_xml_functions        # pre-existing: this tree is built without libxml
ok    10     - ora_datetime_datatype_functions
```

`results/ora_datetime_datatype_functions.out` is byte-identical to the expected file after the run.

## Note on the regression coverage

An earlier revision of this PR also asserted the same boundary for `NEW_TIME`, with hand-written expected output. That case does not work and has been removed:

- `NEW_TIME` takes `sys.oradate`. In the Oracle regression harness a six-digit year is not accepted by the date input path — `select date '294276-12-31' from dual;` reports `ERROR: unmatched format separator "-"`, and `to_date('294276-12-31','YYYY-MM-DD')` reports `ERROR: The value of month is invalid.`
- The hand-written expectation claimed `ERROR: timestamp out of range`, which was never what the harness produced.

The `NEW_TIME` guard is kept: it matches the surrounding code, and a `sys.oradate` carrying a time component can reach the function without going through the sql text parser.

Closes #1862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for Oracle-compatible `new_time` and `FROM_TZ` functions.
  - Out-of-range timestamp values now return a clear `timestamp out of range` error instead of being processed incorrectly.

- **Tests**
  - Added regression coverage confirming that `FROM_TZ` rejects timestamps at the upper supported range boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->