### PR TITLE
Fix broken grammar and spelling in GB18030 conversion header comment

### DIFF
--- a/src/backend/utils/mb/conversion_procs/gb18030_and_gbk/gb18030_and_gbk.c
+++ b/src/backend/utils/mb/conversion_procs/gb18030_and_gbk/gb18030_and_gbk.c
@@ -3,9 +3,9 @@
  * File: gb18030_and_gbk.c
  *
  * Abstract:
- * 		This file was add for compatable windows use gb18030 as server_encoding,
- * 		cause the default codepage was 936(gbk) on windows,without this conversion it will not
- * 		work right on windows.
+ * 		This file provides a GB18030/GBK conversion for Windows, where the
+ * 		default codepage is 936 (GBK). Without this conversion, using GB18030
+ * 		as the server encoding does not work correctly on Windows.
  *
  * Authored by huawenbo@highgo.com, 20231101.
  *


### PR DESCRIPTION
## Summary

Rewrite the header comment in src/backend/utils/mb/conversion_procs/gb18030_and_gbk/gb18030_and_gbk.c to use correct grammar and spelling.

## Root cause

The original comment was grammatically broken and misspelled compatible as compatable.

## Testing

- git diff --check -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1921

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

