### PR TITLE
Mark sys.date_oradate parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime.out
@@ -1260,3 +1260,14 @@ select 25::number <= to_char('1990-01-01'::oradate, 'yyyy');
  t
 (1 row)
 
+
+
+-- Verify date-to-oradate cast helper is parallel safe.
+SELECT count(*) = 1 AS date_oradate_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.date_oradate(pg_catalog.date)'::regprocedure
+  AND proparallel = 's';
+ date_oradate_parallel_safe 
+----------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_datetime.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime.sql
@@ -621,3 +621,10 @@ SELECT 123.456 * interval'365 11:11:11' day(3) to second;
 -- The operator "<=" supports a comparison between the "number" type and the "varchar2" type.
 SET NLS_DATE_FORMAT = 'YYYY-MM-DD';
 select 25::number <= to_char('1990-01-01'::oradate, 'yyyy');
+
+
+-- Verify date-to-oradate cast helper is parallel safe.
+SELECT count(*) = 1 AS date_oradate_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.date_oradate(pg_catalog.date)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -3583,6 +3583,7 @@ RETURNS sys.oradate
 AS 'MODULE_PATHNAME','date_oradate'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (pg_catalog.date AS sys.oradate)


### PR DESCRIPTION
## Summary

- Mark `sys.date_oradate(pg_catalog.date)` as `PARALLEL SAFE`.
- The function is an `IMMUTABLE` C cast helper from PostgreSQL `date` to `sys.oradate`.

## Root cause

The function declaration omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted it to `PARALLEL UNSAFE` despite its immutable, state-free implementation.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_datetime.sql` that checks `pg_proc.proparallel` for the overload.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1898

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marked the date-to-Oracle-date conversion function as parallel safe, enabling it to participate in parallel query execution where appropriate.

* **Tests**
  * Added regression coverage to verify the function’s parallel-safety setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->