### PR TITLE
fix: compare large Oracle intervals without int64 overflow

### DIFF
--- a/contrib/ivorysql_ora/src/datatype/dsinterval.c
+++ b/contrib/ivorysql_ora/src/datatype/dsinterval.c
@@ -1429,13 +1429,33 @@ dsinterval_cmp_value(const Interval *interval)
 	return span;
 }
 
+#ifdef HAVE_INT64_TIMESTAMP
+static inline INT128
+dsinterval_cmp_value128(const Interval *interval)
+{
+	INT128		span;
+
+	span = int64_to_int128(interval->time);
+	int128_add_int64_mul_int64(&span, interval->day, USECS_PER_DAY);
+
+	return span;
+}
+#endif
+
 static int
 dsinterval_cmp_internal(Interval *interval1, Interval *interval2)
 {
+#ifdef HAVE_INT64_TIMESTAMP
+	INT128		span1 = dsinterval_cmp_value128(interval1);
+	INT128		span2 = dsinterval_cmp_value128(interval2);
+
+	return int128_compare(span1, span2);
+#else
 	TimeOffset	span1 = dsinterval_cmp_value(interval1);
 	TimeOffset	span2 = dsinterval_cmp_value(interval2);
 
 	return ((span1 < span2) ? -1 : (span1 > span2) ? 1 : 0);
+#endif
 }
 
 /*****************************************************************************

--- a/contrib/ivorysql_ora/src/datatype/yminterval.c
+++ b/contrib/ivorysql_ora/src/datatype/yminterval.c
@@ -1272,10 +1272,8 @@ yminterval_cmp_value(const Interval *interval)
 static int
 yminterval_cmp_internal(Interval *interval1, Interval *interval2)
 {
-	TimeOffset	span1 = yminterval_cmp_value(interval1);
-	TimeOffset	span2 = yminterval_cmp_value(interval2);
-
-	return ((span1 < span2) ? -1 : (span1 > span2) ? 1 : 0);
+	return ((interval1->month < interval2->month) ? -1 :
+			(interval1->month > interval2->month) ? 1 : 0);
 }
 
 /* yminterval_in()

--- a/contrib/ora_btree_gist/btree_dsinterval.c
+++ b/contrib/ora_btree_gist/btree_dsinterval.c
@@ -5,6 +5,7 @@
 
 #include "btree_gist.h"
 #include "btree_utils_num.h"
+#include "common/int128.h"
 #include "utils/builtins.h"
 #include "utils/timestamp.h"
 
@@ -38,29 +39,33 @@ PG_FUNCTION_INFO_V1(gbt_dsintv_same);
  * For INTERVAL DAY TO SECOND type the field of "MONTH" is invalid.
  * Only calculate the value of "interval->day" and "interval->time".
  */
-static inline TimeOffset
-dsinterval_cmp_value(const Interval *interval)
-{
-	TimeOffset	span;
-
-	span = interval->time;
-
 #ifdef HAVE_INT64_TIMESTAMP
-	span += interval->day * INT64CONST(24) * USECS_PER_HOUR;
-#else
-	span += interval->day * ((double) HOURS_PER_DAY * SECS_PER_HOUR);
-#endif
+static inline INT128
+dsinterval_cmp_value128(const Interval *interval)
+{
+	INT128		span;
+
+	span = int64_to_int128(interval->time);
+	int128_add_int64_mul_int64(&span, interval->day, USECS_PER_DAY);
 
 	return span;
 }
+#endif
 
 static int
 dsinterval_cmp_internal(Interval *interval1, Interval *interval2)
 {
+#ifdef HAVE_INT64_TIMESTAMP
+	INT128		span1 = dsinterval_cmp_value128(interval1);
+	INT128		span2 = dsinterval_cmp_value128(interval2);
+
+	return int128_compare(span1, span2);
+#else
 	TimeOffset	span1 = dsinterval_cmp_value(interval1);
 	TimeOffset	span2 = dsinterval_cmp_value(interval2);
 
 	return ((span1 < span2) ? -1 : (span1 > span2) ? 1 : 0);
+#endif
 }
 
 /*****************************************************************************

--- a/contrib/ora_btree_gist/btree_yminterval.c
+++ b/contrib/ora_btree_gist/btree_yminterval.c
@@ -56,10 +56,8 @@ yminterval_cmp_value(const Interval *interval)
 static int
 yminterval_cmp_internal(Interval *interval1, Interval *interval2)
 {
-	TimeOffset	span1 = yminterval_cmp_value(interval1);
-	TimeOffset	span2 = yminterval_cmp_value(interval2);
-
-	return ((span1 < span2) ? -1 : (span1 > span2) ? 1 : 0);
+	return ((interval1->month < interval2->month) ? -1 :
+			(interval1->month > interval2->month) ? 1 : 0);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
`sys.dsinterval` and `ora_btree_gist` converted `day * USECS_PER_DAY` in `TimeOffset`, which overflows near the supported interval boundary. Compute the DAY TO SECOND span in `INT128`, and compare YEAR TO MONTH by its month field directly. Hash functions keep their existing 64-bit behavior.

Fixes #1943

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100
