### PR TITLE
fix: return NULL from GREATEST/LEAST with any NULL argument in oracle mode

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -4521,3 +4521,66 @@ DETAIL:  "ivorysql" is a reserved prefix.
 reset ivorysql.dummy_config;
 ERROR:  invalid configuration parameter name "ivorysql.dummy_config"
 DETAIL:  "ivorysql" is a reserved prefix.
+--
+-- GREATEST/LEAST return NULL when any argument is NULL in oracle mode
+--
+SELECT greatest(NULL, 1);
+ greatest 
+----------
+         
+(1 row)
+
+SELECT greatest(1, NULL);
+ greatest 
+----------
+         
+(1 row)
+
+SELECT least(NULL, 1);
+ least 
+-------
+      
+(1 row)
+
+SELECT least(1, NULL);
+ least 
+-------
+      
+(1 row)
+
+SELECT greatest(NULL, 1, 2);
+ greatest 
+----------
+         
+(1 row)
+
+SELECT least(NULL, 1, 2);
+ least 
+-------
+      
+(1 row)
+
+SELECT greatest(1, 2, 3);
+ greatest 
+----------
+        3
+(1 row)
+
+SELECT least('abc', NULL);
+ least 
+-------
+ 
+(1 row)
+
+SELECT greatest(NULL, NULL) IS NULL AS all_null;
+ all_null 
+----------
+ t
+(1 row)
+
+SELECT greatest(1.5, NULL) IS NULL AS numeric_null;
+ numeric_null 
+--------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -2464,3 +2464,17 @@ reset default_text_search_config;
 -- should throw errors, because dummy_config is not a valid configuration name
 set ivorysql.dummy_config to dummy;
 reset ivorysql.dummy_config;
+
+--
+-- GREATEST/LEAST return NULL when any argument is NULL in oracle mode
+--
+SELECT greatest(NULL, 1);
+SELECT greatest(1, NULL);
+SELECT least(NULL, 1);
+SELECT least(1, NULL);
+SELECT greatest(NULL, 1, 2);
+SELECT least(NULL, 1, 2);
+SELECT greatest(1, 2, 3);
+SELECT least('abc', NULL);
+SELECT greatest(NULL, NULL) IS NULL AS all_null;
+SELECT greatest(1.5, NULL) IS NULL AS numeric_null;

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -3767,6 +3767,19 @@ ExecEvalMinMax(ExprState *state, ExprEvalStep *op)
 	/* default to null result */
 	*op->resnull = true;
 
+	if (compatible_db == ORA_PARSER)
+	{
+		/*
+		 * In oracle mode, GREATEST/LEAST return NULL if any argument is
+		 * NULL, rather than ignoring NULL inputs.
+		 */
+		for (int off = 0; off < op->d.minmax.nelems; off++)
+		{
+			if (nulls[off])
+				return;
+		}
+	}
+
 	for (int off = 0; off < op->d.minmax.nelems; off++)
 	{
 		/* ignore NULL inputs */


### PR DESCRIPTION
## Problem / Evidence

In oracle mode, GREATEST/LEAST keep PostgreSQL's NULL-ignoring semantics and silently return a non-NULL result. This is a data-correctness gap for migrated Oracle SQL: expressions like `GREATEST(a, b)` used for "pick the larger, else treat as missing" change meaning whenever one side is NULL.

```sql
-- IvorySQL master (commit 375aa370d72, source build), ivorysql.compatible_mode = oracle
SELECT greatest(NULL, 1);   -- 1
SELECT least(NULL, 1);      -- 1
SELECT greatest(NULL, 1, 2) IS NULL;   -- f
```

## Oracle verification

Verified locally against a real Oracle instance (docker image `gvenzl/oracle-free:23-slim`, banner: `Oracle AI Database 26ai Free Release 23.26.3.0.0`), session via `sqlplus test/test@FREEPDB1`. `NVL(TO_CHAR(...), '(null)')` is used only to make NULLs visible in pasted output:

```sql
SQL> SELECT NVL(TO_CHAR(GREATEST(NULL, 1)), '(null)') AS greatest_null_1 FROM dual;

GREA
----
(null)

1 row selected.

SQL> SELECT NVL(TO_CHAR(LEAST(NULL, 1)), '(null)') AS least_null_1 FROM dual;

LEAST_
------
(null)

1 row selected.

SQL> SELECT NVL(TO_CHAR(GREATEST(1, 2, 3)), '(null)') AS greatest_123 FROM dual;

G
-
3

1 row selected.
```

## Root cause / Fix

GREATEST/LEAST compile to MinMaxExpr (the oracle grammar parses them exactly like PostgreSQL's — `ora_gram.y` builds `IS_GREATEST`/`IS_LEAST`), evaluated by `ExecEvalMinMax()` in src/backend/executor/execExprInterp.c, whose loop skips NULL inputs (`if (nulls[off]) continue;`).

In oracle mode (`compatible_db == ORA_PARSER`) the evaluation now returns NULL as soon as any argument is NULL, matching Oracle. PostgreSQL mode is unchanged, and argument lists without NULLs take exactly the same path as before (one extra NULL scan over the already-materialized values array). No existing suite output exercises GREATEST/LEAST, so no test updates were needed outside the new cases.

## Priority / scoring

PRIORITY 70 = impact 28 (silently wrong, data-correctness semantics of a common SQL construct) + scope 10 (GREATEST/LEAST only) + reproducibility 20 (one-liner) + maintenance value 12 (aligns with the oracle-mode NULL semantics the project already implements, e.g. '' = NULL and NULLS LAST ordering). FIX_CONFIDENCE 85: minimal executor change, mode-gated, exact Oracle semantics verified on a real instance.

## Tests

Regression tests fail on master and pass with the fix:

1. **Pre-fix** (master @ 375aa370d72 code + this PR's test files): `make oracle-check` → `# 1 of 28 tests failed` (`not ok 11 - ora_misc_functions`). Actual master output from that run:

   ```sql
   SELECT greatest(NULL, 1);
    greatest
   ----------
           1          -- expected NULL
   ```

2. **Post-fix**: `make oracle-check ORA_REGRESS=ora_misc_functions` → `ok 11 - ora_misc_functions`, and the **full** `make oracle-check` → **`All 28 tests passed`**. No other suite output changed.

New cases in `ora_misc_functions.sql`: NULL propagation for GREATEST/LEAST with two and three arguments (int and text), `greatest(1, 2, 3) = 3` and all-NULL/`IS NULL` guards confirming the unchanged non-NULL behavior.

## Risk

Low: behavior changes only for oracle-mode argument lists containing at least one NULL; pg mode untouched. Non-NULL argument lists take the identical evaluation path as before.

Fixes #1875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Oracle compatibility mode so `GREATEST` and `LEAST` return `NULL` when any argument is `NULL`, including numeric, text, mixed-type, and all-`NULL` inputs.

- **Tests**
  - Added coverage verifying the updated `GREATEST` and `LEAST` behavior and corresponding `IS NULL` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->