### PR TITLE
CI: cancel superseded pull-request runs and add job timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,28 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+concurrency:
+  # Cancel superseded runs of the same pull request (grouped by PR number)
+  # and of non-protected branches (grouped by ref). Preserve every push run
+  # on protected branches (master/IVORY_REL_4_STABLE/IVORYSQL_REL_1_STABLE)
+  # by giving each run a unique group (run_id), so that every pushed commit
+  # is tested.
+  group: |
+    ${{github.workflow }}-${{
+    case(github.event_name == 'pull_request',
+         format('pr-{0}', github.event.pull_request.number),
+         case(github.ref == 'refs/heads/master' ||
+              github.ref == 'refs/heads/IVORY_REL_4_STABLE' ||
+              github.ref == 'refs/heads/IVORYSQL_REL_1_STABLE',
+              github.run_id,
+              github.ref))
+    }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -42,6 +61,7 @@ jobs:
 
   build-clang:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: dependency - linux

--- a/.github/workflows/contrib_regression.yml
+++ b/.github/workflows/contrib_regression.yml
@@ -6,9 +6,28 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+concurrency:
+  # Cancel superseded runs of the same pull request (grouped by PR number)
+  # and of non-protected branches (grouped by ref). Preserve every push run
+  # on protected branches (master/IVORY_REL_4_STABLE/IVORYSQL_REL_1_STABLE)
+  # by giving each run a unique group (run_id), so that every pushed commit
+  # is tested.
+  group: |
+    ${{github.workflow }}-${{
+    case(github.event_name == 'pull_request',
+         format('pr-{0}', github.event.pull_request.number),
+         case(github.ref == 'refs/heads/master' ||
+              github.ref == 'refs/heads/IVORY_REL_4_STABLE' ||
+              github.ref == 'refs/heads/IVORYSQL_REL_1_STABLE',
+              github.run_id,
+              github.ref))
+    }}
+  cancel-in-progress: true
+
 jobs:
   contrib_regression:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/meson_build_pg_test.yml
+++ b/.github/workflows/meson_build_pg_test.yml
@@ -6,9 +6,28 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE ]
 
+concurrency:
+  # Cancel superseded runs of the same pull request (grouped by PR number)
+  # and of non-protected branches (grouped by ref). Preserve every push run
+  # on protected branches (master/IVORY_REL_4_STABLE/IVORYSQL_REL_1_STABLE)
+  # by giving each run a unique group (run_id), so that every pushed commit
+  # is tested.
+  group: |
+    ${{github.workflow }}-${{
+    case(github.event_name == 'pull_request',
+         format('pr-{0}', github.event.pull_request.number),
+         case(github.ref == 'refs/heads/master' ||
+              github.ref == 'refs/heads/IVORY_REL_4_STABLE' ||
+              github.ref == 'refs/heads/IVORYSQL_REL_1_STABLE',
+              github.run_id,
+              github.ref))
+    }}
+  cancel-in-progress: true
+
 jobs:
   meson_build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/oracle_pg_regression.yml
+++ b/.github/workflows/oracle_pg_regression.yml
@@ -6,9 +6,28 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+concurrency:
+  # Cancel superseded runs of the same pull request (grouped by PR number)
+  # and of non-protected branches (grouped by ref). Preserve every push run
+  # on protected branches (master/IVORY_REL_4_STABLE/IVORYSQL_REL_1_STABLE)
+  # by giving each run a unique group (run_id), so that every pushed commit
+  # is tested.
+  group: |
+    ${{github.workflow }}-${{
+    case(github.event_name == 'pull_request',
+         format('pr-{0}', github.event.pull_request.number),
+         case(github.ref == 'refs/heads/master' ||
+              github.ref == 'refs/heads/IVORY_REL_4_STABLE' ||
+              github.ref == 'refs/heads/IVORYSQL_REL_1_STABLE',
+              github.run_id,
+              github.ref))
+    }}
+  cancel-in-progress: true
+
 jobs:
   oracle_pg_regression:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/oracle_regression.yml
+++ b/.github/workflows/oracle_regression.yml
@@ -6,9 +6,28 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+concurrency:
+  # Cancel superseded runs of the same pull request (grouped by PR number)
+  # and of non-protected branches (grouped by ref). Preserve every push run
+  # on protected branches (master/IVORY_REL_4_STABLE/IVORYSQL_REL_1_STABLE)
+  # by giving each run a unique group (run_id), so that every pushed commit
+  # is tested.
+  group: |
+    ${{github.workflow }}-${{
+    case(github.event_name == 'pull_request',
+         format('pr-{0}', github.event.pull_request.number),
+         case(github.ref == 'refs/heads/master' ||
+              github.ref == 'refs/heads/IVORY_REL_4_STABLE' ||
+              github.ref == 'refs/heads/IVORYSQL_REL_1_STABLE',
+              github.run_id,
+              github.ref))
+    }}
+  cancel-in-progress: true
+
 jobs:
   oracle_regression:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/pg_regression.yml
+++ b/.github/workflows/pg_regression.yml
@@ -6,9 +6,28 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+concurrency:
+  # Cancel superseded runs of the same pull request (grouped by PR number)
+  # and of non-protected branches (grouped by ref). Preserve every push run
+  # on protected branches (master/IVORY_REL_4_STABLE/IVORYSQL_REL_1_STABLE)
+  # by giving each run a unique group (run_id), so that every pushed commit
+  # is tested.
+  group: |
+    ${{github.workflow }}-${{
+    case(github.event_name == 'pull_request',
+         format('pr-{0}', github.event.pull_request.number),
+         case(github.ref == 'refs/heads/master' ||
+              github.ref == 'refs/heads/IVORY_REL_4_STABLE' ||
+              github.ref == 'refs/heads/IVORYSQL_REL_1_STABLE',
+              github.run_id,
+              github.ref))
+    }}
+  cancel-in-progress: true
+
 jobs:
   pg_regression:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Closes #1965

## Summary

Add a concurrency policy and conservative job timeouts to IvorySQL's build and regression workflows that currently have neither.

### Concurrency
- Group runs by workflow and pull-request number / ref
- Cancel only superseded pull-request runs (same PR, newer push cancels older)
- Preserve every push run on protected branches (master, IVORY_REL_4_STABLE, IVORYSQL_REL_1_STABLE) by giving each run a unique group (run_id)
- Non-protected branch pushes are grouped by ref and cancel older runs
- The `github.workflow` prefix keeps unrelated workflows in separate groups

### Job timeouts
- 60 min: compilation (`build.yml`, `meson_build_pg_test.yml`)
- 120 min: contrib / basic regression (`contrib_regression.yml`, `oracle_pg_regression.yml`)
- 180 min: full PostgreSQL / Oracle regression (`pg_regression.yml`, `oracle_regression.yml`)

### Out of scope
- `pg-ci.yml` already has both concurrency and per-job timeouts — unchanged
- `build_and_test.yml` is `workflow_dispatch` only and runs on the deprecated `ubuntu-18.04` runner; intentionally left unchanged
- `pr_governance.yml` and `issue-auto-assign.yml` are governance workflows — unchanged
- Test matrices and triggers are unchanged

## Validation
- All six modified workflow files pass YAML syntax validation
- Concurrency expression follows the existing `case()` pattern already used in `.github/workflows/pg-ci.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic cancellation of superseded CI runs for pull requests and non-protected branches.
  * Preserved separate validation runs for every commit pushed to protected branches.
  * Added job time limits ranging from 60 to 180 minutes across build and regression checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->