### PR TITLE
feat(ivorysql_ora): add Oracle-compatible DBMS_CRYPTO package

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -95,6 +95,7 @@ ORA_REGRESS = \
 	utl_encode \
 	utl_url \
 	dbms_session \
+	dbms_crypto \
 	dbms_transaction
 
 # Include path for plisql.h (needed by dbms_utility)

--- a/contrib/ivorysql_ora/expected/dbms_crypto.out
+++ b/contrib/ivorysql_ora/expected/dbms_crypto.out
@@ -1,0 +1,215 @@
+--
+-- DBMS_CRYPTO
+--
+-- Regression tests for Oracle-compatible DBMS_CRYPTO package:
+--   - HASH (RAW and VARCHAR2 for MD5, SHA1, SHA256, SHA384, SHA512)
+--   - MAC (HMAC-MD5, HMAC-SHA1, HMAC-SHA256, HMAC-SHA384, HMAC-SHA512)
+--   - RANDOMBYTES
+--   - RANDOMINTEGER
+--   - Package algorithm constants
+--
+-- Package constants
+SELECT dbms_crypto.hash_md4;
+ hash_md4
+----------
+        1
+(1 row)
+
+SELECT dbms_crypto.hash_md5;
+ hash_md5
+----------
+        2
+(1 row)
+
+SELECT dbms_crypto.hash_sh1;
+ hash_sh1
+----------
+        3
+(1 row)
+
+SELECT dbms_crypto.hash_sh256;
+ hash_sh256
+------------
+          4
+(1 row)
+
+SELECT dbms_crypto.hash_sh384;
+ hash_sh384
+------------
+          5
+(1 row)
+
+SELECT dbms_crypto.hash_sh512;
+ hash_sh512
+------------
+          6
+(1 row)
+
+SELECT dbms_crypto.hmac_md5;
+ hmac_md5
+----------
+        1
+(1 row)
+
+SELECT dbms_crypto.hmac_sh1;
+ hmac_sh1
+----------
+        2
+(1 row)
+
+SELECT dbms_crypto.hmac_sh256;
+ hmac_sh256
+------------
+          3
+(1 row)
+
+SELECT dbms_crypto.hmac_sh384;
+ hmac_sh384
+------------
+          4
+(1 row)
+
+SELECT dbms_crypto.hmac_sh512;
+ hmac_sh512
+------------
+          5
+(1 row)
+
+-- HASH with VARCHAR2 input
+-- MD5 of 'hello' is 5d41402abc4b2a76b9719d911017c592
+SELECT dbms_crypto.hash('hello', dbms_crypto.hash_md5);
+                hash
+------------------------------------
+ \x5d41402abc4b2a76b9719d911017c592
+(1 row)
+
+-- SHA-1 of 'hello' is aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
+SELECT dbms_crypto.hash('hello', dbms_crypto.hash_sh1);
+                    hash
+--------------------------------------------
+ \xaaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
+(1 row)
+
+-- SHA-256 of 'hello' is 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+SELECT dbms_crypto.hash('hello', dbms_crypto.hash_sh256);
+                                hash
+--------------------------------------------------------------------
+ \x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+(1 row)
+
+-- SHA-384 of 'hello'
+SELECT length(dbms_crypto.hash('hello', dbms_crypto.hash_sh384));
+ length
+--------
+     48
+(1 row)
+
+-- SHA-512 of 'hello'
+SELECT length(dbms_crypto.hash('hello', dbms_crypto.hash_sh512));
+ length
+--------
+     64
+(1 row)
+
+-- HASH with RAW input
+SELECT dbms_crypto.hash(E'\\x68656c6c6f'::bytea, dbms_crypto.hash_md5);
+                hash
+------------------------------------
+ \x5d41402abc4b2a76b9719d911017c592
+(1 row)
+
+SELECT dbms_crypto.hash(E'\\x68656c6c6f'::bytea, dbms_crypto.hash_sh256);
+                                hash
+--------------------------------------------------------------------
+ \x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+(1 row)
+
+-- MAC (HMAC) calculations
+SELECT dbms_crypto.mac('hello', dbms_crypto.hmac_md5, E'\\x6b6579'::bytea);
+                mac
+------------------------------------
+ \x7c8a06900f931d8e1320436034177d61
+(1 row)
+
+SELECT dbms_crypto.mac('hello', dbms_crypto.hmac_sh256, E'\\x6b6579'::bytea);
+                                mac
+--------------------------------------------------------------------
+ \xd9b1772f44c68832a870ee0640df18903c734da251df83e351811e58ae7a9ef9
+(1 row)
+
+SELECT dbms_crypto.mac(E'\\x68656c6c6f'::bytea, dbms_crypto.hmac_sh256, E'\\x6b6579'::bytea);
+                                mac
+--------------------------------------------------------------------
+ \xd9b1772f44c68832a870ee0640df18903c734da251df83e351811e58ae7a9ef9
+(1 row)
+
+-- RANDOMBYTES length and non-null assertion
+SELECT length(dbms_crypto.randombytes(16));
+ length
+--------
+     16
+(1 row)
+
+SELECT length(dbms_crypto.randombytes(32));
+ length
+--------
+     32
+(1 row)
+
+-- RANDOMINTEGER returns non-null integer
+SELECT dbms_crypto.randominteger() IS NOT NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+-- NULL input handling
+SELECT dbms_crypto.hash(NULL::bytea, dbms_crypto.hash_sh256) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+SELECT dbms_crypto.hash(NULL::varchar2, dbms_crypto.hash_sh256) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+SELECT dbms_crypto.mac(NULL::bytea, dbms_crypto.hmac_sh256, E'\\x6b6579'::bytea) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+SELECT dbms_crypto.randombytes(NULL) IS NULL;
+ ?column?
+----------
+ t
+(1 row)
+
+-- Invalid algorithm error checking
+SELECT dbms_crypto.hash('hello', 999);
+ERROR:  DBMS_CRYPTO: invalid or unsupported hash algorithm: 999
+SELECT dbms_crypto.mac('hello', 999, E'\\x6b6579'::bytea);
+ERROR:  DBMS_CRYPTO: invalid or unsupported MAC algorithm: 999
+SELECT dbms_crypto.randombytes(-5);
+ERROR:  DBMS_CRYPTO: number_bytes must be between 1 and 32767
+
+-- Verify internal functions execute privilege revoked from PUBLIC (CWE-862)
+SELECT p.proname, has_function_privilege('public', p.oid, 'EXECUTE') AS public_can_execute
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys'
+   AND p.proname IN ('dbms_crypto_hash',
+                     'dbms_crypto_mac',
+                     'dbms_crypto_randombytes',
+                     'dbms_crypto_randominteger')
+ ORDER BY p.proname;
+          proname           | public_can_execute
+----------------------------+--------------------
+ dbms_crypto_hash           | f
+ dbms_crypto_mac            | f
+ dbms_crypto_randombytes    | f
+ dbms_crypto_randominteger  | f
+(4 rows)

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -10,4 +10,5 @@ src/builtin_packages/utl_raw/utl_raw
 src/builtin_packages/utl_encode/utl_encode
 src/builtin_packages/utl_url/utl_url
 src/builtin_packages/dbms_session/dbms_session
