### PR TITLE
Mark additional IvorySQL sys functions parallel safe

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -94,3 +94,16 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+-- Verify CHAR-to-VARCHAR2 cast helpers are parallel safe.
+SELECT count(*) = 4 AS orachar_to_varchar2_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.orachar_oravarchar(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarchar(sys.oracharbyte)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharbyte)'::regprocedure)
+  AND proparallel = 's';
+ orachar_to_varchar2_parallel_safe 
+-----------------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_binary_double.out
+++ b/contrib/ivorysql_ora/expected/ora_binary_double.out
@@ -781,3 +781,13 @@ SELECT (0d - 1e308d) * 10;
  -Inf
 (1 row)
 
+-- Verify numeric-to-binary_double cast helper is parallel safe.
+SELECT count(*) = 1 AS numeric_binary_double_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.numeric_binary_double(numeric)'::regprocedure
+  AND proparallel = 's';
+ numeric_binary_double_parallel_safe 
+-------------------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_character.out
+++ b/contrib/ivorysql_ora/expected/ora_character.out
@@ -444,3 +444,24 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+-- Verify VARCHAR2 concatenation helpers are parallel safe.
+SELECT count(*) = 2 AS varchar2_concat_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.oravarcharcat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure,
+              'sys.concat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure)
+  AND proparallel = 's';
+ varchar2_concat_parallel_safe 
+-------------------------------
+ t
+(1 row)
+
+-- Verify boolean-to-oracharchar cast helper is parallel safe.
+SELECT count(*) = 1 AS bool_orachar_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.bool_orachar(boolean)'::regprocedure
+  AND proparallel = 's';
+ bool_orachar_parallel_safe 
+----------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -4074,3 +4074,15 @@ select to_single_byte(NULL);
  
 (1 row)
 
+-- Verify sys.lengthb(bytea) metadata.
+SELECT count(*) = 1 AS lengthb_bytea_metadata_ok
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.lengthb(bytea)'::regprocedure
+  AND provolatile = 'i'
+  AND proisstrict = true
+  AND proparallel = 's';
+ lengthb_bytea_metadata_ok 
+---------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_datetime.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime.out
@@ -1260,3 +1260,13 @@ select 25::number <= to_char('1990-01-01'::oradate, 'yyyy');
  t
 (1 row)
 
+-- Verify date-to-oradate cast helper is parallel safe.
+SELECT count(*) = 1 AS date_oradate_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.date_oradate(pg_catalog.date)'::regprocedure
+  AND proparallel = 's';
+ date_oradate_parallel_safe 
+----------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -2076,3 +2076,13 @@ drop table ds_tb;
 reset NLS_TIMESTAMP_FORMAT;
 reset NLS_TIMESTAMP_TZ_FORMAT;
 reset NLS_DATE_FORMAT;
+-- Verify oradate-to-date cast helper is parallel safe.
+SELECT count(*) = 1 AS oradate_date_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.oradate_date(sys.oradate)'::regprocedure
+  AND proparallel = 's';
+ oradate_date_parallel_safe 
+----------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -4521,3 +4521,23 @@ DETAIL:  "ivorysql" is a reserved prefix.
 reset ivorysql.dummy_config;
 ERROR:  invalid configuration parameter name "ivorysql.dummy_config"
 DETAIL:  "ivorysql" is a reserved prefix.
+-- Verify sys.round(number, integer) is parallel safe.
+SELECT count(*) = 1 AS round_number_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.round(sys.number,integer)'::regprocedure
+  AND proparallel = 's';
+ round_number_parallel_safe 
+----------------------------
+ t
+(1 row)
+
+-- Verify sys.to_char(text) is parallel safe.
+SELECT count(*) = 1 AS to_char_text_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.to_char(text)'::regprocedure
+  AND proparallel = 's';
+ to_char_text_parallel_safe 
+----------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/expected/ora_number.out
+++ b/contrib/ivorysql_ora/expected/ora_number.out
@@ -1944,3 +1944,14 @@ SELECT to_number('1e-0') AS exp_minus_zero;
 (1 row)
 
 /* End - to_number scientific notation */
+-- Verify number generate_series overloads are parallel safe.
+SELECT count(*) = 2 AS number_generate_series_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.generate_series(sys.number,sys.number)'::regprocedure,
+              'sys.generate_series(sys.number,sys.number,sys.number)'::regprocedure)
+  AND proparallel = 's';
+ number_generate_series_parallel_safe 
+--------------------------------------
+ t
+(1 row)
+

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -81,3 +81,13 @@ drop function s1.f_alter(arg1 number, arg2 number);
 drop function s1.f_alter(arg1 OUT int);
 drop function s1.f_alter(arg1 text);
 drop function s1.f_alter(arg1 number, arg2 number, arg3 number);
