### PR TITLE
fix(oracle): allow VARCHAR2 pattern comparison in workers

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -444,3 +444,12 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+-- Pattern comparison functions are safe to execute in parallel workers.
+SELECT proparallel
+FROM pg_proc
+WHERE oid = 'sys.oravarchar_pattern_gt(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure;
+ proparallel 
+-------------
+ s
+(1 row)

--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -438,12 +438,8 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
                       QUERY PLAN                       
 -------------------------------------------------------
  Index Scan using test_oravarchar_b on test_oravarchar
-   Index Cond: (a = '111'::varchar2)
+ Index Cond: (a = '111'::varchar2)
 (2 rows)
-
--- drop table
-DROP TABLE TEST_ORACHAR;
-DROP TABLE TEST_ORAVARCHAR;
 
 -- Pattern comparison functions are safe to execute in parallel workers.
 SELECT proparallel
@@ -453,3 +449,7 @@ WHERE oid = 'sys.oravarchar_pattern_gt(sys.oravarcharchar,sys.oravarcharchar)'::
 -------------
  s
 (1 row)
+
+-- drop table
+DROP TABLE TEST_ORACHAR;
+DROP TABLE TEST_ORAVARCHAR;

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -183,11 +183,11 @@ VACUUM ANALYZE TEST_ORAVARCHAR;
 
 explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 
--- drop table
-DROP TABLE TEST_ORACHAR;
-DROP TABLE TEST_ORAVARCHAR;
-
 -- Pattern comparison functions are safe to execute in parallel workers.
 SELECT proparallel
 FROM pg_proc
 WHERE oid = 'sys.oravarchar_pattern_gt(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure;
+
+-- drop table
+DROP TABLE TEST_ORACHAR;
+DROP TABLE TEST_ORAVARCHAR;

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -186,3 +186,8 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+-- Pattern comparison functions are safe to execute in parallel workers.
+SELECT proparallel
+FROM pg_proc
+WHERE oid = 'sys.oravarchar_pattern_gt(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure;

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -3027,6 +3027,7 @@ CREATE FUNCTION sys.oravarchar_pattern_gt(sys.oravarcharchar, sys.oravarcharchar
 RETURNS boolean
 AS 'MODULE_PATHNAME','oravarchar_pattern_gt'
 LANGUAGE C
+PARALLEL SAFE
 STRICT
 IMMUTABLE
 LEAKPROOF;


### PR DESCRIPTION
## Summary

- mark the missing `oravarchar_pattern_gt(oravarcharchar, oravarcharchar)` overload as parallel safe
- align its catalog metadata with the other fifteen VARCHAR2 pattern comparison overloads
- add a catalog regression check for the exact overload

Closes #1867

## Testing

- `git diff --check upstream/master...HEAD`
- regression coverage added; full IvorySQL regression suite will run in project CI after maintainer approval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parallel query execution by marking Oracle-compatible pattern comparisons as safe to run in parallel workers.
  - Updated query-plan output to reflect the corrected parallel-safety setting.

- **Tests**
  - Added regression coverage to verify the pattern-comparison function’s parallel execution safety.
  - Adjusted expected results and cleanup ordering to keep regression tests consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->