### PR TITLE
feat: add Oracle-compatible BIT_AND_AGG/BIT_OR_AGG/BIT_XOR_AGG aggregates

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -80,6 +80,7 @@ ORA_REGRESS = \
 	ora_datetime_datatype_functions \
 	ora_misc_functions \
 	ora_vsize \
+	ora_bit_agg \
 	ora_merge \
 	datatype_and_func_bugs \
 	ora_sysview \

--- a/contrib/ivorysql_ora/expected/ora_bit_agg.out
+++ b/contrib/ivorysql_ora/expected/ora_bit_agg.out
@@ -1,0 +1,122 @@
+--
+-- BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG
+--
+-- Oracle-compatible bitwise aggregates (Oracle 21c+).  Operate on the
+-- two's-complement representation of the argument, truncate fractional
+-- input toward zero, ignore NULL inputs, and return 0 (not NULL) over no
+-- non-NULL input.  Return type is always number.
+--
+-- Every expected value below was verified against Oracle 23ai Free.
+--
+CREATE TABLE bit_agg_test (g int, v int);
+INSERT INTO bit_agg_test VALUES (1, 6);
+INSERT INTO bit_agg_test VALUES (1, 3);
+INSERT INTO bit_agg_test VALUES (1, NULL);
+INSERT INTO bit_agg_test VALUES (2, 7);
+INSERT INTO bit_agg_test VALUES (2, 14);
+-- basic aggregation, NULL ignored (Oracle: 2/7/5 and 6/15/9)
+SELECT g, bit_and_agg(v) AS a, bit_or_agg(v) AS o, bit_xor_agg(v) AS x
+FROM bit_agg_test GROUP BY g ORDER BY g;
+ g | a | o  | x 
+---+---+----+---
+ 1 | 2 | 7  | 5
+ 2 | 6 | 15 | 9
+(2 rows)
+
+-- single values pass through
+SELECT bit_and_agg(6) AS a, bit_or_agg(3) AS o, bit_xor_agg(3) AS x;
+ a | o | x 
+---+---+---
+ 6 | 3 | 3
+(1 row)
+
+-- no non-NULL input yields 0 (Oracle returns 0, not NULL)
+SELECT bit_and_agg(v) AS a, bit_or_agg(v) AS o, bit_xor_agg(v) AS x
+FROM bit_agg_test WHERE g > 99;
+ a | o | x 
+---+---+---
+ 0 | 0 | 0
+(1 row)
+
+SELECT bit_and_agg(NULL) AS a, bit_or_agg(NULL) AS o, bit_xor_agg(NULL) AS x;
+ a | o | x 
+---+---+---
+ 0 | 0 | 0
+(1 row)
+
+-- fractional input is truncated toward zero (Oracle: 2 / 3 / -2 / -2 / 2)
+SELECT bit_and_agg(2.7) AS a, bit_and_agg(3.1) AS b, bit_and_agg(-2.5) AS c,
+       bit_and_agg(-2.7) AS d, bit_or_agg(2.7) AS e;
+ a | b | c  | d  | e 
+---+---+----+----+---
+ 2 | 3 | -2 | -2 | 2
+(1 row)
+
+-- negative values follow two's-complement semantics (Oracle: 6 / -10 / -16)
+SELECT bit_and_agg(v) AS a, bit_or_agg(v) AS o, bit_xor_agg(v) AS x
+FROM (SELECT -10 AS v UNION ALL SELECT 6) t;
+ a |  o  |  x  
+---+-----+-----
+ 6 | -10 | -16
+(1 row)
+
+-- DISTINCT is supported (Oracle: 7)
+SELECT bit_or_agg(DISTINCT v) AS o FROM bit_agg_test WHERE g = 1;
+ o 
+---
+ 7
+(1 row)
+
+-- window usage (Oracle: 6 for both rows of g = 2)
+SELECT v, bit_and_agg(v) OVER (PARTITION BY g) AS a
+FROM bit_agg_test WHERE g = 2 ORDER BY v;
+ v  | a 
+----+---
+  7 | 6
+ 14 | 6
+(2 rows)
+
+-- values beyond 64 bits are exact (Oracle: 2^100 + 5)
+SELECT to_char(bit_or_agg(v)) AS large_or
+FROM (SELECT 1267650600228229401496703205376::number AS v
+      UNION ALL SELECT 5) t;
+            large_or             
+---------------------------------
+ 1267650600228229401496703205381
+(1 row)
+
+-- large pairwise AND (Oracle: 2^100 + 1)
+SELECT to_char(bit_and_agg(v)) AS large_and
+FROM (SELECT 1267650600228229401496703205379::number AS v
+      UNION ALL SELECT 1267650600228229401496703205377::number) t;
+            large_and            
+---------------------------------
+ 1267650600228229401496703205377
+(1 row)
+
+-- large negative mixed-sign results (Oracle: 2^100 / -2^100 / -2^101)
+SELECT to_char(bit_and_agg(v)) AS a, to_char(bit_or_agg(v)) AS o, to_char(bit_xor_agg(v)) AS x
+FROM (SELECT -1267650600228229401496703205376::number AS v
+      UNION ALL SELECT 1267650600228229401496703205376::number) t;
+                a                |                o                 |                x                 
+---------------------------------+----------------------------------+----------------------------------
+ 1267650600228229401496703205376 | -1267650600228229401496703205376 | -2535301200456458802993406410752
+(1 row)
+
+-- number(38) boundary values stay exact (2^126 | 2^125, 2^126 ^ 2^125)
+SELECT to_char(bit_or_agg(v)) AS o, to_char(bit_xor_agg(v)) AS x
+FROM (SELECT 85070591730234615865843651857942052864::number AS v
+      UNION ALL SELECT 42535295865117307932921825928971026432::number) t;
+                    o                    |                    x                    
+-----------------------------------------+-----------------------------------------
+ 127605887595351923798765477786913079296 | 127605887595351923798765477786913079296
+(1 row)
+
+-- implicit conversion from text input (Oracle: 6)
+SELECT bit_and_agg('6') AS a;
+ a 
+---
+ 6
+(1 row)
+
+DROP TABLE bit_agg_test;

