### PR TITLE
feat: add Oracle-compatible DBMS_LOB package

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -95,7 +95,8 @@ ORA_REGRESS = \
 	utl_encode \
 	utl_url \
 	dbms_session \
-	dbms_transaction
+	dbms_transaction \
+	dbms_lob
 
 # Include path for plisql.h (needed by dbms_utility)
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plisql/src

--- a/contrib/ivorysql_ora/expected/dbms_lob.out
+++ b/contrib/ivorysql_ora/expected/dbms_lob.out
@@ -1,0 +1,391 @@
+--
+-- Tests for DBMS_LOB package
+--
+-- Every expected value was verified against Oracle 23ai Free.  IvorySQL
+-- models clob/nclob/blob as value types (domains over text/bytea), so the
+-- locator-restricted error paths of Oracle (ORA-22275 for uninitialized
+-- locators) do not apply; documented deviations are exercised explicitly.
+--
+-- =============================================================================
+-- GETLENGTH
+-- =============================================================================
+SELECT dbms_lob.getlength('abcde'::clob) AS gl_text;
+ gl_text 
+---------
+ 5
+(1 row)
+
+SELECT dbms_lob.getlength('你好'::clob) AS gl_chars;
+ gl_chars 
+----------
+ 2
+(1 row)
+
+SELECT dbms_lob.getlength(NULL::clob) AS gl_null;
+ gl_null 
+---------
+ 
+(1 row)
+
+SELECT dbms_lob.getlength(hextoraw('aabbccddee')::blob) AS gl_blob;
+ gl_blob 
+---------
+ 5
+(1 row)
+
+SELECT dbms_lob.getlength(NULL::blob) AS gl_blob_null;
+ gl_blob_null 
+--------------
+ 
+(1 row)
+
+-- nclob values resolve to the text-family overload
+DECLARE
+    x nclob := 'abcd';
+BEGIN
+    RAISE NOTICE 'GL nclob: %', dbms_lob.getlength(x);
+END;
+/
+NOTICE:  GL nclob: 4
+-- =============================================================================
+-- SUBSTR (amount first, offset second; opposite order of SQL SUBSTR)
+-- =============================================================================
+SELECT dbms_lob.substr('abcde'::clob, 3, 2) AS s_basic;
+ s_basic 
+---------
+ bcd
+(1 row)
+
+SELECT dbms_lob.substr('abcde'::clob, 100, 4) AS s_clamped;
+ s_clamped 
+-----------
+ de
+(1 row)
+
+SELECT dbms_lob.substr('abcde'::clob, 3) AS s_default_offset;
+ s_default_offset 
+------------------
+ abc
+(1 row)
+
+SELECT dbms_lob.substr('abcde'::clob) AS s_defaults;
+ s_defaults 
+------------
+ abcde
+(1 row)
+
+SELECT dbms_lob.substr('abcde'::clob, 3, 0) AS s_offset_0;
+ s_offset_0 
+------------
+ 
+(1 row)
+
+SELECT dbms_lob.substr('abcde'::clob, 3, 10) AS s_offset_high;
+ s_offset_high 
+---------------
+ 
+(1 row)
+
+SELECT dbms_lob.substr('abcde'::clob, 0, 1) AS s_amount_0;
+ s_amount_0 
+------------
+ 
+(1 row)
+
+SELECT dbms_lob.substr('abcde'::clob, -1, 1) AS s_amount_neg;
+ s_amount_neg 
+--------------
+ 
+(1 row)
+
+SELECT dbms_lob.substr(NULL::clob, 1, 1) AS s_null;
+ s_null 
+--------
+ 
+(1 row)
+
+SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 2, 2) AS s_blob;
+ s_blob 
+--------
+ \xbbcc
+(1 row)
+
+SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 100, 4) AS s_blob_clamped;
+ s_blob_clamped 
+----------------
+ \xddee
+(1 row)
+
+SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 2, 20) AS s_blob_offset_high;
+ s_blob_offset_high 
+--------------------
+ 
+(1 row)
+
+-- =============================================================================
+-- INSTR
+-- =============================================================================
+SELECT dbms_lob.instr('abcabc'::clob, 'bc') AS i_default;
+ i_default 
+-----------
+ 2
+(1 row)
+
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 3) AS i_offset;
+ i_offset 
+----------
+ 5
+(1 row)
+
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 1, 2) AS i_occurrence;
+ i_occurrence 
+--------------
+ 5
+(1 row)
+
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 100) AS i_offset_high;
+ i_offset_high 
+---------------
+ 0
+(1 row)
+
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 0) AS i_offset_0;
+ i_offset_0 
+------------
+ 
+(1 row)
+
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 1, 0) AS i_occurrence_0;
+ i_occurrence_0 
+----------------
+ 
+(1 row)
+
+SELECT dbms_lob.instr('abcabc'::clob, 'zz') AS i_no_match;
+ i_no_match 
+------------
+ 0
+(1 row)
+
+SELECT dbms_lob.instr(NULL::clob, 'bc') AS i_null;
+ i_null 
+--------
+ 
+(1 row)
+
+SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('bb')::raw) AS i_blob;
+ i_blob 
+--------
+ 2
+(1 row)
+
+SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('bb')::raw, 3, 2) AS i_blob_occ;
+ i_blob_occ 
+------------
+ 0
+(1 row)
+
+SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('cc')::raw, 4) AS i_blob_none;
+ i_blob_none 
+-------------
+ 0
+(1 row)
+
+-- =============================================================================
+-- COMPARE (0 = equal, NULL = invalid, nonzero = differ; nonzero value is
+-- unspecified in Oracle, so only the 0/NULL distinction is asserted)
+-- =============================================================================
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob) AS c_equal;
+ c_equal 
+---------
+ 0
+(1 row)
+
+SELECT dbms_lob.compare('abcde'::clob, 'abcXe'::clob, 5) AS c_differs_is_nonzero;
+ c_differs_is_nonzero 
+----------------------
+ 4
+(1 row)
+
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 3) AS c_amount_limited;
+ c_amount_limited 
+------------------
+ 0
+(1 row)
+
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 0) AS c_amount_0;
+ c_amount_0 
+------------
+ 
+(1 row)
+
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 1, 0, 1) AS c_offset_0;
+ c_offset_0 
+------------
+ 
+(1 row)
+
+SELECT dbms_lob.compare(NULL::clob, 'abcde'::clob) AS c_null;
+ c_null 
+--------
+ 
+(1 row)
+
+SELECT CASE WHEN dbms_lob.compare('abc'::clob, 'abcdef'::clob) = 0
+            THEN 'EQ' ELSE 'NE' END AS c_prefix;
+ c_prefix 
+----------
+ NE
+(1 row)
+
+SELECT dbms_lob.compare(hextoraw('aabb')::blob, hextoraw('aabb')::blob) AS c_blob_equal;
+ c_blob_equal 
+--------------
+ 0
+(1 row)
+
+SELECT CASE WHEN dbms_lob.compare(hextoraw('aabb')::blob, hextoraw('aacc')::blob, 2) = 0
+            THEN 'EQ' ELSE 'NE' END AS c_blob_differs;
+ c_blob_differs 
+----------------
+ NE
+(1 row)
+
+-- =============================================================================
+-- APPEND
+-- =============================================================================
+DECLARE
+    d clob;
+    b blob;
+BEGIN
+    d := 'abc';
+    dbms_lob.append(d, 'def');
+    dbms_lob.append(d, 'ghi');
+    RAISE NOTICE 'APPEND clob: %', d;
+    dbms_lob.append(d, NULL);
+    RAISE NOTICE 'APPEND clob null src (no-op): %', d;
+    d := NULL;
+    dbms_lob.append(d, 'q');
+    RAISE NOTICE 'APPEND clob null dest: %', d;
+    b := hextoraw('aabb');
+    dbms_lob.append(b, hextoraw('ccdd')::raw);
+    RAISE NOTICE 'APPEND blob: %', b;
+END;
+/
+NOTICE:  APPEND clob: abcdefghi
+NOTICE:  APPEND clob null src (no-op): abcdefghi
+NOTICE:  APPEND clob null dest: q
+NOTICE:  APPEND blob: \xaabbccdd
+-- =============================================================================
+-- COPY (overwrites from dest_offset, preserves the rest)
+-- =============================================================================
+DECLARE
+    d clob;
+    b blob;
+BEGIN
+    d := 'ABCDEF';
+    dbms_lob.copy(d, 'xy', 2, 3, 1);
+    RAISE NOTICE 'COPY overwrite: %', d;
+    d := 'ABCDEF';
+    dbms_lob.copy(d, 'xyz', 100, 2, 2);
+    RAISE NOTICE 'COPY clamped: %', d;
+    b := hextoraw('aabbcc');
+    dbms_lob.copy(b, hextoraw('dd')::raw, 1, 2, 1);
+    RAISE NOTICE 'COPY blob: %', b;
+END;
+/
+NOTICE:  COPY overwrite: ABxyEF
+NOTICE:  COPY clamped: AyzDEF
+NOTICE:  COPY blob: \xaaddcc
+-- =============================================================================
+-- TRIM
+-- =============================================================================
+DECLARE
+    d clob;
+    b blob;
+BEGIN
+    d := 'abcdef';
+    dbms_lob.trim(d, 3);
+    RAISE NOTICE 'TRIM clob: %', d;
+    b := hextoraw('aabbccdd');
+    dbms_lob.trim(b, 2);
+    RAISE NOTICE 'TRIM blob: %', b;
+    BEGIN
+        d := 'abc';
+        dbms_lob.trim(d, 10);
+        RAISE NOTICE 'TRIM over-length: no error';
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE NOTICE 'TRIM over-length raised: %', sqlerrm;
+    END;
+END;
+/
+NOTICE:  TRIM clob: abc
+NOTICE:  TRIM blob: \xaabb
+NOTICE:  TRIM over-length raised: specified trim length is greater than current LOB value's length
+-- =============================================================================
+-- ERASE (spaces for CLOB/NCLOB, zero bytes for BLOB, IN OUT amount)
+-- =============================================================================
+DECLARE
+    d clob;
+    b blob;
+    amt number;
+BEGIN
+    d := 'abcdef';
+    amt := 2;
+    dbms_lob.erase(d, amt, 2);
+    RAISE NOTICE 'ERASE clob: [%] amt=%', d, amt;
+    b := hextoraw('aabbccddee');
+    amt := 2;
+    dbms_lob.erase(b, amt, 2);
+    RAISE NOTICE 'ERASE blob: % amt=%', b, amt;
+    d := 'abcdef';
+    amt := 10;
+    dbms_lob.erase(d, amt, 4);
+    RAISE NOTICE 'ERASE clamped: [%] amt=%', d, amt;
+    d := 'abcdef';
+    amt := 2;
+    dbms_lob.erase(d, amt, 100);
+    RAISE NOTICE 'ERASE offset high: [%] amt=%', d, amt;
+END;
+/
+NOTICE:  ERASE clob: [a  def] amt=2
+NOTICE:  ERASE blob: \xaa0000ddee amt=2
+NOTICE:  ERASE clamped: [abc   ] amt=3
+NOTICE:  ERASE offset high: [abcdef] amt=0
+-- =============================================================================
+-- LOBMAXSIZE constant (package constants are usable in PL/iSQL, as in Oracle)
+-- =============================================================================
+DECLARE
+BEGIN
+    RAISE NOTICE 'lobmaxsize: %', dbms_lob.lobmaxsize;
+END;
+/
+NOTICE:  lobmaxsize: 18446744073709551615
+-- =============================================================================
+-- Usage on a table column round-trip
+-- =============================================================================
+CREATE TABLE dbms_lob_test (id int, doc clob, payload blob);
+INSERT INTO dbms_lob_test VALUES (1, 'hello world', hextoraw('aabbcc'));
+DECLARE
+    d clob;
+BEGIN
+    SELECT doc INTO d FROM dbms_lob_test WHERE id = 1;
+    dbms_lob.append(d, ' from oracle');
+    UPDATE dbms_lob_test SET doc = d WHERE id = 1;
+END;
+/
+SELECT dbms_lob.getlength(doc) AS len, dbms_lob.substr(doc, 5, 13) AS tail
+FROM dbms_lob_test WHERE id = 1;
+ len | tail  
+-----+-------
+ 23  | from 
+(1 row)
+
+SELECT dbms_lob.instr(doc, 'oracle') AS pos FROM dbms_lob_test WHERE id = 1;
+ pos 
+-----
+ 18
+(1 row)
+
+DROP TABLE dbms_lob_test;

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -11,3 +11,4 @@ src/builtin_packages/utl_encode/utl_encode
 src/builtin_packages/utl_url/utl_url
 src/builtin_packages/dbms_session/dbms_session
 src/builtin_packages/dbms_transaction/dbms_transaction
