### PR TITLE
Fix sys.lengthb(bytea) function metadata

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -4074,3 +4074,16 @@ select to_single_byte(NULL);
  
 (1 row)
 
+
+
+-- Verify sys.lengthb(bytea) metadata.
+SELECT count(*) = 1 AS lengthb_bytea_metadata_ok
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.lengthb(bytea)'::regprocedure
+  AND provolatile = 'i'
+  AND proisstrict = true
+  AND proparallel = 's';
+ lengthb_bytea_metadata_ok 
+---------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1558,3 +1558,12 @@ select to_single_byte('１．２');
 select to_single_byte(１．２);
 select to_single_byte(3.4);
 select to_single_byte(NULL);
+
+
+-- Verify sys.lengthb(bytea) metadata.
+SELECT count(*) = 1 AS lengthb_bytea_metadata_ok
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.lengthb(bytea)'::regprocedure
+  AND provolatile = 'i'
+  AND proisstrict = true
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -330,7 +330,9 @@ begin
 end;
 $$
 language plpgsql
-PARALLEL SAFE;
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
 
 
 /* trim/ltrim/rtrim functions */


### PR DESCRIPTION
## Summary

- Declare `sys.lengthb(bytea)` as `STRICT`, `PARALLEL SAFE`, and `IMMUTABLE`.
- The function is a PL/pgSQL wrapper around `octet_length($1)` and has no session or database access.

## Root cause

The function was created without explicit volatility or null-call metadata, so PostgreSQL defaulted it to `VOLATILE` and `CALLED ON NULL INPUT`. The earlier `PARALLEL SAFE` marker was present, but the remaining metadata was still incorrect.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql` that checks `pg_proc.provolatile`, `proisstrict`, and `proparallel`.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1895

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `sys.lengthb(bytea)` metadata to accurately identify the function as immutable, strict, and parallel-safe.
  * Added regression coverage to verify these function properties remain correctly registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->