### PR TITLE
fix: preserve full value in identifier_case_transform

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_sysview.out
+++ b/contrib/ivorysql_ora/expected/ora_sysview.out
@@ -403,3 +403,31 @@ LINE 1: SELECT COLLATION_NAME FROM SYS.ALL_TAB_COLUMNS WHERE TABLE_N...
                ^
 \set ON_ERROR_STOP on
 DROP TABLE IF EXISTS TEST_ALL_TAB_COLUMNS;
+--
+-- ORA_CASE_TRANS switches case even for values of NAMEDATALEN bytes or
+-- more, preserving the full value (no truncation warnings)
+--
+SELECT SYS.ORA_CASE_TRANS(RPAD('abc', 80, 'x')) = UPPER(RPAD('abc', 80, 'x')) AS long_lower_upcased;
+ long_lower_upcased 
+--------------------
+ t
+(1 row)
+
+SELECT SYS.ORA_CASE_TRANS(RPAD('ABC', 80, 'X')) = LOWER(RPAD('ABC', 80, 'X')) AS long_upper_downcased;
+ long_upper_downcased 
+----------------------
+ t
+(1 row)
+
+SELECT LENGTH(SYS.ORA_CASE_TRANS(RPAD('abc', 80, 'x'))) AS upcased_len;
+ upcased_len 
+-------------
+          80
+(1 row)
+
+SELECT SYS.ORA_CASE_TRANS('Long Identifier 123') AS mixed_case_kept;
+   mixed_case_kept   
+---------------------
+ Long Identifier 123
+(1 row)
+

--- a/contrib/ivorysql_ora/sql/ora_sysview.sql
+++ b/contrib/ivorysql_ora/sql/ora_sysview.sql
@@ -257,3 +257,12 @@ SELECT COLLATION_NAME FROM SYS.ALL_TAB_COLUMNS WHERE TABLE_NAME = 'TEST_ALL_TAB_
 \set ON_ERROR_STOP on
 
 DROP TABLE IF EXISTS TEST_ALL_TAB_COLUMNS;
+
+--
+-- ORA_CASE_TRANS switches case even for values of NAMEDATALEN bytes or
+-- more, preserving the full value (no truncation warnings)
+--
+SELECT SYS.ORA_CASE_TRANS(RPAD('abc', 80, 'x')) = UPPER(RPAD('abc', 80, 'x')) AS long_lower_upcased;
+SELECT SYS.ORA_CASE_TRANS(RPAD('ABC', 80, 'X')) = LOWER(RPAD('ABC', 80, 'X')) AS long_upper_downcased;
+SELECT LENGTH(SYS.ORA_CASE_TRANS(RPAD('abc', 80, 'x'))) AS upcased_len;
+SELECT SYS.ORA_CASE_TRANS('Long Identifier 123') AS mixed_case_kept;