--- a/contrib/ivorysql_ora/sql/ora_bit_agg.sql
+++ b/contrib/ivorysql_ora/sql/ora_bit_agg.sql
@@ -1,0 +1,69 @@
+--
+-- BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG
+--
+-- Oracle-compatible bitwise aggregates (Oracle 21c+).  Operate on the
+-- two's-complement representation of the argument, truncate fractional
+-- input toward zero, ignore NULL inputs, and return 0 (not NULL) over no
+-- non-NULL input.  Return type is always number.
+--
+-- Every expected value below was verified against Oracle 23ai Free.
+--
+
+CREATE TABLE bit_agg_test (g int, v int);
+INSERT INTO bit_agg_test VALUES (1, 6);
+INSERT INTO bit_agg_test VALUES (1, 3);
+INSERT INTO bit_agg_test VALUES (1, NULL);
+INSERT INTO bit_agg_test VALUES (2, 7);
+INSERT INTO bit_agg_test VALUES (2, 14);
+
+-- basic aggregation, NULL ignored (Oracle: 2/7/5 and 6/15/9)
+SELECT g, bit_and_agg(v) AS a, bit_or_agg(v) AS o, bit_xor_agg(v) AS x
+FROM bit_agg_test GROUP BY g ORDER BY g;
+
+-- single values pass through
+SELECT bit_and_agg(6) AS a, bit_or_agg(3) AS o, bit_xor_agg(3) AS x;
+
+-- no non-NULL input yields 0 (Oracle returns 0, not NULL)
+SELECT bit_and_agg(v) AS a, bit_or_agg(v) AS o, bit_xor_agg(v) AS x
+FROM bit_agg_test WHERE g > 99;
+SELECT bit_and_agg(NULL) AS a, bit_or_agg(NULL) AS o, bit_xor_agg(NULL) AS x;
+
+-- fractional input is truncated toward zero (Oracle: 2 / 3 / -2 / -2 / 2)
+SELECT bit_and_agg(2.7) AS a, bit_and_agg(3.1) AS b, bit_and_agg(-2.5) AS c,
+       bit_and_agg(-2.7) AS d, bit_or_agg(2.7) AS e;
+
+-- negative values follow two's-complement semantics (Oracle: 6 / -10 / -16)
+SELECT bit_and_agg(v) AS a, bit_or_agg(v) AS o, bit_xor_agg(v) AS x
+FROM (SELECT -10 AS v UNION ALL SELECT 6) t;
+
+-- DISTINCT is supported (Oracle: 7)
+SELECT bit_or_agg(DISTINCT v) AS o FROM bit_agg_test WHERE g = 1;
+
+-- window usage (Oracle: 6 for both rows of g = 2)
+SELECT v, bit_and_agg(v) OVER (PARTITION BY g) AS a
+FROM bit_agg_test WHERE g = 2 ORDER BY v;
+
+-- values beyond 64 bits are exact (Oracle: 2^100 + 5)
+SELECT to_char(bit_or_agg(v)) AS large_or
+FROM (SELECT 1267650600228229401496703205376::number AS v
+      UNION ALL SELECT 5) t;
+
+-- large pairwise AND (Oracle: 2^100 + 1)
+SELECT to_char(bit_and_agg(v)) AS large_and
+FROM (SELECT 1267650600228229401496703205379::number AS v
+      UNION ALL SELECT 1267650600228229401496703205377::number) t;
+
+-- large negative mixed-sign results (Oracle: 2^100 / -2^100 / -2^101)
+SELECT to_char(bit_and_agg(v)) AS a, to_char(bit_or_agg(v)) AS o, to_char(bit_xor_agg(v)) AS x
+FROM (SELECT -1267650600228229401496703205376::number AS v
+      UNION ALL SELECT 1267650600228229401496703205376::number) t;
+
+-- number(38) boundary values stay exact (2^126 | 2^125, 2^126 ^ 2^125)
+SELECT to_char(bit_or_agg(v)) AS o, to_char(bit_xor_agg(v)) AS x
+FROM (SELECT 85070591730234615865843651857942052864::number AS v
+      UNION ALL SELECT 42535295865117307932921825928971026432::number) t;
+
+-- implicit conversion from text input (Oracle: 6)
+SELECT bit_and_agg('6') AS a;
+
+DROP TABLE bit_agg_test;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1183,6 +1183,78 @@ STRICT
 PARALLEL SAFE
 IMMUTABLE;
 
