### PR TITLE
Add ecosystem component: pg_track_settings

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -101,6 +101,7 @@ bool		extension_script_pg_dialect = false;
 static const char *const PgDialectExtensions[] = {
 	"pg_profile",
 	"pg_repack",
+	"pg_track_settings",
 };
 
 static bool


### PR DESCRIPTION
Closes #1938

## Overview

When `pg_track_settings` creates its tables, it declares timestamp columns as `timestamp with time zone` (equivalent to `pg_catalog.timestamptz`). In IvorySQL's Oracle parser, the `timestamp with time zone` spelling is resolved to the `sys.oratimestamptz` type, which leads to type incompatibility. We therefore need to restrict it to PG mode during initialization.

## Detailed Analysis

The root cause of `pg_track_settings` not being usable — or even creatable — under Oracle compatibility mode is that its core tables and functions declare a large number of columns and return types like this:

```sql
CREATE TABLE pg_track_settings_history (
    ts timestamp with time zone,
    ...
);  
CREATE FUNCTION pg_track_settings_settings_src(...)
RETURNS TABLE (ts timestamp with time zone, ...) AS $$
    RETURN QUERY SELECT now(), ...
$$; 
```

In `ora_gram.y` (src/backend/oracle_parser/ora_gram.y:17310), the `TIMESTAMP [WITH TIME ZONE]` keywords have dedicated productions:

```yacc
opt_timezone:
			WITH_LA TIME ZONE						{ $$ = true; }
			| WITHOUT_LA TIME ZONE					{ $$ = false; }
			| /*EMPTY*/								{ $$ = false; }
		;
Datetime:
    ...
    | TIMESTAMP opt_timezone
        {
            if (ORA_PARSER == compatible_db)
            {
                if ($2)
                    $$ = OracleSystemTypeName("oratimestamptz");        // resolved to sys.oratimestamptz
                else
                    $$ = OracleSystemTypeName("oratimestamp");
                $$->typmods = list_make1(makeIntConst(6, -1));
                $$->location = @1;
            }
            else
            {
                if ($2)
                    $$ = SystemTypeName("timestamptz");                 // resolved to pg_catalog.timestamptz
                else
                    $$ = SystemTypeName("timestamp");
                $$->location = @1;
            }
        }
    | ...
```

The official PostgreSQL documentation [states explicitly](https://www.postgresql.org/docs/current/datatype-datetime.html) that `timestamptz is accepted as an abbreviation for timestamp with time zone`. Meanwhile, `now()` — a built-in function implemented in C — always has a fixed return type of `pg_catalog.timestamptz` in `pg_proc`, regardless of the current parser mode.