### PR TITLE
Add Oracle-compatible UTL_RECOMP package

### DIFF
--- a/contrib/ivorysql_ora/Makefile
+++ b/contrib/ivorysql_ora/Makefile
@@ -90,6 +90,7 @@ ORA_REGRESS = \
 	ora_ascii \
 	ora_stragg \
 	dbms_lock \
+	utl_recomp \
 	utl_file \
 	utl_raw \
 	utl_encode \

--- a/contrib/ivorysql_ora/expected/utl_recomp.out
+++ b/contrib/ivorysql_ora/expected/utl_recomp.out
@@ -1,0 +1,81 @@
+--
+-- tests for utl_recomp package
+--
+-- create a test schema with routines and a view to recompile
+CREATE SCHEMA rc_test;
+CREATE FUNCTION rc_test.incr(a int) RETURN int AS $$
+BEGIN
+    RETURN a + 1;
+END;
+$$ LANGUAGE plisql;
+CREATE FUNCTION rc_test.sqr(a int) RETURN int AS $$
+    SELECT a * a;
+$$ LANGUAGE sql;
+CREATE VIEW rc_test.v1 AS SELECT rc_test.incr(1) AS x;
+-- 1. RECOMP_SERIAL on an explicit schema recompiles routines and views
+CALL UTL_RECOMP.RECOMP_SERIAL('rc_test');
+-- objects are still usable after recompile
+SELECT rc_test.incr(41) AS incr_result;
+SELECT rc_test.sqr(7) AS sqr_result;
+SELECT * FROM rc_test.v1;
+-- 2. RECOMP_SCHEMA (same effect)
+CALL UTL_RECOMP.RECOMP_SCHEMA('rc_test');
+-- 3. RECOMP_PARALLEL with an explicit thread count
+CALL UTL_RECOMP.RECOMP_PARALLEL(2, 'rc_test');
+-- 4. NULL schema means the current schema
+CALL UTL_RECOMP.RECOMP_SERIAL();
+-- 5. flags argument is accepted (and ignored)
+CALL UTL_RECOMP.RECOMP_SERIAL('rc_test', 1);
+CALL UTL_RECOMP.RECOMP_SCHEMA('rc_test', 42);
+-- 6. a dependency-broken routine is reported as a warning and does not
+--    stop the other objects from being recompiled
+CREATE FUNCTION rc_test.helper() RETURN int AS $$
+    SELECT 2;
+$$ LANGUAGE SQL;
+CREATE FUNCTION rc_test.uses_helper() RETURN int AS $$
+    SELECT rc_test.helper();
+$$ LANGUAGE SQL;
+DROP FUNCTION rc_test.helper();
+CALL UTL_RECOMP.RECOMP_SERIAL('rc_test');
+SELECT rc_test.incr(1) AS still_ok;
+-- clean up before the error cases below
+DROP SCHEMA rc_test CASCADE;
+-- 7. threads must be positive
+CALL UTL_RECOMP.RECOMP_PARALLEL(0, 'rc_test');
+-- 8. an invalid schema is rejected
+CALL UTL_RECOMP.RECOMP_SERIAL('no_such_schema_xyz');
+NOTICE:  UTL_RECOMP: recompiled 3 objects in schema "rc_test" (0 failed)
+ incr_result 
+-------------
+          42
+(1 row)
+
+NOTICE:  UTL_RECOMP: recompiled 3 objects in schema "rc_test" (0 failed)
+ sqr_result 
+------------
+         49
+(1 row)
+
+NOTICE:  UTL_RECOMP: recompiled 3 objects in schema "rc_test" (0 failed)
+ x 
+---
+ 2
+(1 row)
+
+NOTICE:  UTL_RECOMP: recompiled 0 objects in schema "public" (0 failed)
+NOTICE:  UTL_RECOMP: recompiled 3 objects in schema "rc_test" (0 failed)
+NOTICE:  UTL_RECOMP: recompiled 3 objects in schema "rc_test" (0 failed)
+WARNING:  UTL_RECOMP: could not recompile rc_test.uses_helper(): function rc_test.helper() does not exist
+NOTICE:  UTL_RECOMP: recompiled 3 objects in schema "rc_test" (1 failed)
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to function rc_test.incr(pg_catalog.int4)
+drop cascades to function rc_test.sqr(pg_catalog.int4)
+drop cascades to view rc_test.v1
+drop cascades to function rc_test.uses_helper()
+ still_ok 
+----------
+        2
+(1 row)
+
+ERROR:  UTL_RECOMP: threads must be a positive integer
+CONTEXT:  PL/iSQL function sys.utl_recomp.recomp_parallel line 65 at RAISE

--- a/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
+++ b/contrib/ivorysql_ora/ivorysql_ora_merge_sqls
@@ -10,4 +10,5 @@ src/builtin_packages/utl_raw/utl_raw
 src/builtin_packages/utl_encode/utl_encode
 src/builtin_packages/utl_url/utl_url
 src/builtin_packages/dbms_session/dbms_session
