### PR TITLE
Fix misspelled lenght in formatting.c comment

### DIFF
--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -3648,7 +3648,7 @@ DCH_from_char(FormatNode *node, const char *in, TmFromChar *out,
 
 				/*
 				 * Compatible oracle, if the number of fractional seconds is greater than
-				 * the lenght of format picture item 'FFx' should error out.
+				 * the length of format picture item 'FFx' should error out.
 				 * eg: select to_timestamp('1990-1-1 11:11:11.1235', 'yyyy-mm-dd hh24:mi:ss.ff3') from dual;
 				 * errmsg: ORA-01830: date format picture ends before converting entire input string.
 				 */


### PR DESCRIPTION
## Summary

Update lenght to length in a comment in src/backend/utils/adt/formatting.c.

## Root cause

The comment misspelled length as lenght.

## Testing

- git diff --check -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1918

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in an internal error-condition comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->