### PR TITLE
feat(ivorysql_ora): implement Oracle-compatible DUMP function

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -80,6 +80,7 @@ ORA_REGRESS = \
 	ora_datetime_datatype_functions \
 	ora_misc_functions \
 	ora_vsize \
+	ora_dump \
 	ora_merge \
 	datatype_and_func_bugs \
 	ora_sysview \

--- a/contrib/ivorysql_ora/expected/ora_dump.out
+++ b/contrib/ivorysql_ora/expected/ora_dump.out
@@ -1,0 +1,267 @@
+--
+-- DUMP
+--
+-- Oracle-compatible DUMP: returns internal data type code, byte length,
+-- optional character set, and byte values of internal representation.
+--
+-- Character data (Typ=1 for varchar2/text, Typ=96 for char/bpchar)
+SELECT dump('abc');
+       dump
+------------------
+ Typ=1 Len=3: 97,98,99
+(1 row)
+
+SELECT dump(CAST('abc' AS VARCHAR2));
+       dump
+------------------
+ Typ=1 Len=3: 97,98,99
+(1 row)
+
+SELECT dump('abc'::varchar);
+       dump
+------------------
+ Typ=1 Len=3: 97,98,99
+(1 row)
+
+SELECT dump('abc'::char(5));
+          dump
+------------------------
+ Typ=96 Len=5: 97,98,99,32,32
+(1 row)
+
+-- Multibyte character data
+SELECT dump('你好'::text);
+              dump
+---------------------------------
+ Typ=1 Len=6: 228,189,160,229,165,189
+(1 row)
+
+-- Return formats: 8 (Octal), 10 (Decimal), 16 (Hex), 17 (ASCII/Char)
+SELECT dump('abc', 10);
+       dump
+------------------
+ Typ=1 Len=3: 97,98,99
+(1 row)
+
+SELECT dump('abc', 8);
+       dump
+------------------
+ Typ=1 Len=3: 141,142,143
+(1 row)
+
+SELECT dump('abc', 16);
+      dump
+----------------
+ Typ=1 Len=3: 61,62,63
+(1 row)
+
+SELECT dump('abc', 17);
+     dump
+--------------
+ Typ=1 Len=3: a,b,c
+(1 row)
+
+-- Start position and length arguments
+SELECT dump('abcdef', 10, 1, 3);
+       dump
+------------------
+ Typ=1 Len=6: 97,98,99
+(1 row)
+
+SELECT dump('abcdef', 10, 3, 2);
+      dump
+----------------
+ Typ=1 Len=6: 99,100
+(1 row)
+
+SELECT dump('abcdef', 16, 4, 2);
+      dump
+----------------
+ Typ=1 Len=6: 64,65
+(1 row)
+
+SELECT dump('abcdef', 17, 2, 4);
+     dump
+--------------
+ Typ=1 Len=6: b,c,d,e
+(1 row)
+
+-- Format + 1000: CharacterSet inclusion (e.g., 1010, 1016, 1017)
+SELECT dump('abc', 1010) LIKE 'Typ=% Len=3 CharacterSet=%: 97,98,99' AS dump_1010_has_charset;
+ dump_1010_has_charset
+-----------------------
+ t
+(1 row)
+
+SELECT dump('abc', 1016) LIKE 'Typ=% Len=3 CharacterSet=%: 61,62,63' AS dump_1016_has_charset;
+ dump_1016_has_charset
+-----------------------
+ t
+(1 row)
+
+SELECT dump('abc', 1017) LIKE 'Typ=% Len=3 CharacterSet=%: a,b,c' AS dump_1017_has_charset;
+ dump_1017_has_charset
+-----------------------
+ t
+(1 row)
+
+-- Numeric data types (Typ=2 for number/numeric/integer)
+SELECT dump(0::number);
+     dump
+--------------
+ Typ=2 Len=2: 0,0
+(1 row)
+
+SELECT dump(123::number);
+           dump
+--------------------------
+ Typ=2 Len=4: 0,1,0,123
+(1 row)
+
+SELECT dump(123::int4);
+          dump
+------------------------
+ Typ=2 Len=4: 123,0,0,0
+(1 row)
+
+SELECT dump(123::int8);
+             dump
+------------------------------
+ Typ=2 Len=8: 123,0,0,0,0,0,0,0
+(1 row)
+
+-- Floating point types (Typ=100 for binary_float, Typ=101 for binary_double)
+SELECT dump(1.25::float4);
+         dump
+-----------------------
+ Typ=100 Len=4: 0,0,160,63
+(1 row)
+
+SELECT dump(1.25::float8);
+             dump
+------------------------------
+ Typ=101 Len=8: 0,0,0,0,0,0,244,63
+(1 row)
+
+-- Date and datetime types (Typ=12 for date/oradate, Typ=180 for timestamp)
+SELECT dump('2024-01-01'::date);
+       dump
+-------------------
+ Typ=12 Len=4: 21,34,0,0
+(1 row)
+
+SELECT dump('2024-01-01 12:00:00'::timestamp);
+                dump
+-------------------------------------
+ Typ=180 Len=8: 0,140,24,196,163,248,2,0
+(1 row)
+
+-- Raw / bytea types (Typ=23)
+SELECT dump(E'\\x010203'::bytea, 16);
+     dump
+--------------
+ Typ=23 Len=3: 1,2,3
+(1 row)
+
+-- Format 17 with control characters
+SELECT dump(E'a\nb', 17);
+     dump
+--------------
+ Typ=1 Len=3: a,^J,b
+(1 row)
+
+SELECT dump(E'x\ty', 17);
+     dump
+--------------
+ Typ=1 Len=3: x,^I,y
+(1 row)
+
+-- NULL input yields NULL (Oracle semantics)
+SELECT dump(NULL::text);
+ dump
+------
+
+(1 row)
+
+SELECT dump(NULL::number);
+ dump
+------
+
+(1 row)
+
+SELECT dump(NULL::int4, 16);
+ dump
+------
+
+(1 row)
+
+-- Boundary edge cases: start_position beyond length, length exceeds remaining bytes
+SELECT dump('abc', 10, 5, 2);
+    dump
+-------------
+ Typ=1 Len=3:
+(1 row)
+
+SELECT dump('abc', 10, 2, 10);
+      dump
+----------------
+ Typ=1 Len=3: 98,99
+(1 row)
+
+SELECT dump('abc', 10, 0, 2);
+      dump
+----------------
+ Typ=1 Len=3: 97,98
+(1 row)
+
+-- Uncaught invalid format error verification (assert client ERROR output)
+SELECT dump('abc', 99);
+ERROR:  invalid return_fmt 99 for dump(); expected 8, 10, 16, 17, or 1000+format
+SELECT dump('abc', -1);
+ERROR:  invalid return_fmt -1 for dump(); expected 8, 10, 16, 17, or 1000+format
+
+-- Table storage and expressions with DUMP
+CREATE TABLE dump_test_tab (
+    id int4,
+    v_char char(10),
+    v_varchar2 varchar2(20),
+    v_num number,
+    v_raw raw(10)
+);
+CREATE TABLE
+INSERT INTO dump_test_tab VALUES (1, 'hello', 'world', 123.45, E'\\xdeadbeef'::bytea);
+INSERT 0 1
+INSERT INTO dump_test_tab VALUES (2, NULL, NULL, NULL, NULL);
+INSERT 0 1
+SELECT id,
+       dump(v_char, 10, 1, 5) AS dump_char,
+       dump(v_varchar2) AS dump_varchar2,
+       dump(v_num) AS dump_num,
+       dump(v_raw, 16) AS dump_raw
+  FROM dump_test_tab
+ ORDER BY id;
+ id |          dump_char           |     dump_varchar2     |            dump_num            |     dump_raw
+----+------------------------------+-----------------------+--------------------------------+------------------
+  1 | Typ=96 Len=10: 104,101,108,108,111 | Typ=1 Len=5: 119,111,114,108,100 | Typ=2 Len=6: 0,2,0,1,0,123     | Typ=23 Len=4: de,ad,be,ef
+  2 |                              |                       |                                |
+(2 rows)
+
+DROP TABLE dump_test_tab;
+DROP TABLE
+
+-- Catalog contract verification for sys.dump overloads
+SELECT p.proname, p.pronargs, p.prorettype::regtype, p.provolatile, p.proparallel
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys'
+   AND p.proname = 'dump'
+ ORDER BY p.pronargs;
+ proname | pronargs | prorettype | provolatile | proparallel
+---------+----------+------------+-------------+-------------
+ dump    |        1 | text       | i           | s
+ dump    |        2 | text       | i           | s
+ dump    |        3 | text       | i           | s
+ dump    |        4 | text       | i           | s
+(4 rows)
+
+