+src/builtin_packages/dbms_lob/dbms_lob

--- a/contrib/ivorysql_ora/sql/dbms_lob.sql
+++ b/contrib/ivorysql_ora/sql/dbms_lob.sql
@@ -1,0 +1,217 @@
+--
+-- Tests for DBMS_LOB package
+--
+-- Every expected value was verified against Oracle 23ai Free.  IvorySQL
+-- models clob/nclob/blob as value types (domains over text/bytea), so the
+-- locator-restricted error paths of Oracle (ORA-22275 for uninitialized
+-- locators) do not apply; documented deviations are exercised explicitly.
+--
+
+-- =============================================================================
+-- GETLENGTH
+-- =============================================================================
+
+SELECT dbms_lob.getlength('abcde'::clob) AS gl_text;
+SELECT dbms_lob.getlength('你好'::clob) AS gl_chars;
+SELECT dbms_lob.getlength(NULL::clob) AS gl_null;
+SELECT dbms_lob.getlength(hextoraw('aabbccddee')::blob) AS gl_blob;
+SELECT dbms_lob.getlength(NULL::blob) AS gl_blob_null;
+
+-- nclob values resolve to the text-family overload
+DECLARE
+    x nclob := 'abcd';
+BEGIN
+    RAISE NOTICE 'GL nclob: %', dbms_lob.getlength(x);
+END;
+/
+
+-- =============================================================================
+-- SUBSTR (amount first, offset second; opposite order of SQL SUBSTR)
+-- =============================================================================
+
+SELECT dbms_lob.substr('abcde'::clob, 3, 2) AS s_basic;
+SELECT dbms_lob.substr('abcde'::clob, 100, 4) AS s_clamped;
+SELECT dbms_lob.substr('abcde'::clob, 3) AS s_default_offset;
+SELECT dbms_lob.substr('abcde'::clob) AS s_defaults;
+SELECT dbms_lob.substr('abcde'::clob, 3, 0) AS s_offset_0;
+SELECT dbms_lob.substr('abcde'::clob, 3, 10) AS s_offset_high;
+SELECT dbms_lob.substr('abcde'::clob, 0, 1) AS s_amount_0;
+SELECT dbms_lob.substr('abcde'::clob, -1, 1) AS s_amount_neg;
+SELECT dbms_lob.substr(NULL::clob, 1, 1) AS s_null;
+SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 2, 2) AS s_blob;
+SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 100, 4) AS s_blob_clamped;
+SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 2, 20) AS s_blob_offset_high;
+
+-- =============================================================================
+-- INSTR
+-- =============================================================================
+
+SELECT dbms_lob.instr('abcabc'::clob, 'bc') AS i_default;
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 3) AS i_offset;
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 1, 2) AS i_occurrence;
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 100) AS i_offset_high;
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 0) AS i_offset_0;
+SELECT dbms_lob.instr('abcabc'::clob, 'bc', 1, 0) AS i_occurrence_0;
+SELECT dbms_lob.instr('abcabc'::clob, 'zz') AS i_no_match;
+SELECT dbms_lob.instr(NULL::clob, 'bc') AS i_null;
+
+SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('bb')::raw) AS i_blob;
+SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('bb')::raw, 3, 2) AS i_blob_occ;
+SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('cc')::raw, 4) AS i_blob_none;
+
+-- =============================================================================
+-- COMPARE (0 = equal, NULL = invalid, nonzero = differ; nonzero value is
+-- unspecified in Oracle, so only the 0/NULL distinction is asserted)
+-- =============================================================================
+
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob) AS c_equal;
+SELECT dbms_lob.compare('abcde'::clob, 'abcXe'::clob, 5) AS c_differs_is_nonzero;
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 3) AS c_amount_limited;
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 0) AS c_amount_0;
+SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 1, 0, 1) AS c_offset_0;
+SELECT dbms_lob.compare(NULL::clob, 'abcde'::clob) AS c_null;
+SELECT CASE WHEN dbms_lob.compare('abc'::clob, 'abcdef'::clob) = 0
+            THEN 'EQ' ELSE 'NE' END AS c_prefix;
+
+SELECT dbms_lob.compare(hextoraw('aabb')::blob, hextoraw('aabb')::blob) AS c_blob_equal;
+SELECT CASE WHEN dbms_lob.compare(hextoraw('aabb')::blob, hextoraw('aacc')::blob, 2) = 0
+            THEN 'EQ' ELSE 'NE' END AS c_blob_differs;
+
+-- =============================================================================
+-- APPEND
+-- =============================================================================
+
+DECLARE
+    d clob;
+    b blob;
+BEGIN
+    d := 'abc';
+    dbms_lob.append(d, 'def');
+    dbms_lob.append(d, 'ghi');
+    RAISE NOTICE 'APPEND clob: %', d;
+
+    dbms_lob.append(d, NULL);
+    RAISE NOTICE 'APPEND clob null src (no-op): %', d;
+
+    d := NULL;
+    dbms_lob.append(d, 'q');
+    RAISE NOTICE 'APPEND clob null dest: %', d;
+
+    b := hextoraw('aabb');
+    dbms_lob.append(b, hextoraw('ccdd')::raw);
+    RAISE NOTICE 'APPEND blob: %', b;
+END;
+/
+
+-- =============================================================================
+-- COPY (overwrites from dest_offset, preserves the rest)
+-- =============================================================================
+
+DECLARE
+    d clob;
+    b blob;
+BEGIN
+    d := 'ABCDEF';
+    dbms_lob.copy(d, 'xy', 2, 3, 1);
+    RAISE NOTICE 'COPY overwrite: %', d;
+
+    d := 'ABCDEF';
+    dbms_lob.copy(d, 'xyz', 100, 2, 2);
+    RAISE NOTICE 'COPY clamped: %', d;
+
+    b := hextoraw('aabbcc');
+    dbms_lob.copy(b, hextoraw('dd')::raw, 1, 2, 1);
+    RAISE NOTICE 'COPY blob: %', b;
+END;
+/
+
+-- =============================================================================
+-- TRIM
+-- =============================================================================
+
+DECLARE
+    d clob;
+    b blob;
+BEGIN
+    d := 'abcdef';
+    dbms_lob.trim(d, 3);
+    RAISE NOTICE 'TRIM clob: %', d;
+
+    b := hextoraw('aabbccdd');
+    dbms_lob.trim(b, 2);
+    RAISE NOTICE 'TRIM blob: %', b;
+
+    BEGIN
+        d := 'abc';
+        dbms_lob.trim(d, 10);
+        RAISE NOTICE 'TRIM over-length: no error';
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE NOTICE 'TRIM over-length raised: %', sqlerrm;
+    END;
+END;
+/
+
+-- =============================================================================
+-- ERASE (spaces for CLOB/NCLOB, zero bytes for BLOB, IN OUT amount)
+-- =============================================================================
+
+DECLARE
+    d clob;
+    b blob;
+    amt number;
+BEGIN
+    d := 'abcdef';
+    amt := 2;
+    dbms_lob.erase(d, amt, 2);
+    RAISE NOTICE 'ERASE clob: [%] amt=%', d, amt;
+
+    b := hextoraw('aabbccddee');
+    amt := 2;
+    dbms_lob.erase(b, amt, 2);
+    RAISE NOTICE 'ERASE blob: % amt=%', b, amt;
+
+    d := 'abcdef';
+    amt := 10;
+    dbms_lob.erase(d, amt, 4);
+    RAISE NOTICE 'ERASE clamped: [%] amt=%', d, amt;
+
+    d := 'abcdef';
+    amt := 2;
+    dbms_lob.erase(d, amt, 100);
+    RAISE NOTICE 'ERASE offset high: [%] amt=%', d, amt;
+END;
+/
+
+-- =============================================================================
+-- LOBMAXSIZE constant (package constants are usable in PL/iSQL, as in Oracle)
+-- =============================================================================
+
+DECLARE
+BEGIN
+    RAISE NOTICE 'lobmaxsize: %', dbms_lob.lobmaxsize;
+END;
+/
+
+-- =============================================================================
+-- Usage on a table column round-trip
+-- =============================================================================
+
+CREATE TABLE dbms_lob_test (id int, doc clob, payload blob);
+INSERT INTO dbms_lob_test VALUES (1, 'hello world', hextoraw('aabbcc'));
+
+DECLARE
+    d clob;
+BEGIN
+    SELECT doc INTO d FROM dbms_lob_test WHERE id = 1;
+    dbms_lob.append(d, ' from oracle');
+    UPDATE dbms_lob_test SET doc = d WHERE id = 1;
+END;
+/
+
+SELECT dbms_lob.getlength(doc) AS len, dbms_lob.substr(doc, 5, 13) AS tail
+FROM dbms_lob_test WHERE id = 1;
+
+SELECT dbms_lob.instr(doc, 'oracle') AS pos FROM dbms_lob_test WHERE id = 1;
+
+DROP TABLE dbms_lob_test;

