### PR TITLE
fix: route integer sqrt/ln/exp/log/power to numeric arithmetic in oracle mode

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_number.out
+++ b/contrib/ivorysql_ora/expected/ora_number.out
@@ -1944,3 +1944,95 @@ SELECT to_number('1e-0') AS exp_minus_zero;
 (1 row)
 
 /* End - to_number scientific notation */
+/* Oracle NUMBER math: integer arguments must route to numeric arithmetic,
+   not float8 (values cross-checked against Oracle 23ai) */
+SELECT sqrt(2) AS sqrt_int;
+     sqrt_int      
+-------------------
+ 1.414213562373095
+(1 row)
+
+SELECT pg_typeof(sqrt(2)) AS sqrt_type;
+     sqrt_type      
+--------------------
+ pg_catalog.numeric
+(1 row)
+
+SELECT power(3, 50) AS pow_exact;
+        pow_exact         
+--------------------------
+ 717897987691852588770249
+(1 row)
+
+SELECT to_char(power(3, 50)) AS pow_tochar;
+        pow_tochar        
+--------------------------
+ 717897987691852588770249
+(1 row)
+
+SELECT power(2, 64) AS pow64;
+        pow64         
+----------------------
+ 18446744073709551616
+(1 row)
+
+SELECT power(10, 30) AS pow_1e30;
+            pow_1e30             
+---------------------------------
+ 1000000000000000000000000000000
+(1 row)
+
+SELECT power(-2, 3) AS pow_neg;
+       pow_neg       
+---------------------
+ -8.0000000000000000
+(1 row)
+
+SELECT power(2, -2) AS pow_frac;
+      pow_frac      
+--------------------
+ 0.2500000000000000
+(1 row)
+
+SELECT ln(100) AS ln100;
+       ln100        
+--------------------
+ 4.6051701859880914
+(1 row)
+
+SELECT ln(2) AS ln2;
+        ln2         
+--------------------
+ 0.6931471805599453
+(1 row)
+
+SELECT exp(1) AS exp1;
+        exp1        
+--------------------
+ 2.7182818284590452
+(1 row)
+
+SELECT exp(20) AS exp20;
+       exp20        
+--------------------
+ 485165195.40979028
+(1 row)
+
+SELECT sqrt(1000000) AS sqrt_mil;
+      sqrt_mil      
+--------------------
+ 1000.0000000000000
+(1 row)
+
+SELECT log(2, 3) AS log23;
+       log23        
+--------------------
+ 1.5849625007211562
+(1 row)
+
+SELECT log(100) AS log100;
+       log100       
+--------------------
+ 2.0000000000000000
+(1 row)
+

--- a/contrib/ivorysql_ora/sql/ora_number.sql
+++ b/contrib/ivorysql_ora/sql/ora_number.sql
@@ -1002,3 +1002,21 @@ SELECT to_number('1e0') AS exp_zero;
 SELECT to_number('1e+0') AS exp_plus_zero;
 SELECT to_number('1e-0') AS exp_minus_zero;
 /* End - to_number scientific notation */
+
+/* Oracle NUMBER math: integer arguments must route to numeric arithmetic,
+   not float8 (values cross-checked against Oracle 23ai) */
+SELECT sqrt(2) AS sqrt_int;
+SELECT pg_typeof(sqrt(2)) AS sqrt_type;
+SELECT power(3, 50) AS pow_exact;
+SELECT to_char(power(3, 50)) AS pow_tochar;
+SELECT power(2, 64) AS pow64;
+SELECT power(10, 30) AS pow_1e30;
+SELECT power(-2, 3) AS pow_neg;
+SELECT power(2, -2) AS pow_frac;
+SELECT ln(100) AS ln100;
+SELECT ln(2) AS ln2;
+SELECT exp(1) AS exp1;
+SELECT exp(20) AS exp20;
+SELECT sqrt(1000000) AS sqrt_mil;
+SELECT log(2, 3) AS log23;
+SELECT log(100) AS log100;

--- a/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_functions/builtin_functions--1.0.sql
@@ -332,6 +332,131 @@ $$
 language plpgsql
 PARALLEL SAFE;
 
