### PR TITLE
Fix misspelled paramter in parser parameter comments and header

### DIFF
--- a/src/backend/parser/parse_param.c
+++ b/src/backend/parser/parse_param.c
@@ -82,7 +82,7 @@ static OraParamNumbers *CurrentOraParamNode = NULL;
  * DoStmtCheckVar: wether should check bound var matching.
  * Should not check var bound match for grammer:
  *     'select xxx; begin xxx end;begin xxx end;'
- * IsBindByName: the paramter is bound by name.
+ * IsBindByName: the parameter is bound by name.
  * When compile DoStmt, DoStmt always gets compiled after other stmt.
  */
 static bool			IsParseDynSql = false;

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -86,7 +86,7 @@ extern void interpret_function_parameter_list(ParseState *pstate,
 											  List **parameterDefaults,
 											  Oid *variadicArgType,
 											  Oid *requiredResultType,
-											  ArrayType **paramtertypeNames);
+											  ArrayType **parametertypeNames);
 
 /* commands/operatorcmds.c */
 extern ObjectAddress DefineOperator(List *names, List *parameters);


### PR DESCRIPTION
## Summary

Update paramter to parameter in src/backend/parser/parse_param.c and src/include/commands/defrem.h.

## Root cause

The comment and declaration parameter name misspelled parameter as paramter.

## Testing

- git diff --check -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1919

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

