### PR TITLE
Answer vsize() for numeric input in Oracle NUMBER format

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_vsize.out
+++ b/contrib/ivorysql_ora/expected/ora_vsize.out
@@ -47,7 +47,9 @@ SELECT vsize('你好'::text);
      6
 (1 row)
 
--- numeric data
+-- numeric data: byte length in Oracle's internal NUMBER format
+-- (one exponent byte, one mantissa byte per two significant decimal
+-- digits, plus a terminator byte for negative values; zero is one byte)
 SELECT vsize(0::number);
  vsize 
 -------
@@ -75,13 +77,13 @@ SELECT vsize(1.23::number);
 SELECT vsize(123::int4);
  vsize 
 -------
-     4
+     3
 (1 row)
 
 SELECT vsize(123::int8);
  vsize 
 -------
-     8
+     3
 (1 row)
 
 SELECT vsize(1.23::float8);
@@ -94,6 +96,50 @@ SELECT vsize('NaN'::float8);
  vsize 
 -------
      8
+(1 row)
+
+-- NUMBER-format boundaries, values cross-checked against Oracle:
+-- trailing zeros are not stored, negatives carry a terminator byte
+SELECT vsize(100);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(1000000);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(-1);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(-1200);
+ vsize 
+-------
+     3
+(1 row)
+
+SELECT vsize(12345.67);
+ vsize 
+-------
+     5
+(1 row)
+
+SELECT vsize(0.0000000001);
+ vsize 
+-------
+     2
+(1 row)
+
+SELECT vsize(12345678901234567890123456789012345678);
+ vsize 
+-------
+    20
 (1 row)
 
 -- other fixed-width types

--- a/contrib/ivorysql_ora/sql/ora_vsize.sql
+++ b/contrib/ivorysql_ora/sql/ora_vsize.sql
@@ -15,7 +15,9 @@ SELECT vsize('abc') = lengthb('abc') AS same_as_lengthb;
 -- multibyte data
 SELECT vsize('你好'::text);
 
--- numeric data
+-- numeric data: byte length in Oracle's internal NUMBER format
+-- (one exponent byte, one mantissa byte per two significant decimal
+-- digits, plus a terminator byte for negative values; zero is one byte)
 SELECT vsize(0::number);
 SELECT vsize(1::number);
 SELECT vsize(123::number);
@@ -24,6 +26,16 @@ SELECT vsize(123::int4);
 SELECT vsize(123::int8);
 SELECT vsize(1.23::float8);
 SELECT vsize('NaN'::float8);
+
+-- NUMBER-format boundaries, values cross-checked against Oracle:
+-- trailing zeros are not stored, negatives carry a terminator byte
+SELECT vsize(100);
+SELECT vsize(1000000);
+SELECT vsize(-1);
+SELECT vsize(-1200);
+SELECT vsize(12345.67);
+SELECT vsize(0.0000000001);
+SELECT vsize(12345678901234567890123456789012345678);
 
 -- other fixed-width types
 SELECT vsize(true);

--- a/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
@@ -33,6 +33,7 @@
 #include "access/detoast.h"
 #include "utils/formatting.h"
 #include "utils/lsyscache.h"
+#include "catalog/pg_type.h"
 #include "utils/numeric.h"
 #include "varatt.h"
 #include "lib/stringinfo.h"
@@ -50,34 +51,156 @@ PG_FUNCTION_INFO_V1(ora_vsize);
  * Returns the number of bytes in the internal representation of the
  * argument.  NULL input yields NULL (the function is declared STRICT).
  *
- * For varlena types the logical (decompressed) data size is returned,
- * excluding the varlena header, so that VSIZE('abc') is 3, matching
- * Oracle's behavior for character data.  For fixed-width types the
- * type's storage width is returned.
+ * Numeric input is answered in Oracle's internal NUMBER format, because
+ * that is what Oracle's VSIZE reports: one exponent byte, then one
+ * mantissa byte per pair of significant decimal digits (trailing zeros
+ * are not stored), plus one extra terminator byte (0x66) for negative
+ * values; zero occupies a single byte.  So VSIZE(100) is 2, VSIZE(-1)
+ * is 3 and VSIZE(12345.67) is 5, whichever native type carries the
+ * value -- in Oracle every numeric literal is a NUMBER.
+ *
+ * Float4/float8 keep the type's storage width, which already equals
+ * Oracle's BINARY_FLOAT/BINARY_DOUBLE sizes.  For varlena types the
+ * logical (decompressed) data size is returned, excluding the varlena
+ * header, so that VSIZE('abc') is 3, matching Oracle's behavior for
+ * character data.  For fixed-width types the type's storage width is
+ * returned.
  */
