### PR TITLE
Normalize outparameter spelling in pquery.c and libpq comment

### DIFF
--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1340,7 +1340,7 @@ PortalRunMulti(Portal portal,
 {
 	bool		active_snapshot_set = false;
 	ListCell   *stmtlist_item;
-	bool		anonymous_has_outparamter = false;
+	bool		anonymous_has_outparameter = false;
 
 	/* check if anonymous block has OUT parameters */
 	if (portal->stmts != NIL &&
@@ -1354,14 +1354,14 @@ PortalRunMulti(Portal portal,
 			portal->portalParams != NULL &&
 			portal->portalParams->haveout)
 		{
-			anonymous_has_outparamter = true;
+			anonymous_has_outparameter = true;
 		}
 		else if (nodeTag(node) == T_RawStmt &&
 			nodeTag(((RawStmt *)node)->stmt) == T_DoStmt &&
 			portal->portalParams != NULL &&
 			portal->portalParams->haveout)
 		{
-			anonymous_has_outparamter = true;
+			anonymous_has_outparameter = true;
 		}
 	}
 
@@ -1376,9 +1376,9 @@ PortalRunMulti(Portal portal,
 	 * but the results will be discarded unless you use "simple Query"
 	 * protocol.
 	 */
-	if (dest->mydest == DestRemoteExecute && !anonymous_has_outparamter)
+	if (dest->mydest == DestRemoteExecute && !anonymous_has_outparameter)
 		dest = None_Receiver;
-	if (altdest->mydest == DestRemoteExecute && !anonymous_has_outparamter)
+	if (altdest->mydest == DestRemoteExecute && !anonymous_has_outparameter)
 		altdest = None_Receiver;
 
 	/*

--- a/src/interfaces/libpq/ivy-exec.c
+++ b/src/interfaces/libpq/ivy-exec.c
@@ -1607,7 +1607,7 @@ get_field_number_from_coluname(PGresult *res, const char *column)
 
 /*
  * use column name to get realy result of column, 
- * this is because OUT paramters are put before the result.
+ * this is because OUT parameters are put before the result.
  */
 static int
 get_result_off(PGresult *res)


### PR DESCRIPTION
## Summary

Rename anonymous_has_outparamter to anonymous_has_outparameter in src/backend/tcop/pquery.c and fix paramters in a src/interfaces/libpq/ivy-exec.c comment.

## Root cause

The local variable and comment misspelled outparameter/parameters.

## Testing

- git diff --check -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1920

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

