### PR TITLE
feat: add Oracle-compatible EMPTY_CLOB/EMPTY_BLOB constructors

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -80,6 +80,7 @@ ORA_REGRESS = \
 	ora_datetime_datatype_functions \
 	ora_misc_functions \
 	ora_vsize \
+	ora_empty_lob \
 	ora_merge \
 	datatype_and_func_bugs \
 	ora_sysview \

--- a/contrib/ivorysql_ora/expected/ora_empty_lob.out
+++ b/contrib/ivorysql_ora/expected/ora_empty_lob.out
@@ -1,0 +1,95 @@
+--
+-- EMPTY_CLOB / EMPTY_BLOB
+--
+-- Oracle-compatible LOB constructors: return a zero-length, non-NULL LOB
+-- value.  Oracle treats the empty string as NULL, so these constructors are
+-- the only way to initialize a LOB that is not NULL.
+--
+-- Semantics verified against Oracle 23ai Free.
+--
+-- constructors return non-NULL zero-length values
+SELECT empty_clob() IS NULL AS clob_is_null;
+ clob_is_null 
+--------------
+ f
+(1 row)
+
+SELECT empty_blob() IS NULL AS blob_is_null;
+ blob_is_null 
+--------------
+ f
+(1 row)
+
+SELECT length(empty_clob()) AS clob_len;
+ clob_len 
+----------
+        0
+(1 row)
+
+SELECT octet_length(empty_blob()) AS blob_len;
+ blob_len 
+----------
+        0
+(1 row)
+
+-- usable for nclob targets as well
+SELECT length(empty_clob()::nclob) AS nclob_len;
+ nclob_len 
+-----------
+         0
+(1 row)
+
+-- concatenation yields a non-NULL, non-empty value
+SELECT '[' || empty_clob() || ']' AS bracketed;
+ bracketed 
+-----------
+ []
+(1 row)
+
+SELECT length(empty_clob() || 'abc') AS concat_len;
+ concat_len 
+------------
+          3
+(1 row)
+
+-- stored values are not NULL and compare accordingly
+CREATE TABLE lob_empty_test (id int, c clob, nc nclob, b blob);
+INSERT INTO lob_empty_test VALUES (1, empty_clob(), empty_clob(), empty_blob());
+SELECT id, c IS NULL AS c_is_null, nc IS NULL AS nc_is_null, b IS NULL AS b_is_null
+FROM lob_empty_test WHERE id = 1;
+ id | c_is_null | nc_is_null | b_is_null 
+----+-----------+------------+-----------
+  1 | f         | f          | f
+(1 row)
+
+SELECT id, length(c) AS c_len, length(nc) AS nc_len, octet_length(b) AS b_len
+FROM lob_empty_test WHERE id = 1;
+ id | c_len | nc_len | b_len 
+----+-------+--------+-------
+  1 |     0 |      0 |     0
+(1 row)
+
+SELECT count(*) AS not_null_rows FROM lob_empty_test WHERE c IS NOT NULL;
+ not_null_rows 
+---------------
+             1
+(1 row)
+
+-- the plain empty string is NULL, so it does not produce an empty LOB
+INSERT INTO lob_empty_test VALUES (2, '', '', '');
+SELECT id, c IS NULL AS c_is_null FROM lob_empty_test WHERE id = 2;
+ id | c_is_null 
+----+-----------
+  2 | t
+(1 row)
+
+-- assigning the constructor clears the LOB to empty (not NULL)
+UPDATE lob_empty_test SET c = empty_clob() WHERE id = 2;
+SELECT id, c IS NULL AS c_is_null, length(c) AS c_len
+FROM lob_empty_test WHERE id = 2;
+ id | c_is_null | c_len 
+----+-----------+-------
+  2 | f         |     0
+(1 row)
+
+DROP TABLE lob_empty_test;

