### PR TITLE
Mark sys.oradate_date parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -2076,3 +2076,14 @@ drop table ds_tb;
 reset NLS_TIMESTAMP_FORMAT;
 reset NLS_TIMESTAMP_TZ_FORMAT;
 reset NLS_DATE_FORMAT;
+
+
+-- Verify oradate-to-date cast helper is parallel safe.
+SELECT count(*) = 1 AS oradate_date_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.oradate_date(sys.oradate)'::regprocedure
+  AND proparallel = 's';
+ oradate_date_parallel_safe 
+----------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -805,3 +805,10 @@ drop table ds_tb;
 reset NLS_TIMESTAMP_FORMAT;
 reset NLS_TIMESTAMP_TZ_FORMAT;
 reset NLS_DATE_FORMAT;
+
+
+-- Verify oradate-to-date cast helper is parallel safe.
+SELECT count(*) = 1 AS oradate_date_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.oradate_date(sys.oradate)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -3572,6 +3572,7 @@ RETURNS pg_catalog.date
 AS 'MODULE_PATHNAME','oradate_date'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oradate AS pg_catalog.date)


### PR DESCRIPTION
## Summary

- Mark `sys.oradate_date(sys.oradate)` as `PARALLEL SAFE`.
- The function is an `IMMUTABLE` C cast helper from `sys.oradate` to PostgreSQL `date`.

## Root cause

The function declaration omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted it to `PARALLEL UNSAFE` despite its immutable, state-free implementation.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql` that checks `pg_proc.proparallel` for the overload.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1903

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100