+/*
+ * BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG
+ *
+ * Oracle-compatible bitwise aggregates (Oracle 21c+).  They operate on the
+ * two's-complement representation of the argument, truncate fractional
+ * input toward zero, ignore NULL inputs, and return 0 (not NULL) when no
+ * non-NULL value was aggregated.  The return type is always number.
+ */
+CREATE FUNCTION sys.bit_and_agg_transfn(internal, number)
+RETURNS internal
+AS 'MODULE_PATHNAME', 'bit_and_agg_transfn'
+LANGUAGE C
+IMMUTABLE
+PARALLEL SAFE;
+
+CREATE FUNCTION sys.bit_or_agg_transfn(internal, number)
+RETURNS internal
+AS 'MODULE_PATHNAME', 'bit_or_agg_transfn'
+LANGUAGE C
+IMMUTABLE
+PARALLEL SAFE;
+
+CREATE FUNCTION sys.bit_xor_agg_transfn(internal, number)
+RETURNS internal
+AS 'MODULE_PATHNAME', 'bit_xor_agg_transfn'
+LANGUAGE C
+IMMUTABLE
+PARALLEL SAFE;
+
+CREATE FUNCTION sys.bit_and_agg_finalfn(internal)
+RETURNS number
+AS 'MODULE_PATHNAME', 'bit_and_agg_finalfn'
+LANGUAGE C
+IMMUTABLE
+PARALLEL SAFE;
+
+CREATE FUNCTION sys.bit_or_agg_finalfn(internal)
+RETURNS number
+AS 'MODULE_PATHNAME', 'bit_or_agg_finalfn'
+LANGUAGE C
+IMMUTABLE
+PARALLEL SAFE;
+
+CREATE FUNCTION sys.bit_xor_agg_finalfn(internal)
+RETURNS number
+AS 'MODULE_PATHNAME', 'bit_xor_agg_finalfn'
+LANGUAGE C
+IMMUTABLE
+PARALLEL SAFE;
+
+CREATE AGGREGATE sys.bit_and_agg(number) (
+	SFUNC = sys.bit_and_agg_transfn,
+	STYPE = internal,
+	FINALFUNC = sys.bit_and_agg_finalfn,
+	PARALLEL = SAFE
+);
+
+CREATE AGGREGATE sys.bit_or_agg(number) (
+	SFUNC = sys.bit_or_agg_transfn,
+	STYPE = internal,
+	FINALFUNC = sys.bit_or_agg_finalfn,
+	PARALLEL = SAFE
+);
+
+CREATE AGGREGATE sys.bit_xor_agg(number) (
+	SFUNC = sys.bit_xor_agg_transfn,
+	STYPE = internal,
+	FINALFUNC = sys.bit_xor_agg_finalfn,
+	PARALLEL = SAFE
+);
+/* End - BIT_AND_AGG/BIT_OR_AGG/BIT_XOR_AGG */
+
 CREATE FUNCTION sys.nanvl(number, number)
 RETURNS number
 AS 'MODULE_PATHNAME','number_nanvl'