+
+
+-- Verify CHAR-to-VARCHAR2 cast helpers are parallel safe.
+SELECT count(*) = 4 AS orachar_to_varchar2_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.orachar_oravarchar(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharchar)'::regprocedure,
+              'sys.orachar_oravarchar(sys.oracharbyte)'::regprocedure,
+              'sys.orachar_oravarcharbyte(sys.oracharbyte)'::regprocedure)
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/sql/ora_binary_double.sql
+++ b/contrib/ivorysql_ora/sql/ora_binary_double.sql
@@ -279,3 +279,10 @@ SELECT 2d * 3d;
 SELECT 7d / 2d;
 SELECT (0d - 1e308d) * 10;
 
+
+
+-- Verify numeric-to-binary_double cast helper is parallel safe.
+SELECT count(*) = 1 AS numeric_binary_double_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.numeric_binary_double(numeric)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/sql/ora_character.sql
+++ b/contrib/ivorysql_ora/sql/ora_character.sql
@@ -186,3 +186,17 @@ explain (costs off) SELECT * FROM TEST_ORAVARCHAR WHERE a='111';
 -- drop table
 DROP TABLE TEST_ORACHAR;
 DROP TABLE TEST_ORAVARCHAR;
+
+
+-- Verify VARCHAR2 concatenation helpers are parallel safe.
+SELECT count(*) = 2 AS varchar2_concat_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.oravarcharcat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure,
+              'sys.concat(sys.oravarcharchar,sys.oravarcharchar)'::regprocedure)
+  AND proparallel = 's';
+
+-- Verify boolean-to-oracharchar cast helper is parallel safe.
+SELECT count(*) = 1 AS bool_orachar_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.bool_orachar(boolean)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1558,3 +1558,12 @@ select to_single_byte('１．２');
 select to_single_byte(１．２);
 select to_single_byte(3.4);
 select to_single_byte(NULL);
+
+
+-- Verify sys.lengthb(bytea) metadata.
+SELECT count(*) = 1 AS lengthb_bytea_metadata_ok
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.lengthb(bytea)'::regprocedure
+  AND provolatile = 'i'
+  AND proisstrict = true
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/sql/ora_datetime.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime.sql
@@ -621,3 +621,10 @@ SELECT 123.456 * interval'365 11:11:11' day(3) to second;
 -- The operator "<=" supports a comparison between the "number" type and the "varchar2" type.
 SET NLS_DATE_FORMAT = 'YYYY-MM-DD';
 select 25::number <= to_char('1990-01-01'::oradate, 'yyyy');
+
+
+-- Verify date-to-oradate cast helper is parallel safe.
+SELECT count(*) = 1 AS date_oradate_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.date_oradate(pg_catalog.date)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -805,3 +805,10 @@ drop table ds_tb;
 reset NLS_TIMESTAMP_FORMAT;
 reset NLS_TIMESTAMP_TZ_FORMAT;
 reset NLS_DATE_FORMAT;
+
+
+-- Verify oradate-to-date cast helper is parallel safe.
+SELECT count(*) = 1 AS oradate_date_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.oradate_date(sys.oradate)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -2464,3 +2464,16 @@ reset default_text_search_config;
 -- should throw errors, because dummy_config is not a valid configuration name
 set ivorysql.dummy_config to dummy;
 reset ivorysql.dummy_config;
+
+
+-- Verify sys.round(number, integer) is parallel safe.
+SELECT count(*) = 1 AS round_number_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.round(sys.number,integer)'::regprocedure
+  AND proparallel = 's';
+
+-- Verify sys.to_char(text) is parallel safe.
+SELECT count(*) = 1 AS to_char_text_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid = 'sys.to_char(text)'::regprocedure
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/sql/ora_number.sql
+++ b/contrib/ivorysql_ora/sql/ora_number.sql
@@ -1002,3 +1002,11 @@ SELECT to_number('1e0') AS exp_zero;
 SELECT to_number('1e+0') AS exp_plus_zero;
 SELECT to_number('1e-0') AS exp_minus_zero;
 /* End - to_number scientific notation */
+
+
+-- Verify number generate_series overloads are parallel safe.
+SELECT count(*) = 2 AS number_generate_series_parallel_safe
+FROM pg_catalog.pg_proc
+WHERE oid IN ('sys.generate_series(sys.number,sys.number)'::regprocedure,
+              'sys.generate_series(sys.number,sys.number,sys.number)'::regprocedure)
+  AND proparallel = 's';

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -330,7 +330,9 @@ begin
 end;
 $$
 language plpgsql
-PARALLEL SAFE;
+STRICT
+PARALLEL SAFE
+IMMUTABLE;
 
 
 /* trim/ltrim/rtrim functions */

--- a/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
+++ b/contrib/ivorysql_ora/src/datatype/datatype--1.0.sql
@@ -155,6 +155,7 @@ RETURNS sys.oracharchar
 AS 'MODULE_PATHNAME','bool_orachar'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 -- Convert oracharchar to xml
@@ -410,6 +411,7 @@ RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharchar AS sys.oravarcharchar)
@@ -422,6 +424,7 @@ RETURNS sys.oravarcharbyte
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharchar AS sys.oravarcharbyte)
@@ -834,6 +837,7 @@ RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharbyte AS sys.oravarcharchar)
@@ -846,6 +850,7 @@ RETURNS sys.oravarcharbyte
 AS 'MODULE_PATHNAME','rtrim'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oracharbyte AS sys.oravarcharbyte)
