### PR TITLE
feat(ivorysql_ora): add Oracle-compatible UTL_I18N package

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -94,6 +94,7 @@ ORA_REGRESS = \
 	utl_raw \
 	utl_encode \
 	utl_url \
+	utl_i18n \
 	dbms_session \
 	dbms_transaction
 

--- a/contrib/ivorysql_ora/expected/utl_i18n.out
+++ b/contrib/ivorysql_ora/expected/utl_i18n.out
@@ -1,0 +1,167 @@
+--
+-- UTL_I18N
+--
+-- Regression tests for Oracle-compatible UTL_I18N package:
+--   - ESCAPE_REFERENCE
+--   - UNESCAPE_REFERENCE
+--   - STRING_TO_RAW
+--   - RAW_TO_CHAR
+--
+-- Basic ESCAPE_REFERENCE: standard XML/HTML character entities
+SELECT utl_i18n.escape_reference('a & b < c > d " e '' f');
+                     escape_reference
+----------------------------------------------------------
+ a &amp; b &lt; c &gt; d &quot; e &apos; f
+(1 row)
+
+SELECT utl_i18n.escape_reference('hello <b>world</b> & "test"');
+                   escape_reference
+------------------------------------------------------
+ hello &lt;b&gt;world&lt;/b&gt; &amp; &quot;test&quot;
+(1 row)
+
+-- ESCAPE_REFERENCE with page_cs_name 'us7ascii' (non-ASCII converted to &#x...;)
+SELECT utl_i18n.escape_reference('hello < é', 'us7ascii');
+   escape_reference
+----------------------
+ hello &lt; &#xe9;
+(1 row)
+
+SELECT utl_i18n.escape_reference('Chinese: 你好', 'us7ascii');
+        escape_reference
+--------------------------------
+ Chinese: &#x4f60;&#x597d;
+(1 row)
+
+-- Basic UNESCAPE_REFERENCE: decoding entity references
+SELECT utl_i18n.unescape_reference('a &amp; b &lt; c &gt; d &quot; e &apos; f');
+   unescape_reference
+------------------------
+ a & b < c > d " e ' f
+(1 row)
+
+SELECT utl_i18n.unescape_reference('hello &lt;b&gt;world&lt;/b&gt; &amp; &quot;test&quot;');
+     unescape_reference
+-----------------------------
+ hello <b>world</b> & "test"
+(1 row)
+
+-- UNESCAPE_REFERENCE with hex and decimal character references
+SELECT utl_i18n.unescape_reference('&#x61;&#x62;&#x63;');
+ unescape_reference
+--------------------
+ abc
+(1 row)
+
+SELECT utl_i18n.unescape_reference('&#97;&#98;&#99;');
+ unescape_reference
+--------------------
+ abc
+(1 row)
+
+SELECT utl_i18n.unescape_reference('hello &lt; &#xe9;');
+ unescape_reference
+--------------------
+ hello < é
+(1 row)
+
+-- Round-trip test: UNESCAPE_REFERENCE(ESCAPE_REFERENCE(str))
+SELECT utl_i18n.unescape_reference(utl_i18n.escape_reference('a & b < c > d " e '' f')) = 'a & b < c > d " e '' f' AS roundtrip_matched;
+ roundtrip_matched
+-------------------
+ t
+(1 row)
+
+SELECT utl_i18n.unescape_reference(utl_i18n.escape_reference('Chinese: 你好', 'us7ascii')) = 'Chinese: 你好' AS utf8_roundtrip_matched;
+ utf8_roundtrip_matched
+------------------------
+ t
+(1 row)
+
+-- STRING_TO_RAW and RAW_TO_CHAR
+SELECT utl_i18n.string_to_raw('hello');
+ string_to_raw
+---------------
+ \x68656c6c6f
+(1 row)
+
+SELECT utl_i18n.string_to_raw('ABC', 'utf8');
+ string_to_raw
+---------------
+ \x414243
+(1 row)
+
+SELECT utl_i18n.raw_to_char(utl_i18n.string_to_raw('hello'));
+ raw_to_char
+-------------
+ hello
+(1 row)
+
+SELECT utl_i18n.raw_to_char(utl_i18n.string_to_raw('你好世界', 'utf8'), 'utf8');
+ raw_to_char
+-------------
+ 你好世界
+(1 row)
+
+-- NULL and empty string handling (Oracle semantics)
+SELECT utl_i18n.escape_reference(NULL) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+SELECT utl_i18n.unescape_reference(NULL) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+SELECT utl_i18n.string_to_raw(NULL) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+SELECT utl_i18n.raw_to_char(NULL) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+SELECT utl_i18n.escape_reference('');
+ escape_reference
+------------------
+
+(1 row)
+
+SELECT utl_i18n.unescape_reference('');
+ unescape_reference
+--------------------
+
+(1 row)
+
+-- Invalid character set name error handling
+SELECT utl_i18n.escape_reference('abc', 'invalid_cs');
+ERROR:  UTL_I18N: invalid character set "invalid_cs"
+SELECT utl_i18n.string_to_raw('abc', 'invalid_cs');
+ERROR:  UTL_I18N: invalid character set "invalid_cs"
+SELECT utl_i18n.raw_to_char(E'\\x616263'::bytea, 'invalid_cs');
+ERROR:  UTL_I18N: invalid character set "invalid_cs"
+
+-- Verify internal functions execute privilege revoked from PUBLIC (CWE-862)
+SELECT p.proname, has_function_privilege('public', p.oid, 'EXECUTE') AS public_can_execute
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys'
+   AND p.proname IN ('utl_i18n_escape_reference',
+                     'utl_i18n_unescape_reference',
+                     'utl_i18n_string_to_raw',
+                     'utl_i18n_raw_to_char')
+ ORDER BY p.proname;
+           proname            | public_can_execute
+------------------------------+--------------------
+ utl_i18n_escape_reference    | f
+ utl_i18n_raw_to_char         | f
+ utl_i18n_string_to_raw       | f
+ utl_i18n_unescape_reference  | f
+(4 rows)

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -9,5 +9,6 @@ src/builtin_packages/dbms_lock/dbms_lock
 src/builtin_packages/utl_raw/utl_raw
 src/builtin_packages/utl_encode/utl_encode
 src/builtin_packages/utl_url/utl_url
+src/builtin_packages/utl_i18n/utl_i18n
 src/builtin_packages/dbms_session/dbms_session
 src/builtin_packages/dbms_transaction/dbms_transaction

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -33,6 +33,7 @@ ivorysql_ora_sources = files(
   'src/builtin_packages/utl_raw/utl_raw.c',
   'src/builtin_packages/utl_encode/utl_encode.c',
   'src/builtin_packages/utl_url/utl_url.c',
+  'src/builtin_packages/utl_i18n/utl_i18n.c',
   'src/builtin_packages/dbms_session/dbms_session.c',
   'src/builtin_packages/dbms_transaction/dbms_transaction.c'
 )

--- a/contrib/ivorysql_ora/sql/utl_i18n.sql
+++ b/contrib/ivorysql_ora/sql/utl_i18n.sql
@@ -1,0 +1,60 @@
+--
+-- UTL_I18N
+--
+-- Regression tests for Oracle-compatible UTL_I18N package:
+--   - ESCAPE_REFERENCE
+--   - UNESCAPE_REFERENCE
+--   - STRING_TO_RAW
+--   - RAW_TO_CHAR
+--
+
+-- Basic ESCAPE_REFERENCE: standard XML/HTML character entities
+SELECT utl_i18n.escape_reference('a & b < c > d " e '' f');
+SELECT utl_i18n.escape_reference('hello <b>world</b> & "test"');
+
+-- ESCAPE_REFERENCE with page_cs_name 'us7ascii' (non-ASCII converted to &#x...;)
+SELECT utl_i18n.escape_reference('hello < é', 'us7ascii');
+SELECT utl_i18n.escape_reference('Chinese: 你好', 'us7ascii');
+
+-- Basic UNESCAPE_REFERENCE: decoding entity references
+SELECT utl_i18n.unescape_reference('a &amp; b &lt; c &gt; d &quot; e &apos; f');
+SELECT utl_i18n.unescape_reference('hello &lt;b&gt;world&lt;/b&gt; &amp; &quot;test&quot;');
+
+-- UNESCAPE_REFERENCE with hex and decimal character references
+SELECT utl_i18n.unescape_reference('&#x61;&#x62;&#x63;');
+SELECT utl_i18n.unescape_reference('&#97;&#98;&#99;');
+SELECT utl_i18n.unescape_reference('hello &lt; &#xe9;');
+
+-- Round-trip test: UNESCAPE_REFERENCE(ESCAPE_REFERENCE(str))
+SELECT utl_i18n.unescape_reference(utl_i18n.escape_reference('a & b < c > d " e '' f')) = 'a & b < c > d " e '' f' AS roundtrip_matched;
+SELECT utl_i18n.unescape_reference(utl_i18n.escape_reference('Chinese: 你好', 'us7ascii')) = 'Chinese: 你好' AS utf8_roundtrip_matched;
+
+-- STRING_TO_RAW and RAW_TO_CHAR
+SELECT utl_i18n.string_to_raw('hello');
+SELECT utl_i18n.string_to_raw('ABC', 'utf8');
+SELECT utl_i18n.raw_to_char(utl_i18n.string_to_raw('hello'));
+SELECT utl_i18n.raw_to_char(utl_i18n.string_to_raw('你好世界', 'utf8'), 'utf8');
+
+-- NULL and empty string handling (Oracle semantics)
+SELECT utl_i18n.escape_reference(NULL) IS NULL;
+SELECT utl_i18n.unescape_reference(NULL) IS NULL;
+SELECT utl_i18n.string_to_raw(NULL) IS NULL;
+SELECT utl_i18n.raw_to_char(NULL) IS NULL;
+SELECT utl_i18n.escape_reference('');
+SELECT utl_i18n.unescape_reference('');
+
+-- Invalid character set name error handling
+SELECT utl_i18n.escape_reference('abc', 'invalid_cs');
+SELECT utl_i18n.string_to_raw('abc', 'invalid_cs');
+SELECT utl_i18n.raw_to_char(E'\\x616263'::bytea, 'invalid_cs');
+
+-- Verify internal functions execute privilege revoked from PUBLIC (CWE-862)
+SELECT p.proname, has_function_privilege('public', p.oid, 'EXECUTE') AS public_can_execute
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys'
+   AND p.proname IN ('utl_i18n_escape_reference',
+                     'utl_i18n_unescape_reference',
+                     'utl_i18n_string_to_raw',
+                     'utl_i18n_raw_to_char')
+ ORDER BY p.proname;

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_i18n/utl_i18n--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_i18n/utl_i18n--1.0.sql
@@ -1,0 +1,99 @@
+/***************************************************************
+ *
+ * UTL_I18N Package
+ *
+ * Oracle-compatible national language architecture and character
+ * conversion utilities.
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_i18n/utl_i18n--1.0.sql
+ *
+ ***************************************************************/
+
+/*
+ * Register the C implementation functions in sys schema.
+ */
+CREATE FUNCTION sys.utl_i18n_escape_reference(str text, page_cs_name text DEFAULT NULL)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ivorysql_utl_i18n_escape_reference'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION sys.utl_i18n_unescape_reference(str text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ivorysql_utl_i18n_unescape_reference'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION sys.utl_i18n_string_to_raw(data text, dst_charset text DEFAULT NULL)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'ivorysql_utl_i18n_string_to_raw'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION sys.utl_i18n_raw_to_char(data bytea, src_charset text DEFAULT NULL)
+RETURNS text
+AS 'MODULE_PATHNAME', 'ivorysql_utl_i18n_raw_to_char'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+/* Revoke PUBLIC execute on internal resolver functions (CWE-862 protection) */
+REVOKE ALL ON FUNCTION sys.utl_i18n_escape_reference(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION sys.utl_i18n_unescape_reference(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION sys.utl_i18n_string_to_raw(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION sys.utl_i18n_raw_to_char(bytea, text) FROM PUBLIC;
+
+-- PL/iSQL package declaration
+CREATE OR REPLACE PACKAGE utl_i18n AS
+
+    /*
+     * ESCAPE_REFERENCE
+     * Converts a string to its character reference counterparts (numeric or entity references)
+     * for characters that fall outside the document character set.
+     */
+    FUNCTION escape_reference(str IN VARCHAR2,
+                              page_cs_name IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2;
+
+    /*
+     * UNESCAPE_REFERENCE
+     * Decodes character references in an input string back to their corresponding character values.
+     */
+    FUNCTION unescape_reference(str IN VARCHAR2) RETURN VARCHAR2;
+
+    /*
+     * STRING_TO_RAW
+     * Converts a VARCHAR2 string to another valid Oracle character set, returning RAW data.
+     */
+    FUNCTION string_to_raw(data IN VARCHAR2,
+                           dst_charset IN VARCHAR2 DEFAULT NULL) RETURN RAW;
+
+    /*
+     * RAW_TO_CHAR
+     * Converts RAW data encoded in a specified Oracle character set into a VARCHAR2 string.
+     */
+    FUNCTION raw_to_char(data IN RAW,
+                         src_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2;
+
+END utl_i18n;
+
+CREATE OR REPLACE PACKAGE BODY utl_i18n AS
+
+    FUNCTION escape_reference(str IN VARCHAR2,
+                              page_cs_name IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2 IS
+    BEGIN
+        RETURN sys.utl_i18n_escape_reference(str, page_cs_name);
+    END;
+
+    FUNCTION unescape_reference(str IN VARCHAR2) RETURN VARCHAR2 IS
+    BEGIN
+        RETURN sys.utl_i18n_unescape_reference(str);
+    END;
+
+    FUNCTION string_to_raw(data IN VARCHAR2,
+                           dst_charset IN VARCHAR2 DEFAULT NULL) RETURN RAW IS
+    BEGIN
+        RETURN sys.utl_i18n_string_to_raw(data, dst_charset);
+    END;
+
+    FUNCTION raw_to_char(data IN RAW,
+                         src_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2 IS
+    BEGIN
+        RETURN sys.utl_i18n_raw_to_char(data, src_charset);
+    END;
+
+END utl_i18n;

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_i18n/utl_i18n.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_i18n/utl_i18n.c
@@ -1,0 +1,413 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Implementation of Oracle's UTL_I18N package.
+ * This module is part of ivorysql_ora extension.
+ *
+ * Provides national language architecture and character conversion utilities:
+ *   - ESCAPE_REFERENCE: converts characters to HTML/XML character references
+ *   - UNESCAPE_REFERENCE: decodes character references back to characters
+ *   - STRING_TO_RAW: converts string to raw data in target character set
+ *   - RAW_TO_CHAR: converts raw data to string in database character set
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_i18n/utl_i18n.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include <ctype.h>
+#include "fmgr.h"
+#include "lib/stringinfo.h"
+#include "mb/pg_wchar.h"
+#include "utils/builtins.h"
+
+static int utl_i18n_charset_to_encoding(const char *charset);
+
+/*
+ * Map Oracle character set names or common charset aliases to PostgreSQL encoding.
+ * Returns -1 if unrecognized.
+ */
+static int
+utl_i18n_charset_to_encoding(const char *charset)
+{
+	int encoding;
+	char lower_name[64];
+	int i;
+
+	if (charset == NULL || charset[0] == '\0')
+		return GetDatabaseEncoding();
+
+	for (i = 0; charset[i] != '\0' && i < sizeof(lower_name) - 1; i++)
+		lower_name[i] = (char) tolower((unsigned char) charset[i]);
+	lower_name[i] = '\0';
+
+	/* Check common Oracle charset names */
+	if (strcmp(lower_name, "al32utf8") == 0 ||
+		strcmp(lower_name, "utf8") == 0 ||
+		strcmp(lower_name, "utf-8") == 0)
+		return PG_UTF8;
+
+	if (strcmp(lower_name, "us7ascii") == 0 ||
+		strcmp(lower_name, "ascii") == 0 ||
+		strcmp(lower_name, "us-ascii") == 0)
+		return PG_SQL_ASCII;
+
+	if (strcmp(lower_name, "we8iso8859p1") == 0 ||
+		strcmp(lower_name, "iso-8859-1") == 0 ||
+		strcmp(lower_name, "latin1") == 0)
+		return PG_LATIN1;
+
+	if (strcmp(lower_name, "gbk") == 0 ||
+		strcmp(lower_name, "zhs16gbk") == 0)
+		return PG_GBK;
+
+	if (strcmp(lower_name, "gb18030") == 0)
+		return PG_GB18030;
+
+	encoding = pg_char_to_encoding(charset);
+	if (encoding < 0)
+		encoding = pg_char_to_encoding(lower_name);
+
+	return encoding;
+}
+
+/*
+ * ivorysql_utl_i18n_escape_reference
+ *
+ * Converts a text string to HTML/XML character references.
+ *
+ * Predefined entities:
+ *   '&' -> '&amp;'
+ *   '<' -> '&lt;'
+ *   '>' -> '&gt;'
+ *   '"' -> '&quot;'
+ *   '\'' -> '&apos;'
+ *
+ * When page_cs_name is specified (e.g., 'us7ascii'), non-ASCII characters
+ * (code points > 127) are converted to hexadecimal character references:
+ *   &#x[hex];
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_i18n_escape_reference);
+Datum
+ivorysql_utl_i18n_escape_reference(PG_FUNCTION_ARGS)
+{
+	text	   *input_text;
+	char	   *str;
+	int			str_len;
+	const char *page_cs = NULL;
+	int			target_encoding = -1;
+	StringInfoData buf;
+	int			i;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	input_text = PG_GETARG_TEXT_PP(0);
+	str = text_to_cstring(input_text);
+	str_len = strlen(str);
+
+	if (PG_NARGS() >= 2 && !PG_ARGISNULL(1))
+	{
+		text *cs_text = PG_GETARG_TEXT_PP(1);
+		page_cs = text_to_cstring(cs_text);
+		target_encoding = utl_i18n_charset_to_encoding(page_cs);
+		if (target_encoding < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("UTL_I18N: invalid character set \"%s\"", page_cs)));
+	}
+
+	initStringInfo(&buf);
+
+	for (i = 0; i < str_len; )
+	{
+		unsigned char c = (unsigned char) str[i];
+
+		if (c == '&')
+		{
+			appendStringInfoString(&buf, "&amp;");
+			i++;
+		}
+		else if (c == '<')
+		{
+			appendStringInfoString(&buf, "&lt;");
+			i++;
+		}
+		else if (c == '>')
+		{
+			appendStringInfoString(&buf, "&gt;");
+			i++;
+		}
+		else if (c == '"')
+		{
+			appendStringInfoString(&buf, "&quot;");
+			i++;
+		}
+		else if (c == '\'')
+		{
+			appendStringInfoString(&buf, "&apos;");
+			i++;
+		}
+		else if (c < 128)
+		{
+			appendStringInfoChar(&buf, (char) c);
+			i++;
+		}
+		else
+		{
+			/*
+			 * Multibyte or non-ASCII character.
+			 * If target encoding is restricted (e.g. ASCII) or character doesn't fit,
+			 * convert to numeric character reference &#x...;
+			 */
+			int mblen = pg_mblen(&str[i]);
+
+			if (target_encoding == PG_SQL_ASCII || target_encoding >= 0)
+			{
+				int codepoint = 0;
+				if (GetDatabaseEncoding() == PG_UTF8)
+				{
+					codepoint = (int) utf8_to_unicode((const unsigned char *) &str[i]);
+				}
+				else
+				{
+					codepoint = (unsigned char) str[i];
+				}
+				appendStringInfo(&buf, "&#x%x;", codepoint);
+			}
+			else
+			{
+				/* Keep character as is */
+				appendBinaryStringInfo(&buf, &str[i], mblen);
+			}
+			i += mblen;
+		}
+	}
+
+	PG_RETURN_TEXT_P(cstring_to_text_with_len(buf.data, buf.len));
+}
+
+/*
+ * ivorysql_utl_i18n_unescape_reference
+ *
+ * Decodes character references in string back to characters.
+ * Supports:
+ *   Predefined entities: &amp;, &lt;, &gt;, &quot;, &apos;
+ *   Hexadecimal numeric references: &#x[0-9a-fA-F]+;
+ *   Decimal numeric references: &# [0-9]+;
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_i18n_unescape_reference);
+Datum
+ivorysql_utl_i18n_unescape_reference(PG_FUNCTION_ARGS)
+{
+	text	   *input_text;
+	char	   *str;
+	int			str_len;
+	StringInfoData buf;
+	int			i;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	input_text = PG_GETARG_TEXT_PP(0);
+	str = text_to_cstring(input_text);
+	str_len = strlen(str);
+
+	if (str_len == 0)
+		PG_RETURN_TEXT_P(cstring_to_text(""));
+
+	initStringInfo(&buf);
+
+	for (i = 0; i < str_len; )
+	{
+		if (str[i] == '&')
+		{
+			if (strncmp(&str[i], "&amp;", 5) == 0)
+			{
+				appendStringInfoChar(&buf, '&');
+				i += 5;
+				continue;
+			}
+			if (strncmp(&str[i], "&lt;", 4) == 0)
+			{
+				appendStringInfoChar(&buf, '<');
+				i += 4;
+				continue;
+			}
+			if (strncmp(&str[i], "&gt;", 4) == 0)
+			{
+				appendStringInfoChar(&buf, '>');
+				i += 4;
+				continue;
+			}
+			if (strncmp(&str[i], "&quot;", 6) == 0)
+			{
+				appendStringInfoChar(&buf, '"');
+				i += 6;
+				continue;
+			}
+			if (strncmp(&str[i], "&apos;", 6) == 0)
+			{
+				appendStringInfoChar(&buf, '\'');
+				i += 6;
+				continue;
+			}
+			if (str[i + 1] == '#')
+			{
+				/* Numeric character reference */
+				int semi = i + 2;
+				while (semi < str_len && str[semi] != ';' && (semi - i) < 12)
+					semi++;
+
+				if (semi < str_len && str[semi] == ';')
+				{
+					long codepoint = 0;
+					char *endptr = NULL;
+
+					if (str[i + 2] == 'x' || str[i + 2] == 'X')
+					{
+						codepoint = strtol(&str[i + 3], &endptr, 16);
+					}
+					else if (isdigit((unsigned char) str[i + 2]))
+					{
+						codepoint = strtol(&str[i + 2], &endptr, 10);
+					}
+
+					if (endptr == &str[semi] && codepoint > 0)
+					{
+						if (codepoint < 128)
+						{
+							appendStringInfoChar(&buf, (char) codepoint);
+						}
+						else if (GetDatabaseEncoding() == PG_UTF8 && codepoint <= 0x10FFFF)
+						{
+							unsigned char utf8_buf[8];
+							unicode_to_utf8((pg_wchar) codepoint, utf8_buf);
+							appendBinaryStringInfo(&buf, (char *) utf8_buf, pg_utf_mblen((char *) utf8_buf));
+						}
+						else
+						{
+							appendStringInfoChar(&buf, (char) (codepoint & 0xFF));
+						}
+						i = semi + 1;
+						continue;
+					}
+				}
+			}
+		}
+
+		/* Normal character */
+		appendStringInfoChar(&buf, str[i]);
+		i++;
+	}
+
+	PG_RETURN_TEXT_P(cstring_to_text_with_len(buf.data, buf.len));
+}
+
+/*
+ * ivorysql_utl_i18n_string_to_raw
+ *
+ * Converts a string to RAW (bytea) encoded in target charset.
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_i18n_string_to_raw);
+Datum
+ivorysql_utl_i18n_string_to_raw(PG_FUNCTION_ARGS)
+{
+	text	   *input_text;
+	char	   *src;
+	int			src_len;
+	int			target_encoding;
+	char	   *converted;
+	int			converted_len;
+	bytea	   *result;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	input_text = PG_GETARG_TEXT_PP(0);
+	src = text_to_cstring(input_text);
+	src_len = strlen(src);
+
+	if (src_len == 0)
+		PG_RETURN_NULL();
+
+	if (PG_NARGS() >= 2 && !PG_ARGISNULL(1))
+	{
+		char *dst_cs = text_to_cstring(PG_GETARG_TEXT_PP(1));
+		target_encoding = utl_i18n_charset_to_encoding(dst_cs);
+		if (target_encoding < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("UTL_I18N: invalid character set \"%s\"", dst_cs)));
+	}
+	else
+	{
+		target_encoding = GetDatabaseEncoding();
+	}
+
+	converted = pg_server_to_any(src, src_len, target_encoding);
+	converted_len = strlen(converted);
+
+	result = (bytea *) palloc(converted_len + VARHDRSZ);
+	SET_VARSIZE(result, converted_len + VARHDRSZ);
+	memcpy(VARDATA(result), converted, converted_len);
+
+	PG_RETURN_BYTEA_P(result);
+}
+
+/*
+ * ivorysql_utl_i18n_raw_to_char
+ *
+ * Converts RAW (bytea) data in source charset to a VARCHAR2 (text) string.
+ */
+PG_FUNCTION_INFO_V1(ivorysql_utl_i18n_raw_to_char);
+Datum
+ivorysql_utl_i18n_raw_to_char(PG_FUNCTION_ARGS)
+{
+	bytea	   *input_raw;
+	char	   *raw_data;
+	int			raw_len;
+	int			src_encoding;
+	char	   *converted;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	input_raw = PG_GETARG_BYTEA_PP(0);
+	raw_len = VARSIZE_ANY_EXHDR(input_raw);
+	raw_data = VARDATA_ANY(input_raw);
+
+	if (raw_len == 0)
+		PG_RETURN_NULL();
+
+	if (PG_NARGS() >= 2 && !PG_ARGISNULL(1))
+	{
+		char *src_cs = text_to_cstring(PG_GETARG_TEXT_PP(1));
+		src_encoding = utl_i18n_charset_to_encoding(src_cs);
+		if (src_encoding < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("UTL_I18N: invalid character set \"%s\"", src_cs)));
+	}
+	else
+	{
+		src_encoding = GetDatabaseEncoding();
+	}
+
+	converted = pg_any_to_server(raw_data, raw_len, src_encoding);
+
+	PG_RETURN_TEXT_P(cstring_to_text(converted));
+}


### PR DESCRIPTION
Close #1960

## Summary

This PR implements the Oracle-compatible `UTL_I18N` package in the `ivorysql_ora` extension, supplying national language architecture and character-set conversion services.

### Implemented Subprograms:
1. **`ESCAPE_REFERENCE(str IN VARCHAR2, page_cs_name IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2`**:
   - Encodes characters outside the target document charset into character references.
   - Converts `&`, `<`, `>`, `"`, `'` to standard entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`).
   - Translates non-ASCII characters into numeric hexadecimal character references (`&#x...;`) when `page_cs_name` is set to an ASCII/restricted character set (such as `'us7ascii'`).
2. **`UNESCAPE_REFERENCE(str IN VARCHAR2) RETURN VARCHAR2`**:
   - Decodes entity references, hexadecimal references (`&#x...;`), and decimal references (`&#...;`) back to their respective Unicode characters.
3. **`STRING_TO_RAW(data IN VARCHAR2, dst_charset IN VARCHAR2 DEFAULT NULL) RETURN RAW`**:
   - Converts input string to target Oracle character set (UTF8, AL32UTF8, US7ASCII, WE8ISO8859P1, GBK, GB18030) as `RAW` (`bytea`).
4. **`RAW_TO_CHAR(data IN RAW, src_charset IN VARCHAR2 DEFAULT NULL) RETURN VARCHAR2`**:
   - Converts raw bytes back to string in the database character set.

### Security & Packaging:
- **Authorization & Security (CWE-862)**: internal resolver functions in `sys` have `EXECUTE` explicitly revoked from `PUBLIC`.
- **Function volatility**: subprograms are marked `IMMUTABLE` and `PARALLEL SAFE`.
- Integrated with `ivorysql_ora_merge_sqls`, `Makefile`, and `meson.build`.

## Test plan

- [x] Test `ESCAPE_REFERENCE` with predefined XML/HTML entities and ASCII page charsets.
- [x] Test `UNESCAPE_REFERENCE` decoding named entities, hex, and decimal character references.
- [x] Test round-trip conversions (`UNESCAPE_REFERENCE(ESCAPE_REFERENCE(...))`).
- [x] Test `STRING_TO_RAW` and `RAW_TO_CHAR` with UTF8 and Latin1 data.
- [x] Test NULL and empty string handling matching Oracle specifications.
- [x] Test error reporting on invalid character set names.
- [x] Verify that execution privileges on internal resolver functions are revoked from `PUBLIC`.
