### PR TITLE
Mark sys.orachar_oravarchar and sys.orachar_oravarcharbyte parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -94,3 +94,17 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+
+
+-- Verify CHAR-to-VARCHAR2 cast helpers are parallel safe.
+SELECT count(*) = 4 AS orachar_to_varchar2_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.orachar_oravarchar(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarchar(sys.oracharbyte)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharbyte)'::regprocedure)
+  AND proparallel = 's';
+ orachar_to_varchar2_parallel_safe 
+-----------------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -81,3 +81,13 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+
+
+-- Verify CHAR-to-VARCHAR2 cast helpers are parallel safe.
+SELECT count(*) = 4 AS orachar_to_varchar2_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.orachar_oravarchar(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarchar(sys.oracharbyte)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharbyte)'::regprocedure)
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -410,6 +410,7 @@ RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharchar AS sys.oravarcharchar)
@@ -422,6 +423,7 @@ RETURNS sys.oravarcharbyte
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharchar AS sys.oravarcharbyte)
@@ -834,6 +836,7 @@ RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharbyte AS sys.oravarcharchar)
@@ -846,6 +849,7 @@ RETURNS sys.oravarcharbyte
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharbyte AS sys.oravarcharbyte)


### PR DESCRIPTION
## Summary

- Mark the four `sys.orachar_oravarchar` / `sys.orachar_oravarcharbyte` cast helpers as `PARALLEL SAFE`.
- All four are `IMMUTABLE` and use the same state-free C string-trimming implementation.

## Root cause

The function declarations omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted them to `PARALLEL UNSAFE` despite their immutable, state-free implementation.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql` that checks `pg_proc.proparallel` for all four overloads.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1902

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100