### PR TITLE
Remove obsolete #if 0 preload check in ivorysql_ora

### DIFF
--- a/contrib/ivorysql_ora/src/ivorysql_ora.c
+++ b/contrib/ivorysql_ora/src/ivorysql_ora.c
@@ -86,12 +86,6 @@ void _PG_fini(void);
 void
 _PG_init(void)
 {
-#if 0
-	/* Must be loaded with shared_preload_libaries */
-	if (!process_shared_preload_libraries_in_progress)
-		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				errmsg("ivorysql_ora must be loaded via shared_preload_libraries")));
-#endif
 
 	/* Define custom GUC variables */
 	IvorysqlOraDefineGucs();


### PR DESCRIPTION
## Summary

Remove the obsolete #if 0 block in contrib/ivorysql_ora/src/ivorysql_ora.c that would reject loading unless shared_preload_libraries is in progress.

## Root cause

The extension is loaded normally and the preload check is dead code.

## Testing

- git diff --check -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1923

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