--- a/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
@@ -47,6 +47,195 @@ PG_FUNCTION_INFO_V1(binary_float_nanvl);
 PG_FUNCTION_INFO_V1(binary_double_nanvl);
 PG_FUNCTION_INFO_V1(ora_to_binary_float);
 PG_FUNCTION_INFO_V1(ora_to_binary_double);
+PG_FUNCTION_INFO_V1(bit_and_agg_transfn);
+PG_FUNCTION_INFO_V1(bit_or_agg_transfn);
+PG_FUNCTION_INFO_V1(bit_xor_agg_transfn);
+PG_FUNCTION_INFO_V1(bit_and_agg_finalfn);
+PG_FUNCTION_INFO_V1(bit_or_agg_finalfn);
+PG_FUNCTION_INFO_V1(bit_xor_agg_finalfn);
+
+
+/*
+ * Oracle-compatible BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG aggregates.
+ *
+ * Oracle operates on the two's-complement representation of the argument,
+ * truncating fractional input toward zero.  On Oracle 23ai the accumulator
+ * behaves as a 128-bit two's-complement integer: values within the 128-bit
+ * range are exact (including negative operands), inputs beyond it wrap, and
+ * an aggregate over no non-NULL input yields 0 (not NULL).  NULL inputs are
+ * ignored, the return type is always NUMBER, and DISTINCT / window usage
+ * follow from the regular PostgreSQL aggregate machinery.
+ *
+ * The accumulator is kept as an unsigned 128-bit value so that both the
+ * digit accumulation of out-of-range inputs and the two's-complement
+ * negation wrap naturally.  On platforms without a 128-bit integer type the
+ * accumulator degrades to 64 bits.
+ */
+#ifdef HAVE_INT128
+typedef unsigned __int128 ora_uint128;
+#else
+typedef uint64 ora_uint128;
+#endif
+
+typedef struct BitAggState
+{
+	ora_uint128 bits;			/* two's-complement accumulator */
+	bool		have_input;		/* seen at least one non-NULL input */
+} BitAggState;
+
+/*
+ * Convert a NUMBER to its two's-complement bit pattern.  Fractional values
+ * are truncated toward zero (Oracle: BIT_AND_AGG(2.7) = 2, (-2.5) = -2).
+ */
+static ora_uint128
+numeric_two_complement_bits(Numeric num)
+{
+	char	   *str = DatumGetCString(DirectFunctionCall1(numeric_out,
+														   NumericGetDatum(num)));
+	const char *s = str;
+	bool		neg = false;
+	ora_uint128 acc = 0;
+
+	if (*s == '-')
+	{
+		neg = true;
+		s++;
+	}
+	else if (*s == '+')
+		s++;
+
+	/* integer digits only; stops at '.' or the end of the decimal string */
+	for (; *s >= '0' && *s <= '9'; s++)
+		acc = acc * (ora_uint128) 10 + (ora_uint128) (*s - '0');
+
+	pfree(str);
+
+	/* negation in two's complement wraps modulo 2^(8*sizeof(ora_uint128)) */
+	return neg ? (ora_uint128) 0 - acc : acc;
+}
+
+/* Convert the accumulator's two's-complement bits back to a NUMBER. */
+static Numeric
+bits_to_numeric(ora_uint128 bits)
+{
+	char		buf[64];
+	char	   *p = buf + sizeof(buf) - 1;
+	bool		neg = ((bits >> (sizeof(ora_uint128) * 8 - 1)) != 0);
+	ora_uint128 mag;
+
+	*p = '\0';
+	mag = neg ? (ora_uint128) 0 - bits : bits;
+	do
+	{
+		*--p = '0' + (char) (mag % (ora_uint128) 10);
+		mag /= (ora_uint128) 10;
+	} while (mag != 0);
+	if (neg)
+		*--p = '-';
+
+	return DatumGetNumeric(DirectFunctionCall3(numeric_in,
+											   CStringGetDatum(p),
+											   ObjectIdGetDatum(InvalidOid),
+											   Int32GetDatum(-1)));
+}
+
+static Datum
+bit_agg_transfn(PG_FUNCTION_ARGS, ora_uint128 seed, ora_uint128 (*op) (ora_uint128, ora_uint128))
+{
+	MemoryContext aggcontext;
+	BitAggState *state;
+
+	if (!AggCheckCallContext(fcinfo, &aggcontext))
+		elog(ERROR, "bit agg transition function called in non-aggregate context");
+
+	if (PG_ARGISNULL(0))
+	{
+		MemoryContext oldcontext = MemoryContextSwitchTo(aggcontext);
+
+		state = (BitAggState *) palloc(sizeof(BitAggState));
+		state->bits = seed;
+		state->have_input = false;
+		MemoryContextSwitchTo(oldcontext);
+	}
+	else
+		state = (BitAggState *) PG_GETARG_POINTER(0);
+
+	if (!PG_ARGISNULL(1))
+	{
+		Numeric		num = PG_GETARG_NUMERIC(1);
+
+		state->bits = op(state->bits, numeric_two_complement_bits(num));
+		state->have_input = true;
+	}
+
+	PG_RETURN_POINTER(state);
+}
+
+static ora_uint128
+bit_op_and(ora_uint128 a, ora_uint128 b)
+{
+	return a & b;
+}
+
+static ora_uint128
+bit_op_or(ora_uint128 a, ora_uint128 b)
+{
+	return a | b;
+}
+
+static ora_uint128
+bit_op_xor(ora_uint128 a, ora_uint128 b)
+{
+	return a ^ b;
+}
+
+static Datum
+bit_agg_finalfn_int(PG_FUNCTION_ARGS)
+{
+	BitAggState *state = PG_ARGISNULL(0) ? NULL : (BitAggState *) PG_GETARG_POINTER(0);
+
+	/* Oracle yields 0 (not NULL) when no non-NULL input was aggregated */
+	if (state == NULL || !state->have_input)
+		return PointerGetDatum(bits_to_numeric(0));
+
+	PG_RETURN_NUMERIC(bits_to_numeric(state->bits));
+}
+
+Datum
+bit_and_agg_transfn(PG_FUNCTION_ARGS)
+{
+	return bit_agg_transfn(fcinfo, ~(ora_uint128) 0, bit_op_and);
+}
+
+Datum
+bit_or_agg_transfn(PG_FUNCTION_ARGS)
+{
+	return bit_agg_transfn(fcinfo, (ora_uint128) 0, bit_op_or);
+}
+
+Datum
+bit_xor_agg_transfn(PG_FUNCTION_ARGS)
+{
+	return bit_agg_transfn(fcinfo, (ora_uint128) 0, bit_op_xor);
+}
+
+Datum
+bit_and_agg_finalfn(PG_FUNCTION_ARGS)
+{
+	return bit_agg_finalfn_int(fcinfo);
+}
+
+Datum
+bit_or_agg_finalfn(PG_FUNCTION_ARGS)
+{
+	return bit_agg_finalfn_int(fcinfo);
+}
+
+Datum
+bit_xor_agg_finalfn(PG_FUNCTION_ARGS)
+{
+	return bit_agg_finalfn_int(fcinfo);
+}
 
 
 Datum


