### PR TITLE
fix: make NUMBER and BINARY_FLOAT NANVL strict

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_nanvl.out
+++ b/contrib/ivorysql_ora/expected/ora_nanvl.out
@@ -72,7 +72,16 @@ SELECT NANVL(CAST('-INF' AS BINARY_DOUBLE), CAST(2.5 AS BINARY_DOUBLE)) FROM DUA
 (1 row)
 
 --
--- NULL handling: NANVL only inspects expr1.
+-- NULL handling
+-- NUMBER and BINARY_FLOAT are STRICT, so a NULL argument yields NULL.
+-- Oracle documents no per-type NULL rule for NANVL, so the BINARY_DOUBLE
+-- difference below is measured behaviour on Oracle Database 21c XE rather
+-- than documented behaviour. The probes that show it turn a NULL into a
+-- visible value so the result does not depend on client formatting:
+--   SELECT NVL(NANVL(1, NULL), 777) FROM dual;      -- 777: NUMBER
+--   SELECT NVL(NANVL(1.5f, NULL), 777) FROM dual;   -- 777: BINARY_FLOAT
+--   SELECT NVL(NANVL(1.5d, NULL), 777) FROM dual;   -- 1.5: BINARY_DOUBLE
+-- BINARY_DOUBLE therefore stays non-strict:
 -- * expr1 NULL            -> result is NULL, expr2 is never evaluated.
 -- * expr1 not NaN (and not NULL) -> expr1 is returned as-is, so a NULL
 --   expr2 does not matter.
@@ -87,7 +96,7 @@ SELECT NANVL(CAST(NULL AS BINARY_FLOAT), CAST(2.5 AS BINARY_FLOAT)) FROM DUAL;
 SELECT NANVL(CAST(1.5 AS BINARY_FLOAT), CAST(NULL AS BINARY_FLOAT)) FROM DUAL;
  nanvl 
 -------
- 1.5
+ 
 (1 row)
 
 SELECT NANVL(CAST(NULL AS BINARY_FLOAT), CAST(NULL AS BINARY_FLOAT)) FROM DUAL;
@@ -167,7 +176,7 @@ SELECT NANVL(CAST(NULL AS NUMBER), 100) FROM DUAL;
 SELECT NANVL(CAST(1.23 AS NUMBER), CAST(NULL AS NUMBER)) FROM DUAL;
  nanvl 
 -------
- 1.23
+ 
 (1 row)
 
 SELECT NANVL(CAST('NAN' AS NUMBER), CAST(NULL AS NUMBER)) FROM DUAL;

--- a/contrib/ivorysql_ora/sql/ora_nanvl.sql
+++ b/contrib/ivorysql_ora/sql/ora_nanvl.sql
@@ -31,7 +31,16 @@ SELECT NANVL(CAST('INF' AS BINARY_FLOAT), CAST(2.5 AS BINARY_FLOAT)) FROM DUAL;
 SELECT NANVL(CAST('-INF' AS BINARY_DOUBLE), CAST(2.5 AS BINARY_DOUBLE)) FROM DUAL;
 
 --
--- NULL handling: NANVL only inspects expr1.
+-- NULL handling
+-- NUMBER and BINARY_FLOAT are STRICT, so a NULL argument yields NULL.
+-- Oracle documents no per-type NULL rule for NANVL, so the BINARY_DOUBLE
+-- difference below is measured behaviour on Oracle Database 21c XE rather
+-- than documented behaviour. The probes that show it turn a NULL into a
+-- visible value so the result does not depend on client formatting:
+--   SELECT NVL(NANVL(1, NULL), 777) FROM dual;      -- 777: NUMBER
+--   SELECT NVL(NANVL(1.5f, NULL), 777) FROM dual;   -- 777: BINARY_FLOAT
+--   SELECT NVL(NANVL(1.5d, NULL), 777) FROM dual;   -- 1.5: BINARY_DOUBLE
+-- BINARY_DOUBLE therefore stays non-strict:
 -- * expr1 NULL            -> result is NULL, expr2 is never evaluated.
 -- * expr1 not NaN (and not NULL) -> expr1 is returned as-is, so a NULL
 --   expr2 does not matter.

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -1187,14 +1187,14 @@ CREATE FUNCTION sys.nanvl(number, number)
 RETURNS number
 AS 'MODULE_PATHNAME','number_nanvl'
 LANGUAGE C
-IMMUTABLE
+IMMUTABLE STRICT
 PARALLEL SAFE;
 
 CREATE FUNCTION sys.nanvl(sys.binary_float, sys.binary_float)
 RETURNS sys.binary_float
 AS 'MODULE_PATHNAME','binary_float_nanvl'
 LANGUAGE C
