### PR TITLE
Mark sys.bool_orachar parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -444,3 +444,14 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+
+-- Verify boolean-to-oracharchar cast helper is parallel safe.
+SELECT count(*) = 1 AS bool_orachar_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.bool_orachar(boolean)'::regprocedure
+  AND proparallel = 's';
+ bool_orachar_parallel_safe 
+----------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -186,3 +186,10 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+
+-- Verify boolean-to-oracharchar cast helper is parallel safe.
+SELECT count(*) = 1 AS bool_orachar_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.bool_orachar(boolean)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -155,6 +155,7 @@ RETURNS sys.oracharchar
 AS 'MODULE_PATHNAME','bool_orachar'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 -- Convert oracharchar to xml


### PR DESCRIPTION
## Summary

- Mark `sys.bool_orachar(boolean)` as `PARALLEL SAFE`.
- The function is an `IMMUTABLE` C cast helper from PostgreSQL `boolean` to `sys.oracharchar`.

## Root cause

The function declaration omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted it to `PARALLEL UNSAFE` despite its immutable, state-free implementation.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_character.sql` that checks `pg_proc.proparallel` for the overload.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1904

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100