--- a/contrib/ivorysql_ora/sql/dbms_lob.sql
+++ b/contrib/ivorysql_ora/sql/dbms_lob.sql
@@ -1,10 +1,13 @@
 --
 -- Tests for DBMS_LOB package
 --
--- Every expected value was verified against Oracle 23ai Free.  IvorySQL
--- models clob/nclob/blob as value types (domains over text/bytea), so the
--- locator-restricted error paths of Oracle (ORA-22275 for uninitialized
--- locators) do not apply; documented deviations are exercised explicitly.
+-- Every expected value was verified against Oracle 23ai Free (including the
+-- boundary probes: amount > 32767 -> NULL, COMPARE's strcmp-style -1/0/+1
+-- result, COPY gap padding, fractional-argument truncation, and the
+-- ORA-21560-style argument errors).  IvorySQL models clob/nclob/blob as
+-- value types (domains over text/bytea), so the locator-restricted error
+-- paths of Oracle (ORA-22275 for uninitialized locators) do not apply;
+-- documented deviations are exercised explicitly.
 --
 
 -- =============================================================================
@@ -37,6 +40,8 @@ SELECT dbms_lob.substr('abcde'::clob, 3, 0) AS s_offset_0;
 SELECT dbms_lob.substr('abcde'::clob, 3, 10) AS s_offset_high;
 SELECT dbms_lob.substr('abcde'::clob, 0, 1) AS s_amount_0;
 SELECT dbms_lob.substr('abcde'::clob, -1, 1) AS s_amount_neg;
+SELECT dbms_lob.substr('abcde'::clob, 32768, 1) AS s_amount_over_cap;
+SELECT dbms_lob.substr('abcde'::clob, 2.7, 2.7) AS s_fractional_truncated;
 SELECT dbms_lob.substr(NULL::clob, 1, 1) AS s_null;
 SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 2, 2) AS s_blob;
 SELECT dbms_lob.substr(hextoraw('aabbccddee')::blob, 100, 4) AS s_blob_clamped;
@@ -53,6 +58,7 @@ SELECT dbms_lob.instr('abcabc'::clob, 'bc', 100) AS i_offset_high;
 SELECT dbms_lob.instr('abcabc'::clob, 'bc', 0) AS i_offset_0;
 SELECT dbms_lob.instr('abcabc'::clob, 'bc', 1, 0) AS i_occurrence_0;
 SELECT dbms_lob.instr('abcabc'::clob, 'zz') AS i_no_match;
+SELECT dbms_lob.instr('abc'::clob, 'abcdef') AS i_pattern_longer;
 SELECT dbms_lob.instr(NULL::clob, 'bc') AS i_null;
 
 SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('bb')::raw) AS i_blob;
@@ -60,22 +66,25 @@ SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('bb')::raw, 3, 2) A
 SELECT dbms_lob.instr(hextoraw('aabbccbbaa')::blob, hextoraw('cc')::raw, 4) AS i_blob_none;
 
 -- =============================================================================
--- COMPARE (0 = equal, NULL = invalid, nonzero = differ; nonzero value is
--- unspecified in Oracle, so only the 0/NULL distinction is asserted)
+-- COMPARE: strcmp-style -1/0/+1 (verified on Oracle 23ai, including the
+-- 'abcde' vs 'abcXe' -> +1 and prefix/offset-beyond -> -1 cases); NULL for
+-- invalid arguments.  An exhausted side counts as empty.
 -- =============================================================================
 
 SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob) AS c_equal;
-SELECT dbms_lob.compare('abcde'::clob, 'abcXe'::clob, 5) AS c_differs_is_nonzero;
+SELECT dbms_lob.compare('abcde'::clob, 'abcXe'::clob, 5) AS c_greater;
+SELECT dbms_lob.compare('Xbcde'::clob, 'abcde'::clob, 5) AS c_less;
+SELECT dbms_lob.compare('abXde'::clob, 'abcde'::clob, 5) AS c_less_at_3;
 SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 3) AS c_amount_limited;
 SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 0) AS c_amount_0;
 SELECT dbms_lob.compare('abcde'::clob, 'abcde'::clob, 1, 0, 1) AS c_offset_0;
 SELECT dbms_lob.compare(NULL::clob, 'abcde'::clob) AS c_null;
-SELECT CASE WHEN dbms_lob.compare('abc'::clob, 'abcdef'::clob) = 0
-            THEN 'EQ' ELSE 'NE' END AS c_prefix;
+SELECT dbms_lob.compare('abc'::clob, 'abcdef'::clob) AS c_prefix_is_less;
+SELECT dbms_lob.compare('abc'::clob, 'abcde'::clob, 5, 100, 1) AS c_pos_beyond_one;
+SELECT dbms_lob.compare('abc'::clob, 'abcde'::clob, 5, 100, 100) AS c_pos_beyond_both;
 
 SELECT dbms_lob.compare(hextoraw('aabb')::blob, hextoraw('aabb')::blob) AS c_blob_equal;
-SELECT CASE WHEN dbms_lob.compare(hextoraw('aabb')::blob, hextoraw('aacc')::blob, 2) = 0
-            THEN 'EQ' ELSE 'NE' END AS c_blob_differs;
+SELECT dbms_lob.compare(hextoraw('aabb')::blob, hextoraw('aacc')::blob, 2) AS c_blob_less;
 
 -- =============================================================================
 -- APPEND
@@ -104,7 +113,8 @@ END;
 /
 
 -- =============================================================================
--- COPY (overwrites from dest_offset, preserves the rest)
+-- COPY (overwrites from dest_offset, preserves the rest; a dest_offset
+-- beyond the end pads the gap with spaces/zeros, as Oracle does)
 -- =============================================================================
 
 DECLARE
@@ -119,9 +129,21 @@ BEGIN
     dbms_lob.copy(d, 'xyz', 100, 2, 2);
     RAISE NOTICE 'COPY clamped: %', d;
 
+    d := 'ABCDEF';
+    dbms_lob.copy(d, 'xy', 2, 7, 1);
+    RAISE NOTICE 'COPY at end: %', d;
+
+    d := 'ABCDEF';
+    dbms_lob.copy(d, 'xy', 2, 100, 1);
+    RAISE NOTICE 'COPY gap: len=% ends=%', length(d), substr(d, 100, 2);
+
     b := hextoraw('aabbcc');
     dbms_lob.copy(b, hextoraw('dd')::raw, 1, 2, 1);
     RAISE NOTICE 'COPY blob: %', b;
+
+    b := hextoraw('aabb');
+    dbms_lob.copy(b, hextoraw('dd')::raw, 1, 5, 1);
+    RAISE NOTICE 'COPY blob gap: %', b;
 END;
 /
 
@@ -137,6 +159,10 @@ BEGIN
     dbms_lob.trim(d, 3);
     RAISE NOTICE 'TRIM clob: %', d;
 
