### PR TITLE
fix: truncate fractional months toward zero in add_months like Oracle

### DIFF
--- a/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
+++ b/contrib/ivorysql_ora/expected/datatype_and_func_bugs.out
@@ -29,6 +29,48 @@ select add_months('2022-08-23',3) from dual;
  2022-11-23 00:00:00
 (1 row)
 
+select add_months(date '2020-01-31', 1.5) from dual;
+     add_months      
+---------------------
+ 2020-02-29 00:00:00
+(1 row)
+
+select add_months(date '2020-01-31', 1.9) from dual;
+     add_months      
+---------------------
+ 2020-02-29 00:00:00
+(1 row)
+
+select add_months(date '2020-03-31', -1.5) from dual;
+     add_months      
+---------------------
+ 2020-02-29 00:00:00
+(1 row)
+
+select add_months(date '2020-03-31', -0.5) from dual;
+     add_months      
+---------------------
+ 2020-03-31 00:00:00
+(1 row)
+
+select add_months(date '2020-03-31', 0.5) from dual;
+     add_months      
+---------------------
+ 2020-03-31 00:00:00
+(1 row)
+
+select add_months(date '2020-03-31', -12.5) from dual;
+     add_months      
+---------------------
+ 2019-03-31 00:00:00
+(1 row)
+
+select add_months(date '2020-03-31', 2.0) from dual;
+     add_months      
+---------------------
+ 2020-05-31 00:00:00
+(1 row)
+
 alter session set NLS_LENGTH_SEMANTICS='BYTE';
 create table char_tb(char_clo char(3));
 insert into char_tb values('测试');

--- a/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
+++ b/contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql
@@ -17,6 +17,13 @@ END;
 
 alter session set NLS_DATE_FORMAT='yyyy-mm-dd hh24:mi:ss';
 select add_months('2022-08-23',3) from dual;
+select add_months(date '2020-01-31', 1.5) from dual;
+select add_months(date '2020-01-31', 1.9) from dual;
+select add_months(date '2020-03-31', -1.5) from dual;
+select add_months(date '2020-03-31', -0.5) from dual;
+select add_months(date '2020-03-31', 0.5) from dual;
+select add_months(date '2020-03-31', -12.5) from dual;
+select add_months(date '2020-03-31', 2.0) from dual;
 alter session set NLS_LENGTH_SEMANTICS='BYTE';
 create table char_tb(char_clo char(3));
 insert into char_tb values('测试');

--- a/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
+++ b/contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c
@@ -404,6 +404,15 @@ add_months(PG_FUNCTION_ARGS)
 	int64		n;
 	Numeric		num = PG_GETARG_NUMERIC(1);
 
+	/*
+	 * Oracle truncates the fractional part of the months argument toward
+	 * zero (e.g. add_months(date, 1.5) advances one month), so round the
+	 * value down before the integral conversion, which would otherwise
+	 * round half away from zero.
+	 */
+	num = DatumGetNumeric(DirectFunctionCall2(numeric_trunc,
+											  NumericGetDatum(num),
+											  Int32GetDatum(0)));
 	n = DatumGetInt32(DirectFunctionCall1(numeric_int8, NumericGetDatum(num)));
 
 	TMODULO(time, date, USECS_PER_DAY);


### PR DESCRIPTION
## Problem

In Oracle compatible mode, `add_months()` mis-handles fractional month arguments. IvorySQL converts
the numeric months argument with `numeric_int8`, which rounds half away from zero, while Oracle
**truncates the fractional part toward zero**. The result is a silently wrong date.

### Evidence (master @ 03b24b1c468, oracle mode)

