### PR TITLE
fix: raise an error when NEW_TIME/FROM_TZ overflow the timestamp range

### DIFF
--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -631,7 +631,10 @@ ora_new_time(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 	tz1 = tz1 - tz2;
-	tm2timestamp(tm, fsec, &tz1, &result);
+	if (tm2timestamp(tm, fsec, &tz1, &result) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("timestamp out of range")));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -769,7 +772,10 @@ ora_from_tz(PG_FUNCTION_ARGS)
 				 errmsg("timestamp out of range")));
 
 	tz = DetermineTimeZoneOffset(tm, timezonedat);
-	tm2timestamp(tm, fsec, &tz, &result);
+	if (tm2timestamp(tm, fsec, &tz, &result) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("timestamp out of range")));
 
 	PG_RETURN_TIMESTAMPTZ(result);
 }


### PR DESCRIPTION
`NEW_TIME` and `FROM_TZ` call `tm2timestamp()` after applying a time-zone offset but ignore its failure return. Near the supported timestamp boundary, the offset can move an otherwise valid input out of range and leave the result undefined. Check the return value and raise `ERRCODE_DATETIME_VALUE_OUT_OF_RANGE`, matching the surrounding conversions.

Fixes #1862

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date and time conversion error handling.
  - Out-of-range timestamp conversions now display a clear error instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->