+
+/*
+ * Count the significant decimal digits in the textual form of a number,
+ * skipping the sign, the decimal point, leading and trailing zeros.
+ * Sets *negative when the value carries a minus sign.  Returns 0 when
+ * every digit is zero.
+ */
+static int
+count_significant_decimal_digits(const char *s, bool *negative)
+{
+	const char *p;
+	const char *first = NULL;
+	const char *last = NULL;
+	int			ndigits = 0;
+
+	*negative = false;
+	if (*s == '-')
+	{
+		*negative = true;
+		s++;
+	}
+	else if (*s == '+')
+		s++;
+
+	for (p = s; *p; p++)
+	{
+		if (*p == '.')
+			continue;
+		if (*p != '0')
+		{
+			if (first == NULL)
+				first = p;
+			last = p;
+		}
+	}
+	if (first == NULL)
+		return 0;
+
+	for (p = first; p <= last; p++)
+	{
+		if (*p != '.')
+			ndigits++;
+	}
+	return ndigits;
+}
+
+/*
+ * Byte length of a value in Oracle's internal NUMBER format, given the
+ * count of significant decimal digits and the sign of the value.
+ */
+static int32
+oracle_number_byte_length(int ndigits, bool negative)
+{
+	if (ndigits == 0)
+		return 1;			/* zero is stored as the single byte 0x80 */
+	return 1 + (ndigits + 1) / 2 + (negative ? 1 : 0);
+}
+
 Datum
 ora_vsize(PG_FUNCTION_ARGS)
 {
 	Datum		value = PG_GETARG_DATUM(0);
 	int32		result;
 	int			typlen;
+	Oid			argtypeid;
 
 	/* On first call, get the input type's typlen, and save at *fn_extra */
 	if (fcinfo->flinfo->fn_extra == NULL)
 	{
 		/* Lookup the datatype of the supplied argument */
-		Oid			argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+		argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
 
 		typlen = get_typlen(argtypeid);
 		if (typlen == 0)		/* should not happen */
 			elog(ERROR, "cache lookup failed for type %u", argtypeid);
 
 		fcinfo->flinfo->fn_extra = MemoryContextAlloc(fcinfo->flinfo->fn_mcxt,
-													  sizeof(int));
+													  sizeof(int) + sizeof(Oid));
 		*((int *) fcinfo->flinfo->fn_extra) = typlen;
+		*((Oid *) ((char *) fcinfo->flinfo->fn_extra + sizeof(int))) = argtypeid;
 	}
 	else
+	{
 		typlen = *((int *) fcinfo->flinfo->fn_extra);
+		argtypeid = *((Oid *) ((char *) fcinfo->flinfo->fn_extra + sizeof(int)));
+	}
+
+	if (argtypeid == INT2OID || argtypeid == INT4OID ||
+		argtypeid == INT8OID || argtypeid == NUMERICOID)
+	{
+		char		buf[64];
+		const char *str;
+		bool		negative;
+		int			ndigits;
+
+		if (argtypeid == NUMERICOID)
+		{
+			Numeric		num = DatumGetNumeric(value);
+
+			/*
+			 * Oracle's NUMBER has no NaN/Infinity counterpart, so keep the
+			 * storage-size answer for those instead of inventing a
+			 * NUMBER-format length for them.
+			 */
+			if (numeric_is_nan(num) || numeric_is_inf(num))
+			{
+				result = toast_raw_datum_size(value) - VARHDRSZ;
+				PG_RETURN_INT32(result);
+			}
+			str = DatumGetCString(DirectFunctionCall1(numeric_out,
+													  NumericGetDatum(num)));
+		}
+		else
+		{
+			int64		v;
+
+			switch (argtypeid)
+			{
+				case INT2OID:
+					v = DatumGetInt16(value);
+					break;
+				case INT4OID:
+					v = DatumGetInt32(value);
+					break;
+				default:
+					v = DatumGetInt64(value);
+					break;
+			}
+			snprintf(buf, sizeof(buf), INT64_FORMAT, v);
+			str = buf;
+		}
+
+		ndigits = count_significant_decimal_digits(str, &negative);
+		PG_RETURN_INT32(oracle_number_byte_length(ndigits, negative));
+	}
 
 	if (typlen == -1)
 	{


### PR DESCRIPTION
Thanks @jiaoshuntian for the pointer — and sorry for the overlap; I hadn't seen #1859 when I opened this.

After reading it, I agree #1859 is the more complete fix: it derives the Oracle NUMBER internal size from the decimal rendering, so it also covers the paths this PR missed — explicit `::number` casts and NUMBER columns report PG varlena widths with this patch (e.g. `vsize(12345.67::number)` returns 8 vs Oracle's 5; a NUMBER column holding 12345 returns 6 vs 4).

Withdrawing this PR in favor of #1859. One input that may be useful for its review: I verified the values against Oracle 23ai before opening this PR, and they all agree with the algorithm in #1859, including the decimal-point anchoring added in 8197bf8:

- `vsize(0)` = 1
- `vsize(1)` = 2
- `vsize(123)` = 3
- `vsize(1.23)` = 3
- `vsize(12345.67)` = 5
- `vsize(NUMBER column = 12345)` = 4
- `vsize(cast(12345.67 as number))` = 5 (same as the literal)

The CAST/column rows might be worth adding as regression cases in #1859, since the current test file only covers literals.