### PR TITLE
test: cover Oracle date/time functions and timezone conversions

### DIFF
--- a/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
+++ b/contrib/ivorysql_ora/expected/ora_datetime_datatype_functions.out
@@ -2076,3 +2076,66 @@ drop table ds_tb;
 reset NLS_TIMESTAMP_FORMAT;
 reset NLS_TIMESTAMP_TZ_FORMAT;
 reset NLS_DATE_FORMAT;
+-- Tests for sysdate / systimestamp / current_timestamp / localtimestamp
+SET ivorysql.compatible_mode = oracle;
+SELECT sysdate IS NOT NULL AS sysdate_not_null FROM dual;
+ sysdate_not_null 
+------------------
+ t
+(1 row)
+
+SELECT systimestamp IS NOT NULL AS systimestamp_not_null FROM dual;
+ systimestamp_not_null 
+-----------------------
+ t
+(1 row)
+
+SELECT pg_typeof(current_timestamp) = 'timestamp with time zone'::regtype AS cts_type,
+       pg_typeof(current_timestamp(3)) = 'timestamp with time zone'::regtype AS cts3_type,
+       pg_typeof(localtimestamp) = 'timestamp without time zone'::regtype AS lts_type,
+       pg_typeof(systimestamp) = 'timestamp with time zone'::regtype AS sts_type
+  FROM dual;
+ cts_type | cts3_type | lts_type | sts_type 
+----------+-----------+----------+----------
+ t        | t         | t        | t
+(1 row)
+
+-- sessiontimezone reflects the session setting
+SET TIME ZONE 'America/New_York';
+SELECT sessiontimezone() AS sess_tz FROM dual;
+     sess_tz      
+------------------
+ America/New_York
+(1 row)
+
+RESET TIME ZONE;
+-- from_tz under a fixed (UTC) session timezone for stable output
+SET TIME ZONE 'UTC';
+SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '+14:00') AS fmax FROM dual;
+               fmax                
+-----------------------------------
+ 2000-03-27 18:00:00.000000 +00:00
+(1 row)
+
+SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '-12:00') AS fmin FROM dual;
+               fmin                
+-----------------------------------
+ 2000-03-28 20:00:00.000000 +00:00
+(1 row)
+
+SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '99:99') AS fbad FROM dual;
+ERROR:  timezone hour between -12 and 14
+RESET TIME ZONE;
+-- sys_extract_utc: NULL propagation and offset conversion
+SELECT sys_extract_utc(NULL) IS NULL AS seu_null FROM dual;
+ seu_null 
+----------
+ t
+(1 row)
+
+SELECT sys_extract_utc(TIMESTAMP '2018-03-02 12:01:02 +14:00') AS seu FROM dual;
+            seu             
+----------------------------
+ 2018-03-01 22:01:02.000000
+(1 row)
+

--- a/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
+++ b/contrib/ivorysql_ora/sql/ora_datetime_datatype_functions.sql
@@ -805,3 +805,29 @@ drop table ds_tb;
 reset NLS_TIMESTAMP_FORMAT;
 reset NLS_TIMESTAMP_TZ_FORMAT;
 reset NLS_DATE_FORMAT;
+
+-- Tests for sysdate / systimestamp / current_timestamp / localtimestamp
+SET ivorysql.compatible_mode = oracle;
+SELECT sysdate IS NOT NULL AS sysdate_not_null FROM dual;
+SELECT systimestamp IS NOT NULL AS systimestamp_not_null FROM dual;
+SELECT pg_typeof(current_timestamp) = 'timestamp with time zone'::regtype AS cts_type,
+       pg_typeof(current_timestamp(3)) = 'timestamp with time zone'::regtype AS cts3_type,
+       pg_typeof(localtimestamp) = 'timestamp without time zone'::regtype AS lts_type,
+       pg_typeof(systimestamp) = 'timestamp with time zone'::regtype AS sts_type
+  FROM dual;
+
+-- sessiontimezone reflects the session setting
+SET TIME ZONE 'America/New_York';
+SELECT sessiontimezone() AS sess_tz FROM dual;
+RESET TIME ZONE;
+
+-- from_tz under a fixed (UTC) session timezone for stable output
+SET TIME ZONE 'UTC';
+SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '+14:00') AS fmax FROM dual;
+SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '-12:00') AS fmin FROM dual;
+SELECT FROM_TZ(TIMESTAMP '2000-03-28 08:00:00', '99:99') AS fbad FROM dual;
+RESET TIME ZONE;
+
+-- sys_extract_utc: NULL propagation and offset conversion
+SELECT sys_extract_utc(NULL) IS NULL AS seu_null FROM dual;
+SELECT sys_extract_utc(TIMESTAMP '2018-03-02 12:01:02 +14:00') AS seu FROM dual;


### PR DESCRIPTION
Closes #2026.

Adds regression coverage for the Oracle date/time functions that had
none or one call only:

- sysdate()/systimestamp() non-NULL assertions (their only previous
  mentions were in comments);
- pg_typeof checks for current_timestamp (incl. (3) precision form),
  localtimestamp and systimestamp;
- sessiontimezone() under SET TIME ZONE;
- from_tz() offsets +14:00/-12:00 under a fixed UTC session plus the
  out-of-range '99:99' error;
- sys_extract_utc() NULL propagation and offset conversion.

No production code changes; tests + expected output only. All outputs
are stable across host time zones.

Verified: make -C contrib/ivorysql_ora oracle-check -> 28/28.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Oracle-compatible datetime functions, including system and current timestamp values and their data types.
  * Added validation for session time zone behavior and time zone conversion, including invalid offset handling.
  * Added checks for UTC extraction, NULL propagation, and offset conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->