### PR TITLE
Fix misspelled unpriviledged in rewriteGraphTable.c comment

### DIFF
--- a/src/backend/rewrite/rewriteGraphTable.c
+++ b/src/backend/rewrite/rewriteGraphTable.c
@@ -500,7 +500,7 @@ generate_query_for_graph_path(RangeTblEntry *rte, List *graph_path)
 		 * rule 4) does not specify whose access privileges to use when
 		 * accessing the element tables: property graph owner's or current
 		 * user's. It is safer to use current user's privileges so as not to
-		 * make property graphs as a hole for unpriviledged data access. This
+		 * make property graphs as a hole for unprivileged data access. This
 		 * is inline with the views being security_invoker by default.
 		 */
 		rel = table_open(pe->reloid, AccessShareLock);


### PR DESCRIPTION
## Summary

Update unpriviledged to unprivileged in a comment in src/backend/rewrite/rewriteGraphTable.c.

## Root cause

The comment misspelled unprivileged as unpriviledged.

## Testing

- git diff --check -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1917

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in an internal code comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->