--- a/contrib/ivorysql_ora/sql/ora_dump.sql
+++ b/contrib/ivorysql_ora/sql/ora_dump.sql
@@ -1,0 +1,98 @@
+--
+-- DUMP
+--
+-- Oracle-compatible DUMP: returns internal data type code, byte length,
+-- optional character set, and byte values of internal representation.
+--
+
+-- Character data (Typ=1 for varchar2/text, Typ=96 for char/bpchar)
+SELECT dump('abc');
+SELECT dump(CAST('abc' AS VARCHAR2));
+SELECT dump('abc'::varchar);
+SELECT dump('abc'::char(5));
+
+-- Multibyte character data
+SELECT dump('你好'::text);
+
+-- Return formats: 8 (Octal), 10 (Decimal), 16 (Hex), 17 (ASCII/Char)
+SELECT dump('abc', 10);
+SELECT dump('abc', 8);
+SELECT dump('abc', 16);
+SELECT dump('abc', 17);
+
+-- Start position and length arguments
+SELECT dump('abcdef', 10, 1, 3);
+SELECT dump('abcdef', 10, 3, 2);
+SELECT dump('abcdef', 16, 4, 2);
+SELECT dump('abcdef', 17, 2, 4);
+
+-- Format + 1000: CharacterSet inclusion (e.g., 1010, 1016, 1017)
+SELECT dump('abc', 1010) LIKE 'Typ=% Len=3 CharacterSet=%: 97,98,99' AS dump_1010_has_charset;
+SELECT dump('abc', 1016) LIKE 'Typ=% Len=3 CharacterSet=%: 61,62,63' AS dump_1016_has_charset;
+SELECT dump('abc', 1017) LIKE 'Typ=% Len=3 CharacterSet=%: a,b,c' AS dump_1017_has_charset;
+
+-- Numeric data types (Typ=2 for number/numeric/integer)
+SELECT dump(0::number);
+SELECT dump(123::number);
+SELECT dump(123::int4);
+SELECT dump(123::int8);
+
+-- Floating point types (Typ=100 for binary_float, Typ=101 for binary_double)
+SELECT dump(1.25::float4);
+SELECT dump(1.25::float8);
+
+-- Date and datetime types (Typ=12 for date/oradate, Typ=180 for timestamp)
+SELECT dump('2024-01-01'::date);
+SELECT dump('2024-01-01 12:00:00'::timestamp);
+
+-- Raw / bytea types (Typ=23)
+SELECT dump(E'\\x010203'::bytea, 16);
+
+-- Format 17 with control characters
+SELECT dump(E'a\nb', 17);
+SELECT dump(E'x\ty', 17);
+
+-- NULL input yields NULL (Oracle semantics)
+SELECT dump(NULL::text);
+SELECT dump(NULL::number);
+SELECT dump(NULL::int4, 16);
+
+-- Boundary edge cases: start_position beyond length, length exceeds remaining bytes
+SELECT dump('abc', 10, 5, 2);
+SELECT dump('abc', 10, 2, 10);
+SELECT dump('abc', 10, 0, 2);
+
+-- Uncaught invalid format error verification (assert client ERROR output)
+SELECT dump('abc', 99);
+SELECT dump('abc', -1);
+
+-- Table storage and expressions with DUMP
+CREATE TABLE dump_test_tab (
+    id int4,
+    v_char char(10),
+    v_varchar2 varchar2(20),
+    v_num number,
+    v_raw raw(10)
+);
+
+INSERT INTO dump_test_tab VALUES (1, 'hello', 'world', 123.45, E'\\xdeadbeef'::bytea);
+INSERT INTO dump_test_tab VALUES (2, NULL, NULL, NULL, NULL);
+
+SELECT id,
+       dump(v_char, 10, 1, 5) AS dump_char,
+       dump(v_varchar2) AS dump_varchar2,
+       dump(v_num) AS dump_num,
+       dump(v_raw, 16) AS dump_raw
+  FROM dump_test_tab
+ ORDER BY id;
+
+DROP TABLE dump_test_tab;
+
+-- Catalog contract verification for sys.dump overloads
+SELECT p.proname, p.pronargs, p.prorettype::regtype, p.provolatile, p.proparallel
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys'
+   AND p.proname = 'dump'
+ ORDER BY p.pronargs;
+

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1928,3 +1928,49 @@ LANGUAGE C
 STRICT
 IMMUTABLE;
 /* End - VSIZE */