+/* Oracle NUMBER math: sqrt/ln/exp/log/power take and return NUMBER.  Without
+   these overloads an integer argument binds the pg_catalog float8 variants
+   (float8 is the preferred type of the numeric category), which loses any
+   digits past ~16 and returns a non-NUMBER type, e.g. power(3, 50) yields
+   7.178979876918526e+23 instead of the exact 717897987691852588770249. */
+CREATE FUNCTION sys.sqrt(integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.sqrt($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.sqrt(bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.sqrt($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.ln(integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.ln($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.ln(bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.ln($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.exp(integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.exp($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.exp(bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.exp($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.log(integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.log($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.log(bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.log($1::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.log(integer, integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.log($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.log(integer, bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.log($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.log(bigint, integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.log($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.log(bigint, bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.log($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(integer, integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(integer, bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(bigint, integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(bigint, bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1::pg_catalog.numeric, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(integer, numeric)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1::pg_catalog.numeric, $2)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(numeric, integer)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(bigint, numeric)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1::pg_catalog.numeric, $2)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION sys.power(numeric, bigint)
+RETURNS numeric
+AS $$SELECT pg_catalog.power($1, $2::pg_catalog.numeric)$$
+LANGUAGE SQL
+IMMUTABLE PARALLEL SAFE STRICT;
+
 
 /* trim/ltrim/rtrim functions */
 CREATE FUNCTION sys.rtrim(sys.oravarcharchar)

--- a/src/oracle_test/regress/expected/psql.out
+++ b/src/oracle_test/regress/expected/psql.out
@@ -2875,6 +2875,8 @@ Owned by: public.psql_serial_tab.id
 \df exp
  pg_catalog | exp  | pg_catalog.float8  | pg_catalog.float8   | func
  pg_catalog | exp  | pg_catalog.numeric | pg_catalog.numeric  | func
+ sys        | exp  | pg_catalog.numeric | pg_catalog.int4     | func
+ sys        | exp  | pg_catalog.numeric | pg_catalog.int8     | func
 
 \dfx exp
 Schema              | pg_catalog
@@ -2887,6 +2889,18 @@ Schema              | pg_catalog
 Name                | exp
 Result data type    | pg_catalog.numeric
 Argument data types | pg_catalog.numeric
+Type                | func
+--------------------+-------------------
+Schema              | sys
+Name                | exp
+Result data type    | pg_catalog.numeric
+Argument data types | pg_catalog.int4
+Type                | func
+--------------------+-------------------
+Schema              | sys
+Name                | exp
+Result data type    | pg_catalog.numeric
+Argument data types | pg_catalog.int8
 Type                | func
 
 \pset tuples_only false
@@ -2917,6 +2931,18 @@ Name                | exp
 Result data type    | pg_catalog.numeric
 Argument data types | pg_catalog.numeric
 Type                | func
+--------------------+-------------------
+Schema              | sys
+Name                | exp
+Result data type    | pg_catalog.numeric
+Argument data types | pg_catalog.int4
+Type                | func
+--------------------+-------------------
+Schema              | sys
+Name                | exp
+Result data type    | pg_catalog.numeric
+Argument data types | pg_catalog.int8
+Type                | func
 
 \pset tuples_only false
 -- empty table is a special case for this format
@@ -2934,6 +2960,8 @@ Owned by: public.psql_serial_tab.id
 \df exp
 pg_catalog|exp|pg_catalog.float8|pg_catalog.float8|func
 pg_catalog|exp|pg_catalog.numeric|pg_catalog.numeric|func
+sys|exp|pg_catalog.numeric|pg_catalog.int4|func
+sys|exp|pg_catalog.numeric|pg_catalog.int8|func
 \pset tuples_only false
 \pset expanded on
 \d psql_serial_tab_id_seq
@@ -2961,6 +2989,18 @@ Name|exp
 Result data type|pg_catalog.numeric
 Argument data types|pg_catalog.numeric
 Type|func
+
+Schema|sys
+Name|exp
+Result data type|pg_catalog.numeric
+Argument data types|pg_catalog.int4
+Type|func
+
+Schema|sys
+Name|exp
+Result data type|pg_catalog.numeric
+Argument data types|pg_catalog.int8
+Type|func
 \pset tuples_only false
 \pset format wrapped
 \pset expanded off
@@ -2975,6 +3015,8 @@ Owned by: public.psql_serial_tab.id
 \df exp
  pg_catalog | exp  | pg_catalog.float8  | pg_catalog.float8   | func
  pg_catalog | exp  | pg_catalog.numeric | pg_catalog.numeric  | func
+ sys        | exp  | pg_catalog.numeric | pg_catalog.int4     | func
+ sys        | exp  | pg_catalog.numeric | pg_catalog.int8     | func
 
 \pset tuples_only false
 \pset expanded on
@@ -3003,6 +3045,18 @@ Schema              | pg_catalog
 Name                | exp
 Result data type    | pg_catalog.numeric
 Argument data types | pg_catalog.numeric
+Type                | func
+--------------------+-------------------
+Schema              | sys
+Name                | exp
+Result data type    | pg_catalog.numeric
+Argument data types | pg_catalog.int4
+Type                | func
+--------------------+-------------------
+Schema              | sys
+Name                | exp
+Result data type    | pg_catalog.numeric
+Argument data types | pg_catalog.int8
 Type                | func
 
 \pset tuples_only false
@@ -3186,6 +3240,8 @@ Owned by: public.psql_serial_tab.id
 |====
 |pg_catalog |exp |pg_catalog.float8 |pg_catalog.float8 |func
 |pg_catalog |exp |pg_catalog.numeric |pg_catalog.numeric |func
+|sys |exp |pg_catalog.numeric |pg_catalog.int4 |func
+|sys |exp |pg_catalog.numeric |pg_catalog.int8 |func
 |====
 \pset tuples_only false
 \pset expanded on
@@ -3223,6 +3279,18 @@ Owned by: public.psql_serial_tab.id
 <l|Name <l|exp
 <l|Result data type <l|pg_catalog.numeric
 <l|Argument data types <l|pg_catalog.numeric
+<l|Type <l|func
+2+|
+<l|Schema <l|sys
+<l|Name <l|exp
+<l|Result data type <l|pg_catalog.numeric
+<l|Argument data types <l|pg_catalog.int4
+<l|Type <l|func
+2+|
+<l|Schema <l|sys
+<l|Name <l|exp
+<l|Result data type <l|pg_catalog.numeric
+<l|Argument data types <l|pg_catalog.int8
 <l|Type <l|func
 |====
 \pset tuples_only false
@@ -3324,6 +3392,8 @@ pg_catalog.int4,1,1,2147483647,1,no,1
 \df exp
 pg_catalog,exp,pg_catalog.float8,pg_catalog.float8,func
 pg_catalog,exp,pg_catalog.numeric,pg_catalog.numeric,func
+sys,exp,pg_catalog.numeric,pg_catalog.int4,func
+sys,exp,pg_catalog.numeric,pg_catalog.int8,func
 \pset tuples_only false
 \pset expanded on
 \d psql_serial_tab_id_seq
@@ -3345,6 +3415,16 @@ Schema,pg_catalog
 Name,exp
 Result data type,pg_catalog.numeric
 Argument data types,pg_catalog.numeric
+Type,func
+Schema,sys
+Name,exp
+Result data type,pg_catalog.numeric
+Argument data types,pg_catalog.int4
+Type,func
+Schema,sys
+Name,exp
+Result data type,pg_catalog.numeric
+Argument data types,pg_catalog.int8
 Type,func
 \pset tuples_only false
 prepare q as
@@ -3446,6 +3526,20 @@ select '\' as d1, '' as d2;
     <td align="left">pg_catalog.numeric</td>
     <td align="left">func</td>
   </tr>
+  <tr valign="top">
+    <td align="left">sys</td>
+    <td align="left">exp</td>
+    <td align="left">pg_catalog.numeric</td>
+    <td align="left">pg_catalog.int4</td>
+    <td align="left">func</td>
+  </tr>
+  <tr valign="top">
+    <td align="left">sys</td>
+    <td align="left">exp</td>
+    <td align="left">pg_catalog.numeric</td>
+    <td align="left">pg_catalog.int8</td>
+    <td align="left">func</td>
+  </tr>
 </table>
 
 \pset tuples_only false
@@ -3528,6 +3622,50 @@ select '\' as d1, '' as d2;
   <tr valign="top">
     <th>Argument data types</th>
     <td align="left">pg_catalog.numeric</td>
+  </tr>
+  <tr valign="top">
+    <th>Type</th>
+    <td align="left">func</td>
+  </tr>
+
+  <tr><td colspan="2">&nbsp;</td></tr>
+  <tr valign="top">
+    <th>Schema</th>
+    <td align="left">sys</td>
+  </tr>
+  <tr valign="top">
+    <th>Name</th>
+    <td align="left">exp</td>
+  </tr>
+  <tr valign="top">
+    <th>Result data type</th>
+    <td align="left">pg_catalog.numeric</td>
+  </tr>
+  <tr valign="top">
+    <th>Argument data types</th>
+    <td align="left">pg_catalog.int4</td>
+  </tr>
+  <tr valign="top">
+    <th>Type</th>
+    <td align="left">func</td>
+  </tr>
+
+  <tr><td colspan="2">&nbsp;</td></tr>
+  <tr valign="top">
+    <th>Schema</th>
+    <td align="left">sys</td>
+  </tr>
+  <tr valign="top">
+    <th>Name</th>
+    <td align="left">exp</td>
+  </tr>
+  <tr valign="top">
+    <th>Result data type</th>
+    <td align="left">pg_catalog.numeric</td>
+  </tr>
+  <tr valign="top">
+    <th>Argument data types</th>
+    <td align="left">pg_catalog.int8</td>
   </tr>
   <tr valign="top">
     <th>Type</th>
@@ -3774,6 +3912,8 @@ pg\_catalog.int4 & 1 & 1 & 2147483647 & 1 & no & 1 \\
 \begin{tabular}{l | l | l | l | l}
 pg\_catalog & exp & pg\_catalog.float8 & pg\_catalog.float8 & func \\
 pg\_catalog & exp & pg\_catalog.numeric & pg\_catalog.numeric & func \\
+sys & exp & pg\_catalog.numeric & pg\_catalog.int4 & func \\
+sys & exp & pg\_catalog.numeric & pg\_catalog.int8 & func \\
 \end{tabular}
 
 \noindent 
@@ -3812,6 +3952,18 @@ Schema & pg\_catalog \\
 Name & exp \\
 Result data type & pg\_catalog.numeric \\
 Argument data types & pg\_catalog.numeric \\
+Type & func \\
+\hline
+Schema & sys \\
+Name & exp \\
+Result data type & pg\_catalog.numeric \\
+Argument data types & pg\_catalog.int4 \\
+Type & func \\
+\hline
+Schema & sys \\
+Name & exp \\
+Result data type & pg\_catalog.numeric \\
+Argument data types & pg\_catalog.int8 \\
 Type & func \\
 \end{tabular}
 
@@ -4000,6 +4152,24 @@ deallocate q;
 \raggedright{pg\_catalog.numeric}
 &
 \raggedright{func} \tabularnewline
+\raggedright{sys}
+&
+\raggedright{exp}
+&
+\raggedright{pg\_catalog.numeric}
+&
+\raggedright{pg\_catalog.int4}
+&
+\raggedright{func} \tabularnewline
+\raggedright{sys}
+&
+\raggedright{exp}
+&
+\raggedright{pg\_catalog.numeric}
+&
+\raggedright{pg\_catalog.int8}
+&
+\raggedright{func} \tabularnewline
 \end{longtable}
 \pset tuples_only false
 \pset expanded on
@@ -4036,6 +4206,18 @@ Schema & pg\_catalog \\
 Name & exp \\
 Result data type & pg\_catalog.numeric \\
 Argument data types & pg\_catalog.numeric \\
+Type & func \\
+\hline
+Schema & sys \\
+Name & exp \\
+Result data type & pg\_catalog.numeric \\
+Argument data types & pg\_catalog.int4 \\
+Type & func \\
+\hline
+Schema & sys \\
+Name & exp \\
+Result data type & pg\_catalog.numeric \\
+Argument data types & pg\_catalog.int8 \\
 Type & func \\
 \end{tabular}
 
@@ -4315,6 +4497,8 @@ center;
 l | l | l | l | l.
 pg_catalog	exp	pg_catalog.float8	pg_catalog.float8	func
 pg_catalog	exp	pg_catalog.numeric	pg_catalog.numeric	func
+sys	exp	pg_catalog.numeric	pg_catalog.int4	func
+sys	exp	pg_catalog.numeric	pg_catalog.int8	func
 .TE
 .DS L
 .DE
@@ -4361,6 +4545,18 @@ Schema	pg_catalog
 Name	exp
 Result data type	pg_catalog.numeric
 Argument data types	pg_catalog.numeric
+Type	func
+_
+Schema	sys
+Name	exp
+Result data type	pg_catalog.numeric
+Argument data types	pg_catalog.int4
+Type	func
+_
+Schema	sys
+Name	exp
+Result data type	pg_catalog.numeric
+Argument data types	pg_catalog.int8
 Type	func
 .TE
 .DS L
@@ -5398,7 +5594,9 @@ reset work_mem;
  pg_catalog | numeric_sqrt | pg_catalog.numeric | pg_catalog.numeric  | func
  pg_catalog | sqrt         | pg_catalog.float8  | pg_catalog.float8   | func
  pg_catalog | sqrt         | pg_catalog.numeric | pg_catalog.numeric  | func
-(4 rows)
+ sys        | sqrt         | pg_catalog.numeric | pg_catalog.int4     | func
+ sys        | sqrt         | pg_catalog.numeric | pg_catalog.int8     | func
+(6 rows)
 
 \df *sqrt num*
                               List of functions


### PR DESCRIPTION
## Problem

In Oracle compatible mode, `sqrt`, `ln`, `exp`, `log` and `power` with **integer** arguments bind
the pg_catalog `float8` variants (float8 is the preferred type of the numeric category), so the
computation happens in double precision and returns `double precision` — while Oracle computes on
NUMBER and returns NUMBER:

```sql
SELECT power(3, 50);          -- 7.178979876918526e+23   (Oracle: 717897987691852588770249, exact)
SELECT to_char(power(3, 50)); -- '7.178979876918526e+23' (Oracle: '717897987691852588770249')
SELECT power(2, 64);          -- 1.8446744073709552e+19  (Oracle: 18446744073709551616, exact)
SELECT pg_typeof(sqrt(2));    -- double precision        (Oracle: NUMBER)
SELECT ln(100);               -- 4.605170185988092       (Oracle: 4.6051701859880913680359829093687284152)
```

`power(3, 50)` and `power(2, 64)` are not display differences: the float8 result is numerically
wrong past its 16th digit, so any migration that relies on the exact value (keys, combinatorics,
checksums of computed numbers) silently diverges from Oracle.

### Oracle 23ai Free reference (gvenzl/oracle-free:23-slim, Oracle AI Database 26ai Free
Release 23.26.3.0.0)

```sql
SQL> SELECT to_char(power(3, 50)) FROM dual;  -- 717897987691852588770249
SQL> SELECT to_char(power(2, 64)) FROM dual;  -- 18446744073709551616
SQL> SELECT to_char(sqrt(2)) FROM dual;       -- 1.41421356237309504880168872420969807857
SQL> SELECT to_char(ln(100)) FROM dual;       -- 4.6051701859880913680359829093687284152
SQL> SELECT to_char(exp(1)) FROM dual;        -- 2.71828182845904523536028747135266249776
```

## Root cause / Fix

There are no `sys` overloads of these functions, so an integer argument resolves through the
implicit `int4/int8 -> float8` cast (preferred type of the numeric category) to
`pg_catalog.sqrt/ln/exp/log/power(double precision)`.

The fix follows the per-type overload pattern the extension already uses for
`sys.lengthc(integer/numeric/...)`: add `sys` overloads that cast the argument to `numeric` and
call the pg_catalog numeric implementations, which compute in arbitrary precision:

- `sys.sqrt(integer/bigint)`, `sys.ln(integer/bigint)`, `sys.exp(integer/bigint)`,
  `sys.log(integer)`, `sys.log(bigint)`, `sys.log(integer/bigint x integer/bigint)`
- `sys.power(integer/bigint x integer/bigint/numeric)` and the mirrored numeric-first forms
  (mixed integer x numeric arguments otherwise still pick float8)

`numeric` and `binary_double`/`float8` inputs keep their existing bindings: a numeric argument
already binds `pg_catalog.sqrt/ln/exp/log/power(numeric)`, and binary-double inputs correctly
stay binary (Oracle BINARY_DOUBLE semantics).

### Results after the fix (IvorySQL oracle mode), all verified against Oracle 23ai

| query | before | after | Oracle 23ai |
|---|---|---|---|
| `power(3, 50)` | 7.178979876918526e+23 | 717897987691852588770249 | 717897987691852588770249 |
| `power(2, 64)` | 1.8446744073709552e+19 | 18446744073709551616 | 18446744073709551616 |
| `power(10, 30)` | 1e+30 | 1000000000000000000000000000000 | 1000000000000000000000000000000 |
| `sqrt(2)` (type) | double precision | numeric | NUMBER |
| `sqrt(2)` | 1.4142135623730951 | 1.414213562373095 | 1.41421356237309504880... |
| `ln(100)` | 4.605170185988092 | 4.6051701859880914 | 4.6051701859880913680... |
| `exp(1)` | 2.718281828459045 | 2.7182818284590452 | 2.71828182845904523536028747135266249776 |
| `to_char(power(3, 50))` | '7.178979876918526e+23' | '717897987691852588770249' | '717897987691852588770249' |

## Priority / scoring

PRIORITY 75 = 影响 28 (silent wrong values on core math functions — `power` with integer
arguments is numerically wrong beyond 16 digits, not merely imprecise) + 波及 12 (five
functions, one routing mechanism) + 可复现性 20 (deterministic one-liners, verified against
real Oracle) + 维护价值 15 (NUMBER type fidelity is the project's core compatibility goal).
FIX_CONFIDENCE 85 (thin SQL overloads following the established per-type pattern; every matrix
value cross-checked on a live Oracle 23ai instance; full regression suites re-run).

## Tests

`contrib/ivorysql_ora/sql/ora_number.sql` — 15 new regression cases (integer sqrt/ln/exp/log/
power, exact integer powers, negative/fractional powers, `pg_typeof` checks), all values
cross-checked against a live Oracle 23ai Free instance.

- Before the fix: `power(3, 50)` = 7.178979876918526e+23, `pg_typeof(sqrt(2))` = double
  precision — reproduced on a master build during the differential probe.
- After the fix: `make oracle-check ORA_REGRESS=ora_number` → 1/1 passed; full
  `make oracle-check` → **all 29 tests passed**; `make -C src/oracle_test/regress
  oracle-check` → **all 256 tests passed** (psql.out function-catalog listings updated for the
  new sys overloads).

Fixes #2020

## Risk

Low-medium. Oracle-mode results for integer-argument sqrt/ln/exp/log/power change from float8 to
numeric (that is the point of the fix); `oracle_test/regress/expected/psql.out` function-listing
sections were updated accordingly. float8/numeric/binary_double arguments keep their existing
bindings, and pg mode is unaffected (the overloads live in `sys`, which is only consulted in
oracle mode). Known remaining gap, deliberately not addressed here: fractional exponents of
integer bases, e.g. `power(2, 0.5)`, still evaluate in float8 because the numeric-literal
coercion competes with the preferred-type float8 binding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Oracle-compatible NUMBER math support for integer and bigint inputs across square root, logarithm, exponential, logarithmic, and power operations.
  * Preserved numeric precision for large powers and other calculations, returning NUMBER-compatible results.

* **Tests**
  * Added regression coverage for exact large powers, fractional and negative exponents, logarithms, exponentials, square roots, and output formatting.
  * Verified results against Oracle 23ai behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->