```sql
SELECT add_months(DATE '2020-01-31', 1.5);   -- IvorySQL: 2020-03-31   (advanced 2 months)
SELECT add_months(DATE '2020-01-31', 1.9);   -- IvorySQL: 2020-03-31   (advanced 2 months)
SELECT add_months(DATE '2020-03-31', -1.5);  -- IvorySQL: 2020-01-31   (went back 2 months)
SELECT add_months(DATE '2020-03-31', -0.5);  -- IvorySQL: 2020-02-29   (went back 1 month)
SELECT add_months(DATE '2020-03-31',  0.5);  -- IvorySQL: 2020-04-30   (advanced 1 month)
SELECT add_months(DATE '2020-03-31', -12.5); -- IvorySQL: 2019-02-28   (went back 13 months)
```

### Oracle 23ai Free (gvenzl/oracle-free:23-slim, Oracle AI Database 26ai Free Release 23.26.3.0.0) reference

```sql
SQL> SELECT add_months(DATE '2020-01-31', 1.5) FROM dual;   -- 29-FEB-20  (+1 month)
SQL> SELECT add_months(DATE '2020-01-31', 1.9) FROM dual;   -- 29-FEB-20  (+1 month)
SQL> SELECT add_months(DATE '2020-03-31', -1.5) FROM dual;  -- 29-FEB-20  (-1 month)
SQL> SELECT add_months(DATE '2020-03-31', -0.5) FROM dual;  -- 31-MAR-20  (+0)
SQL> SELECT add_months(DATE '2020-03-31',  0.5) FROM dual;  -- 31-MAR-20  (+0)
SQL> SELECT add_months(DATE '2020-03-31', -12.5) FROM dual; -- 31-MAR-19  (-12 months)
```

## Root cause / Fix

`contrib/ivorysql_ora/src/builtin_functions/datetime_datatype_functions.c`, `add_months()`:
the numeric argument is fed to `numeric_int8` directly, and PG's numeric→int8 cast *rounds*
half away from zero (0.5 → 1, -1.5 → -2).

Fix: truncate the numeric argument to zero decimal places with `numeric_trunc(num, 0)` (toward
zero, like Oracle) before the integral conversion. Integer inputs are unaffected; `1.0`, `2.0`,
`12.0` behave exactly as before.

Note: this is a different defect from the BC-year normalization (open PR #1762) and from the
out-of-range narrowing reported in closed issue #1621; no open PR covers the fractional truncation.

## Priority / scoring

PRIORITY 77 = 影响 30 (silently wrong dates from a core date function; fractional month counts
arise naturally from expressions such as `add_months(d, months_between(x,y)/2)`) + 波及 12
(single function) + 可复现性 20 (deterministic one-liners, verified against real Oracle) +
维护价值 15. FIX_CONFIDENCE 90 (one contained conversion change, all semantics verified on Oracle 23ai).

## Tests

`contrib/ivorysql_ora/sql/datatype_and_func_bugs.sql` — 7 new regression cases with fractional
month arguments (`1.5`, `1.9`, `-1.5`, `-0.5`, `0.5`, `-12.5`, `2.0`), all values cross-checked
against Oracle 23ai on a live instance.

- Before the fix, the new cases fail (e.g. `1.5` produced `2020-03-31`, expected `2020-02-29`)
  — reproduced on a master build during the differential probe.
- After the fix: `make oracle-check ORA_REGRESS=datatype_and_func_bugs` → 1/1 passed;
  full `make oracle-check` → **All 29 tests passed** (baseline on master is also 29/29, so no
  collateral changes).

## Risk

Low. Only the conversion of the months argument changes; integer arguments and the
last-day clamping logic are untouched. Huge fractional arguments that still exceed int8 after
truncation keep erroring with "integer out of range" (Oracle wraps around internally — its
output for `add_months(DATE '2020-03-31', 1e30)` is garbage (`30-JUN-35`), which I did not
reproduce on purpose).

Fixes #2014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected fractional month handling in `add_months` to truncate values toward zero, providing Oracle-compatible date calculations.
  - Prevented fractional values such as 1.5 or -1.5 from being rounded into an unintended additional month.
  - Month-end dates now produce the expected results when using fractional month arguments.

- **Tests**
  - Added coverage for positive and negative fractional month values across month-end dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->