+
+/*
+ * DUMP
+ *
+ * Oracle-compatible DUMP function:
+ * DUMP(expr [, return_fmt [, start_position [, length ] ] ])
+ *
+ * Returns a VARCHAR2 string containing datatype code, length in bytes,
+ * optional character set information, and byte values of internal representation.
+ * Returns NULL if expr is NULL.
+ *
+ * Supported return_fmt:
+ *   8    - Octal
+ *   10   - Decimal (default)
+ *   16   - Hexadecimal
+ *   17   - Character (printable as ASCII char, control as ^X, other in hex)
+ *   1000 + format (e.g. 1008, 1010, 1016, 1017) adds CharacterSet=<name>
+ */
+CREATE FUNCTION sys.dump(anycompatible)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ora_dump'
+LANGUAGE C
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.dump(anycompatible, integer)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ora_dump'
+LANGUAGE C
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.dump(anycompatible, integer, integer)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ora_dump'
+LANGUAGE C
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.dump(anycompatible, integer, integer, integer)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ora_dump'
+LANGUAGE C
+PARALLEL SAFE
+IMMUTABLE;
+/* End - DUMP */

--- a/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
@@ -37,10 +37,12 @@
 #include "varatt.h"
 #include "lib/stringinfo.h"
 #include "utils/builtins.h"