--- a/src/backend/parser/scansup.c
+++ b/src/backend/parser/scansup.c
@@ -110,8 +110,16 @@ identifier_case_transform(const char *ident, int len)
 {
 	char *upper_ident = NULL, *lower_ident = NULL, *result = NULL;
 
-	upper_ident = upcase_identifier(ident, len, true, true);
-	lower_ident = downcase_identifier(ident, len, true, true);
+	/*
+	 * Fold with truncation disabled: this function returns the full value
+	 * with its case switched, so truncating the folded probes to
+	 * NAMEDATALEN would emit spurious truncation warnings for long values
+	 * and make the comparisons below fail, silently skipping the case
+	 * switch for values of NAMEDATALEN bytes or more.  Callers that need a
+	 * name of at most NAMEDATALEN - 1 bytes truncate the result themselves.
+	 */
+	upper_ident = upcase_identifier(ident, len, false, false);
+	lower_ident = downcase_identifier(ident, len, false, false);
 
 	if (strcmp(upper_ident, ident) == 0)
 	{


### PR DESCRIPTION
## Problem / Evidence

`identifier_case_transform()` (used by `SYS.ORA_CASE_TRANS` and the oracle-mode identifier case-switch paths) folds its input with `upcase_identifier()` / `downcase_identifier()` called with truncation enabled. For any value of NAMEDATALEN (64) bytes or more, both folded probes get truncated to 63 bytes, so neither `strcmp(upper_ident, ident)` nor `strcmp(lower_ident, ident)` can match, and the function falls through to the "return unchanged" branch:

```sql
-- IvorySQL master (commit 375aa370d72, source build), oracle mode
SELECT sys.ora_case_trans('short');              -- SHORT    (case switched, correct)
SELECT sys.ora_case_trans(rpad('abc', 80, 'x')); -- abcxxx...(unchanged, bug)
```

Two consequences, both captured from an actual pre-fix run:

1. **The case switch silently stops working for long values.** A long all-lowercase value that must switch to uppercase (exactly what the short-value behavior does) is returned as-is — user-visible through the Oracle-compatible catalog views, which call `SYS.ORA_CASE_TRANS(...)` on every owner/table/column name column (SYS.ALL_TAB_COLUMNS etc.).

2. **Two spurious truncation warnings are emitted on every such call**, even though the returned value is never actually truncated:

   ```console
   NOTICE:  identifier "ABCXXXX...XXXX" will be truncated to "ABCXXXX...XXX"
   NOTICE:  identifier "abcxxxx...xxxx" will be truncated to "abcxxxx...xxx"
    long_lower_upcased
   --------------------
    f                    -- expected t
   ```

   With ON_ERROR_STOP off in a session these NOTICEs also reach plain DDL sessions whenever a long identifier is folded.

Reported as #1845 ("ORA_CASE_TRANS truncates long VARCHAR2 values"); on inspection the truncation applies to the internal folding probes — the observable defects are the silently skipped case switch plus the spurious warnings, which this PR fixes while preserving the full value, exactly as the issue requests.

## Root cause / Fix

`identifier_case_transform()` in src/backend/parser/scansup.c folded with truncation enabled. The fix folds with truncation disabled (`upcase_identifier(ident, len, false, false)` and the same for `downcase_identifier`), so the comparisons see full-length probes and long values get their case switched like short ones.

Caller audit (why disabling truncation here is safe):

- `SplitIdentifierString` in varlena.c (cursor-name paths) explicitly calls `truncate_identifier()` on the result right after the transform, so identifier-length enforcement is preserved;
- `backend_startup.c` (db/user names) only ever sees names that already fit `Name` storage — a longer name cannot exist in the catalog either way;
- `ri_triggers.c` and `dbms_utility.c` fold already-stored identifier names;
- `sysview_functions.c` (`ora_case_trans`) is the contract this PR restores: return the full value with its case switched.

## Priority / scoring

PRIORITY 71 = impact 26 (case transformation silently wrong for long identifiers + warning noise on catalog scans) + scope 10 (one helper, all callers improve) + reproducibility 20 (one-liner) + maintenance value 15 (restores the function's invariant). FIX_CONFIDENCE 85: mechanism fully understood, fix is two argument flips, no caller depends on the old truncated-probe behavior.

## Tests

Regression tests fail on master and pass with the fix:

1. **Pre-fix** (master @ 375aa370d72 code + this PR's test files): `make oracle-check` → `# 1 of 28 tests failed` (`not ok 15 - ora_sysview`). Actual pre-fix output for the new cases:

   ```console
   SELECT SYS.ORA_CASE_TRANS(RPAD('abc', 80, 'x')) = UPPER(RPAD('abc', 80, 'x')) AS long_lower_upcased;
   NOTICE:  identifier "ABCXXX...XXX" will be truncated to "ABCXX...XX"
   NOTICE:  identifier "abcxxx...xxx" will be truncated to "abcxx...xx"
    long_lower_upcased
   --------------------
    f
   ```

   (expected `t`, with no notices)

2. **Post-fix**: `make oracle-check ORA_REGRESS=ora_sysview` → `ok 1 - ora_sysview`, and the **full** `make oracle-check` → **`All 28 tests passed`**. The diff between master's expected outputs and this branch's is limited to the new test section (`git diff master..HEAD -- contrib/ivorysql_ora/expected/` shows only `ora_sysview.out` gaining 28 lines).

New cases in `ora_sysview.sql`: long lowercase switches to uppercase (compared against `upper()`), long uppercase switches to lowercase (against `lower()`), `length()` preserved at 80, mixed-case value returned unchanged. The comparison form keeps the expected output stable under psql's long-string wrapping.

## Risk

Low: the only observable changes are (a) long values now get their case switched, matching the short-value contract, and (b) the spurious truncation warnings disappear. No expected output anywhere in the suite depended on either old behavior.

Fixes #1845

---

**Note for reviewers:** #1849 (opened by the reporter of #1845) is another open draft addressing the same issue at the `sysview_functions.c` level. This PR fixes the shared helper `identifier_case_transform()` in `src/backend/parser/scansup.c` instead, which additionally removes the spurious truncation warnings for every caller (backend startup, cursor-name splitting, ri_triggers, dbms_utility) rather than only the sysview function. Both drafts target #1845; maintainers may prefer either approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed case conversion for identifiers at or above the maximum identifier length.
  - Long lowercase and uppercase values are now converted without truncation or warnings.
  - Preserved the original length of converted values.
  - Mixed-case identifiers, such as “Long Identifier 123,” remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->