@@ -3498,6 +3503,7 @@ CREATE FUNCTION sys.oravarcharcat(sys.oravarcharchar, sys.oravarcharchar)
 RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','oravarcharcat'
 LANGUAGE C
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE OPERATOR ||  (
@@ -3510,6 +3516,7 @@ CREATE FUNCTION sys.concat(sys.oravarcharchar, sys.oravarcharchar)
 RETURNS sys.oravarcharchar
 AS 'MODULE_PATHNAME','oravarcharcat'
 LANGUAGE C
+PARALLEL SAFE
 IMMUTABLE;
 /***************************************************************
  *
@@ -3572,6 +3579,7 @@ RETURNS pg_catalog.date
 AS 'MODULE_PATHNAME','oradate_date'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oradate AS pg_catalog.date)
@@ -3583,6 +3591,7 @@ RETURNS sys.oradate
 AS 'MODULE_PATHNAME','date_oradate'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (pg_catalog.date AS sys.oradate)
@@ -9573,6 +9582,7 @@ RETURNS sys.binary_double
 AS 'MODULE_PATHNAME','number_binary_double'
 LANGUAGE C
 STRICT
+PARALLEL SAFE
 IMMUTABLE
 LEAKPROOF;
 
@@ -10583,16 +10593,16 @@ AS IMPLICIT;
 
 --create function for sgrdb
 -- add immutable
-create or replace function sys.to_char(text) RETURNS text AS $$ SELECT $1 $$ LANGUAGE SQL IMMUTABLE;
+create or replace function sys.to_char(text) RETURNS text AS $$ SELECT $1 $$ LANGUAGE SQL PARALLEL SAFE IMMUTABLE;
 
 -- generate_series support int2,int4,int8 but number has more choices will result error
 CREATE FUNCTION sys.generate_series(number, number) returns setof numeric AS $$
 SELECT PG_CATALOG.generate_series($1::numeric,$2::numeric)
-$$ LANGUAGE SQL IMMUTABLE;
+$$ LANGUAGE SQL PARALLEL SAFE IMMUTABLE;
 
 CREATE FUNCTION sys.generate_series(number, number, number) returns setof numeric AS $$
 SELECT PG_CATALOG.generate_series($1::numeric,$2::numeric, $3::numeric)
-$$ LANGUAGE SQL IMMUTABLE;
+$$ LANGUAGE SQL PARALLEL SAFE IMMUTABLE;
 
 CREATE CAST (sys.oravarcharchar AS pg_catalog.int4)
 WITH INOUT
@@ -10614,6 +10624,7 @@ RETURNS numeric
 AS $$SELECT pg_catalog.round($1,$2);$$
 LANGUAGE SQL
 STRICT
+PARALLEL SAFE
 IMMUTABLE;
 
 CREATE CAST (sys.oravarcharchar AS float8)


### PR DESCRIPTION
## Summary

Consolidate the IvorySQL sys-function parallel-safety metadata fixes that were previously opened as ten separate one-line PRs into one cohesive change.

- mark `sys.oravarcharcat` and `sys.concat` parallel safe
- mark `sys.date_oradate`, `sys.oradate_date`, and `sys.to_char(text)` parallel safe
- mark `sys.generate_series(number, ...)` overloads and `sys.round(number, integer)` parallel safe
- mark `sys.numeric_binary_double` parallel safe
- mark `sys.orachar_oravarchar` and `sys.orachar_oravarcharbyte` parallel safe
- mark `sys.bool_orachar` parallel safe
- fix `sys.lengthb(bytea)` function metadata

Each updated overload has focused regression coverage.

## Testing

Rebased onto `master` (`03b24b1c46`) and verified on Ubuntu 22.04 (gcc 12.3) with this branch applied:

```
$ make -C contrib/ivorysql_ora oracle-check
ok: 28   not ok: 1
not ok 17    - ora_xml_functions        # pre-existing, built without libxml
```

`ora_xml_functions` is the only failure and fails on plain `master` in the same tree as well, because the build does not include libxml.

The rebase needed a conflict resolution: `master` added the `to_number` scientific-notation tests to `sql/ora_number.sql` / `expected/ora_number.out` at the same point where this change appends the `generate_series` parallel-safety check, so both blocks are kept. The expected outputs were regenerated with the run above; the eight files this change touches had only blank-line and end-of-file differences before regeneration, no result differences.

## Related

Closes #1895, #1897, #1898, #1899, #1900, #1901, #1902, #1903, #1904, #1905

Replaces closed PRs #1906 through #1915.

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Marked additional compatibility functions as safe for parallel execution, enabling eligible queries to use parallel processing.
  - Updated character-length function metadata for stricter and more predictable execution.

- **Bug Fixes**
  - Corrected function metadata to reflect immutability, strict argument handling, and parallel-safety guarantees.

- **Tests**
  - Added regression coverage for parallel execution attributes and function metadata across character, date/time, numeric, formatting, and series functionality.
  - Expanded numeric conversion tests for scientific notation, padding, boundary values, invalid inputs, and empty strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->