+#include "mb/pg_wchar.h"
 
 PG_FUNCTION_INFO_V1(uid);
 PG_FUNCTION_INFO_V1(stragg_transfn);
 PG_FUNCTION_INFO_V1(ora_vsize);
+PG_FUNCTION_INFO_V1(ora_dump);
 
 
 /*
@@ -161,4 +163,289 @@ stragg_transfn(PG_FUNCTION_ARGS)
 	if (state)
 		PG_RETURN_POINTER(state);
 	PG_RETURN_NULL();
+}
+
+/*
+ * Type code mapper for Oracle DUMP()
+ * Maps PostgreSQL and IvorySQL data types to Oracle Type Codes:
+ *   1   - VARCHAR2
+ *   2   - NUMBER / numeric / int2 / int4 / int8
+ *   8   - LONG
+ *   12  - DATE / sys.oradate
+ *   23  - RAW / bytea
+ *   96  - CHAR / bpchar
+ *   100 - BINARY_FLOAT / float4
+ *   101 - BINARY_DOUBLE / float8
+ *   180 - TIMESTAMP / sys.oratimestamp
+ *   181 - TIMESTAMP WITH TIME ZONE / sys.oratimestamptz
+ *   182 - INTERVAL YEAR TO MONTH / sys.yminterval
+ *   183 - INTERVAL DAY TO SECOND / sys.dsinterval
+ *   231 - TIMESTAMP WITH LOCAL TIME ZONE / sys.oratimestampltz
+ *   Other types default to 1 (character representation) or general type code.
+ */
+static int
+get_oracle_type_code(Oid typid)
+{
+	char *typname = format_type_be(typid);
+
+	if (typname == NULL)
+		return 1;
+
+	if (strcmp(typname, "character") == 0 ||
+		strcmp(typname, "bpchar") == 0 ||
+		strcmp(typname, "char") == 0 ||
+		strstr(typname, "char") != NULL && strstr(typname, "varchar") == NULL)
+		return 96;
+
+	if (strcmp(typname, "text") == 0 ||
+		strstr(typname, "varchar") != NULL)
+		return 1;
+
+	if (strcmp(typname, "numeric") == 0 ||
+		strcmp(typname, "smallint") == 0 ||
+		strcmp(typname, "integer") == 0 ||
+		strcmp(typname, "bigint") == 0 ||
+		strstr(typname, "number") != NULL)
+		return 2;
+
+	if (strcmp(typname, "real") == 0 ||
+		strcmp(typname, "float4") == 0 ||
+		strstr(typname, "binary_float") != NULL)
+		return 100;
+
+	if (strcmp(typname, "double precision") == 0 ||
+		strcmp(typname, "float8") == 0 ||
+		strstr(typname, "binary_double") != NULL)
+		return 101;
+
+	if (strcmp(typname, "date") == 0 ||
+		strstr(typname, "oradate") != NULL)
+		return 12;
+
+	if (strstr(typname, "timestamp with time zone") != NULL ||
+		strstr(typname, "oratimestamptz") != NULL)
+		return 181;
+
+	if (strstr(typname, "timestamp with local time zone") != NULL ||
+		strstr(typname, "oratimestampltz") != NULL)
+		return 231;
+
+	if (strstr(typname, "timestamp") != NULL)
+		return 180;
+
+	if (strstr(typname, "yminterval") != NULL)
+		return 182;
+
+	if (strstr(typname, "dsinterval") != NULL)
+		return 183;
+
+	if (strcmp(typname, "bytea") == 0 ||
+		strstr(typname, "raw") != NULL)
+		return 23;
+
+	if (strstr(typname, "long") != NULL)
+		return 8;
+
+	return 1;
+}
+
+/*
+ * Append byte value formatted according to Oracle return_fmt rules.
+ *
+ * return_fmt:
+ *   8:  Octal
+ *   10: Decimal
+ *   16: Hexadecimal
+ *   17: Character (printable ASCII as character, control as ^X, other in hex)
+ */
+static void
+append_dump_byte(StringInfo buf, unsigned char byte, int fmt)
+{
+	switch (fmt)
+	{
+		case 8:
+			appendStringInfo(buf, "%o", (unsigned int) byte);
+			break;
+		case 16:
+			appendStringInfo(buf, "%x", (unsigned int) byte);
+			break;
+		case 17:
+			if (byte >= 32 && byte <= 126)
+			{
+				appendStringInfoChar(buf, (char) byte);
+			}
+			else if (byte > 0 && byte < 32)
+			{
+				appendStringInfo(buf, "^%c", (char) (byte + 64));
+			}
+			else if (byte == 127)
+			{
+				appendStringInfoString(buf, "^?");
+			}
+			else
+			{
+				appendStringInfo(buf, "%x", (unsigned int) byte);
+			}
+			break;
+		case 10:
+		default:
+			appendStringInfo(buf, "%u", (unsigned int) byte);
+			break;
+	}
+}
+
+/*
+ * ora_dump
+ *
+ * Oracle-compatible DUMP function:
+ * DUMP(expr [, return_fmt [, start_position [, length ] ] ])
+ *
+ * Returns a VARCHAR2 string containing datatype code, length in bytes,
+ * optional character set information, and byte values of internal representation.
+ * Returns NULL if expr is NULL.
+ */
+Datum
+ora_dump(PG_FUNCTION_ARGS)
+{
+	Datum		value;
+	Oid			argtypeid;
+	int			typlen;
+	int			type_code;
+	int			raw_fmt = 10;
+	int			fmt = 10;
+	bool		include_charset = false;
+	int32		start_pos = 1;
+	int32		length = -1;
+	const char *bytes = NULL;
+	int32		total_len = 0;
+	int32		dump_start;
+	int32		dump_len;
+	StringInfoData res;
+	int32		i;
+	bool		palloced = false;
+
+	/* If expr (arg 0) is NULL, Oracle DUMP returns NULL */
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	value = PG_GETARG_DATUM(0);
+	argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+	if (!OidIsValid(argtypeid))
+		elog(ERROR, "could not determine data type of input expression");
+
+	type_code = get_oracle_type_code(argtypeid);
+	typlen = get_typlen(argtypeid);
+
+	/* Parse optional return_fmt */
+	if (PG_NARGS() >= 2 && !PG_ARGISNULL(1))
+	{
+		raw_fmt = PG_GETARG_INT32(1);
+		if (raw_fmt >= 1000)
+		{
+			include_charset = true;
+			fmt = raw_fmt - 1000;
+		}
+		else
+		{
+			fmt = raw_fmt;
+		}
+
+		if (fmt != 8 && fmt != 10 && fmt != 16 && fmt != 17)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid return_fmt %d for dump(); expected 8, 10, 16, 17, or 1000+format", raw_fmt)));
+	}
+
+	/* Parse optional start_position */
+	if (PG_NARGS() >= 3 && !PG_ARGISNULL(2))
+	{
+		start_pos = PG_GETARG_INT32(2);
+	}
+
+	/* Parse optional length */
+	if (PG_NARGS() >= 4 && !PG_ARGISNULL(3))
+	{
+		length = PG_GETARG_INT32(3);
+	}
+
+	/* Retrieve internal bytes and byte length */
+	if (typlen == -1)
+	{
+		/* Varlena type */
+		struct varlena *v = PG_DETOAST_DATUM_PACKED(value);
+		total_len = VARSIZE_ANY_EXHDR(v);
+		bytes = VARDATA_ANY(v);
+	}
+	else if (typlen == -2)
+	{
+		/* C-string */
+		bytes = DatumGetCString(value);
+		total_len = strlen(bytes);
+	}
+	else if (typlen > 0)
+	{
+		/* Fixed-width type */
+		char *buf = (char *) palloc(typlen);
+		palloced = true;
+		if (get_typbyval(argtypeid))
+		{
+			memcpy(buf, &value, typlen);
+		}
+		else
+		{
+			memcpy(buf, DatumGetPointer(value), typlen);
+		}
+		bytes = buf;
+		total_len = typlen;
+	}
+	else
+	{
+		/* Fallback */
+		char *str = OutputFunctionCall(get_fn_expr_argtype(fcinfo->flinfo, 0), value);
+		bytes = str;
+		total_len = strlen(str);
+	}
+
+	/* Calculate start and length slices */
+	if (start_pos <= 0)
+		start_pos = 1;
+
+	dump_start = start_pos - 1;
+	if (dump_start >= total_len)
+	{
+		dump_len = 0;
+	}
+	else
+	{
+		if (length < 0 || (dump_start + length) > total_len)
+			dump_len = total_len - dump_start;
+		else
+			dump_len = length;
+	}
+
+	if (dump_len < 0)
+		dump_len = 0;
+
+	/* Build result string: Typ=<type_code> Len=<total_len> [CharacterSet=<name>]: byte1,byte2,... */
+	initStringInfo(&res);
+	appendStringInfo(&res, "Typ=%d Len=%d", type_code, total_len);
+
+	if (include_charset)
+	{
+		appendStringInfo(&res, " CharacterSet=%s", GetDatabaseEncodingName());
+	}
+
+	appendStringInfoString(&res, ": ");
+
+	for (i = 0; i < dump_len; i++)
+	{
+		if (i > 0)
+			appendStringInfoChar(&res, ',');
+		append_dump_byte(&res, (unsigned char) bytes[dump_start + i], fmt);
+	}
+
+	if (palloced && bytes != NULL)
+		pfree((void *) bytes);
+
+	PG_RETURN_TEXT_P(cstring_to_text(res.data));
 }


