### PR TITLE
Fix bare INTERVAL type name in Oracle parser mode

### DIFF
--- a/src/backend/oracle_parser/ora_gram.y
+++ b/src/backend/oracle_parser/ora_gram.y
@@ -16832,12 +16832,11 @@ SimpleTypename:
 						A_Const *n;
 
 						if (typmods == NULL)
-							ereport(ERROR,
-									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-									 errmsg("missing or invalid datetime field.")));
-
-						//n = lfirst(typmods->elements[0]);
-						n = linitial(typmods);
+							$$ = $1;
+						else
+						{
+							//n = lfirst(typmods->elements[0]);
+							n = linitial(typmods);
 
 						/*
 						 * Compatible oracle
@@ -16866,6 +16865,7 @@ SimpleTypename:
 									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 									 errmsg("unsupported interval type.")));
 						}
+					}
 					}
 					else
 					{

--- a/src/oracle_test/regress/expected/interval.out
+++ b/src/oracle_test/regress/expected/interval.out
@@ -1507,5 +1507,13 @@ CREATE TABLE interval_bare_oracle (a interval);
 CREATE TABLE
 DROP TABLE interval_bare_oracle;
 DROP TABLE
+-- Extension install scripts also reference a bare INTERVAL in CREATE CAST.
+CREATE CAST (int4 AS interval) WITH INOUT;
+DROP CAST (int4 AS interval);
+-- Function signatures in extension install scripts may use bare INTERVAL
+-- for both arguments and return type.
+CREATE FUNCTION interval_bare_oracle_func(interval) RETURNS interval LANGUAGE SQL AS $$ SELECT $1 $$;
+/
+DROP FUNCTION interval_bare_oracle_func(interval);
 SET ivorysql.compatible_mode = pg;
 SET

--- a/src/oracle_test/regress/expected/interval.out
+++ b/src/oracle_test/regress/expected/interval.out
@@ -1499,3 +1499,13 @@ SELECT PGEXTRACT(epoch from interval '1000000000 days');
 ERROR:  syntax error at or near ")"
 LINE 1: SELECT PGEXTRACT(epoch from interval '1000000000 days');
                                                             ^
+
+-- Bare INTERVAL type name is accepted in oracle parser mode.
+SET ivorysql.compatible_mode = oracle;
+SET
+CREATE TABLE interval_bare_oracle (a interval);
+CREATE TABLE
+DROP TABLE interval_bare_oracle;
+DROP TABLE
+SET ivorysql.compatible_mode = pg;
+SET

--- a/src/oracle_test/regress/expected/interval_1.out
+++ b/src/oracle_test/regress/expected/interval_1.out
@@ -1690,3 +1690,13 @@ reset ivorysql.enable_emptystring_to_null;
 ERROR:  syntax error at or near ")"
 LINE 20:      (VALUES (interval '-infinity'),
                                            ^
+
+-- Bare INTERVAL type name is accepted in oracle parser mode.
+SET ivorysql.compatible_mode = oracle;
+SET
+CREATE TABLE interval_bare_oracle (a interval);
+CREATE TABLE
+DROP TABLE interval_bare_oracle;
+DROP TABLE
+SET ivorysql.compatible_mode = pg;
+SET

--- a/src/oracle_test/regress/expected/interval_1.out
+++ b/src/oracle_test/regress/expected/interval_1.out
@@ -1698,5 +1698,13 @@ CREATE TABLE interval_bare_oracle (a interval);
 CREATE TABLE
 DROP TABLE interval_bare_oracle;
 DROP TABLE
+-- Extension install scripts also reference a bare INTERVAL in CREATE CAST.
+CREATE CAST (int4 AS interval) WITH INOUT;
+DROP CAST (int4 AS interval);
+-- Function signatures in extension install scripts may use bare INTERVAL
+-- for both arguments and return type.
+CREATE FUNCTION interval_bare_oracle_func(interval) RETURNS interval LANGUAGE SQL AS $$ SELECT $1 $$;
+/
+DROP FUNCTION interval_bare_oracle_func(interval);
 SET ivorysql.compatible_mode = pg;
 SET

--- a/src/oracle_test/regress/sql/interval.sql
+++ b/src/oracle_test/regress/sql/interval.sql
@@ -800,3 +800,9 @@ SELECT INTERVAL 'infinity ago';
 SELECT INTERVAL '+infinity -infinity';
 SELECT PGEXTRACT(epoch from interval '1000000000 days');
 reset ivorysql.enable_emptystring_to_null;
+
+-- Bare INTERVAL type name is accepted in oracle parser mode.
+SET ivorysql.compatible_mode = oracle;
+CREATE TABLE interval_bare_oracle (a interval);
+DROP TABLE interval_bare_oracle;
+SET ivorysql.compatible_mode = pg;

--- a/src/oracle_test/regress/sql/interval.sql
+++ b/src/oracle_test/regress/sql/interval.sql
@@ -805,4 +805,12 @@ reset ivorysql.enable_emptystring_to_null;
 SET ivorysql.compatible_mode = oracle;
 CREATE TABLE interval_bare_oracle (a interval);
 DROP TABLE interval_bare_oracle;
+-- Extension install scripts also reference a bare INTERVAL in CREATE CAST.
+CREATE CAST (int4 AS interval) WITH INOUT;
+DROP CAST (int4 AS interval);
+-- Function signatures in extension install scripts may use bare INTERVAL
+-- for both arguments and return type.
+CREATE FUNCTION interval_bare_oracle_func(interval) RETURNS interval LANGUAGE SQL AS $$ SELECT $1 $$;
+/
+DROP FUNCTION interval_bare_oracle_func(interval);
 SET ivorysql.compatible_mode = pg;


### PR DESCRIPTION
## Summary

- Accept a bare, unqualified `INTERVAL` type name in Oracle parser mode.
- In the `SimpleTypename: ConstInterval opt_interval_type` production, fall back to the PostgreSQL `interval` type when `opt_interval_type` is empty instead of raising `missing or invalid datetime field.`.
- Add Oracle regression coverage that creates and drops a table with a bare `INTERVAL` column while `ivorysql.compatible_mode = oracle`.

## Root cause

`src/backend/oracle_parser/ora_gram.y` unconditionally raised `ERRCODE_FEATURE_NOT_SUPPORTED` when the optional interval-field-qualifier list was empty. That made a plain `INTERVAL` type reference fail only in Oracle parser mode, breaking statements such as `CREATE TABLE t (x interval)` and extension install scripts that reference a bare `INTERVAL`.

## Testing

Commands run on the Windows preparation host:

- `git diff --check` -> passed, exit code 0
- `git diff --stat` reviewed: 4 files changed, 32 insertions(+), 6 deletions(-)

A full PostgreSQL/IvorySQL build and the Oracle regression suite are not available on this Windows host. Full regression execution will run in project CI after maintainer approval.

## Disclosure

Fixes #1784

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bare `INTERVAL` type declarations are now accepted in Oracle compatibility mode instead of producing an invalid datetime field error.

* **Tests**
  * Expanded regression coverage to verify bare `INTERVAL` support in table definitions, casts, and function argument and return types, including successful cleanup in Oracle compatibility mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->