### PR TITLE
Mark sys.oravarcharcat and sys.concat parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -444,3 +444,15 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+
+-- Verify VARCHAR2 concatenation helpers are parallel safe.
+SELECT count(*) = 2 AS varchar2_concat_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.oravarcharcat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure,
+              'sys.concat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure)
+  AND proparallel = 's';
+ varchar2_concat_parallel_safe 
+-------------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -186,3 +186,11 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+
+-- Verify VARCHAR2 concatenation helpers are parallel safe.
+SELECT count(*) = 2 AS varchar2_concat_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.oravarcharcat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure,
+              'sys.concat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure)
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -3498,6 +3498,7 @@ CREATE FUNCTION sys.oravarcharcat(sys.oravarcharchar, sys.oravarcharchar)
 RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','oravarcharcat'
 LANGUAGE C
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE OPERATOR ||  (
@@ -3510,6 +3511,7 @@ CREATE FUNCTION sys.concat(sys.oravarcharchar, sys.oravarcharchar)
 RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','oravarcharcat'
 LANGUAGE C
+PARALLEL SAFE
 IMMUTABLE;
 /***************************************************************
  *


### PR DESCRIPTION
## Summary

- Mark `sys.oravarcharcat(sys.oravarcharchar, sys.oravarcharchar)` as `PARALLEL SAFE`.
- Mark `sys.concat(sys.oravarcharchar, sys.oravarcharchar)` as `PARALLEL SAFE`.
- Both functions are `IMMUTABLE` and use the same C implementation.

## Root cause

The two function declarations omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted them to `PARALLEL UNSAFE` despite their immutable, state-free implementation.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_character.sql` that checks `pg_proc.proparallel` for both overloads.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1897

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marked `sys.oravarcharcat` and `sys.concat` as parallel safe when used with `sys.oravarcharchar` arguments.
  * Added regression coverage to verify the parallel-safety settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->