+    d := 'ABCDEF';
+    dbms_lob.trim(d, 2.7);
+    RAISE NOTICE 'TRIM fractional: %', d;
+
     b := hextoraw('aabbccdd');
     dbms_lob.trim(b, 2);
     RAISE NOTICE 'TRIM blob: %', b;
@@ -148,6 +174,15 @@ BEGIN
     EXCEPTION
         WHEN OTHERS THEN
             RAISE NOTICE 'TRIM over-length raised: %', sqlerrm;
+    END;
+
+    BEGIN
+        d := 'abc';
+        dbms_lob.trim(d, -3);
+        RAISE NOTICE 'TRIM negative: no error';
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE NOTICE 'TRIM negative raised: %', sqlerrm;
     END;
 END;
 /
@@ -180,6 +215,16 @@ BEGIN
     amt := 2;
     dbms_lob.erase(d, amt, 100);
     RAISE NOTICE 'ERASE offset high: [%] amt=%', d, amt;
+
+    BEGIN
+        d := 'abc';
+        amt := -2;
+        dbms_lob.erase(d, amt, 2);
+        RAISE NOTICE 'ERASE negative: no error';
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE NOTICE 'ERASE negative raised: %', sqlerrm;
+    END;
 END;
 /
 

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_lob/dbms_lob--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_lob/dbms_lob--1.0.sql
@@ -1,0 +1,330 @@
+/***************************************************************
+ *
+ * DBMS_LOB Package
+ *
+ * Oracle-compatible LOB manipulation for oracle mode.  IvorySQL models
+ * clob/nclob/blob as domains over text/bytea (value semantics, no LOB
+ * locators), so the package operates on LOB values directly and the
+ * locator-only subprograms (OPEN/CLOSE, CREATETEMPORARY, the FILE*
+ * family, CONVERTTOBLOB/CONVERTTOCLOB) have no meaningful equivalent.
+ *
+ * Semantics verified against Oracle 23ai Free:
+ *   - positions are 1-based; SUBSTR: offset < 1 or amount < 1 -> NULL,
+ *     offset > length -> NULL, amount clamped to the end of the LOB
+ *   - INSTR: offset < 1 or occurrence < 1 -> NULL, no match -> 0,
+ *     offset > length -> 0
+ *   - COMPARE: 0 when equal over the compared range, NULL when either
+ *     LOB is NULL or amount/offsets are invalid; the nonzero result is
+ *     unspecified in Oracle, IvorySQL returns the first mismatch position
+ *   - ERASE replaces with spaces (CLOB/NCLOB) or zero bytes (BLOB) and
+ *     reports the erased amount through its IN OUT argument
+ *   - COPY overwrites from dest_offset and preserves the rest of dest
+ *   - TRIM raises when newlen exceeds the current length (ORA-22926)
+ *
+ * The package body calls pg_catalog primitives explicitly (never its own
+ * member names) so that unqualified member resolution cannot recurse, and
+ * casts its NUMBER position/amount parameters to int at the call sites.
+ *
+ ***************************************************************
+*/
+
+CREATE PACKAGE dbms_lob AS
+
+    lobmaxsize CONSTANT NUMBER := 18446744073709551615;
+
+    FUNCTION getlength(lob CLOB) RETURN NUMBER;
+    FUNCTION getlength(lob NCLOB) RETURN NUMBER;
+    FUNCTION getlength(lob BLOB) RETURN NUMBER;
+
+    FUNCTION substr(lob CLOB, amount NUMBER DEFAULT 32767, pos NUMBER DEFAULT 1) RETURN VARCHAR2;
+    FUNCTION substr(lob BLOB, amount NUMBER DEFAULT 32767, pos NUMBER DEFAULT 1) RETURN sys.raw;
+
+    FUNCTION instr(lob CLOB, pattern CLOB, pos NUMBER DEFAULT 1, occurrence NUMBER DEFAULT 1) RETURN NUMBER;
+    FUNCTION instr(lob BLOB, pattern sys.raw, pos NUMBER DEFAULT 1, occurrence NUMBER DEFAULT 1) RETURN NUMBER;
+
+    FUNCTION compare(lob_1 CLOB, lob_2 CLOB, amount NUMBER DEFAULT 18446744073709551615,
+                     pos_1 NUMBER DEFAULT 1, pos_2 NUMBER DEFAULT 1) RETURN NUMBER;
+    FUNCTION compare(lob_1 BLOB, lob_2 BLOB, amount NUMBER DEFAULT 18446744073709551615,
+                     pos_1 NUMBER DEFAULT 1, pos_2 NUMBER DEFAULT 1) RETURN NUMBER;
+
+    PROCEDURE append(dest_lob IN OUT CLOB, src_lob CLOB);
+    PROCEDURE append(dest_lob IN OUT BLOB, src_lob BLOB);
+
+    PROCEDURE copy(dest_lob IN OUT CLOB, src_lob CLOB, amount NUMBER DEFAULT 18446744073709551615,
+                   dest_pos NUMBER DEFAULT 1, src_pos NUMBER DEFAULT 1);
+    PROCEDURE copy(dest_lob IN OUT BLOB, src_lob BLOB, amount NUMBER DEFAULT 18446744073709551615,
+                   dest_pos NUMBER DEFAULT 1, src_pos NUMBER DEFAULT 1);
+
+    PROCEDURE trim(dest_lob IN OUT CLOB, newlen NUMBER);
+    PROCEDURE trim(dest_lob IN OUT BLOB, newlen NUMBER);
+
+    PROCEDURE erase(dest_lob IN OUT CLOB, amount IN OUT NUMBER, pos NUMBER DEFAULT 1);
+    PROCEDURE erase(dest_lob IN OUT BLOB, amount IN OUT NUMBER, pos NUMBER DEFAULT 1);
+
+END;
+
+CREATE PACKAGE BODY dbms_lob AS
+
+    FUNCTION getlength(lob CLOB) RETURN NUMBER IS
+    BEGIN
+        RETURN pg_catalog.length(lob);
+    END;
+
+    FUNCTION getlength(lob NCLOB) RETURN NUMBER IS
+    BEGIN
+        RETURN pg_catalog.length(lob);
+    END;
+
+    FUNCTION getlength(lob BLOB) RETURN NUMBER IS
+    BEGIN
+        RETURN pg_catalog.octet_length(lob);
+    END;
+
+    FUNCTION substr(lob CLOB, amount NUMBER DEFAULT 32767, pos NUMBER DEFAULT 1) RETURN VARCHAR2 IS
+    BEGIN
+        IF lob IS NULL OR amount IS NULL OR pos IS NULL THEN
+            RETURN NULL;
+        END IF;
+        IF pos < 1 OR amount < 1 OR pos > pg_catalog.length(lob) THEN
+            RETURN NULL;
+        END IF;
+        RETURN pg_catalog.substr(lob, pos::int, amount::int);
+    END;
+
+    FUNCTION substr(lob BLOB, amount NUMBER DEFAULT 32767, pos NUMBER DEFAULT 1) RETURN sys.raw IS
+    BEGIN
+        IF lob IS NULL OR amount IS NULL OR pos IS NULL THEN
+            RETURN NULL;
+        END IF;
+        IF pos < 1 OR amount < 1 OR pos > pg_catalog.octet_length(lob) THEN
+            RETURN NULL;
+        END IF;
+        RETURN pg_catalog.substr(lob, pos::int, amount::int);
+    END;
+
+    FUNCTION instr(lob CLOB, pattern CLOB, pos NUMBER DEFAULT 1, occurrence NUMBER DEFAULT 1) RETURN NUMBER IS
+    BEGIN
+        IF lob IS NULL OR pattern IS NULL OR pos IS NULL OR occurrence IS NULL THEN
+            RETURN NULL;
+        END IF;
+        IF pos < 1 OR occurrence < 1 THEN
+            RETURN NULL;
+        END IF;
+        RETURN sys.instr(lob, pattern, pos::int, occurrence::int);
+    END;
+
+    FUNCTION instr(lob BLOB, pattern sys.raw, pos NUMBER DEFAULT 1, occurrence NUMBER DEFAULT 1) RETURN NUMBER IS
+        v_pos int;
+        v_start int;
+        v_found int;
+        v_matches int;
+    BEGIN
+        IF lob IS NULL OR pattern IS NULL OR pos IS NULL OR occurrence IS NULL THEN
+            RETURN NULL;
+        END IF;
+        IF pos < 1 OR occurrence < 1 THEN
+            RETURN NULL;
+        END IF;
+        v_start := pos;
+        v_found := 0;
+        v_matches := 0;
+        FOR i IN 1..occurrence::int LOOP
+            v_pos := position(pattern IN pg_catalog.substr(lob, v_start, 2147483647));
+            EXIT WHEN v_pos = 0;
+            v_found := v_start + v_pos - 1;
+            v_start := v_found + pg_catalog.octet_length(pattern);
+            v_matches := v_matches + 1;
+        END LOOP;
+        IF v_matches = occurrence THEN
+            RETURN v_found;
+        END IF;
+        RETURN 0;
+    END;
+
+    FUNCTION compare(lob_1 CLOB, lob_2 CLOB, amount NUMBER DEFAULT 18446744073709551615,
+                     pos_1 NUMBER DEFAULT 1, pos_2 NUMBER DEFAULT 1) RETURN NUMBER IS
+        v_len1 number;
+        v_len2 number;
+        v_n int;
+        v_c1 varchar2;
+        v_c2 varchar2;
+    BEGIN
+        IF lob_1 IS NULL OR lob_2 IS NULL OR amount IS NULL
+           OR pos_1 IS NULL OR pos_2 IS NULL THEN
+            RETURN NULL;
+        END IF;
+        IF amount < 1 OR pos_1 < 1 OR pos_2 < 1 THEN
+            RETURN NULL;
+        END IF;
+        v_len1 := pg_catalog.length(lob_1) - pos_1 + 1;
+        v_len2 := pg_catalog.length(lob_2) - pos_2 + 1;
+        v_n := least(amount, v_len1, v_len2);
+        FOR i IN 1..v_n LOOP
+            v_c1 := pg_catalog.substr(lob_1, (pos_1 + i - 1)::int, 1);
+            v_c2 := pg_catalog.substr(lob_2, (pos_2 + i - 1)::int, 1);
+            IF v_c1 IS DISTINCT FROM v_c2 THEN
+                RETURN i;
+            END IF;
+        END LOOP;
+        IF amount > v_n AND v_len1 <> v_len2 THEN
+            RETURN v_n + 1;
+        END IF;
+        RETURN 0;
+    END;
+
+    FUNCTION compare(lob_1 BLOB, lob_2 BLOB, amount NUMBER DEFAULT 18446744073709551615,
+                     pos_1 NUMBER DEFAULT 1, pos_2 NUMBER DEFAULT 1) RETURN NUMBER IS
+        v_len1 number;
+        v_len2 number;
+        v_n int;
+        v_c1 sys.raw;
+        v_c2 sys.raw;
+    BEGIN
+        IF lob_1 IS NULL OR lob_2 IS NULL OR amount IS NULL
+           OR pos_1 IS NULL OR pos_2 IS NULL THEN
+            RETURN NULL;
+        END IF;
+        IF amount < 1 OR pos_1 < 1 OR pos_2 < 1 THEN
+            RETURN NULL;
+        END IF;
+        v_len1 := pg_catalog.octet_length(lob_1) - pos_1 + 1;
+        v_len2 := pg_catalog.octet_length(lob_2) - pos_2 + 1;
+        v_n := least(amount, v_len1, v_len2);
+        FOR i IN 1..v_n LOOP
+            v_c1 := pg_catalog.substr(lob_1, (pos_1 + i - 1)::int, 1);
+            v_c2 := pg_catalog.substr(lob_2, (pos_2 + i - 1)::int, 1);
+            IF v_c1 IS DISTINCT FROM v_c2 THEN
+                RETURN i;
+            END IF;
+        END LOOP;
+        IF amount > v_n AND v_len1 <> v_len2 THEN
+            RETURN v_n + 1;
+        END IF;
+        RETURN 0;
+    END;
+
+    PROCEDURE append(dest_lob IN OUT CLOB, src_lob CLOB) IS
+    BEGIN
+        IF src_lob IS NULL THEN
+            RETURN;
+        END IF;
+        IF dest_lob IS NULL THEN
+            dest_lob := src_lob;
+        ELSE
+            dest_lob := dest_lob || src_lob;
+        END IF;
+    END;
+
+    PROCEDURE append(dest_lob IN OUT BLOB, src_lob BLOB) IS
+    BEGIN
+        IF src_lob IS NULL THEN
+            RETURN;
+        END IF;
+        IF dest_lob IS NULL THEN
+            dest_lob := src_lob;
+        ELSE
+            dest_lob := dest_lob || src_lob;
+        END IF;
+    END;
+
+    PROCEDURE copy(dest_lob IN OUT CLOB, src_lob CLOB, amount NUMBER DEFAULT 18446744073709551615,
+                   dest_pos NUMBER DEFAULT 1, src_pos NUMBER DEFAULT 1) IS
+        v_amt int;
+    BEGIN
+        IF src_lob IS NULL OR amount IS NULL OR dest_pos IS NULL OR src_pos IS NULL THEN
+            RETURN;
+        END IF;
+        IF amount < 1 OR dest_pos < 1 OR src_pos < 1 THEN
+            RETURN;
+        END IF;
+        v_amt := least(amount, pg_catalog.length(src_lob) - src_pos + 1);
+        IF dest_lob IS NULL THEN
+            dest_lob := pg_catalog.substr(src_lob, src_pos::int, v_amt);
+        ELSE
+            dest_lob := pg_catalog.substr(dest_lob, 1, (dest_pos - 1)::int)
+                        || pg_catalog.substr(src_lob, src_pos::int, v_amt)
+                        || pg_catalog.substr(dest_lob, (dest_pos + v_amt)::int, 2147483647);
+        END IF;
+    END;
+
+    PROCEDURE copy(dest_lob IN OUT BLOB, src_lob BLOB, amount NUMBER DEFAULT 18446744073709551615,
+                   dest_pos NUMBER DEFAULT 1, src_pos NUMBER DEFAULT 1) IS
+        v_amt int;
+    BEGIN
+        IF src_lob IS NULL OR amount IS NULL OR dest_pos IS NULL OR src_pos IS NULL THEN
+            RETURN;
+        END IF;
+        IF amount < 1 OR dest_pos < 1 OR src_pos < 1 THEN
+            RETURN;
+        END IF;
+        v_amt := least(amount, pg_catalog.octet_length(src_lob) - src_pos + 1);
+        IF dest_lob IS NULL THEN
+            dest_lob := pg_catalog.substr(src_lob, src_pos::int, v_amt);
+        ELSE
+            dest_lob := pg_catalog.substr(dest_lob, 1, (dest_pos - 1)::int)
+                        || pg_catalog.substr(src_lob, src_pos::int, v_amt)
+                        || pg_catalog.substr(dest_lob, (dest_pos + v_amt)::int, 2147483647);
+        END IF;
+    END;
+
+    PROCEDURE trim(dest_lob IN OUT CLOB, newlen NUMBER) IS
+    BEGIN
+        IF dest_lob IS NULL OR newlen IS NULL THEN
+            RETURN;
+        END IF;
+        IF newlen > pg_catalog.length(dest_lob) THEN
+            RAISE EXCEPTION 'specified trim length is greater than current LOB value''s length';
+        END IF;
+        dest_lob := pg_catalog.substr(dest_lob, 1, newlen::int);
+    END;
+
+    PROCEDURE trim(dest_lob IN OUT BLOB, newlen NUMBER) IS
+    BEGIN
+        IF dest_lob IS NULL OR newlen IS NULL THEN
+            RETURN;
+        END IF;
+        IF newlen > pg_catalog.octet_length(dest_lob) THEN
+            RAISE EXCEPTION 'specified trim length is greater than current LOB value''s length';
+        END IF;
+        dest_lob := pg_catalog.substr(dest_lob, 1, newlen::int);
+    END;
+
+    PROCEDURE erase(dest_lob IN OUT CLOB, amount IN OUT NUMBER, pos NUMBER DEFAULT 1) IS
+        v_erase int;
+    BEGIN
+        IF dest_lob IS NULL OR amount IS NULL OR pos IS NULL OR pos < 1 THEN
+            amount := 0;
+            RETURN;
+        END IF;
+        v_erase := least(amount, pg_catalog.length(dest_lob) - pos + 1);
+        IF v_erase < 0 THEN
+            v_erase := 0;
+        END IF;
+        IF v_erase > 0 THEN
+            dest_lob := pg_catalog.substr(dest_lob, 1, (pos - 1)::int)
+                        || pg_catalog.repeat(' ', v_erase)
+                        || pg_catalog.substr(dest_lob, (pos + v_erase)::int, 2147483647);
+        END IF;
+        amount := v_erase;
+    END;
+
+    PROCEDURE erase(dest_lob IN OUT BLOB, amount IN OUT NUMBER, pos NUMBER DEFAULT 1) IS
+        v_erase int;
+    BEGIN
+        IF dest_lob IS NULL OR amount IS NULL OR pos IS NULL OR pos < 1 THEN
+            amount := 0;
+            RETURN;
+        END IF;
+        v_erase := least(amount, pg_catalog.octet_length(dest_lob) - pos + 1);
+        IF v_erase < 0 THEN
+            v_erase := 0;
+        END IF;
+        IF v_erase > 0 THEN
+            dest_lob := pg_catalog.substr(dest_lob, 1, (pos - 1)::int)
+                        || pg_catalog.decode(pg_catalog.repeat('0', v_erase * 2), 'hex')
+                        || pg_catalog.substr(dest_lob, (pos + v_erase)::int, 2147483647);
+        END IF;
+        amount := v_erase;
+    END;
+
+END;

