### PR TITLE
Mark sys.generate_series(number, ...) overloads parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_number.out
+++ b/contrib/ivorysql_ora/expected/ora_number.out
@@ -1750,3 +1750,15 @@ SELECT BITAND('6',8) re FROM DUAL;
 (1 row)
 
 /* End - bug0000478 */
+
+
+-- Verify number generate_series overloads are parallel safe.
+SELECT count(*) = 2 AS number_generate_series_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.generate_series(sys.number,sys.number)'::regprocedure,
+              'sys.generate_series(sys.number,sys.number,sys.number)'::regprocedure)
+  AND proparallel = 's';
+ number_generate_series_parallel_safe 
+--------------------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_number.sql
+++ b/contrib/ivorysql_ora/sql/ora_number.sql
@@ -943,3 +943,11 @@ SELECT BITAND('6','8') re FROM DUAL;
 SELECT BITAND(6,'8') re FROM DUAL;
 SELECT BITAND('6',8) re FROM DUAL;
 /* End - bug0000478 */
+
+
+-- Verify number generate_series overloads are parallel safe.
+SELECT count(*) = 2 AS number_generate_series_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.generate_series(sys.number,sys.number)'::regprocedure,
+              'sys.generate_series(sys.number,sys.number,sys.number)'::regprocedure)
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -10588,11 +10588,11 @@ create or replace function sys.to_char(text) RETURNS text AS $$ SELECT $1 $$ LAN
 -- generate_series support int2,int4,int8 but number has more choices will result error
 CREATE FUNCTION sys.generate_series(number, number) returns setof numeric AS $$
 SELECT PG_CATALOG.generate_series($1::numeric,$2::numeric)
-$$ LANGUAGE SQL IMMUTABLE;
+$$ LANGUAGE SQL PARALLEL SAFE IMMUTABLE;
 
 CREATE FUNCTION sys.generate_series(number, number, number) returns setof numeric AS $$
 SELECT PG_CATALOG.generate_series($1::numeric,$2::numeric, $3::numeric)
-$$ LANGUAGE SQL IMMUTABLE;
+$$ LANGUAGE SQL PARALLEL SAFE IMMUTABLE;
 
 CREATE CAST (sys.oravarcharchar AS pg_catalog.int4)
 WITH INOUT


### PR DESCRIPTION
## Summary

- Mark `sys.generate_series(sys.number, sys.number)` as `PARALLEL SAFE`.
- Mark `sys.generate_series(sys.number, sys.number, sys.number)` as `PARALLEL SAFE`.
- Both overloads are `IMMUTABLE` SQL wrappers around PostgreSQL's immutable numeric `generate_series`.

## Root cause

The two function declarations omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted them to `PARALLEL UNSAFE` despite their immutable, state-free SQL bodies.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_number.sql` that checks `pg_proc.proparallel` for both overloads.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1899

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - `sys.generate_series` now supports parallel execution for its two-argument and three-argument `number` variants, improving performance in parallel query plans.

- **Tests**
  - Added regression checks to verify that both overloads are marked parallel safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->