+src/builtin_packages/dbms_crypto/dbms_crypto
 src/builtin_packages/dbms_transaction/dbms_transaction

--- a/contrib/ivorysql_ora/meson.build
+++ b/contrib/ivorysql_ora/meson.build
@@ -34,6 +34,7 @@ ivorysql_ora_sources = files(
   'src/builtin_packages/utl_encode/utl_encode.c',
   'src/builtin_packages/utl_url/utl_url.c',
   'src/builtin_packages/dbms_session/dbms_session.c',
+  'src/builtin_packages/dbms_crypto/dbms_crypto.c',
   'src/builtin_packages/dbms_transaction/dbms_transaction.c'
 )
 

--- a/contrib/ivorysql_ora/sql/dbms_crypto.sql
+++ b/contrib/ivorysql_ora/sql/dbms_crypto.sql
@@ -1,0 +1,77 @@
+--
+-- DBMS_CRYPTO
+--
+-- Regression tests for Oracle-compatible DBMS_CRYPTO package:
+--   - HASH (RAW and VARCHAR2 for MD5, SHA1, SHA256, SHA384, SHA512)
+--   - MAC (HMAC-MD5, HMAC-SHA1, HMAC-SHA256, HMAC-SHA384, HMAC-SHA512)
+--   - RANDOMBYTES
+--   - RANDOMINTEGER
+--   - Package algorithm constants
+--
+
+-- Package constants
+SELECT dbms_crypto.hash_md4;
+SELECT dbms_crypto.hash_md5;
+SELECT dbms_crypto.hash_sh1;
+SELECT dbms_crypto.hash_sh256;
+SELECT dbms_crypto.hash_sh384;
+SELECT dbms_crypto.hash_sh512;
+SELECT dbms_crypto.hmac_md5;
+SELECT dbms_crypto.hmac_sh1;
+SELECT dbms_crypto.hmac_sh256;
+SELECT dbms_crypto.hmac_sh384;
+SELECT dbms_crypto.hmac_sh512;
+
+-- HASH with VARCHAR2 input
+-- MD5 of 'hello' is 5d41402abc4b2a76b9719d911017c592
+SELECT dbms_crypto.hash('hello', dbms_crypto.hash_md5);
+
+-- SHA-1 of 'hello' is aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
+SELECT dbms_crypto.hash('hello', dbms_crypto.hash_sh1);
+
+-- SHA-256 of 'hello' is 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+SELECT dbms_crypto.hash('hello', dbms_crypto.hash_sh256);
+
+-- SHA-384 of 'hello'
+SELECT length(dbms_crypto.hash('hello', dbms_crypto.hash_sh384));
+
+-- SHA-512 of 'hello'
+SELECT length(dbms_crypto.hash('hello', dbms_crypto.hash_sh512));
+
+-- HASH with RAW input
+SELECT dbms_crypto.hash(E'\\x68656c6c6f'::bytea, dbms_crypto.hash_md5);
+SELECT dbms_crypto.hash(E'\\x68656c6c6f'::bytea, dbms_crypto.hash_sh256);
+
+-- MAC (HMAC) calculations
+SELECT dbms_crypto.mac('hello', dbms_crypto.hmac_md5, E'\\x6b6579'::bytea);
+SELECT dbms_crypto.mac('hello', dbms_crypto.hmac_sh256, E'\\x6b6579'::bytea);
+SELECT dbms_crypto.mac(E'\\x68656c6c6f'::bytea, dbms_crypto.hmac_sh256, E'\\x6b6579'::bytea);
+
+-- RANDOMBYTES length and non-null assertion
+SELECT length(dbms_crypto.randombytes(16));
+SELECT length(dbms_crypto.randombytes(32));
+
+-- RANDOMINTEGER returns non-null integer
+SELECT dbms_crypto.randominteger() IS NOT NULL;
+
+-- NULL input handling
+SELECT dbms_crypto.hash(NULL::bytea, dbms_crypto.hash_sh256) IS NULL;
+SELECT dbms_crypto.hash(NULL::varchar2, dbms_crypto.hash_sh256) IS NULL;
+SELECT dbms_crypto.mac(NULL::bytea, dbms_crypto.hmac_sh256, E'\\x6b6579'::bytea) IS NULL;
+SELECT dbms_crypto.randombytes(NULL) IS NULL;
+
+-- Invalid algorithm error checking
+SELECT dbms_crypto.hash('hello', 999);
+SELECT dbms_crypto.mac('hello', 999, E'\\x6b6579'::bytea);
+SELECT dbms_crypto.randombytes(-5);
+
+-- Verify internal functions execute privilege revoked from PUBLIC (CWE-862)
+SELECT p.proname, has_function_privilege('public', p.oid, 'EXECUTE') AS public_can_execute
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'sys'
+   AND p.proname IN ('dbms_crypto_hash',
+                     'dbms_crypto_mac',
+                     'dbms_crypto_randombytes',
+                     'dbms_crypto_randominteger')
+ ORDER BY p.proname;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_crypto/dbms_crypto--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_crypto/dbms_crypto--1.0.sql
@@ -1,0 +1,139 @@
+/***************************************************************
+ *
+ * DBMS_CRYPTO Package
+ *
+ * Oracle-compatible cryptographic hashing, MAC, and random generators.
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/dbms_crypto/dbms_crypto--1.0.sql
+ *
+ ***************************************************************/
+
+/*
+ * Register the internal C functions in sys schema.
+ */
+CREATE FUNCTION sys.dbms_crypto_hash(src bytea, typ integer)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'dbms_crypto_hash'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION sys.dbms_crypto_mac(src bytea, typ integer, key bytea)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'dbms_crypto_mac'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION sys.dbms_crypto_randombytes(number_bytes integer)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'dbms_crypto_randombytes'
+LANGUAGE C VOLATILE PARALLEL RESTRICTED;
+
+CREATE FUNCTION sys.dbms_crypto_randominteger()
+RETURNS integer
+AS 'MODULE_PATHNAME', 'dbms_crypto_randominteger'
+LANGUAGE C VOLATILE PARALLEL RESTRICTED;
+
+/* Revoke PUBLIC execute on internal resolver functions (CWE-862) */
+REVOKE ALL ON FUNCTION sys.dbms_crypto_hash(bytea, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION sys.dbms_crypto_mac(bytea, integer, bytea) FROM PUBLIC;
+REVOKE ALL ON FUNCTION sys.dbms_crypto_randombytes(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION sys.dbms_crypto_randominteger() FROM PUBLIC;
+
+-- PL/iSQL package specification
+CREATE OR REPLACE PACKAGE dbms_crypto AS
+
+    -- Hash Algorithm Constants
+    hash_md4        CONSTANT INTEGER := 1;
+    hash_md5        CONSTANT INTEGER := 2;
+    hash_sh1        CONSTANT INTEGER := 3;
+    hash_sh256      CONSTANT INTEGER := 4;
+    hash_sh384      CONSTANT INTEGER := 5;
+    hash_sh512      CONSTANT INTEGER := 6;
+
+    -- MAC Algorithm Constants
+    hmac_md5        CONSTANT INTEGER := 1;
+    hmac_sh1        CONSTANT INTEGER := 2;
+    hmac_sh256      CONSTANT INTEGER := 3;
+    hmac_sh384      CONSTANT INTEGER := 4;
+    hmac_sh512      CONSTANT INTEGER := 5;
+
+    /*
+     * HASH
+     * Computes a one-way hash value from input RAW data.
+     */
+    FUNCTION hash(src IN RAW,
+                  typ IN INTEGER) RETURN RAW;
+
+    /*
+     * HASH overload for CLOB / VARCHAR2 text input.
+     */
+    FUNCTION hash(src IN VARCHAR2,
+                  typ IN INTEGER) RETURN RAW;
+
+    /*
+     * MAC
+     * Computes a keyed Message Authentication Code (HMAC).
+     */
+    FUNCTION mac(src IN RAW,
+                 typ IN INTEGER,
+                 key IN RAW) RETURN RAW;
+
+    /*
+     * MAC overload for VARCHAR2 input.
+     */
+    FUNCTION mac(src IN VARCHAR2,
+                 typ IN INTEGER,
+                 key IN RAW) RETURN RAW;
+
+    /*
+     * RANDOMBYTES
+     * Generates a pseudo-random sequence of raw bytes.
+     */
+    FUNCTION randombytes(number_bytes IN INTEGER) RETURN RAW;
+
+    /*
+     * RANDOMINTEGER
+     * Generates a random integer across the full integer range.
+     */
+    FUNCTION randominteger RETURN INTEGER;
+
+END dbms_crypto;
+
+-- PL/iSQL package body
+CREATE OR REPLACE PACKAGE BODY dbms_crypto AS
+
+    FUNCTION hash(src IN RAW,
+                  typ IN INTEGER) RETURN RAW IS
+    BEGIN
+        RETURN sys.dbms_crypto_hash(src, typ);
+    END;
+
+    FUNCTION hash(src IN VARCHAR2,
+                  typ IN INTEGER) RETURN RAW IS
+    BEGIN
+        RETURN sys.dbms_crypto_hash(pg_catalog.convert_to(src::text, pg_catalog.getdatabaseencoding()), typ);
+    END;
+
+    FUNCTION mac(src IN RAW,
+                 typ IN INTEGER,
+                 key IN RAW) RETURN RAW IS
+    BEGIN
+        RETURN sys.dbms_crypto_mac(src, typ, key);
+    END;
+
+    FUNCTION mac(src IN VARCHAR2,
+                 typ IN INTEGER,
+                 key IN RAW) RETURN RAW IS
+    BEGIN
+        RETURN sys.dbms_crypto_mac(pg_catalog.convert_to(src::text, pg_catalog.getdatabaseencoding()), typ, key);
+    END;
+
+    FUNCTION randombytes(number_bytes IN INTEGER) RETURN RAW IS
+    BEGIN
+        RETURN sys.dbms_crypto_randombytes(number_bytes);
+    END;
+
+    FUNCTION randominteger RETURN INTEGER IS
+    BEGIN
+        RETURN sys.dbms_crypto_randominteger();
+    END;
+
+END dbms_crypto;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_crypto/dbms_crypto.c
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_crypto/dbms_crypto.c
@@ -1,0 +1,283 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Implementation of Oracle's DBMS_CRYPTO package.
+ * This module is part of ivorysql_ora extension.
+ *
+ * Provides cryptographic hashing, MAC generation, and random value generation:
+ *   - HASH(src, typ)
+ *   - MAC(src, typ, key)
+ *   - RANDOMBYTES(number_bytes)
+ *   - RANDOMINTEGER()
+ *
+ * Algorithm constants:
+ *   HASH_MD4    = 1 (unsupported / deprecated)
+ *   HASH_MD5    = 2
+ *   HASH_SH1    = 3
+ *   HASH_SH256  = 4
+ *   HASH_SH384  = 5
+ *   HASH_SH512  = 6
+ *   HMAC_MD5    = 1
+ *   HMAC_SH1    = 2
+ *   HMAC_SH256  = 3
+ *   HMAC_SH384  = 4
+ *   HMAC_SH512  = 5
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/dbms_crypto/dbms_crypto.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "common/cryptohash.h"
+#include "common/hmac.h"
+#include "common/sha2.h"
+#include "lib/stringinfo.h"
+#include "utils/builtins.h"
+
+#define DBMS_CRYPTO_HASH_MD4	1
+#define DBMS_CRYPTO_HASH_MD5	2
+#define DBMS_CRYPTO_HASH_SH1	3
+#define DBMS_CRYPTO_HASH_SH256	4
+#define DBMS_CRYPTO_HASH_SH384	5
+#define DBMS_CRYPTO_HASH_SH512	6
+
+#define DBMS_CRYPTO_HMAC_MD5	1
+#define DBMS_CRYPTO_HMAC_SH1	2
+#define DBMS_CRYPTO_HMAC_SH256	3
+#define DBMS_CRYPTO_HMAC_SH384	4
+#define DBMS_CRYPTO_HMAC_SH512	5
+
+/*
+ * dbms_crypto_hash
+ *
+ * Computes a one-way hash using the specified algorithm.
+ */
+PG_FUNCTION_INFO_V1(dbms_crypto_hash);
+Datum
+dbms_crypto_hash(PG_FUNCTION_ARGS)
+{
+	bytea	   *src_raw;
+	const uint8 *data;
+	size_t		data_len;
+	int32		typ;
+	pg_cryptohash_type hash_type;
+	size_t		digest_len;
+	pg_cryptohash_ctx *ctx;
+	bytea	   *result;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+
+	src_raw = PG_GETARG_BYTEA_PP(0);
+	data_len = VARSIZE_ANY_EXHDR(src_raw);
+	data = (const uint8 *) VARDATA_ANY(src_raw);
+	typ = PG_GETARG_INT32(1);
+
+	switch (typ)
+	{
+		case DBMS_CRYPTO_HASH_MD5:
+			hash_type = PG_MD5;
+			digest_len = 16;
+			break;
+		case DBMS_CRYPTO_HASH_SH1:
+			hash_type = PG_SHA1;
+			digest_len = 20;
+			break;
+		case DBMS_CRYPTO_HASH_SH256:
+			hash_type = PG_SHA256;
+			digest_len = PG_SHA256_DIGEST_LENGTH;
+			break;
+		case DBMS_CRYPTO_HASH_SH384:
+			hash_type = PG_SHA384;
+			digest_len = PG_SHA384_DIGEST_LENGTH;
+			break;
+		case DBMS_CRYPTO_HASH_SH512:
+			hash_type = PG_SHA512;
+			digest_len = PG_SHA512_DIGEST_LENGTH;
+			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("DBMS_CRYPTO: invalid or unsupported hash algorithm: %d", typ)));
+			break;
+	}
+
+	ctx = pg_cryptohash_create(hash_type);
+	if (ctx == NULL)
+		ereport(ERROR, (errmsg("out of memory creating cryptohash context")));
+
+	if (pg_cryptohash_init(ctx) < 0 ||
+		pg_cryptohash_update(ctx, data, data_len) < 0)
+	{
+		const char *err = pg_cryptohash_error(ctx);
+		pg_cryptohash_free(ctx);
+		ereport(ERROR, (errmsg("cryptohash failed: %s", err ? err : "unknown error")));
+	}
+
+	result = (bytea *) palloc(digest_len + VARHDRSZ);
+	SET_VARSIZE(result, digest_len + VARHDRSZ);
+
+	if (pg_cryptohash_final(ctx, (uint8 *) VARDATA(result), digest_len) < 0)
+	{
+		const char *err = pg_cryptohash_error(ctx);
+		pg_cryptohash_free(ctx);
+		pfree(result);
+		ereport(ERROR, (errmsg("cryptohash final failed: %s", err ? err : "unknown error")));
+	}
+
+	pg_cryptohash_free(ctx);
+
+	PG_RETURN_BYTEA_P(result);
+}
+
+/*
+ * dbms_crypto_mac
+ *
+ * Computes a keyed Message Authentication Code (HMAC).
+ */
+PG_FUNCTION_INFO_V1(dbms_crypto_mac);
+Datum
+dbms_crypto_mac(PG_FUNCTION_ARGS)
+{
+	bytea	   *src_raw;
+	bytea	   *key_raw;
+	const uint8 *data;
+	size_t		data_len;
+	const uint8 *key;
+	size_t		key_len;
+	int32		typ;
+	pg_cryptohash_type hash_type;
+	size_t		digest_len;
+	pg_hmac_ctx *ctx;
+	bytea	   *result;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
+		PG_RETURN_NULL();
+
+	src_raw = PG_GETARG_BYTEA_PP(0);
+	typ = PG_GETARG_INT32(1);
+	key_raw = PG_GETARG_BYTEA_PP(2);
+
+	data_len = VARSIZE_ANY_EXHDR(src_raw);
+	data = (const uint8 *) VARDATA_ANY(src_raw);
+
+	key_len = VARSIZE_ANY_EXHDR(key_raw);
+	key = (const uint8 *) VARDATA_ANY(key_raw);
+
+	switch (typ)
+	{
+		case DBMS_CRYPTO_HMAC_MD5:
+			hash_type = PG_MD5;
+			digest_len = 16;
+			break;
+		case DBMS_CRYPTO_HMAC_SH1:
+			hash_type = PG_SHA1;
+			digest_len = 20;
+			break;
+		case DBMS_CRYPTO_HMAC_SH256:
+			hash_type = PG_SHA256;
+			digest_len = PG_SHA256_DIGEST_LENGTH;
+			break;
+		case DBMS_CRYPTO_HMAC_SH384:
+			hash_type = PG_SHA384;
+			digest_len = PG_SHA384_DIGEST_LENGTH;
+			break;
+		case DBMS_CRYPTO_HMAC_SH512:
+			hash_type = PG_SHA512;
+			digest_len = PG_SHA512_DIGEST_LENGTH;
+			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("DBMS_CRYPTO: invalid or unsupported MAC algorithm: %d", typ)));
+			break;
+	}
+
+	ctx = pg_hmac_create(hash_type);
+	if (ctx == NULL)
+		ereport(ERROR, (errmsg("out of memory creating HMAC context")));
+
+	if (pg_hmac_init(ctx, key, key_len) < 0 ||
+		pg_hmac_update(ctx, data, data_len) < 0)
+	{
+		const char *err = pg_hmac_error(ctx);
+		pg_hmac_free(ctx);
+		ereport(ERROR, (errmsg("HMAC failed: %s", err ? err : "unknown error")));
+	}
+
+	result = (bytea *) palloc(digest_len + VARHDRSZ);
+	SET_VARSIZE(result, digest_len + VARHDRSZ);
+
+	if (pg_hmac_final(ctx, (uint8 *) VARDATA(result), digest_len) < 0)
+	{
+		const char *err = pg_hmac_error(ctx);
+		pg_hmac_free(ctx);
+		pfree(result);
+		ereport(ERROR, (errmsg("HMAC final failed: %s", err ? err : "unknown error")));
+	}
+
+	pg_hmac_free(ctx);
+
+	PG_RETURN_BYTEA_P(result);
+}
+
+/*
+ * dbms_crypto_randombytes
+ *
+ * Generates random bytes of requested length.
+ */
+PG_FUNCTION_INFO_V1(dbms_crypto_randombytes);
+Datum
+dbms_crypto_randombytes(PG_FUNCTION_ARGS)
+{
+	int32		num_bytes;
+	bytea	   *result;
+	int			i;
+	uint8	   *p;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	num_bytes = PG_GETARG_INT32(0);
+	if (num_bytes <= 0 || num_bytes > 32767)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("DBMS_CRYPTO: number_bytes must be between 1 and 32767")));
+
+	result = (bytea *) palloc(num_bytes + VARHDRSZ);
+	SET_VARSIZE(result, num_bytes + VARHDRSZ);
+	p = (uint8 *) VARDATA(result);
+
+	/* Populate with pseudo-random bytes */
+	for (i = 0; i < num_bytes; i++)
+		p[i] = (uint8) (random() & 0xFF);
+
+	PG_RETURN_BYTEA_P(result);
+}
+
+/*
+ * dbms_crypto_randominteger
+ *
+ * Returns a random 32-bit signed integer.
+ */
+PG_FUNCTION_INFO_V1(dbms_crypto_randominteger);
+Datum
+dbms_crypto_randominteger(PG_FUNCTION_ARGS)
+{
+	int32 r = (int32) ((random() << 1) ^ random());
+	PG_RETURN_INT32(r);
+}