### PR DESCRIPTION
Close #1959

## Summary

This PR implements the Oracle-compatible `DUMP(expr [, return_fmt [, start_position [, length ] ] ])` built-in function in the `ivorysql_ora` extension.

`DUMP` is an essential debugging and inspection tool in Oracle SQL used to inspect the internal representation, data type code, byte length, and optional character set of expressions.

### Key capabilities:
- **Oracle Data Type Codes**:
  - `VARCHAR2` / `text`: `Typ=1`
  - `NUMBER` / `numeric` / integer types: `Typ=2`
  - `LONG`: `Typ=8`
  - `DATE` / `oradate`: `Typ=12`
  - `RAW` / `bytea`: `Typ=23`
  - `CHAR` / `bpchar`: `Typ=96`
  - `BINARY_FLOAT`: `Typ=100`
  - `BINARY_DOUBLE`: `Typ=101`
  - `TIMESTAMP`: `Typ=180`
  - `TIMESTAMP WITH TIME ZONE`: `Typ=181`
  - `INTERVAL YEAR TO MONTH`: `Typ=182`
  - `INTERVAL DAY TO SECOND`: `Typ=183`
  - `TIMESTAMP WITH LOCAL TIME ZONE`: `Typ=231`
- **Output Formats (`return_fmt`)**:
  - `8`: Octal notation
  - `10`: Decimal notation (default)
  - `16`: Hexadecimal notation
  - `17`: Character/ASCII notation (printable as ASCII characters, control chars formatted as `^X`, non-printable/high-order in hex)
  - `+1000` (e.g., `1008`, `1010`, `1016`, `1017`): appends `CharacterSet=<encoding>` to output metadata
- **Slicing**:
  - `start_position` (1-based index) and `length` control internal byte slicing and boundary extraction.
- **Oracle-compatible NULL semantics**:
  - `DUMP(NULL)` returns `NULL`.
- **Metadata**:
  - Declared in schema `sys`, labeled `IMMUTABLE` and `PARALLEL SAFE`.

## Test plan

- [x] Run full regression tests covering character, multibyte, numeric, float, date, raw, and null data types (`ora_dump.sql`).
- [x] Verify return format representations: Octal (8), Decimal (10), Hexadecimal (16), Character (17), and CharacterSet (+1000).
- [x] Verify slice boundary behaviors with zero, negative, out-of-range start positions, and excess lengths.
- [x] Verify client error output for invalid `return_fmt` parameters.
- [x] Verify table storage query expressions with DUMP.
- [x] Verify catalog contract for all `sys.dump` overloads.