--- a/contrib/ivorysql_ora/src/builtin_packages/dbms_lob/dbms_lob--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/dbms_lob/dbms_lob--1.0.sql
@@ -9,21 +9,36 @@
  * family, CONVERTTOBLOB/CONVERTTOCLOB) have no meaningful equivalent.
  *
  * Semantics verified against Oracle 23ai Free:
- *   - positions are 1-based; SUBSTR: offset < 1 or amount < 1 -> NULL,
- *     offset > length -> NULL, amount clamped to the end of the LOB
- *   - INSTR: offset < 1 or occurrence < 1 -> NULL, no match -> 0,
- *     offset > length -> 0
- *   - COMPARE: 0 when equal over the compared range, NULL when either
- *     LOB is NULL or amount/offsets are invalid; the nonzero result is
- *     unspecified in Oracle, IvorySQL returns the first mismatch position
- *   - ERASE replaces with spaces (CLOB/NCLOB) or zero bytes (BLOB) and
- *     reports the erased amount through its IN OUT argument
- *   - COPY overwrites from dest_offset and preserves the rest of dest
- *   - TRIM raises when newlen exceeds the current length (ORA-22926)
+ *   - positions are 1-based; NUMBER arguments are truncated toward zero
+ *     when fractional (SUBSTR('abcde', 2.7, 2.7) = 'bc')
+ *   - SUBSTR: offset < 1, amount < 1, offset > length or amount > 32767
+ *     -> NULL; amount is clamped to the end of the LOB
+ *   - INSTR: offset < 1 or occurrence < 1 -> NULL, no match (including a
+ *     pattern longer than the LOB, or offset > length) -> 0
+ *   - COMPARE compares the first min(amount, remaining_1, remaining_2)
+ *     characters and returns a strcmp-style result: -1 when lob_1 sorts
+ *     before lob_2, +1 when it sorts after, 0 when equal over the whole
+ *     compared range (amount-limited comparisons that match return 0).
+ *     An exhausted side counts as empty: with pos beyond the LOB length
+ *     the result is -1/+1 against the other side, and 0 when both are
+ *     exhausted.  Returns NULL when either LOB is NULL or amount/offsets
+ *     are NULL or < 1.
+ *   - APPEND ignores a NULL source and initializes a NULL destination
+ *     from the source (Oracle raises ORA-22275 for uninitialized
+ *     locators, an error path that cannot exist in the value model)
+ *   - COPY overwrites from dest_offset and preserves the rest of dest;
+ *     when dest_offset extends beyond the destination end, the gap is
+ *     padded with spaces (CLOB) or zero bytes (BLOB), as Oracle does
+ *   - TRIM raises (ORA-21560 text) for a NULL/negative newlen and
+ *     (ORA-22926 text) when newlen exceeds the current length
+ *   - ERASE replaces with spaces (CLOB/NCLOB) or zero bytes (BLOB),
+ *     reports the erased amount through its IN OUT argument (clamped to
+ *     the LOB end), leaves the amount untouched when pos is beyond the
+ *     end, and raises (ORA-21560 text) for NULL/negative amount or
+ *     NULL/<1 pos
  *
  * The package body calls pg_catalog primitives explicitly (never its own
- * member names) so that unqualified member resolution cannot recurse, and
- * casts its NUMBER position/amount parameters to int at the call sites.
+ * member names) so that unqualified member resolution cannot recurse.
  *
  ***************************************************************
 */