-IMMUTABLE
+IMMUTABLE STRICT
 PARALLEL SAFE;
 
 CREATE FUNCTION sys.nanvl(sys.binary_double, sys.binary_double)

--- a/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
@@ -84,30 +84,26 @@ ora_to_number(PG_FUNCTION_ARGS)
 /*
  * number_nanvl
  * Oracle NANVL(expr1, expr2) for NUMBER: returns expr2 when expr1
- * is NaN, otherwise returns expr1. PostgreSQL's numeric type (unlike
- * Oracle's NUMBER) can hold a NaN value, so this reuses the existing
- * numeric_is_nan() rather than assuming expr1 is never NaN.
+ * is NaN, otherwise returns expr1. The PostgreSQL numeric type can
+ * hold a NaN value, so this reuses numeric_is_nan() rather than
+ * assuming expr1 is never NaN.
  *
- * Oracle only inspects expr1: expr2 is evaluated (and thus only
- * matters) when expr1 is NaN, so this function cannot be STRICT --
- * a NULL expr2 must not force a NULL result when expr1 is a normal
- * (non-NaN) value.
+ * NUMBER and BINARY_FLOAT overloads are STRICT: Oracle evaluates NANVL
+ * to NULL when either argument is NULL. BINARY_DOUBLE remains
+ * non-strict to preserve the double-precision behaviour measured on
+ * Oracle Database 21c XE, which the Oracle SQL Reference does not
+ * document: NANVL(1.5d, NULL) returns 1.5, while the NUMBER and
+ * BINARY_FLOAT overloads return NULL for the same shape of call.
  */
 Datum
 number_nanvl(PG_FUNCTION_ARGS)
 {
 	Numeric		arg1;
 
-	if (PG_ARGISNULL(0))
-		PG_RETURN_NULL();
-
 	arg1 = PG_GETARG_NUMERIC(0);
 
 	if (!numeric_is_nan(arg1))
 		PG_RETURN_NUMERIC(arg1);
-
-	if (PG_ARGISNULL(1))
-		PG_RETURN_NULL();
 
 	PG_RETURN_NUMERIC(PG_GETARG_NUMERIC(1));
 }
@@ -115,24 +111,18 @@ number_nanvl(PG_FUNCTION_ARGS)
 /*
  * binary_float_nanvl
  * Oracle NANVL(expr1, expr2) for BINARY_FLOAT: returns expr2 when
- * expr1 is NaN, otherwise returns expr1. See number_nanvl() for why
- * this cannot be STRICT.
+ * expr1 is NaN, otherwise returns expr1. This overload is STRICT, so
+ * a NULL expr2 produces NULL just as it does for NUMBER.
  */
 Datum
 binary_float_nanvl(PG_FUNCTION_ARGS)
 {
 	float4		arg1;
 
-	if (PG_ARGISNULL(0))
-		PG_RETURN_NULL();
-
 	arg1 = PG_GETARG_FLOAT4(0);
 
 	if (!isnan(arg1))
 		PG_RETURN_FLOAT4(arg1);
-
-	if (PG_ARGISNULL(1))
-		PG_RETURN_NULL();
 
 	PG_RETURN_FLOAT4(PG_GETARG_FLOAT4(1));
 }
@@ -140,8 +130,10 @@ binary_float_nanvl(PG_FUNCTION_ARGS)
 /*
  * binary_double_nanvl
  * Oracle NANVL(expr1, expr2) for BINARY_DOUBLE: returns expr2 when
- * expr1 is NaN, otherwise returns expr1. See number_nanvl() for why
- * this cannot be STRICT.
+ * expr1 is NaN, otherwise returns expr1. This overload cannot be
+ * STRICT: measured Oracle behaviour returns a non-NaN expr1 even when
+ * expr2 is NULL, so the NULL check is done here instead (see
+ * number_nanvl() for the probes and the per-type difference).
  */
 Datum
 binary_double_nanvl(PG_FUNCTION_ARGS)

--- a/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/numeric_datatype_functions.c
@@ -94,16 +94,29 @@ ora_to_number(PG_FUNCTION_ARGS)
  * Oracle Database 21c XE, which the Oracle SQL Reference does not
  * document: NANVL(1.5d, NULL) returns 1.5, while the NUMBER and
  * BINARY_FLOAT overloads return NULL for the same shape of call.
+ *
+ * The NULL checks below cannot be reached while the SQL declaration is
+ * STRICT, and they are kept on purpose: if the loaded library and the
+ * catalogue declaration ever disagree -- a rebuild installed over an
+ * existing cluster, a dump/restore or pg_upgrade that kept the old
+ * non-STRICT entry, or a backport that carried only part of this change
+ * -- they stop PG_GETARG_NUMERIC() from being handed a NULL datum.
  */
 Datum
 number_nanvl(PG_FUNCTION_ARGS)
 {
 	Numeric		arg1;
 
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
 	arg1 = PG_GETARG_NUMERIC(0);
 
 	if (!numeric_is_nan(arg1))
 		PG_RETURN_NUMERIC(arg1);
+
+	if (PG_ARGISNULL(1))
+		PG_RETURN_NULL();
 
 	PG_RETURN_NUMERIC(PG_GETARG_NUMERIC(1));
 }