+src/builtin_packages/utl_recomp/utl_recomp
 src/builtin_packages/dbms_transaction/dbms_transaction

--- a/contrib/ivorysql_ora/sql/utl_recomp.sql
+++ b/contrib/ivorysql_ora/sql/utl_recomp.sql
@@ -1,0 +1,59 @@
+--
+-- tests for utl_recomp package
+--
+
+-- create a test schema with routines and a view to recompile
+CREATE SCHEMA rc_test;
+CREATE FUNCTION rc_test.incr(a int) RETURN int AS $$
+BEGIN
+    RETURN a + 1;
+END;
+$$ LANGUAGE plisql;
+
+CREATE FUNCTION rc_test.sqr(a int) RETURN int AS $$
+    SELECT a * a;
+$$ LANGUAGE sql;
+
+CREATE VIEW rc_test.v1 AS SELECT rc_test.incr(1) AS x;
+
+-- 1. RECOMP_SERIAL on an explicit schema recompiles routines and views
+CALL UTL_RECOMP.RECOMP_SERIAL('rc_test');
+
+-- objects are still usable after recompile
+SELECT rc_test.incr(41) AS incr_result;
+SELECT rc_test.sqr(7) AS sqr_result;
+SELECT * FROM rc_test.v1;
+
+-- 2. RECOMP_SCHEMA (same effect)
+CALL UTL_RECOMP.RECOMP_SCHEMA('rc_test');
+
+-- 3. RECOMP_PARALLEL with an explicit thread count
+CALL UTL_RECOMP.RECOMP_PARALLEL(2, 'rc_test');
+
+-- 4. NULL schema means the current schema
+CALL UTL_RECOMP.RECOMP_SERIAL();
+
+-- 5. flags argument is accepted (and ignored)
+CALL UTL_RECOMP.RECOMP_SERIAL('rc_test', 1);
+CALL UTL_RECOMP.RECOMP_SCHEMA('rc_test', 42);
+
+-- 6. a dependency-broken routine is reported as a warning and does not
+--    stop the other objects from being recompiled
+CREATE FUNCTION rc_test.helper() RETURN int AS $$
+    SELECT 2;
+$$ LANGUAGE SQL;
+CREATE FUNCTION rc_test.uses_helper() RETURN int AS $$
+    SELECT rc_test.helper();
+$$ LANGUAGE SQL;
+DROP FUNCTION rc_test.helper();
+CALL UTL_RECOMP.RECOMP_SERIAL('rc_test');
+SELECT rc_test.incr(1) AS still_ok;
+
+-- clean up before the error cases below
+DROP SCHEMA rc_test CASCADE;
+
+-- 7. threads must be positive
+CALL UTL_RECOMP.RECOMP_PARALLEL(0, 'rc_test');
+
+-- 8. an invalid schema is rejected
+CALL UTL_RECOMP.RECOMP_SERIAL('no_such_schema_xyz');

