### PR TITLE
fix: remove duplicate set_ParseDynSql call in inline handler

### DIFF
--- a/src/pl/plisql/src/pl_handler.c
+++ b/src/pl/plisql/src/pl_handler.c
@@ -754,7 +754,6 @@ plisql_inline_handler(PG_FUNCTION_ARGS)
 		set_ParseDynSql(true);
 		set_parseDynDoStmt(true);
 		set_haspgparam(false);
-		set_ParseDynSql(true);
 		set_doStmtCheckVar(check_var);
 
 		if (codeblock->params->paramnames != NULL)


### PR DESCRIPTION
The parameterized inline-handler path enabled the dynamic-SQL parse mode twice in succession. Remove the duplicate call; the other parse-mode initialisation in the block is unchanged.

Fixes #1165

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of anonymous code blocks with parameters by removing an unnecessary dynamic SQL parsing step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->