### PR DESCRIPTION
## Problem / Evidence

The collaborator-filed feature requests #1734, #1735 and #1736 ask for the Oracle 21c+ bitwise aggregates `BIT_AND_AGG`, `BIT_OR_AGG` and `BIT_XOR_AGG`. None of the three exists in IvorySQL today (no match anywhere in `src/` or `contrib/`), and no open PR addresses them.

External reference: Oracle Database 23ai SQL Language Reference, BIT_AND_AGG / BIT_OR_AGG / BIT_XOR_AGG (https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/BIT_AND_AGG.html). The three issues are part of the repo's collaborator-driven `oracle compatibility feature:` series, so this is an explicit in-repo requirement, not a model-invented feature.

## Oracle verification (23ai Free, gvenzl/oracle-free:23-slim)

Every expected value in the new regression test was checked on the real database, at full precision via `TO_CHAR` where display rounding would hide digits:

```
SQL> -- NULLs ignored, group aggregation
SQL> SELECT g, BIT_AND_AGG(v), BIT_OR_AGG(v), BIT_XOR_AGG(v) FROM bit_agg_t GROUP BY g ORDER BY g;
         1          2          7          5
         2          6         15          9
SQL> -- empty input / all-NULL input return 0, not NULL
SQL> SELECT BIT_AND_AGG(NULL), BIT_OR_AGG(NULL), BIT_XOR_AGG(NULL) FROM dual;
         0          0          0
SQL> -- fractional input is truncated toward zero
SQL> SELECT BIT_AND_AGG(2.7), BIT_AND_AGG(3.1), BIT_AND_AGG(-2.5), BIT_AND_AGG(-2.7), BIT_OR_AGG(2.7) FROM dual;
         2          3         -2         -2          2
SQL> -- two's-complement semantics for negatives
SQL> SELECT BIT_AND_AGG(v), BIT_OR_AGG(v), BIT_XOR_AGG(v) FROM (SELECT -10 v FROM dual UNION ALL SELECT 6 FROM dual);
         6        -10        -16
SQL> -- values beyond 64 bits are exact
SQL> SELECT TO_CHAR(BIT_AND_AGG(v)) FROM (SELECT 1267650600228229401496703205379 v FROM dual UNION ALL SELECT 1267650600228229401496703205377 FROM dual);
1267650600228229401496703205377
SQL> SELECT TO_CHAR(BIT_AND_AGG(v)), TO_CHAR(BIT_OR_AGG(v)), TO_CHAR(BIT_XOR_AGG(v)) FROM (SELECT -1267650600228229401496703205376 v FROM dual UNION ALL SELECT 1267650600228229401496703205376 FROM dual);
1267650600228229401496703205376  -1267650600228229401496703205376  -2535301200456458802993406410752
SQL> -- DISTINCT and window usage
SQL> SELECT BIT_OR_AGG(DISTINCT v) ... → 7
```

