### PR TITLE
test: cover sys.uid (incl. UID pseudo-column) and to_clob/to_blob

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_character_datatype_functions.out
@@ -4074,3 +4074,38 @@ select to_single_byte(NULL);
  
 (1 row)
 
+-- Tests for to_clob() and to_blob() (text -> clob/blob domain conversion)
+SELECT length(to_clob('abc')) AS clob_len;
+ clob_len 
+----------
+        3
+(1 row)
+
+SELECT length(to_blob('abc')) AS blob_len;
+ blob_len 
+----------
+        3
+(1 row)
+
+-- multibyte input: length is in characters
+SELECT length(to_clob('中文')) AS clob_mb_len;
+ clob_mb_len 
+-------------
+           2
+(1 row)
+
+-- oracle mode: empty string is NULL, functions are STRICT
+SET ivorysql.compatible_mode = oracle;
+SELECT to_clob('') IS NULL AS clob_empty_null;
+ clob_empty_null 
+-----------------
+ t
+(1 row)
+
+SELECT to_blob('') IS NULL AS blob_empty_null;
+ blob_empty_null 
+-----------------
+ t
+(1 row)
+
+RESET ivorysql.compatible_mode;

--- a/contrib/ivorysql_ora/expected/ora_misc_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_misc_functions.out
@@ -4521,3 +4521,27 @@ DETAIL:  "ivorysql" is a reserved prefix.
 reset ivorysql.dummy_config;
 ERROR:  invalid configuration parameter name "ivorysql.dummy_config"
 DETAIL:  "ivorysql" is a reserved prefix.
+-- Tests for sys.uid()
+-- sys.uid() returns the current user's OID; compare rather than print it so
+-- the result is stable across environments.
+SELECT sys.uid() = current_user::regrole::oid AS uid_matches;
+ uid_matches 
+-------------
+ t
+(1 row)
+
+-- Oracle mode: the UID pseudo-column binds to sys.uid()
+SET ivorysql.compatible_mode = oracle;
+SELECT UID = current_user::regrole::oid AS oracle_uid_matches FROM dual;
+ oracle_uid_matches 
+--------------------
+ t
+(1 row)
+
+SELECT sys.uid() = UID AS uid_consistent;
+ uid_consistent 
+----------------
+ t
+(1 row)
+
+RESET ivorysql.compatible_mode;

--- a/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_character_datatype_functions.sql
@@ -1558,3 +1558,14 @@ select to_single_byte('１．２');
 select to_single_byte(１．２);
 select to_single_byte(3.4);
 select to_single_byte(NULL);
+
+-- Tests for to_clob() and to_blob() (text -> clob/blob domain conversion)
+SELECT length(to_clob('abc')) AS clob_len;
+SELECT length(to_blob('abc')) AS blob_len;
+-- multibyte input: length is in characters
+SELECT length(to_clob('中文')) AS clob_mb_len;
+-- oracle mode: empty string is NULL, functions are STRICT
+SET ivorysql.compatible_mode = oracle;
+SELECT to_clob('') IS NULL AS clob_empty_null;
+SELECT to_blob('') IS NULL AS blob_empty_null;
+RESET ivorysql.compatible_mode;

--- a/contrib/ivorysql_ora/sql/ora_misc_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_misc_functions.sql
@@ -2464,3 +2464,13 @@ reset default_text_search_config;
 -- should throw errors, because dummy_config is not a valid configuration name
 set ivorysql.dummy_config to dummy;
 reset ivorysql.dummy_config;
+
+-- Tests for sys.uid()
+-- sys.uid() returns the current user's OID; compare rather than print it so
+-- the result is stable across environments.
+SELECT sys.uid() = current_user::regrole::oid AS uid_matches;
+-- Oracle mode: the UID pseudo-column binds to sys.uid()
+SET ivorysql.compatible_mode = oracle;
+SELECT UID = current_user::regrole::oid AS oracle_uid_matches FROM dual;
+SELECT sys.uid() = UID AS uid_consistent;
+RESET ivorysql.compatible_mode;


### PR DESCRIPTION
Closes #2024.

Adds regression coverage for three implemented but untested functions:

- sys.uid(): compared against current_user::regrole::oid (stable
  output); oracle-mode UID pseudo-column asserted equal to the same and
  to sys.uid().
- to_clob()/to_blob(): lengths for ascii and multibyte input; STRICT
  empty-string-to-NULL behavior in oracle mode.

No production code changes; tests + expected output only.

Verified: make -C contrib/ivorysql_ora oracle-check -> 28/28.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for text-to-LOB conversions, including ASCII, multibyte text, and Oracle-compatible empty-string handling.
  - Added validation that `sys.uid()` and Oracle-compatible `UID` return the current user’s identifier consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->