### PR TITLE
Mark sys.to_char(text) parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -4521,3 +4521,14 @@ DETAIL:  "ivorysql" is a reserved prefix.
 reset ivorysql.dummy_config;
 ERROR:  invalid configuration parameter name "ivorysql.dummy_config"
 DETAIL:  "ivorysql" is a reserved prefix.
+
+
+-- Verify sys.to_char(text) is parallel safe.
+SELECT count(*) = 1 AS to_char_text_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.to_char(text)'::regprocedure
+  AND proparallel = 's';
+ to_char_text_parallel_safe 
+----------------------------
+ t
+(1 row)

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -2464,3 +2464,10 @@ reset default_text_search_config;
 -- should throw errors, because dummy_config is not a valid configuration name
 set ivorysql.dummy_config to dummy;
 reset ivorysql.dummy_config;
+
+
+-- Verify sys.to_char(text) is parallel safe.
+SELECT count(*) = 1 AS to_char_text_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.to_char(text)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -10583,7 +10583,7 @@ AS IMPLICIT;
 
 --create function for sgrdb
 -- add immutable
-create or replace function sys.to_char(text) RETURNS text AS $$ SELECT $1 $$ LANGUAGE SQL IMMUTABLE;
+create or replace function sys.to_char(text) RETURNS text AS $$ SELECT $1 $$ LANGUAGE SQL PARALLEL SAFE IMMUTABLE;
 
 -- generate_series support int2,int4,int8 but number has more choices will result error
 CREATE FUNCTION sys.generate_series(number, number) returns setof numeric AS $$


### PR DESCRIPTION
## Summary

- Mark `sys.to_char(text)` as `PARALLEL SAFE`.
- The function is an `IMMUTABLE` SQL identity wrapper (`SELECT $1`).

## Root cause

The function declaration omitted the `PARALLEL SAFE` catalog clause, so PostgreSQL defaulted it to `PARALLEL UNSAFE` despite its immutable, state-free SQL body.

## Testing

- `git diff --check upstream/master...HEAD`
- Actual result: `git diff --check` exited 0 with no whitespace errors.
- Added a regression assertion in `contrib/ivorysql_ora/sql/ora_misc_functions.sql` that checks `pg_proc.proparallel` for the overload.
- Full IvorySQL regression suite will run in project CI after maintainer approval; it was not run locally because a full Windows IvorySQL build is not available in this environment.

Fixes #1905

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100