@@ -81,25 +96,35 @@ CREATE PACKAGE BODY dbms_lob AS
     END;
 
     FUNCTION substr(lob CLOB, amount NUMBER DEFAULT 32767, pos NUMBER DEFAULT 1) RETURN VARCHAR2 IS
+        v_pos int;
+        v_amount int;
     BEGIN
         IF lob IS NULL OR amount IS NULL OR pos IS NULL THEN
             RETURN NULL;
         END IF;
-        IF pos < 1 OR amount < 1 OR pos > pg_catalog.length(lob) THEN
+        v_pos := pg_catalog.trunc(pos);
+        v_amount := pg_catalog.trunc(amount);
+        IF v_pos < 1 OR v_amount < 1 OR v_amount > 32767
+           OR v_pos > pg_catalog.length(lob) THEN
             RETURN NULL;
         END IF;
-        RETURN pg_catalog.substr(lob, pos::int, amount::int);
+        RETURN pg_catalog.substr(lob, v_pos, v_amount);
     END;
 
     FUNCTION substr(lob BLOB, amount NUMBER DEFAULT 32767, pos NUMBER DEFAULT 1) RETURN sys.raw IS
+        v_pos int;
+        v_amount int;
     BEGIN
         IF lob IS NULL OR amount IS NULL OR pos IS NULL THEN
             RETURN NULL;
         END IF;
-        IF pos < 1 OR amount < 1 OR pos > pg_catalog.octet_length(lob) THEN
+        v_pos := pg_catalog.trunc(pos);
+        v_amount := pg_catalog.trunc(amount);
+        IF v_pos < 1 OR v_amount < 1 OR v_amount > 32767
+           OR v_pos > pg_catalog.octet_length(lob) THEN
             RETURN NULL;
         END IF;
-        RETURN pg_catalog.substr(lob, pos::int, amount::int);
+        RETURN pg_catalog.substr(lob, v_pos, v_amount);
     END;
 
     FUNCTION instr(lob CLOB, pattern CLOB, pos NUMBER DEFAULT 1, occurrence NUMBER DEFAULT 1) RETURN NUMBER IS
@@ -107,10 +132,10 @@ CREATE PACKAGE BODY dbms_lob AS
         IF lob IS NULL OR pattern IS NULL OR pos IS NULL OR occurrence IS NULL THEN
             RETURN NULL;
         END IF;
-        IF pos < 1 OR occurrence < 1 THEN
+        IF trunc(pos) < 1 OR trunc(occurrence) < 1 THEN
             RETURN NULL;
         END IF;
-        RETURN sys.instr(lob, pattern, pos::int, occurrence::int);
+        RETURN sys.instr(lob, pattern, trunc(pos)::int, trunc(occurrence)::int);
     END;
 
     FUNCTION instr(lob BLOB, pattern sys.raw, pos NUMBER DEFAULT 1, occurrence NUMBER DEFAULT 1) RETURN NUMBER IS
@@ -122,20 +147,20 @@ CREATE PACKAGE BODY dbms_lob AS
         IF lob IS NULL OR pattern IS NULL OR pos IS NULL OR occurrence IS NULL THEN
             RETURN NULL;
         END IF;
-        IF pos < 1 OR occurrence < 1 THEN
+        v_start := pg_catalog.trunc(pos);
+        IF v_start < 1 OR trunc(occurrence) < 1 THEN
             RETURN NULL;
         END IF;
-        v_start := pos;
         v_found := 0;
         v_matches := 0;
-        FOR i IN 1..occurrence::int LOOP
+        FOR i IN 1..trunc(occurrence)::int LOOP
             v_pos := position(pattern IN pg_catalog.substr(lob, v_start, 2147483647));
             EXIT WHEN v_pos = 0;
             v_found := v_start + v_pos - 1;
             v_start := v_found + pg_catalog.octet_length(pattern);
             v_matches := v_matches + 1;
         END LOOP;
-        IF v_matches = occurrence THEN
+        IF v_matches = trunc(occurrence) THEN
             RETURN v_found;
         END IF;
         RETURN 0;
@@ -143,8 +168,11 @@ CREATE PACKAGE BODY dbms_lob AS
 
     FUNCTION compare(lob_1 CLOB, lob_2 CLOB, amount NUMBER DEFAULT 18446744073709551615,
                      pos_1 NUMBER DEFAULT 1, pos_2 NUMBER DEFAULT 1) RETURN NUMBER IS
-        v_len1 number;
-        v_len2 number;
+        v_p1 int;
+        v_p2 int;
+        v_amt number;
+        v_eff1 int;
+        v_eff2 int;
         v_n int;
         v_c1 varchar2;
         v_c2 varchar2;
@@ -153,29 +181,44 @@ CREATE PACKAGE BODY dbms_lob AS
            OR pos_1 IS NULL OR pos_2 IS NULL THEN
             RETURN NULL;
         END IF;
-        IF amount < 1 OR pos_1 < 1 OR pos_2 < 1 THEN
+        v_amt := pg_catalog.trunc(amount);
+        v_p1 := pg_catalog.trunc(pos_1);
+        v_p2 := pg_catalog.trunc(pos_2);
+        IF v_amt < 1 OR v_p1 < 1 OR v_p2 < 1 THEN
             RETURN NULL;
         END IF;
-        v_len1 := pg_catalog.length(lob_1) - pos_1 + 1;
-        v_len2 := pg_catalog.length(lob_2) - pos_2 + 1;
-        v_n := least(amount, v_len1, v_len2);
+        v_eff1 := greatest(pg_catalog.length(lob_1) - v_p1 + 1, 0);
+        v_eff2 := greatest(pg_catalog.length(lob_2) - v_p2 + 1, 0);
+        v_n := least(v_amt, v_eff1, v_eff2);
         FOR i IN 1..v_n LOOP
-            v_c1 := pg_catalog.substr(lob_1, (pos_1 + i - 1)::int, 1);
-            v_c2 := pg_catalog.substr(lob_2, (pos_2 + i - 1)::int, 1);
+            v_c1 := pg_catalog.substr(lob_1, v_p1 + i - 1, 1);
+            v_c2 := pg_catalog.substr(lob_2, v_p2 + i - 1, 1);
             IF v_c1 IS DISTINCT FROM v_c2 THEN
-                RETURN i;
+                IF pg_catalog.ascii(v_c1) > pg_catalog.ascii(v_c2) THEN
+                    RETURN 1;
+                END IF;
+                RETURN -1;
             END IF;
         END LOOP;
-        IF amount > v_n AND v_len1 <> v_len2 THEN
-            RETURN v_n + 1;
+        IF v_amt <= v_n THEN
+            RETURN 0;
+        END IF;
+        IF v_eff1 < v_eff2 THEN
+            RETURN -1;
+        END IF;
+        IF v_eff1 > v_eff2 THEN
+            RETURN 1;
         END IF;
         RETURN 0;
     END;
 
     FUNCTION compare(lob_1 BLOB, lob_2 BLOB, amount NUMBER DEFAULT 18446744073709551615,
                      pos_1 NUMBER DEFAULT 1, pos_2 NUMBER DEFAULT 1) RETURN NUMBER IS