--- a/contrib/ivorysql_ora/sql/ora_empty_lob.sql
+++ b/contrib/ivorysql_ora/sql/ora_empty_lob.sql
@@ -1,0 +1,45 @@
+--
+-- EMPTY_CLOB / EMPTY_BLOB
+--
+-- Oracle-compatible LOB constructors: return a zero-length, non-NULL LOB
+-- value.  Oracle treats the empty string as NULL, so these constructors are
+-- the only way to initialize a LOB that is not NULL.
+--
+-- Semantics verified against Oracle 23ai Free.
+--
+
+-- constructors return non-NULL zero-length values
+SELECT empty_clob() IS NULL AS clob_is_null;
+SELECT empty_blob() IS NULL AS blob_is_null;
+SELECT length(empty_clob()) AS clob_len;
+SELECT octet_length(empty_blob()) AS blob_len;
+
+-- usable for nclob targets as well
+SELECT length(empty_clob()::nclob) AS nclob_len;
+
+-- concatenation yields a non-NULL, non-empty value
+SELECT '[' || empty_clob() || ']' AS bracketed;
+SELECT length(empty_clob() || 'abc') AS concat_len;
+
+-- stored values are not NULL and compare accordingly
+CREATE TABLE lob_empty_test (id int, c clob, nc nclob, b blob);
+INSERT INTO lob_empty_test VALUES (1, empty_clob(), empty_clob(), empty_blob());
+
+SELECT id, c IS NULL AS c_is_null, nc IS NULL AS nc_is_null, b IS NULL AS b_is_null
+FROM lob_empty_test WHERE id = 1;
+
+SELECT id, length(c) AS c_len, length(nc) AS nc_len, octet_length(b) AS b_len
+FROM lob_empty_test WHERE id = 1;
+
+SELECT count(*) AS not_null_rows FROM lob_empty_test WHERE c IS NOT NULL;
+
+-- the plain empty string is NULL, so it does not produce an empty LOB
+INSERT INTO lob_empty_test VALUES (2, '', '', '');
+SELECT id, c IS NULL AS c_is_null FROM lob_empty_test WHERE id = 2;
+
+-- assigning the constructor clears the LOB to empty (not NULL)
+UPDATE lob_empty_test SET c = empty_clob() WHERE id = 2;
+SELECT id, c IS NULL AS c_is_null, length(c) AS c_len
+FROM lob_empty_test WHERE id = 2;
+
+DROP TABLE lob_empty_test;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1928,3 +1928,29 @@ LANGUAGE C
 STRICT
 IMMUTABLE;
 /* End - VSIZE */
+
+/*
+ * EMPTY_CLOB()/EMPTY_BLOB()
+ *
+ * Oracle-compatible LOB constructors.  Oracle treats the empty string as
+ * NULL, so EMPTY_CLOB()/EMPTY_BLOB() are the only way to initialize a
+ * zero-length LOB that is not NULL.  IvorySQL implements clob/nclob/blob
+ * as domains over text/bytea, so the constructors return a zero-length
+ * base-type value which is not NULL.
+ */
+CREATE FUNCTION sys.empty_clob()
+RETURNS sys.clob
+AS 'MODULE_PATHNAME', 'ora_empty_clob'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+
+CREATE FUNCTION sys.empty_blob()
+RETURNS sys.blob
+AS 'MODULE_PATHNAME', 'ora_empty_blob'
+LANGUAGE C
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
+/* End - EMPTY_CLOB/EMPTY_BLOB */

--- a/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/misc_functions.c
@@ -41,6 +41,8 @@
 PG_FUNCTION_INFO_V1(uid);
 PG_FUNCTION_INFO_V1(stragg_transfn);
 PG_FUNCTION_INFO_V1(ora_vsize);