--- a/contrib/ivorysql_ora/src/builtin_packages/utl_recomp/utl_recomp--1.0.sql
+++ b/contrib/ivorysql_ora/src/builtin_packages/utl_recomp/utl_recomp--1.0.sql
@@ -1,0 +1,143 @@
+/*-------------------------------------------------------------------------
+ * Copyright 2026 IvorySQL Global Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * utl_recomp--1.0.sql
+ *
+ * Oracle-compatible UTL_RECOMP package.
+ *
+ * RECOMP_SERIAL / RECOMP_SCHEMA / RECOMP_PARALLEL revalidate the
+ * PL/iSQL/PL/pgSQL/SQL routines and views of a schema by re-executing
+ * their definitions through CREATE OR REPLACE (the only way PostgreSQL
+ * forces a recompile).  Objects that fail re-validation (missing
+ * dependencies, syntax errors recovered from a broken body, etc.) are
+ * reported as WARNINGs and do not stop the remaining objects.
+ *
+ * Semantics differ from Oracle where PostgreSQL requires it:
+ * - a NULL schema means the current schema (instead of "all schemas"),
+ *   so that a regular user never recompiles objects it cannot own;
+ * - the flags argument is accepted for signature compatibility and is
+ *   currently ignored;
+ * - RECOMP_PARALLEL runs serially; the threads argument is accepted for
+ *   compatibility and ignored.
+ *
+ * AUTHID CURRENT_USER: objects are recompiled under the caller's
+ * privileges, so a caller can only recompile objects in schemas where it
+ * has CREATE privileges, mirroring Oracle's statement that the package
+ * "recompiles database objects with the user's privileges".
+ *
+ * contrib/ivorysql_ora/src/builtin_packages/utl_recomp/utl_recomp--1.0.sql
+ *
+ *-------------------------------------------------------------------------
+ */
+
+CREATE OR REPLACE PACKAGE utl_recomp AUTHID CURRENT_USER IS
+
+    PROCEDURE recomp_serial(schema IN VARCHAR2 DEFAULT NULL,
+                            flags IN INTEGER DEFAULT 0);
+
+    PROCEDURE recomp_parallel(threads IN INTEGER,
+                              schema IN VARCHAR2 DEFAULT NULL,
+                              flags IN INTEGER DEFAULT 0);
+
+    PROCEDURE recomp_schema(schema IN VARCHAR2 DEFAULT NULL,
+                            flags IN INTEGER DEFAULT 0);
+
+END utl_recomp;
+
+CREATE OR REPLACE PACKAGE BODY utl_recomp IS
+
+    /*
+     * Recompile every routine (non-C, non-internal language) and every
+     * non-materialized view in the given schema.  Each object's definition
+     * is regenerated with pg_get_functiondef()/pg_get_viewdef() and
+     * re-executed via CREATE OR REPLACE, which forces PostgreSQL to
+     * re-parse and re-validate it.
+     */
+    PROCEDURE recompile_schema_objects(p_schema VARCHAR2,
+                                       p_flags INTEGER) IS
+        v_schema VARCHAR2 := p_schema;
+        r RECORD;
+        done int := 0;
+        failed int := 0;
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = v_schema) THEN
+            RAISE EXCEPTION 'UTL_RECOMP: schema "%" does not exist', v_schema;
+        END IF;
+
+        FOR r IN
+            SELECT oid::regprocedure AS sig,
+                   pg_get_functiondef(oid) AS def
+              FROM pg_proc
+             WHERE pronamespace = (SELECT oid FROM pg_namespace
+                                    WHERE nspname = v_schema)
+               AND prokind IN ('f', 'p')
+               AND prolang NOT IN (SELECT oid FROM pg_language
+                                    WHERE lanname IN ('internal', 'c'))
+        LOOP
+            BEGIN
+                EXECUTE r.def;
+                done := done + 1;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE WARNING 'UTL_RECOMP: could not recompile %: %', r.sig, SQLERRM;
+                failed := failed + 1;
+            END;
+        END LOOP;
+
+        FOR r IN
+            SELECT quote_ident(v_schema) || '.' || quote_ident(c.relname) AS qualname,
+                   'CREATE OR REPLACE VIEW ' ||
+                       quote_ident(v_schema) || '.' || quote_ident(c.relname) ||
+                       ' AS ' || pg_get_viewdef(c.oid) AS def
+              FROM pg_class c
+             WHERE c.relnamespace = (SELECT oid FROM pg_namespace
+                                      WHERE nspname = v_schema)
+               AND c.relkind = 'v'
+        LOOP
+            BEGIN
+                EXECUTE r.def;
+                done := done + 1;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE WARNING 'UTL_RECOMP: could not recompile %: %', r.qualname, SQLERRM;
+                failed := failed + 1;
+            END;
+        END LOOP;
+
+        RAISE NOTICE 'UTL_RECOMP: recompiled % objects in schema "%" (% failed)',
+                     done, v_schema, failed;
+    END;
+
+    PROCEDURE recomp_serial(schema IN VARCHAR2 DEFAULT NULL,
+                            flags IN INTEGER DEFAULT 0) IS
+    BEGIN
+        recompile_schema_objects(COALESCE(schema, current_schema()::text), flags);
+    END;
+
+    PROCEDURE recomp_parallel(threads IN INTEGER,
+                              schema IN VARCHAR2 DEFAULT NULL,
+                              flags IN INTEGER DEFAULT 0) IS
+    BEGIN
+        IF threads <= 0 THEN
+            RAISE EXCEPTION 'UTL_RECOMP: threads must be a positive integer';
+        END IF;
+        recompile_schema_objects(COALESCE(schema, current_schema()::text), flags);
+    END;
+
+    PROCEDURE recomp_schema(schema IN VARCHAR2 DEFAULT NULL,
+                            flags IN INTEGER DEFAULT 0) IS
+    BEGIN
+        recompile_schema_objects(COALESCE(schema, current_schema()::text), flags);
+    END;
+
+END utl_recomp;


### PR DESCRIPTION
Closes #2028.

Adds the UTL_RECOMP built-in package (RECOMP_SERIAL, RECOMP_SCHEMA,
RECOMP_PARALLEL) to ivorysql_ora. Recompilation re-executes each
object's CREATE OR REPLACE definition, forcing PostgreSQL to re-parse
and re-validate it; failures are WARNINGs and do not stop the rest.

Documented oracle/PostgreSQL differences:
- NULL schema = current schema (caller-safe, AUTHID CURRENT_USER)
- flags accepted but ignored
- RECOMP_PARALLEL runs serially

Regression: 8 scenarios covering entry points, NULL schema, flags,
usability after recompile, dependency-broken objects, invalid schema
and thread errors.

Verified: make -C contrib/ivorysql_ora oracle-check -> 29/29.

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Oracle-compatible `UTL_RECOMP` package.
  - Supports serial, schema-level, and parallel recompilation procedures.
  - Recompiles eligible routines and views, reports successful and failed objects, and validates thread counts.
  - Supports current-schema targeting when no schema is specified.

- **Tests**
  - Added regression coverage for successful recompilation, invalid schemas, dependency failures, warnings, and accepted options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->