### PR TITLE
Fix misspelled Overriden in oracle tsdicts regression comment

### DIFF
--- a/src/oracle_test/regress/expected/tsdicts.out
+++ b/src/oracle_test/regress/expected/tsdicts.out
@@ -689,7 +689,7 @@ CREATE TEXT SEARCH DICTIONARY tsdict_case
 ERROR:  unrecognized Ispell parameter: "DictFile"
 -- Test grammar for configurations
 CREATE TEXT SEARCH CONFIGURATION dummy_tst (COPY=english);
--- Overriden mapping change with duplicated tokens.
+-- Overridden mapping change with duplicated tokens.
 ALTER TEXT SEARCH CONFIGURATION dummy_tst
   ALTER MAPPING FOR word, word WITH ispell;
 -- Not a token supported by the configuration's parser, fails.

--- a/src/oracle_test/regress/sql/tsdicts.sql
+++ b/src/oracle_test/regress/sql/tsdicts.sql
@@ -254,7 +254,7 @@ CREATE TEXT SEARCH DICTIONARY tsdict_case
 
 -- Test grammar for configurations
 CREATE TEXT SEARCH CONFIGURATION dummy_tst (COPY=english);
--- Overriden mapping change with duplicated tokens.
+-- Overridden mapping change with duplicated tokens.
 ALTER TEXT SEARCH CONFIGURATION dummy_tst
   ALTER MAPPING FOR word, word WITH ispell;
 -- Not a token supported by the configuration's parser, fails.


### PR DESCRIPTION
## Summary

Update `Overriden` to `Overridden` in the Oracle regression comment in `src/oracle_test/regress/sql/tsdicts.sql` and its expected output `src/oracle_test/regress/expected/tsdicts.out`.

## Root cause

The regression comment misspelled `Overridden` as `Overriden`.

## Testing

- `git diff --check` -> passed, exit code 0

A full PostgreSQL/IvorySQL build is not available on this Windows host. Full CI and regression execution will run after maintainer approval.

Fixes #1934

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100