+PG_FUNCTION_INFO_V1(ora_empty_clob);
+PG_FUNCTION_INFO_V1(ora_empty_blob);
 
 
 /*
@@ -109,6 +111,33 @@ Datum
 uid(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_UINT32(GetUserId());
+}
+
+/*
+ * ora_empty_clob / ora_empty_blob
+ *
+ * Oracle-compatible EMPTY_CLOB()/EMPTY_BLOB() constructors.
+ *
+ * In Oracle an empty string is NULL, so a zero-length LOB can only be
+ * initialized through EMPTY_CLOB()/EMPTY_BLOB(), which return a non-NULL
+ * LOB value of length zero.  IvorySQL implements clob/blob/nclob as
+ * domains over text/bytea, so the constructors return a zero-length
+ * varlena of the base type and let the return-type domain produce
+ * sys.clob/sys.blob values.
+ */
+Datum
+ora_empty_clob(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TEXT_P(cstring_to_text(""));
+}
+
+Datum
+ora_empty_blob(PG_FUNCTION_ARGS)
+{
+	bytea	   *result = (bytea *) palloc(VARHDRSZ);
+
+	SET_VARSIZE(result, VARHDRSZ);
+	PG_RETURN_BYTEA_P(result);
 }
 
 /*


### PR DESCRIPTION
## Source

- Oracle Database 23ai SQL Language Reference, [EMPTY_BLOB, EMPTY_CLOB](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/EMPTY_BLOB-EMPTY_CLOB.html) — the functions this PR implements; the page explicitly states "An empty LOB is not the same as a null LOB".
- EDB Postgres Advanced Server (mature Oracle-compatible PostgreSQL product) ships both functions: [DBMS_LOB / LOB support](https://www.enterprisedb.com/docs/epas/latest/reference/oracle_compatibility_reference/epas_compat_bip_guide/03_built-in_packages/06_dbms_lob/).
- openGauss: its official migration tool [ora2og explicitly maps EMPTY_CLOB()/EMPTY_BLOB()](https://gitee.com/openGauss/openGauss-tools-ora2og/blob/master/changelog) and the [openGauss-server](https://gitee.com/openGauss/openGauss-server) kernel implements them in its Oracle ("A") compatibility mode.
- Feature request filed for this PR: #1886.

## Current gap

`grep -ri "empty_clob\|empty_blob" src/ contrib/` on master (375aa370d72) returns nothing: the two functions do not exist anywhere in the tree. They are not an intentional omission — IvorySQL already ships the `clob`/`nclob`/`blob` types (pg_type.dat, domains over text/bytea) precisely to support Oracle LOB usage, and oracle mode deliberately treats the empty string as NULL (matching Oracle), which makes the constructors the *only* way to initialize a zero-length, non-NULL LOB. No open PR addressed this before this one.

## Project fit

IvorySQL's stated goal is PostgreSQL with Oracle compatibility. The LOB types already exist as first-class types in the `sys` schema, and the project's established pattern for Oracle built-ins is small C functions registered in `sys` (cf. `sys.vsize`, `sys.uid`, `sys.asciistr` in the same `builtin_functions` layer this PR extends). The constructors complete the LOB story that the types started, without touching the core.

## Scope

Two zero-argument functions, `sys.empty_clob()` and `sys.empty_blob()`:

- return a zero-length, **non-NULL** LOB value (`IS NULL` → false; `length()`/`octet_length()` → 0);
- can be stored in `clob`/`nclob`/`blob` columns, after which `IS NULL`/`IS NOT NULL` treat the row as holding an empty LOB — distinct from `''`, which oracle mode stores as NULL;
- work through UPDATE assignment and concatenation (`empty_clob() || 'abc'` → `'abc'`).

Not included: nothing else changes. Oracle's `EMPTY_CLOB()` returns a mutable locator that cannot be passed to DBMS_LOB ("The returned locator cannot be used as a parameter to the DBMS_LOB package" — Oracle doc, same page); IvorySQL's value model has no locators, so there is no locator API to exclude.

## Implementation

- `contrib/ivorysql_ora/src/builtin_functions/misc_functions.c`: `ora_empty_clob` returns a zero-length text varlena (`cstring_to_text("")`), `ora_empty_blob` returns a zero-length bytea varlena. Both are pure value constructors.
- `contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql`: register `sys.empty_clob()` RETURNS `sys.clob` and `sys.empty_blob()` RETURNS `sys.blob` (the unconstrained domains over text/bytea supply the Oracle type names; both are IMMUTABLE/PARALLEL SAFE, matching the `sys.vsize` registration style).

## Tests

All commands run in the WSL build tree (`~/build/src`), Oracle semantics verified against Oracle 23ai Free (gvenzl/oracle-free:23-slim container, sqlplus session recorded in the PR and in issue #1886):

- New regression test `contrib/ivorysql_ora/sql/ora_empty_lob.sql` (+ expected): constructor non-NULLness, zero lengths, `nclob` usage, concatenation, storage into clob/nclob/blob columns, `IS NULL`/`IS NOT NULL` filtering, distinction from the NULL empty string, update-through-constructor.
- Oracle 23ai reference values used: `EMPTY_CLOB() IS NULL` → FALSE; `DBMS_LOB.GETLENGTH(empty_clob())` → 0; stored constructor values in CLOB/NCLOB/BLOB columns → NOT NULL with length 0; `''` → NULL; `LENGTH(empty_clob() || 'abc')` → 3.
- `make oracle-check ORA_REGRESS=ora_empty_lob` → **1/1 pass**.
- `make oracle-check` (full suite) → **29/29 pass** (28 pre-existing + 1 new).

## Compatibility / Risk

- Additive only: two new `sys`-schema functions in oracle mode; no existing function, parser, or core behavior is modified.
- Value-vs-locator difference is documented: Oracle returns a locator (per the doc page above, unusable with DBMS_LOB anyway); IvorySQL returns a value. Observable SQL semantics (non-NULL, length 0, distinct from `''`) match Oracle.
- No new dependencies; no generated/vendor code touched; license-compatible (original implementation).
- psql displays `bytea` as hex (`\x`), so raw-display parity with SQL*Plus is not asserted in tests; `octet_length`/`IS NULL` are used instead.

## Issue

Closes #1886.