## Implementation

- `contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c`: three aggregates sharing one transition helper over a 128-bit two's-complement accumulator (`unsigned __int128`; falls back to 64 bits on platforms without `HAVE_INT128`). Input conversion parses the numeric's decimal digits (truncating fractions toward zero) into the accumulator; the final function converts the accumulator back through `numeric_in`, so the return type is always `number`.
- `contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql`: register the transition/final functions and the three `sys.bit_*_agg(number)` aggregates (`STYPE = internal`, `PARALLEL = SAFE`).

`DISTINCT` and `OVER (PARTITION BY ...)` work through PostgreSQL's regular aggregate machinery, matching Oracle. Differences from Oracle: for inputs beyond the 128-bit range (i.e., unscaled `NUMBER` far outside the number(38) integer range, |v| ≥ 2^127) IvorySQL wraps modulo 2^128 where Oracle 23ai returns an internal conversion artifact (three distinct inputs such as 1E64, 1E100 and 2^127 all produce the same spurious value 140727893917664). Every value within the number(38) integer range — which covers all realistic bitwise-aggregate data — is reproduced exactly.

## Priority / scoring

FEATURE_PRIORITY 86 = 项目需求 34 (three collaborator-filed feature issues #1734/#1735/#1736) + 外部实现成熟度 24 (documented Oracle 21c+ built-ins) + 项目契合度 18 (plain PostgreSQL aggregates in the existing builtin-function layer, no new dependency) + 可测试性 10 (deterministic, Oracle-verified values). IMPLEMENTATION_CONFIDENCE 88 (self-contained aggregate implementation; semantics fully mapped on a real Oracle instance).

## Tests

- New regression test `contrib/ivorysql_ora/sql/ora_bit_agg.sql` (+ expected): group aggregation, NULL handling, empty-set 0, fractional truncation, negative two's-complement results, DISTINCT, window usage, 2^100/2^126-scale exactness (all values Oracle-verified at full precision), and text-input implicit conversion.
- `make oracle-check ORA_REGRESS=ora_bit_agg` → 1/1 pass.
- `make oracle-check` (full suite) → **29/29 pass**.

## Risk

Low: three new aggregates in the `sys` schema of oracle mode; no core-code changes. The only behavioral corner that differs from Oracle (inputs at or beyond 2^127) is documented above and unreachable for number(38) data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Oracle-compatible `BIT_AND_AGG`, `BIT_OR_AGG`, and `BIT_XOR_AGG` aggregate functions for numeric values.
  * Supports NULL handling, empty inputs, fractional values, negative numbers, `DISTINCT`, window usage, large numeric values, and implicit text conversion.

* **Tests**
  * Added regression coverage validating aggregate behavior, boundary values, and Oracle-compatible results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->