### PR TITLE
CI: restrict read-only token permissions and checkout credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: dependancy - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
@@ -44,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: dependency - linux
       run: |
         sudo apt-get update

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,9 @@ name: "Build and Test"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   regression:
     runs-on: ubuntu-18.04
@@ -12,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Build ${{ matrix.container-os }} Docker
       if: ${{ matrix.container-os == 'centos-7' }}
       run: |

--- a/.github/workflows/contrib_regression.yml
+++ b/.github/workflows/contrib_regression.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   contrib_regression:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: dependancy
       run: |
         sudo apt-get update

--- a/.github/workflows/meson_build_pg_test.yml
+++ b/.github/workflows/meson_build_pg_test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE ]
 
+permissions:
+  contents: read
+
 jobs:
   meson_build:
     runs-on: ${{ matrix.os }}
@@ -15,6 +18,8 @@ jobs:
       
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: dependency - linux
       run: |
         sudo apt-get update

--- a/.github/workflows/oracle_pg_regression.yml
+++ b/.github/workflows/oracle_pg_regression.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   oracle_pg_regression:
     runs-on: ${{ matrix.os }}
@@ -15,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: dependancy
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/.github/workflows/oracle_regression.yml
+++ b/.github/workflows/oracle_regression.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   oracle_regression:
     runs-on: ${{ matrix.os }}
@@ -15,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: dependancy
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/.github/workflows/pg-ci.yml
+++ b/.github/workflows/pg-ci.yml
@@ -292,6 +292,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: ${{ env.CLONE_DEPTH }}
+          persist-credentials: false
 
       # We restore both the ccache from the default branch (typically master),
       # and from the current branch. This will often allow feature branches to

--- a/.github/workflows/pg_regression.yml
+++ b/.github/workflows/pg_regression.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master , IVORY_REL_4_STABLE , IVORYSQL_REL_1_STABLE]
 
+permissions:
+  contents: read
+
 jobs:
   pg_regression:
     runs-on: ${{ matrix.os }}
@@ -15,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: dependancy
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |


### PR DESCRIPTION
Closes #1964

## Summary

Restrict GITHUB_TOKEN permissions and checkout credentials in read-only build and regression workflows, following GitHub's least-privilege guidance.

### Changes
- Add `permissions: contents: read` to 7 read-only build/regression workflows
- Set `persist-credentials: false` on all checkout steps (including the shared checkout anchor in `pg-ci.yml`)
- No changes to action versions, triggers, or test commands

### Workflows updated
- `build.yml`
- `contrib_regression.yml`
- `pg_regression.yml`
- `oracle_pg_regression.yml`
- `oracle_regression.yml`
- `meson_build_pg_test.yml`
- `build_and_test.yml`
- `pg-ci.yml` (checkout `persist-credentials` only; `permissions` already present)

### Out of scope
- `issue-auto-assign.yml`: retains `issues: write` (needed for `/assign` command)
- `pr_governance.yml`: retains `pull-requests: read, issues: read`

## Validation
- All 8 modified workflow files pass YAML syntax validation
- No behavior change: token remains read-only, checkout no longer persists credentials to the runner filesystem


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Reduced CI workflow permissions to read-only repository contents.
  * Prevented checkout steps from persisting Git credentials, limiting token exposure during builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->