### PR TITLE
test: cover UTL_FILE NCHAR variants, FGETPOS and PUT_RAW

### DIFF
--- a/contrib/ivorysql_ora/expected/utl_file.out
+++ b/contrib/ivorysql_ora/expected/utl_file.out
@@ -184,6 +184,46 @@ end;
 NOTICE:  is_open = t
 NOTICE:  is_open = t
 NOTICE:  is_open = f
+-- test NCHAR variants (fopen_nchar/get_line_nchar/put_line_nchar) with multibyte content
+-- and FGETPOS position reporting
+declare
+    f sys.ora_utl_file_file_type;
+    line_n text;
+    pos_n integer;
+begin
+    f := utl_file.fopen_nchar('data_directory', 'regress_nchar.txt', 'W', 1024);
+    utl_file.put_line_nchar(f, 'hello 世界');
+    utl_file.put_line_nchar(f, 'héllo');
+    pos_n := utl_file.fgetpos(f);
+    raise notice 'fgetpos after two nchar lines = %', pos_n;
+    utl_file.fclose(f);
+    f := utl_file.fopen_nchar('data_directory', 'regress_nchar.txt', 'R', 1024);
+    utl_file.get_line_nchar(f, line_n);
+    raise notice 'first nchar line = %', line_n;
+    utl_file.get_line_nchar(f, line_n);
+    raise notice 'second nchar line = %', line_n;
+    utl_file.fclose(f);
+    utl_file.fremove('data_directory', 'regress_nchar.txt');
+end;
+/
+NOTICE:  fgetpos after two nchar lines = 20
+NOTICE:  first nchar line = hello 世界
+NOTICE:  second nchar line = héllo
+-- test PUT_RAW writes binary bytes verbatim (including embedded NUL)
+declare
+    f sys.ora_utl_file_file_type;
+    raw_len integer;
+begin
+    f := utl_file.fopen('data_directory', 'regress_raw.bin', 'W');
+    utl_file.put_raw(f, decode('41420043440a', 'hex'));
+    utl_file.fclose(f);
+    select length(pg_read_binary_file(current_setting('data_directory') || '/regress_raw.bin'))
+      into raw_len;
+    raise notice 'raw file length = % (expect 6)', raw_len;
+    utl_file.fremove('data_directory', 'regress_raw.bin');
+end;
+/
+NOTICE:  raw file length = 6 (expect 6)
 -- clean up
 delete from sys.utl_file_directory where dirname = 'data_directory';
 /

--- a/contrib/ivorysql_ora/sql/utl_file.sql
+++ b/contrib/ivorysql_ora/sql/utl_file.sql
@@ -164,6 +164,45 @@ begin
 end;
 /
 
+-- test NCHAR variants (fopen_nchar/get_line_nchar/put_line_nchar) with multibyte content
+-- and FGETPOS position reporting
+declare
+    f sys.ora_utl_file_file_type;
+    line_n text;
+    pos_n integer;
+begin
+    f := utl_file.fopen_nchar('data_directory', 'regress_nchar.txt', 'W', 1024);
+    utl_file.put_line_nchar(f, 'hello 世界');
+    utl_file.put_line_nchar(f, 'héllo');
+    pos_n := utl_file.fgetpos(f);
+    raise notice 'fgetpos after two nchar lines = %', pos_n;
+    utl_file.fclose(f);
+
+    f := utl_file.fopen_nchar('data_directory', 'regress_nchar.txt', 'R', 1024);
+    utl_file.get_line_nchar(f, line_n);
+    raise notice 'first nchar line = %', line_n;
+    utl_file.get_line_nchar(f, line_n);
+    raise notice 'second nchar line = %', line_n;
+    utl_file.fclose(f);
+    utl_file.fremove('data_directory', 'regress_nchar.txt');
+end;
+/
+
+-- test PUT_RAW writes binary bytes verbatim (including embedded NUL)
+declare
+    f sys.ora_utl_file_file_type;
+    raw_len integer;
+begin
+    f := utl_file.fopen('data_directory', 'regress_raw.bin', 'W');
+    utl_file.put_raw(f, decode('41420043440a', 'hex'));
+    utl_file.fclose(f);
+    select length(pg_read_binary_file(current_setting('data_directory') || '/regress_raw.bin'))
+      into raw_len;
+    raise notice 'raw file length = % (expect 6)', raw_len;
+    utl_file.fremove('data_directory', 'regress_raw.bin');
+end;
+/
+
 -- clean up
 delete from sys.utl_file_directory where dirname = 'data_directory';
 /


### PR DESCRIPTION
Closes #2022.

Adds regression coverage for UTL_FILE members that had none:

- FOPEN_NCHAR / PUT_LINE_NCHAR / GET_LINE_NCHAR: write and read back
  multibyte UTF8 lines (CJK + precomposed characters), checking
  round-trip equality.
- FGETPOS: file position reported after writing two lines.
- PUT_RAW: binary write with an embedded NUL, verifying the on-disk
  byte count via pg_read_binary_file().

No production code changes; test + expected output only.

Verified: make -C contrib/ivorysql_ora oracle-check -> 28/28.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for NCHAR file operations using multibyte text, including writing, reading, position reporting, and cleanup.
  * Added validation that binary output preserves exact byte lengths, including embedded NUL characters.
  * Expanded checks for file handling behavior across text and raw data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->