### PR TITLE
fix: do not mutate a PLiSQL hash table while iterating it

### DIFF
--- a/src/pl/plisql/src/pl_funcs.c
+++ b/src/pl/plisql/src/pl_funcs.c
@@ -817,13 +817,18 @@ plisql_free_function_memory(PLiSQL_function * func,
 			 */
 			if (subprocfunc->function->action != NULL)
 			{
-				hash_seq_init(&status, subprocfunc->poly_tab);
+			List	   *functions = NIL;
+			ListCell   *lc;
 
-				while ((entry = (plisql_HashEnt *) hash_seq_search(&status)) != NULL)
-				{
-					hash_search(subprocfunc->poly_tab, (void *) (&(entry->key)), HASH_REMOVE, NULL);
-					plisql_free_function_memory(entry->function, subprocfunc->lastoutvardno, subprocfunc->lastoutsubprocfno);
-				}
+			hash_seq_init(&status, subprocfunc->poly_tab);
+			while ((entry = (plisql_HashEnt *) hash_seq_search(&status)) != NULL)
+				functions = lappend(functions, entry->function);
+
+			foreach(lc, functions)
+				plisql_free_function_memory((PLiSQL_function *) lfirst(lc),
+											subprocfunc->lastoutvardno,
+											subprocfunc->lastoutsubprocfno);
+			list_free(functions);
 			}
 			hash_destroy(subprocfunc->poly_tab);
 		}


### PR DESCRIPTION
`plisql_free_function_memory()` removed hash entries from `poly_tab` while walking it with `hash_seq_search()`. Collect the function pointers during the walk, free them afterwards, and let `hash_destroy()` release the hash entries.

Fixes #1166

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of inline functions associated with polymorphic arguments.
  * Prevented potential issues when releasing function memory during hash table cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->