### PR TITLE
Mark sys.round(number, integer) parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -4521,3 +4521,14 @@ DETAIL:  "ivorysql" is a reserved prefix.
 reset ivorysql.dummy_config;
 ERROR:  invalid configuration parameter name "ivorysql.dummy_config"
 DETAIL:  "ivorysql" is a reserved prefix.
+
+
+-- Verify sys.round(number, integer) is parallel safe.
+SELECT count(*) = 1 AS round_number_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.round(sys.number,integer)'::regprocedure
+  AND proparallel = 's';
+ round_number_parallel_safe 
+----------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -2464,3 +2464,10 @@ reset default_text_search_config;
 -- should throw errors, because dummy_config is not a valid configuration name
 set ivorysql.dummy_config to dummy;
 reset ivorysql.dummy_config;
+
+
+-- Verify sys.round(number, integer) is parallel safe.
+SELECT count(*) = 1 AS round_number_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.round(sys.number,integer)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -10614,6 +10614,7 @@ RETURNS numeric
 AS $$SELECT pg_catalog.round($1,$2);$$
 LANGUAGE SQL
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oravarcharchar AS float8)


### PR DESCRIPTION
## Summary

- Mark `sys.round(sys.number, integer)` as `PARALLEL SAFE`.
- The function is an `IMMUTABLE` SQL wrapper around PostgreSQL's immutable `round(numeric, integer)`.

## Root cause

The function declaration omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted it to `PARALLEL UNSAFE` despite its immutable, state-free SQL body.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_misc_functions.sql` that checks `pg_proc.proparallel` for the overload.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1900

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100