-        v_len1 number;
-        v_len2 number;
+        v_p1 int;
+        v_p2 int;
+        v_amt number;
+        v_eff1 int;
+        v_eff2 int;
         v_n int;
         v_c1 sys.raw;
         v_c2 sys.raw;
@@ -184,21 +227,33 @@ CREATE PACKAGE BODY dbms_lob AS
            OR pos_1 IS NULL OR pos_2 IS NULL THEN
             RETURN NULL;
         END IF;
-        IF amount < 1 OR pos_1 < 1 OR pos_2 < 1 THEN
+        v_amt := pg_catalog.trunc(amount);
+        v_p1 := pg_catalog.trunc(pos_1);
+        v_p2 := pg_catalog.trunc(pos_2);
+        IF v_amt < 1 OR v_p1 < 1 OR v_p2 < 1 THEN
             RETURN NULL;
         END IF;
-        v_len1 := pg_catalog.octet_length(lob_1) - pos_1 + 1;
-        v_len2 := pg_catalog.octet_length(lob_2) - pos_2 + 1;
-        v_n := least(amount, v_len1, v_len2);
+        v_eff1 := greatest(pg_catalog.octet_length(lob_1) - v_p1 + 1, 0);
+        v_eff2 := greatest(pg_catalog.octet_length(lob_2) - v_p2 + 1, 0);
+        v_n := least(v_amt, v_eff1, v_eff2);
         FOR i IN 1..v_n LOOP
-            v_c1 := pg_catalog.substr(lob_1, (pos_1 + i - 1)::int, 1);
-            v_c2 := pg_catalog.substr(lob_2, (pos_2 + i - 1)::int, 1);
+            v_c1 := pg_catalog.substr(lob_1, v_p1 + i - 1, 1);
+            v_c2 := pg_catalog.substr(lob_2, v_p2 + i - 1, 1);
             IF v_c1 IS DISTINCT FROM v_c2 THEN
-                RETURN i;
+                IF pg_catalog.get_byte(v_c1, 0) > pg_catalog.get_byte(v_c2, 0) THEN
+                    RETURN 1;
+                END IF;
+                RETURN -1;
             END IF;
         END LOOP;
-        IF amount > v_n AND v_len1 <> v_len2 THEN
-            RETURN v_n + 1;
+        IF v_amt <= v_n THEN
+            RETURN 0;
+        END IF;
+        IF v_eff1 < v_eff2 THEN
+            RETURN -1;
+        END IF;
+        IF v_eff1 > v_eff2 THEN
+            RETURN 1;
         END IF;
         RETURN 0;
     END;
@@ -229,100 +284,150 @@ CREATE PACKAGE BODY dbms_lob AS
 
     PROCEDURE copy(dest_lob IN OUT CLOB, src_lob CLOB, amount NUMBER DEFAULT 18446744073709551615,
                    dest_pos NUMBER DEFAULT 1, src_pos NUMBER DEFAULT 1) IS
+        v_dpos int;
+        v_spos int;
+        v_amount number;
         v_amt int;
+        v_gap int;
     BEGIN
         IF src_lob IS NULL OR amount IS NULL OR dest_pos IS NULL OR src_pos IS NULL THEN
             RETURN;
         END IF;
-        IF amount < 1 OR dest_pos < 1 OR src_pos < 1 THEN
+        v_dpos := pg_catalog.trunc(dest_pos);
+        v_spos := pg_catalog.trunc(src_pos);
+        v_amount := pg_catalog.trunc(amount);
+        IF v_dpos < 1 OR v_spos < 1 OR v_amount < 1
+           OR v_spos > pg_catalog.length(src_lob) THEN
             RETURN;
         END IF;
-        v_amt := least(amount, pg_catalog.length(src_lob) - src_pos + 1);
+        v_amt := least(v_amount, pg_catalog.length(src_lob) - v_spos + 1)::int;
+        v_gap := greatest(v_dpos - 1 - pg_catalog.length(dest_lob), 0);
         IF dest_lob IS NULL THEN
-            dest_lob := pg_catalog.substr(src_lob, src_pos::int, v_amt);
+            dest_lob := pg_catalog.substr(src_lob, v_spos, v_amt);
         ELSE
-            dest_lob := pg_catalog.substr(dest_lob, 1, (dest_pos - 1)::int)
-                        || pg_catalog.substr(src_lob, src_pos::int, v_amt)
-                        || pg_catalog.substr(dest_lob, (dest_pos + v_amt)::int, 2147483647);
+            dest_lob := pg_catalog.substr(dest_lob, 1, v_dpos - 1)
+                        || pg_catalog.repeat(' ', v_gap)
+                        || pg_catalog.substr(src_lob, v_spos, v_amt)
+                        || pg_catalog.substr(dest_lob, v_dpos + v_amt, 2147483647);
         END IF;
     END;
 
     PROCEDURE copy(dest_lob IN OUT BLOB, src_lob BLOB, amount NUMBER DEFAULT 18446744073709551615,
                    dest_pos NUMBER DEFAULT 1, src_pos NUMBER DEFAULT 1) IS
+        v_dpos int;
+        v_spos int;
+        v_amount number;
         v_amt int;
+        v_gap int;
     BEGIN
         IF src_lob IS NULL OR amount IS NULL OR dest_pos IS NULL OR src_pos IS NULL THEN
             RETURN;
         END IF;
-        IF amount < 1 OR dest_pos < 1 OR src_pos < 1 THEN
+        v_dpos := pg_catalog.trunc(dest_pos);
+        v_spos := pg_catalog.trunc(src_pos);
+        v_amount := pg_catalog.trunc(amount);
+        IF v_dpos < 1 OR v_spos < 1 OR v_amount < 1
+           OR v_spos > pg_catalog.octet_length(src_lob) THEN
             RETURN;
         END IF;
-        v_amt := least(amount, pg_catalog.octet_length(src_lob) - src_pos + 1);
+        v_amt := least(v_amount, pg_catalog.octet_length(src_lob) - v_spos + 1)::int;
+        v_gap := greatest(v_dpos - 1 - pg_catalog.octet_length(dest_lob), 0);
         IF dest_lob IS NULL THEN
-            dest_lob := pg_catalog.substr(src_lob, src_pos::int, v_amt);
+            dest_lob := pg_catalog.substr(src_lob, v_spos, v_amt);
         ELSE
-            dest_lob := pg_catalog.substr(dest_lob, 1, (dest_pos - 1)::int)
-                        || pg_catalog.substr(src_lob, src_pos::int, v_amt)
-                        || pg_catalog.substr(dest_lob, (dest_pos + v_amt)::int, 2147483647);
+            dest_lob := pg_catalog.substr(dest_lob, 1, v_dpos - 1)
+                        || pg_catalog.decode(pg_catalog.repeat('0', v_gap * 2), 'hex')
+                        || pg_catalog.substr(src_lob, v_spos, v_amt)
+                        || pg_catalog.substr(dest_lob, v_dpos + v_amt, 2147483647);
         END IF;
     END;
 
     PROCEDURE trim(dest_lob IN OUT CLOB, newlen NUMBER) IS
     BEGIN
-        IF dest_lob IS NULL OR newlen IS NULL THEN
+        IF dest_lob IS NULL THEN
             RETURN;
+        END IF;
+        IF newlen IS NULL OR newlen < 0 THEN
+            RAISE EXCEPTION 'argument 2 is null, invalid, or out of range';
         END IF;
         IF newlen > pg_catalog.length(dest_lob) THEN
             RAISE EXCEPTION 'specified trim length is greater than current LOB value''s length';
         END IF;
-        dest_lob := pg_catalog.substr(dest_lob, 1, newlen::int);
+        dest_lob := pg_catalog.substr(dest_lob, 1, pg_catalog.trunc(newlen)::int);
     END;
 
     PROCEDURE trim(dest_lob IN OUT BLOB, newlen NUMBER) IS
     BEGIN
-        IF dest_lob IS NULL OR newlen IS NULL THEN
+        IF dest_lob IS NULL THEN
             RETURN;
+        END IF;
+        IF newlen IS NULL OR newlen < 0 THEN
+            RAISE EXCEPTION 'argument 2 is null, invalid, or out of range';
         END IF;
         IF newlen > pg_catalog.octet_length(dest_lob) THEN
             RAISE EXCEPTION 'specified trim length is greater than current LOB value''s length';
         END IF;
-        dest_lob := pg_catalog.substr(dest_lob, 1, newlen::int);
+        dest_lob := pg_catalog.substr(dest_lob, 1, pg_catalog.trunc(newlen)::int);
     END;
 
     PROCEDURE erase(dest_lob IN OUT CLOB, amount IN OUT NUMBER, pos NUMBER DEFAULT 1) IS
+        v_pos int;
+        v_amount number;
         v_erase int;
     BEGIN
-        IF dest_lob IS NULL OR amount IS NULL OR pos IS NULL OR pos < 1 THEN
-            amount := 0;
+        IF amount IS NULL THEN
+            RAISE EXCEPTION 'argument 2 is null, invalid, or out of range';
+        END IF;
+        IF pos IS NULL THEN
+            RAISE EXCEPTION 'argument 3 is null, invalid, or out of range';
+        END IF;
+        v_pos := pg_catalog.trunc(pos);
+        v_amount := pg_catalog.trunc(amount);
+        IF v_amount < 0 THEN
+            RAISE EXCEPTION 'argument 2 is null, invalid, or out of range';
+        END IF;
+        IF v_pos < 1 THEN
+            RAISE EXCEPTION 'argument 3 is null, invalid, or out of range';
+        END IF;
+        IF dest_lob IS NULL OR v_pos > pg_catalog.length(dest_lob) THEN
             RETURN;
         END IF;
