### PR TITLE
Fix misspelled paralell in vacuumparallel.c comment

### DIFF
--- a/src/backend/commands/vacuumparallel.c
+++ b/src/backend/commands/vacuumparallel.c
@@ -545,7 +545,7 @@ parallel_vacuum_end(ParallelVacuumState *pvs, IndexBulkDeleteResult **istats)
 /*
  * DSM detach callback. This is invoked when an autovacuum worker detaches
  * from the DSM segment holding PVShared. It ensures to reset the local pointer
- * to the shared state even if paralell vacuum raises an error and doesn't
+ * to the shared state even if parallel vacuum raises an error and doesn't
  * call parallel_vacuum_end().
  */
 static void


### PR DESCRIPTION
## Summary

Update paralell to parallel in a comment in src/backend/commands/vacuumparallel.c.

## Root cause

The comment misspelled parallel as paralell.

## Testing

- git diff --check -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1925

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