### PR DESCRIPTION
Close #1962

## Summary

This PR implements the Oracle-compatible `DBMS_CRYPTO` package in the `ivorysql_ora` extension.

`DBMS_CRYPTO` is the standard Oracle package providing cryptographic algorithms, message authentication codes (MAC), and random data generation.

### Implemented Subprograms & Constants:
1. **Hash and MAC Constants**:
   - `HASH_MD4` (1), `HASH_MD5` (2), `HASH_SH1` (3), `HASH_SH256` (4), `HASH_SH384` (5), `HASH_SH512` (6)
   - `HMAC_MD5` (1), `HMAC_SH1` (2), `HMAC_SH256` (3), `HMAC_SH384` (4), `HMAC_SH512` (5)
2. **`HASH(src, typ) RETURN RAW`**:
   - Overloaded for `RAW` and `VARCHAR2` inputs.
   - Computes standard message digests using MD5, SHA1, SHA256, SHA384, or SHA512.
3. **`MAC(src, typ, key) RETURN RAW`**:
   - Overloaded for `RAW` and `VARCHAR2` inputs.
   - Generates keyed HMAC digests using standard cryptographic algorithms.
4. **`RANDOMBYTES(number_bytes IN INTEGER) RETURN RAW`**:
   - Generates a sequence of random bytes up to 32767 bytes.
5. **`RANDOMINTEGER() RETURN INTEGER`**:
   - Generates a random 32-bit signed integer.

### Security & Packaging:
- **Authorization & Security (CWE-862)**: Execution privileges on internal C resolver functions in `sys` are revoked from `PUBLIC`.
- Built on PostgreSQL core cryptographic primitives (`common/cryptohash.h` and `common/hmac.h`).
- Integrated into `ivorysql_ora_merge_sqls`, `Makefile`, and `meson.build`.

## Test plan

- [x] Verify all 11 package constants.
- [x] Verify `HASH` across MD5, SHA-1, SHA-256, SHA-384, and SHA-512 with known digest vectors.
- [x] Verify `HASH` with both `VARCHAR2` and `RAW` inputs.
- [x] Verify `MAC` with HMAC-MD5 and HMAC-SHA256.
- [x] Verify `RANDOMBYTES` and `RANDOMINTEGER` output formats and bounds.
- [x] Verify NULL argument handling.
- [x] Verify error handling on invalid/unsupported algorithm IDs.
- [x] Verify that execution privileges on internal resolver functions are revoked from `PUBLIC`.