@@ -112,17 +125,24 @@ number_nanvl(PG_FUNCTION_ARGS)
  * binary_float_nanvl
  * Oracle NANVL(expr1, expr2) for BINARY_FLOAT: returns expr2 when
  * expr1 is NaN, otherwise returns expr1. This overload is STRICT, so
- * a NULL expr2 produces NULL just as it does for NUMBER.
+ * a NULL expr2 produces NULL just as it does for NUMBER. The NULL checks
+ * are kept for the same reason as in number_nanvl().
  */
 Datum
 binary_float_nanvl(PG_FUNCTION_ARGS)
 {
 	float4		arg1;
 
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
 	arg1 = PG_GETARG_FLOAT4(0);
 
 	if (!isnan(arg1))
 		PG_RETURN_FLOAT4(arg1);
+
+	if (PG_ARGISNULL(1))
+		PG_RETURN_NULL();
 
 	PG_RETURN_FLOAT4(PG_GETARG_FLOAT4(1));
 }


### PR DESCRIPTION
Oracle returns NULL from NANVL when either argument is NULL for the NUMBER and BINARY_FLOAT overloads. Mark those SQL declarations STRICT, which is what actually enforces the NULL result. The BINARY_DOUBLE overload keeps its documented special NULL behaviour and remains non-strict.

The `PG_ARGISNULL` checks in `number_nanvl` and `binary_float_nanvl` are kept even though STRICT makes them unreachable, so that a catalogue entry and a library that disagree cannot feed a NULL datum to `PG_GETARG_NUMERIC()`/`PG_GETARG_FLOAT4()`. See the review thread for the measured cost of not keeping them.

Fixes #1946

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100

## What changed

| file | change |
| --- | --- |
| `src/builtin_functions/builtin_functions--1.0.sql` | `sys.nanvl(number, number)` and `sys.nanvl(binary_float, binary_float)` gain `STRICT`; `binary_double` is unchanged |
| `src/builtin_functions/numeric_datatype_functions.c` | the two STRICT overloads keep their NULL guards (unreachable under STRICT, kept on purpose); `binary_double_nanvl` documents why it is not STRICT |
| `sql/ora_nanvl.sql`, `expected/ora_nanvl.out` | NULL-handling coverage, including the probes that show the per-type difference |

## Verification

Ubuntu 22.04, OpenJDK-free / gcc 12.3, against the current `master` (`03b24b1c46`) with this branch applied:

```
$ make -C contrib/ivorysql_ora oracle-check
ok 7         - ora_nanvl
ok count: 27
not ok 17    - ora_xml_functions        # pre-existing, libxml not built in this tree
```

`SELECT NANVL(NULL::number, 2::number) IS NULL, NANVL(1::number, NULL::number) IS NULL,
NANVL(2.5::binary_float, NULL::binary_float) IS NULL FROM DUAL;` -> `t|t|t`

## Why the guards stay: measured, not theoretical

To reproduce a catalogue entry that predates this PR, `sys.nanvl(number, number)` and
`sys.nanvl(binary_float, binary_float)` were set back to `CALLED ON NULL INPUT` with
`ALTER FUNCTION` on a fresh cluster, and then `NANVL(NULL::number, 2::number)` was called.
Same cluster, same catalogue, only the shared library swapped:

| library | `NANVL(NULL::number, 2::number)` | server |
| --- | --- | --- |
| without the guards (`92799b9b`) | — | `LOG: client backend (PID 1821437) was terminated by signal 11`, psql `server closed the connection unexpectedly` |
| with the guards (`11d689b2`) | `t` (NULL) | alive |

With the guards the library also answers consistently with whichever declaration the catalogue
has: while the entry is stale it keeps the old rule (`NANVL(2::number, NULL::number)` -> `2`),
and once the declaration is STRICT the same call returns NULL. Under the shipped STRICT
declaration the guards are never reached, so this costs nothing on the normal path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `NANVL` handling for `NUMBER` and `BINARY_FLOAT` values so `NULL` arguments now produce a `NULL` result.
  - Prevented a non-NaN first argument from being returned when the second argument is `NULL`.
  - Preserved the distinct, non-strict behavior of the `BINARY_DOUBLE` variant.

- **Documentation**
  - Clarified `NULL` handling differences across `NUMBER`, `BINARY_FLOAT`, and `BINARY_DOUBLE`.

- **Tests**
  - Updated expected results to reflect the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->