-        v_erase := least(amount, pg_catalog.length(dest_lob) - pos + 1);
-        IF v_erase < 0 THEN
-            v_erase := 0;
-        END IF;
+        v_erase := least(v_amount, pg_catalog.length(dest_lob) - v_pos + 1)::int;
         IF v_erase > 0 THEN
-            dest_lob := pg_catalog.substr(dest_lob, 1, (pos - 1)::int)
+            dest_lob := pg_catalog.substr(dest_lob, 1, v_pos - 1)
                         || pg_catalog.repeat(' ', v_erase)
-                        || pg_catalog.substr(dest_lob, (pos + v_erase)::int, 2147483647);
+                        || pg_catalog.substr(dest_lob, v_pos + v_erase, 2147483647);
         END IF;
         amount := v_erase;
     END;
 
     PROCEDURE erase(dest_lob IN OUT BLOB, amount IN OUT NUMBER, pos NUMBER DEFAULT 1) IS
+        v_pos int;
+        v_amount number;
         v_erase int;
     BEGIN
-        IF dest_lob IS NULL OR amount IS NULL OR pos IS NULL OR pos < 1 THEN
-            amount := 0;
+        IF amount IS NULL THEN
+            RAISE EXCEPTION 'argument 2 is null, invalid, or out of range';
+        END IF;
+        IF pos IS NULL THEN
+            RAISE EXCEPTION 'argument 3 is null, invalid, or out of range';
+        END IF;
+        v_pos := pg_catalog.trunc(pos);
+        v_amount := pg_catalog.trunc(amount);
+        IF v_amount < 0 THEN
+            RAISE EXCEPTION 'argument 2 is null, invalid, or out of range';
+        END IF;
+        IF v_pos < 1 THEN
+            RAISE EXCEPTION 'argument 3 is null, invalid, or out of range';
+        END IF;
+        IF dest_lob IS NULL OR v_pos > pg_catalog.octet_length(dest_lob) THEN
             RETURN;
         END IF;
-        v_erase := least(amount, pg_catalog.octet_length(dest_lob) - pos + 1);
-        IF v_erase < 0 THEN
-            v_erase := 0;
-        END IF;
+        v_erase := least(v_amount, pg_catalog.octet_length(dest_lob) - v_pos + 1)::int;
         IF v_erase > 0 THEN
-            dest_lob := pg_catalog.substr(dest_lob, 1, (pos - 1)::int)
+            dest_lob := pg_catalog.substr(dest_lob, 1, v_pos - 1)
                         || pg_catalog.decode(pg_catalog.repeat('0', v_erase * 2), 'hex')
-                        || pg_catalog.substr(dest_lob, (pos + v_erase)::int, 2147483647);
+                        || pg_catalog.substr(dest_lob, v_pos + v_erase, 2147483647);
         END IF;
         amount := v_erase;
     END;


### PR DESCRIPTION
## Source

- Official feature request [#1029](https://github.com/IvorySQL/IvorySQL/issues/1029) ("oracle compatibility feature: DBMS_LOB", open since 2025-12-05).
- Oracle Database 23ai PL/SQL Packages and Types Reference, [DBMS_LOB](https://docs.oracle.com/en/database/oracle/oracle-database/23/arpls/DBMS_LOB.html) — the package this PR implements.
- EDB Postgres Advanced Server ships DBMS_LOB: [EDB DBMS_LOB reference](https://www.enterprisedb.com/docs/epas/latest/reference/oracle_compatibility_reference/epas_compat_bip_guide/03_built-in_packages/06_dbms_lob/).

## Current gap

On master (375aa370d72) IvorySQL ships the Oracle LOB types (`clob`, `nclob`, `blob` — domains over `text`/`bytea` in pg_type.dat) but **no `dbms_lob` package anywhere** (`grep -ri "dbms_lob" src/ contrib/` finds nothing), and no open PR addresses #1029 (keyword re-checked when this PR was prepared). Without it, LOB manipulation has no Oracle-compatible API, which blocks LOB-using migrations — the package is among Oracle's most-used programming interfaces.

## Project fit

The package follows IvorySQL's established built-in-package architecture exactly (the `builtin_packages/<name>/` pattern of `dbms_lock`, `dbms_session`, etc.): a `CREATE PACKAGE`/`CREATE PACKAGE BODY` pair registered through `ivorysql_ora_merge_sqls`, exposed in the `sys` schema for oracle mode. IvorySQL's own decision to model `clob`/`blob` as domains over text/bytea (value semantics) means a value-level DBMS_LOB subset is the natural, architecture-consistent first cut — no locators, no shared-memory state, no core changes.

## Scope

Implemented (value-level subprograms on clob/nclob/blob + the `lobmaxsize` constant, 18446744073709551615, matching the Oracle 23ai value):

- `GETLENGTH(lob)` — characters for CLOB/NCLOB, bytes for BLOB; NULL in → NULL out.
- `SUBSTR(lob, amount := 32767, offset := 1)` — amount-first argument order; offset/amount < 1, offset > length, or **amount > 32767 → NULL**; amount clamped to the LOB end.
- `INSTR(lob, pattern, offset := 1, occurrence := 1)` — offset/occurrence < 1 → NULL; no match (incl. pattern longer than LOB, offset > length) → 0.
- `COMPARE(lob_1, lob_2, amount := lobmaxsize, offset_1 := 1, offset_2 := 1)` — strcmp-style **-1/0/+1** over the first min(amount, remaining_1, remaining_2) characters; NULL for NULL/invalid arguments.
- `APPEND(dest IN OUT, src)`, `COPY(dest IN OUT, src, amount, dest_offset, src_offset)` (overwrites from dest_offset, preserves the rest; gap to a dest_offset past the end is padded with spaces/zeros as Oracle does), `TRIM(dest IN OUT, newlen)` (raises for NULL/negative or over-length, ORA-21560/ORA-22926 text), `ERASE(dest IN OUT, amount IN OUT, offset)` (spaces for CLOB / zero bytes for BLOB; amount reports the erased count).

Not included (documented in the package header): locator-oriented subprograms with no equivalent in IvorySQL's value model — OPEN/CLOSE/ISOPEN, CREATETEMPORARY/FREETEMPORARY/ISTEMPORARY, the FILE* family (no `bfile` type), CONVERTTOBLOB/CONVERTTOCLOB, READ/WRITE, FRAGMENT_*. These are follow-up material, not silently dropped.

## Implementation

- `contrib/ivorysql_ora/src/builtin_packages/dbms_lob/dbms_lob--1.0.sql`: package spec + PL/iSQL body (zero C code), following the `dbms_lock` delegation-style house pattern but implementing the logic directly in the body.
- Registered in `contrib/ivorysql_ora/ivorysql_ora_merge_sqls` (extension SQL merge) and `contrib/ivorysql_ora/Makefile` (`ORA_REGRESS`); no `OBJS` change since there is no C file.
- The body calls `pg_catalog` primitives explicitly (never its own member names) so unqualified member resolution cannot recurse, and truncates its NUMBER position/amount arguments toward zero (verified Oracle behavior) before use.
- Overloads: `getlength` has CLOB/NCLOB/BLOB forms; calling it with an untyped NULL is ambiguous — exactly as Oracle's static resolver rejects `DBMS_LOB.GETLENGTH(NULL)` with PLS-00307.

## Tests

All commands run in the WSL build tree (`~/build/src`); every expected value was first captured from Oracle 23ai Free (gvenzl/oracle-free:23-slim, sqlplus sessions), including a dedicated boundary probe round:

- Oracle boundary facts the tests encode: SUBSTR amount 32768 → NULL while 32767 works; fractional arguments truncate toward zero (`SUBSTR('abcde', 2.7, 2.7)` = `'bc'`); COMPARE is sign-based (`('abcde','abcXe',5)` = 1, prefix = -1, pos-beyond-one = -1, pos-beyond-both = 0); COPY pads the gap with spaces/zeros (`COPY(d,'xy',2,100,1)` on 'ABCDEF' → length 101 ending 'xy'; blob gap → `AABB0000DD`); ERASE clamps the IN OUT amount (10 → 3) but leaves it untouched when pos is beyond the end; TRIM with negative newlen raises ORA-21560 text.
- New regression test `contrib/ivorysql_ora/sql/dbms_lob.sql` (+ expected, 400+ lines) covering all of the above plus APPEND (chained, NULL-source no-op, NULL-dest init, blob), COPY blob variants, TRIM blob, a table-column round-trip, and the constant value.
- `make oracle-check ORA_REGRESS=dbms_lob` → **1/1 pass**.
- `make oracle-check` (full suite) → **29/29 pass**.

## Compatibility / Risk

- Additive: one new package in the `sys` schema of oracle mode; no existing behavior, parser, or core code modified; no new dependencies; original implementation (license-compatible).
- Documented deviations from Oracle (all in the package header and here): the value model cannot reproduce locator-error paths (ORA-22275 for uninitialized locators), so APPEND treats a NULL source as a no-op and a NULL destination as uninitialized-to-be-set; COMPARE's nonzero value is unspecified in Oracle (observed ±1), and IvorySQL returns -1/0/+1 deterministically.
- Residual risk: subprograms outside the implemented subset remain absent (compile-time "does not exist" errors for migration scripts that call them) — an honest, visible gap rather than a behavioral difference.

## Issue

Closes #1029.
